### PR TITLE
chore(book): book expansion

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -8,4 +8,5 @@
 - [Design](design.md)
   - [Transaction Format](design/transaction-format.md)
   - [Action Circuit](design/action-circuit.md)
+  - [Orchard to Ironwood Migration](design/migration.md) <!-- todo -->
 - [Formal Verification](formal-verification.md) <!-- todo -->

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -7,4 +7,5 @@
 - [User Documentation](user.md) <!-- todo -->
 - [Design](design.md)
   - [Transaction Format](design/transaction-format.md)
+  - [Action Circuit](design/action-circuit.md)
 - [Formal Verification](formal-verification.md) <!-- todo -->

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -7,3 +7,4 @@
 - [User Documentation](user.md) <!-- todo -->
 - [Design](design.md)
   - [Transaction Format](design/transaction-format.md)
+- [Formal Verification](formal-verification.md) <!-- todo -->

--- a/book/src/concepts.md
+++ b/book/src/concepts.md
@@ -32,8 +32,9 @@ funds.
 
 ## Quantum-Recoverable Notes
 
-ZIP 2005 defines the Ironwood note plaintext format with lead byte `0x03`. This
-is the quantum-recoverable note plaintext format.
+ZIP 2005 defines a new Orchard note plaintext format with lead byte `0x03`: the
+quantum-recoverable note plaintext format. Ironwood adopts this format for its
+notes.
 
 In wallet-facing code, Ironwood notes are Orchard-shaped notes using the
 Ironwood note plaintext format. Existing Orchard notes remain ordinary Orchard

--- a/book/src/concepts/quantum-recoverability.md
+++ b/book/src/concepts/quantum-recoverability.md
@@ -18,7 +18,7 @@ randomness is derived.
 
 ## Ironwood Notes
 
-ZIP 2005 defines a new Orchard note plaintext format with lead byte `0x03`: the
+ZIP 2005 defines a new note plaintext format with lead byte `0x03`: the
 quantum-recoverable note plaintext format. Ironwood adopts this format for its
 notes. ZIP 2005 changes how Orchard notes are constructed; it does not by itself
 define the Ironwood pool, note commitment tree, or nullifier set. Those are

--- a/book/src/concepts/quantum-recoverability.md
+++ b/book/src/concepts/quantum-recoverability.md
@@ -18,11 +18,17 @@ randomness is derived.
 
 ## Ironwood Notes
 
-ZIP 2005 defines the Ironwood note plaintext format with lead byte `0x03`. This
-is the quantum-recoverable note plaintext format.
+ZIP 2005 defines a new Orchard note plaintext format with lead byte `0x03`: the
+quantum-recoverable note plaintext format. Ironwood adopts this format for its
+notes. ZIP 2005 changes how Orchard notes are constructed; it does not by itself
+define the Ironwood pool, note commitment tree, or nullifier set. Those are
+Ironwood's own design, layered on top of the ZIP 2005 note-level change.
 
 Older Orchard notes use note plaintext lead byte `0x02`. For those notes, the note
-commitment randomness is derived from `rseed` and the note position seed `rho`.
+commitment randomness is derived from `rseed` and `rho`. `rseed` is the 32-byte
+random seed the sender picks for a note. When a note is created, its `rho` is
+set to `nf^old`, the nullifier of the input note spent in the same action (the
+nullifier that action reveals).
 
 For Ironwood notes, the randomness is instead derived from the note contents. The
 derivation binds the randomness to:
@@ -50,7 +56,11 @@ flowchart LR
 
 This makes it possible for a future recovery protocol to prove that a recovered
 note corresponds to a real note with fixed contents, rather than to a forged
-choice of note fields.
+choice of note fields. Because `rcm` is now a hash of the note contents, the
+derivation can be recomputed from the recovered fields and checked against the
+on-chain commitment. The Ironwood spend proof does not itself enforce this
+derivation; the check is instead carried out by a future, dedicated recovery
+statement that proves `rcm` was derived from the note contents.
 
 Ironwood outputs are Orchard-style notes using the Ironwood note plaintext
 format. Ironwood still uses Orchard-shaped actions, receivers, and note

--- a/book/src/design.md
+++ b/book/src/design.md
@@ -76,8 +76,9 @@ to Ironwood instead.
 
 ## Quantum-Recoverable Ironwood Notes
 
