### PR TITLE
Fix the overclaim about formal verification in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 # $\mathtt{ironwood} \gets \text{Setup}(1^\lambda)$
 
 Ironwood is a new shielded pool, built to restore confidence for all Zcash'rs
-in the supply integrity of Zcash. It runs a formally verified Orchard circuit.
+in the supply integrity of Zcash. A formal verification is in progress, which
+is intended to cover at least soundness of the Action circuit used by the
+Orchard and Ironwood pools, before the upgrade that activates Ironwood.
+An important part of this effort will be to clearly and accurately document
+the scope of what is and is not formally verified.
 
 ## Documentation
 


### PR DESCRIPTION
The README previously said
> Ironwood is a new shielded pool, built to restore confidence for all Zcash'rs in the supply integrity of Zcash. It runs a formally verified Orchard circuit.

We cannot claim this while the formal verification has not been done. This PR changes the second sentence to:

> A formal verification is in progress, which is intended to cover at least soundness of the Action circuit used by the Orchard and Ironwood pools, before the upgrade that activates Ironwood. An important part of this effort will be to clearly and accurately document the scope of what is and is not formally verified.