-ZIP 2005 defines the Ironwood note plaintext format with lead byte `0x03`. This
-is the quantum-recoverable note plaintext format.
+ZIP 2005 defines a new Orchard note plaintext format with lead byte `0x03`: the
+quantum-recoverable note plaintext format. Ironwood adopts this format for its
+notes.
 
 This gives Ironwood a concrete note-level distinction while preserving Orchard
 keys and receiver handling. Wallet code can therefore model Ironwood notes as

--- a/book/src/design.md
+++ b/book/src/design.md
@@ -2,7 +2,9 @@
 
 This page summarizes the main design decisions behind Ironwood.
 
-## Goals
+## Overview
+
+### Goals
 
 Ironwood is intended to introduce a new shielded pool without discarding the
 parts of Orchard that are still useful. The design therefore separates
@@ -12,7 +14,7 @@ wallet infrastructure where possible.
 The result is a new pool with a smaller implementation and deployment surface
 than a fully independent shielded protocol.
 
-## New Shielded Pool
+### New Shielded Pool
 
 Ironwood is a new shielded value pool and value balance based on Orchard. This
 is consensus-relevant: transactions account for Ironwood value separately from
@@ -31,7 +33,9 @@ Orchard component is the same Orchard bundle, but version 6 changes how it is
 encoded, hashed, and verified; see
 [Orchard Bundle Changes in Version 6](#orchard-bundle-changes-in-version-6).
 
-## Separate State
+## Pool State
+
+### Separate State
 
 Ironwood has a separate note commitment tree and a separate nullifier set.
 
@@ -43,7 +47,28 @@ set.
 This prevents Orchard and Ironwood from sharing anonymity-set state by accident
 and gives the protocol a clean migration path away from legacy Orchard state.
 
-## Orchard-Style Bundle
+### Chain History Tree
+
+The chain history tree (the FlyClient MMR introduced in
+[ZIP 221](https://zips.z.cash/zip-0221)) gains Ironwood metadata. From NU7
+onward, history nodes use a new node-data version that, in addition to the
+existing Sapling and Orchard fields, commits to:
+
+- the Ironwood note commitment tree root at the start of the node's block range,
+- the Ironwood note commitment tree root at the end of the node's block range,
+  and
+- the number of transactions in the range that contain an Ironwood bundle.
+
+A leaf's start and end Ironwood roots are both the final Ironwood tree root after
+its block. Combining two subtrees takes the left child's start root, the right
+child's end root, and the sum of the two transaction counts, and the maximum
+history node-data size grows to hold the new fields. The effect is that, from
+NU7 onward, the chain history commitment binds the Ironwood tree state and
+Ironwood activity of every range, just as it already binds Sapling and Orchard.
+
+## Actions and Notes
+
+### Orchard-Style Bundle
 
 The Ironwood bundle reuses Orchard action and bundle structure. In the
 implementation this appears as a second Orchard-shaped bundle with an Ironwood
@@ -60,7 +85,7 @@ This means Ironwood inherits:
 Quantum recoverability is the only note-level change for new Ironwood outputs.
 The rest of the bundle structure follows Orchard.
 
-## Orchard Circuit Constraint
+### Orchard Circuit Constraint
 
 After NU7, Orchard is constrained so that it can only remove value from Orchard
 or split existing Orchard notes into change notes. It must not allow new value
@@ -82,7 +107,7 @@ circuit as the cross-address restriction. The "no new value" half is the
 value-balance rule below. See [Action Circuit](design/action-circuit.md) for the
 exact circuit mechanism.
 
-## Quantum-Recoverable Ironwood Notes
+### Quantum-Recoverable Ironwood Notes
 
 ZIP 2005 defines a new Orchard note plaintext format with lead byte `0x03`: the
 quantum-recoverable note plaintext format. Ironwood adopts this format for its
@@ -98,7 +123,9 @@ Orchard-shaped notes, but classify them by note plaintext format:
 When an Ironwood note is spent, the witness is obtained from the Ironwood note
 commitment tree, not the Orchard tree.
 
-## Version 6 Transaction Format
+## Transaction Format and Hashing
+
+### Version 6 Transaction Format
 
 Transaction version 6 adds the Ironwood bundle to the transaction format. The
 bundle order is:
@@ -114,7 +141,7 @@ Orchard bundle, but is interpreted under the Ironwood protocol context.
 Version 6 is the default transaction version for NU7. Version 5 remains the
 transaction version for NU5 through NU6.2.
 
-## Orchard Bundle Changes in Version 6
+### Orchard Bundle Changes in Version 6
 
 The Orchard bundle keeps its version 5 layout, but version 6 changes it in three
 consensus-visible ways. Together these wind Orchard down into a spend-only,
@@ -134,18 +161,7 @@ same-address pool while reusing its action machinery.
   circuit verifying key, not the version 5 (post-NU6.2) key, because the
   cross-address restriction must be enforceable on Orchard actions.
 
-<<<<<<< HEAD
-## ZIP 233 in Version 6
-
-Version 6 transactions do not carry a ZIP 233 explicit-fee (burn) field. ZIP 233
-handling is confined to the experimental `zfuture` path and is not part of the
-NU7 version 6 format. NU7 and `zfuture` are mutually exclusive deployments and
-cannot be enabled together.
-
-## Transaction Hashing
-=======
 ### Transaction Hashing
->>>>>>> 128e1e6 (nit remove)
 
 Ironwood uses Orchard-style bundle and action hashing, but with
 Ironwood-specific personalization strings.
@@ -171,26 +187,9 @@ binds the anchor, a spend can be pre-signed before the anchor it is finalized
 against exists. The anchor is still bound at the consensus layer, through the
 block's authorizing-data commitment.
 
-## Chain History Tree
+## Consensus Value Rules
 
-The chain history tree (the FlyClient MMR introduced in
-[ZIP 221](https://zips.z.cash/zip-0221)) gains Ironwood metadata. From NU7
-onward, history nodes use a new node-data version that, in addition to the
-existing Sapling and Orchard fields, commits to:
-
-- the Ironwood note commitment tree root at the start of the node's block range,
-- the Ironwood note commitment tree root at the end of the node's block range,
-  and
-- the number of transactions in the range that contain an Ironwood bundle.
-
-A leaf's start and end Ironwood roots are both the final Ironwood tree root after
-its block. Combining two subtrees takes the left child's start root, the right
-child's end root, and the sum of the two transaction counts, and the maximum
-history node-data size grows to hold the new fields. The effect is that, from
-NU7 onward, the chain history commitment binds the Ironwood tree state and
-Ironwood activity of every range, just as it already binds Sapling and Orchard.
-
-## Post-NU7 Orchard Value Rule
+### Post-NU7 Orchard Value Rule
 
 After NU7 activation, no funds can flow into Orchard. Transactions must not have
 a negative Orchard value balance.
@@ -204,7 +203,7 @@ The rule still permits:
 This lets wallets spend existing Orchard funds while preventing newly created
 shielded value from being placed back into Orchard.
 
-## Coinbase After NU7
+### Coinbase After NU7
 
 Because new value may not enter Orchard after NU7, coinbase rules change so that
 block rewards are never paid into the Orchard pool:
@@ -222,7 +221,9 @@ block rewards are never paid into the Orchard pool:
   Ironwood bundle (`EnableSpendsIronwood` must be unset), mirroring the existing
   rule for Orchard.
 
-## Wallet Routing
+## Wallet and Tooling
+
+### Wallet Routing
 
 Wallet-created Orchard receiver outputs are routed to Ironwood after NU7.
 
@@ -240,7 +241,7 @@ format:
 This allows legacy Orchard notes to migrate out through ordinary spends while
 ensuring new outputs land in Ironwood.
 
-## Wallet Storage And APIs
+### Wallet Storage And APIs
 
 Ironwood is exposed as a distinct pool in wallet-facing state, while reusing
 Orchard-shaped note data internally.
@@ -264,7 +265,7 @@ Compact block and lightwallet protocol data also grow Ironwood fields:
 This gives light clients enough information to maintain the Ironwood note
 commitment tree and detect Ironwood spends and outputs independently of Orchard.
 
-## PCZT
+### PCZT
 
 Partially-created Zcash transactions include an Ironwood bundle in the updated
 PCZT format.
@@ -279,7 +280,9 @@ PCZT version 2 can carry:
 The PCZT Orchard action fields also include note plaintext version, because
 verifiers and provers need the note version to reconstruct note commitments.
 
-## Open Placeholders
+## Status
+
+### Open Placeholders
 
 The current design still has placeholders that should be finalized before a
 production protocol specification:

--- a/book/src/design.md
+++ b/book/src/design.md
@@ -25,9 +25,11 @@ Version 6 transactions support the following pools:
 - Orchard, and
 - Ironwood.
 
-Transaction version 6 is the same as transaction version 5, except that it adds
-an Ironwood bundle. Sapling, Orchard, and transparent transaction components are
-otherwise unchanged from version 5.
+Transaction version 6 is based on transaction version 5 and adds an Ironwood
+bundle. Transparent and Sapling components are unchanged from version 5. The
+Orchard component is the same Orchard bundle, but version 6 changes how it is
+encoded, hashed, and verified; see
+[Orchard Bundle Changes in Version 6](#orchard-bundle-changes-in-version-6).
 
 ## Separate State
 
@@ -112,7 +114,38 @@ Orchard bundle, but is interpreted under the Ironwood protocol context.
 Version 6 is the default transaction version for NU7. Version 5 remains the
 transaction version for NU5 through NU6.2.
 
+## Orchard Bundle Changes in Version 6
+
+The Orchard bundle keeps its version 5 layout, but version 6 changes it in three
+consensus-visible ways. Together these wind Orchard down into a spend-only,
+same-address pool while reusing its action machinery.
+
+- **Flag encoding.** Orchard bundle flags are serialized in the NU6.3 flag
+  format, which gives meaning to the `enableCrossAddress` flag (bit 2). In
+  version 5 that bit is reserved and must be zero. After NU7 an Orchard bundle
+  must *not* set `enableCrossAddress`: consensus rejects a version 6 Orchard
+  bundle that sets it, which forces the circuit's `disableCrossAddress` input and
+  restricts Orchard actions to change or withdrawal. Ironwood, by contrast, may
+  set `enableCrossAddress`. See [Action Circuit](design/action-circuit.md).
+- **Anchor placement.** The Orchard anchor is excluded from the version 6 txid
+  and signature hash and is committed in the authorization digest instead, the
+  same as Ironwood. See [Transaction Hashing](#transaction-hashing).
+- **Verifying key.** Version 6 Orchard bundles are verified with the Ironwood
+  circuit verifying key, not the version 5 (post-NU6.2) key, because the
+  cross-address restriction must be enforceable on Orchard actions.
+
+<<<<<<< HEAD
+## ZIP 233 in Version 6
+
+Version 6 transactions do not carry a ZIP 233 explicit-fee (burn) field. ZIP 233
+handling is confined to the experimental `zfuture` path and is not part of the
+NU7 version 6 format. NU7 and `zfuture` are mutually exclusive deployments and
+cannot be enabled together.
+
 ## Transaction Hashing
+=======
+### Transaction Hashing
+>>>>>>> 128e1e6 (nit remove)
 
 Ironwood uses Orchard-style bundle and action hashing, but with
 Ironwood-specific personalization strings.
@@ -138,6 +171,25 @@ binds the anchor, a spend can be pre-signed before the anchor it is finalized
 against exists. The anchor is still bound at the consensus layer, through the
 block's authorizing-data commitment.
 
+## Chain History Tree
+
+The chain history tree (the FlyClient MMR introduced in
+[ZIP 221](https://zips.z.cash/zip-0221)) gains Ironwood metadata. From NU7
+onward, history nodes use a new node-data version that, in addition to the
+existing Sapling and Orchard fields, commits to:
+
+- the Ironwood note commitment tree root at the start of the node's block range,
+- the Ironwood note commitment tree root at the end of the node's block range,
+  and
+- the number of transactions in the range that contain an Ironwood bundle.
+
+A leaf's start and end Ironwood roots are both the final Ironwood tree root after
+its block. Combining two subtrees takes the left child's start root, the right
+child's end root, and the sum of the two transaction counts, and the maximum
+history node-data size grows to hold the new fields. The effect is that, from
+NU7 onward, the chain history commitment binds the Ironwood tree state and
+Ironwood activity of every range, just as it already binds Sapling and Orchard.
+
 ## Post-NU7 Orchard Value Rule
 
 After NU7 activation, no funds can flow into Orchard. Transactions must not have
@@ -151,6 +203,24 @@ The rule still permits:
 
 This lets wallets spend existing Orchard funds while preventing newly created
 shielded value from being placed back into Orchard.
+
+## Coinbase After NU7
+
+Because new value may not enter Orchard after NU7, coinbase rules change so that
+block rewards are never paid into the Orchard pool:
+
+- **No Orchard coinbase outputs.** Coinbase reward outputs are routed to Sapling
+  or transparent receivers; the Orchard receiver is no longer a reward
+  destination after NU7. A miner address whose unified address contains *only* an
+  Orchard receiver is therefore rejected for coinbase use.
+- **Coinbase value balance includes Ironwood.** The coinbase balance check
+  accounts for the Ironwood value balance alongside Sapling and Orchard. Any
+  Ironwood output in a coinbase transaction must be decryptable with the all-zero
+  outgoing viewing key, as already required for Sapling and Orchard, so that
+  coinbase funds are not burned.
+- **No coinbase spends.** A coinbase transaction must not enable spends in its
+  Ironwood bundle (`EnableSpendsIronwood` must be unset), mirroring the existing
+  rule for Orchard.
 
 ## Wallet Routing
 

--- a/book/src/design.md
+++ b/book/src/design.md
@@ -59,12 +59,9 @@ existing Sapling and Orchard fields, commits to:
   and
 - the number of transactions in the range that contain an Ironwood bundle.
 
-A leaf's start and end Ironwood roots are both the final Ironwood tree root after
-its block. Combining two subtrees takes the left child's start root, the right
-child's end root, and the sum of the two transaction counts, and the maximum
-history node-data size grows to hold the new fields. The effect is that, from
-NU7 onward, the chain history commitment binds the Ironwood tree state and
-Ironwood activity of every range, just as it already binds Sapling and Orchard.
+The effect is that, from NU7 onward, the chain history commitment binds the
+Ironwood tree state and Ironwood activity of every block range, just as it
+already binds Sapling and Orchard.
 
 ## Actions and Notes
 
@@ -147,19 +144,17 @@ The Orchard bundle keeps its version 5 layout, but version 6 changes it in three
 consensus-visible ways. Together these wind Orchard down into a spend-only,
 same-address pool while reusing its action machinery.
 
-- **Flag encoding.** Orchard bundle flags are serialized in the NU6.3 flag
-  format, which gives meaning to the `enableCrossAddress` flag (bit 2). In
-  version 5 that bit is reserved and must be zero. After NU7 an Orchard bundle
-  must *not* set `enableCrossAddress`: consensus rejects a version 6 Orchard
-  bundle that sets it, which forces the circuit's `disableCrossAddress` input and
-  restricts Orchard actions to change or withdrawal. Ironwood, by contrast, may
-  set `enableCrossAddress`. See [Action Circuit](design/action-circuit.md).
+- **Flag encoding.** Orchard bundle flags gain a new `enableCrossAddress` flag.
+  After NU7 an Orchard bundle must *not* set it: consensus rejects a version 6
+  Orchard bundle that does, restricting Orchard actions to change or withdrawal.
+  Ironwood, by contrast, may set it. See
+  [Action Circuit](design/action-circuit.md).
 - **Anchor placement.** The Orchard anchor is excluded from the version 6 txid
   and signature hash and is committed in the authorization digest instead, the
   same as Ironwood. See [Transaction Hashing](#transaction-hashing).
 - **Verifying key.** Version 6 Orchard bundles are verified with the Ironwood
-  circuit verifying key, not the version 5 (post-NU6.2) key, because the
-  cross-address restriction must be enforceable on Orchard actions.
+  circuit verifying key, not the version 5 key, because the cross-address
+  restriction must be enforceable on Orchard actions.
 
 ### Transaction Hashing
 
@@ -213,13 +208,11 @@ block rewards are never paid into the Orchard pool:
   destination after NU7. A miner address whose unified address contains *only* an
   Orchard receiver is therefore rejected for coinbase use.
 - **Coinbase value balance includes Ironwood.** The coinbase balance check
-  accounts for the Ironwood value balance alongside Sapling and Orchard. Any
-  Ironwood output in a coinbase transaction must be decryptable with the all-zero
-  outgoing viewing key, as already required for Sapling and Orchard, so that
-  coinbase funds are not burned.
+  accounts for the Ironwood value balance alongside Sapling and Orchard, and
+  Ironwood coinbase outputs must be recoverable, as already required for Sapling
+  and Orchard, so that coinbase funds are not burned.
 - **No coinbase spends.** A coinbase transaction must not enable spends in its
-  Ironwood bundle (`EnableSpendsIronwood` must be unset), mirroring the existing
-  rule for Orchard.
+  Ironwood bundle, mirroring the existing rule for Orchard.
 
 ## Wallet and Tooling
 

--- a/book/src/design.md
+++ b/book/src/design.md
@@ -74,6 +74,12 @@ But transactions cannot use Orchard as a destination for newly created value.
 New shielded outputs that would previously have been Orchard outputs are routed
 to Ironwood instead.
 
+The "split into change notes" half of this constraint (requiring each retained
+output to return to the address it was spent from) is enforced in the Action
+circuit as the cross-address restriction. The "no new value" half is the
+value-balance rule below. See [Action Circuit](design/action-circuit.md) for the
+exact circuit mechanism.
+
 ## Quantum-Recoverable Ironwood Notes
 
 ZIP 2005 defines a new Orchard note plaintext format with lead byte `0x03`: the
@@ -203,6 +209,10 @@ The current design still has placeholders that should be finalized before a
 production protocol specification:
 
 - the NU7 consensus branch ID,
-- the exact circuit/proof-system changes, if any, beyond Orchard reuse,
 - final ZIP text for transaction version 6 and Ironwood hashing, and
 - final activation heights and deployment rules.
+
+The circuit and proof-system changes, previously open here, are now specified in
+[Action Circuit](design/action-circuit.md): Ironwood reuses the Orchard Action
+circuit and adds a single new constraint, the cross-address restriction, with its
+own proving and verifying keys.

--- a/book/src/design.md
+++ b/book/src/design.md
@@ -132,6 +132,12 @@ digest, not by reusing Orchard's empty-bundle digest.
 Version 6 signature hashing uses the version 6 transaction hash path. This
 ensures signatures bind to the Ironwood bundle when it is present.
 
+The bundle anchor is excluded from version 6 txid and signature hashing, and is
+committed in the authorization digest instead. Because the signature no longer
+binds the anchor, a spend can be pre-signed before the anchor it is finalized
+against exists. The anchor is still bound at the consensus layer, through the
+block's authorizing-data commitment.
+
 ## Post-NU7 Orchard Value Rule
 
 After NU7 activation, no funds can flow into Orchard. Transactions must not have

--- a/book/src/design/action-circuit.md
+++ b/book/src/design/action-circuit.md
@@ -2,7 +2,7 @@
 
 Ironwood reuses the Orchard Action circuit. The proof system, curves, gadgets,
 and the action statement are inherited from Orchard unchanged. There is exactly
-one circuit-level addition: an optional **cross-address restriction** that, when
+one circuit-level addition: a chain-wide, configurable **cross-address restriction** that, when
 active, forces an action's output note to be addressed to the same receiver as
 the note it spends.
 

--- a/book/src/design/action-circuit.md
+++ b/book/src/design/action-circuit.md
@@ -1,0 +1,113 @@
+# Action Circuit
+
+Ironwood reuses the Orchard Action circuit. The proof system, curves, gadgets,
+and the action statement are inherited from Orchard unchanged. There is exactly
+one circuit-level addition: an optional **cross-address restriction** that, when
+active, forces an action's output note to be addressed to the same receiver as
+the note it spends.
+
+## What Ironwood Reuses
+
+An Ironwood action proves the
+[Action Statement (Orchard)](https://zips.z.cash/protocol/protocol.pdf#actionstatement)
+plus the cross-address restriction below, reusing the same machinery: the same
+Halo 2 proof system and gadgets.
+
+The circuit keeps the same advice columns, the same custom gates, and the same
+circuit size. Ironwood proofs are therefore the same size as Orchard proofs.
+
+## The Cross-Address Restriction
+
+The one new circuit constraint enforces a same-receiver property. An Orchard
+note is addressed to a diversified address, represented in the circuit by the
+diversified base `g_d` and the diversified transmission key `pk_d`. When the
+restriction is active, an action's output note and spent note must share that
+address:
+
+> `(g_d, pk_d)` of the output note must equal `(g_d, pk_d)` of the spent note.
+
+When active, the restriction limits each action to change (the output returns to
+the spent note's address) or withdrawal (value leaves the pool through a positive
+value balance), rather than a *cross-address transfer*. Its purpose is to
+discourage economic activity within the pool.
+
+This is the circuit mechanism behind the
+[Orchard Circuit Constraint](../design.md#orchard-circuit-constraint): after NU7,
+legacy Orchard actions disable cross-address transfers and the pool is wound
+down, while pools that accept new payments (Ironwood) keep cross-address
+transfers enabled.
+
+The companion rule that no new value may enter Orchard after NU7 (that the
+Orchard value balance must not be negative) is not enforced by this circuit. The
+per-action circuit only ties `v_old - v_new` to the action's value commitment
+`cv_net`; the sign of the bundle's value balance is a transaction-level concern
+outside the orchard crate. See
+[Post-NU7 Orchard Value Rule](../design.md#post-nu7-orchard-value-rule).
+
+### A new public input
+
+The public-input layout is unified across all circuit versions: every version's
+instance carries the same ten public inputs, with `disableCrossAddress` added
+after the existing Orchard action inputs.
+
+| Index | Public input |
+|------:|--------------|
+| 0 | anchor |
+| 1–2 | value commitment `cv_net` |
+| 3 | nullifier `nf_old` |
+| 4–5 | randomized spend-auth key `rk` |
+| 6 | output note commitment `cmx` |
+| 7 | `enableSpend` |
+| 8 | `enableOutput` |
+| 9 | `disableCrossAddress` |
+
+The bundle-level flag is `enableCrossAddress` (the NU6.3 flag, bit 2); the
+circuit-level public input is its negation, `disableCrossAddress`. The Ironwood
+circuit constrains it: `0` imposes no extra constraint, and
+`1` enforces the same-receiver property above. Older circuit versions carry and
+commit the input but leave it unconstrained, relying on the proving and
+verification API to reject a set flag they cannot enforce. Because instance
+columns are zero-padded over the evaluation domain, an unrestricted statement
+(`disableCrossAddress = 0`) commits identically to the historical nine-input
+Orchard encoding.
+
+### How the constraint is enforced
+
+Ironwood adds the constraint without adding a gate or a column. The existing
+"Orchard circuit checks" gate (which checks value balance, the computed Merkle
+root against the anchor, and the enable flags) already contains a product
+constraint of the form `v_old · (root − anchor) = 0`, exactly the shape needed
+for `disableCrossAddress · (old_coord − new_coord) = 0`.
+
+The circuit reuses that gate on four extra rows, one per affine coordinate of
+`g_d` and `pk_d`. Copy constraints place `disableCrossAddress` and the spent and
+output coordinates into the gate, and its selector is enabled on those rows; with
+the gate's other terms neutralized, the surviving constraint is:
+
+```text
+disableCrossAddress · (old_coord − new_coord) = 0
+```
+
+Any nonzero `disableCrossAddress` forces each coordinate of the output address to
+equal the spent address; a zero leaves them free. The check is conditional on the
+flag and does not rely on the flag being boolean.
+
+## Keys And Enforcement
+
+Ironwood is a new *circuit version* in the orchard crate that extends the fixed
+post-NU6.2 circuit with the cross-address constraint. It ships with its own
+proving and verifying keys.
+
+- **The verifying key differs.** Enabling the shared gate on the four extra rows
+  changes the circuit's fixed (selector) columns, so the Ironwood verifying key
+  is distinct from the fixed-circuit verifying key, even though the proof size
+  and verification cost are unchanged.
+- **Restricted statements require Ironwood keys.** Because older versions cannot
+  constrain `disableCrossAddress`, a statement that disables cross-address
+  transfers is rejected outright when proved or verified with a non-Ironwood key;
+  unrestricted statements are not gated this way.
+
+The circuit is the cryptographic enforcement point: a prover cannot satisfy a
+restricted statement with a cross-address output. The builder, PCZT,
+and signer layers add a same-receiver structural check so that honest
+participants do not construct a restricted bundle that would fail to prove.

--- a/book/src/design/migration.md
+++ b/book/src/design/migration.md
@@ -1,0 +1,10 @@
+# Orchard to Ironwood Migration
+
+Moving existing Orchard funds into Ironwood is an ordinary version 6 transaction
+rather than a special protocol operation: it spends Orchard notes and creates
+Ironwood outputs. It is the case where the post-NU7 rules compose. The Orchard
+side has a positive value balance (value leaves Orchard, which the value rule
+permits), and the Ironwood side has a negative value balance (value enters
+Ironwood); the two net to the fee.
+
+*Exact wallet migration mechanics to be described.*

--- a/book/src/design/transaction-format.md
+++ b/book/src/design/transaction-format.md
@@ -34,7 +34,7 @@ flowchart TD
     subgraph Shape["Same Orchard-style bundle hash shape"]
         Compact["actions compact hash<br/>nf, cmx, epk, compact ciphertext"]
         Memos["actions memo hash<br/>memo ciphertext"]
-        NonCompact["actions non-compact hash<br/>cv, rk, remaining ciphertext"]
+        NonCompact["actions non-compact hash<br/>cv, rk, remaining enc ciphertext, out ciphertext"]
         Flags["bundle flags"]
         Value["value balance"]
         Anchor["bundle anchor"]

--- a/book/src/design/transaction-format.md
+++ b/book/src/design/transaction-format.md
@@ -2,8 +2,7 @@
 
 Version 6 follows the version 5 transaction format, with an Ironwood bundle
 added after the Orchard bundle. Within version 6, the Orchard bundle keeps its
-version 5 layout but switches to the NU6.3 flag encoding, which gives the
-`enableCrossAddress` flag (bit 2) its meaning. See
+version 5 layout but gains a new `enableCrossAddress` flag. See
 [Orchard Bundle Changes in Version 6](../design.md#orchard-bundle-changes-in-version-6).
 
 At the transaction ID layer, Ironwood is another child in the transaction hash

--- a/book/src/design/transaction-format.md
+++ b/book/src/design/transaction-format.md
@@ -37,7 +37,6 @@ flowchart TD
         NonCompact["actions non-compact hash<br/>cv, rk, remaining enc ciphertext, out ciphertext"]
         Flags["bundle flags"]
         Value["value balance"]
-        Anchor["bundle anchor"]
     end
 
     OrchardBundle --> Compact
@@ -45,16 +44,20 @@ flowchart TD
     OrchardBundle --> NonCompact
     OrchardBundle --> Flags
     OrchardBundle --> Value
-    OrchardBundle --> Anchor
 
     IronwoodBundle -. same fields .-> Compact
     IronwoodBundle -. same fields .-> Memos
     IronwoodBundle -. same fields .-> NonCompact
     IronwoodBundle -. same fields .-> Flags
     IronwoodBundle -. same fields .-> Value
-    IronwoodBundle -. same fields .-> Anchor
 ```
 
 The same rule applies to authorization hashing: Ironwood follows the Orchard
 bundle authorization structure, but uses Ironwood-specific personalization
 strings.
+
+In version 6 the bundle **anchor** is excluded from the txid bundle digest
+shown above, and is instead committed in the **authorization digest**. This
+keeps both the txid and the signature sighash independent of the anchor, so a
+spend can be signed before the anchor it is finalized against — the
+note-commitment-tree root — exists.

--- a/book/src/design/transaction-format.md
+++ b/book/src/design/transaction-format.md
@@ -1,7 +1,10 @@
 # Transaction Format
 
 Version 6 follows the version 5 transaction format, with an Ironwood bundle
-added after the Orchard bundle.
+added after the Orchard bundle. Within version 6, the Orchard bundle keeps its
+version 5 layout but switches to the NU6.3 flag encoding, which gives the
+`enableCrossAddress` flag (bit 2) its meaning. See
+[Orchard Bundle Changes in Version 6](../design.md#orchard-bundle-changes-in-version-6).
 
 At the transaction ID layer, Ironwood is another child in the transaction hash
 tree:

--- a/book/src/formal-verification.md
+++ b/book/src/formal-verification.md
@@ -1,0 +1,1 @@
+# Formal Verification


### PR DESCRIPTION
- minor fixes and clarifications for https://github.com/zcash/ironwood/pull/3 in https://github.com/zcash/ironwood/pull/5/changes/4b499ecaf7cd5bdf48a1abdcdae31445c62887fe which serves as my review of that PR (cc @ValarDragon),
- stubs formal verification and pool migration sections,
- action circuit entry modeling specification in https://github.com/zcash/orchard/pull/504 (subject to change as the PR changes),
- transaction format update: anchor will be removed from sighash and treated as auth data (see [ZIP 244](https://zips.z.cash/zip-0244)),
- align design with NU6.3 Ironwood implementation and specs across zebra, librustzcash, lightwalletd, and Keystone, and wallet which are [collectively](https://github.com/valargroup) in-progress.