### PR TITLE
fv: fix Fiat-Shamir lookup permuted-commitment absorb order (D1)

### DIFF
--- a/Zcash/Snark/Verifier/FiatShamir.lean
+++ b/Zcash/Snark/Verifier/FiatShamir.lean
@@ -58,6 +58,13 @@ def absorbPoints2 {F G : Type*} {a b : ℕ} (f : Fin a → Fin b → G) : List (
 def absorbScalars2 {F G : Type*} {a b : ℕ} (f : Fin a → Fin b → F) : List (TranscriptElt F G) :=
   (List.ofFn (fun i => absorbScalars (f i))).flatten
 
+/-- Absorb the lookup permuted commitments in the deployed order (halo2 `read_permuted_commitments`):
+per proof, per lookup, the permuted-input commitment then the permuted-table commitment. -/
+def absorbLookupPermuted {F G : Type*} {a b : ℕ} (input table : Fin a → Fin b → G) :
+    List (TranscriptElt F G) :=
+  (List.ofFn (fun p =>
+    (List.ofFn (fun l => [TranscriptElt.point (input p l), TranscriptElt.point (table p l)])).flatten)).flatten
+
 /-- Absorb a permutation set's evaluations (`eval`, `nextEval`, and `lastEval` when present). -/
 def absorbPermSet {F G : Type*} (e : PermSetEval F) : List (TranscriptElt F G) :=
   [.scalar e.eval, .scalar e.nextEval] ++ (e.lastEval.map TranscriptElt.scalar).toList
@@ -79,7 +86,7 @@ def deriveChallenges {shape : Shape} {F G : Type*} [Zero F] (fs : FiatShamir F G
   let t := init ++ absorbPoints2 ps.adviceCommitments
   let theta := fs.squeeze t
   -- lookup permuted commitments → β, γ
-  let t := t ++ [.scalar theta] ++ absorbPoints2 ps.lookupPermutedInput ++ absorbPoints2 ps.lookupPermutedTable
+  let t := t ++ [.scalar theta] ++ absorbLookupPermuted ps.lookupPermutedInput ps.lookupPermutedTable
   let beta := fs.squeeze t
   let t := t ++ [.scalar beta]
   let gamma := fs.squeeze t


### PR DESCRIPTION
Fixes the lookup permuted-commitment absorb order in the Fiat–Shamir schedule (`deriveChallenges`).

`deriveChallenges` absorbed the lookup permuted commitments as **all permuted-input commitments, then all permuted-table commitments** (`absorbPoints2 lookupPermutedInput ++ absorbPoints2 lookupPermutedTable`). The deployed halo2 verifier instead reads, **per lookup, the input commitment then the table commitment** — [`lookup/verifier.rs:43-44`](https://github.com/zcash/halo2/blob/261faaccd5a30c19bb8468600841a0dac305adf5/halo2_proofs/src/plonk/lookup/verifier.rs#L43-L44) (`read_permuted_commitments`), looped per lookup at [`plonk/verifier.rs:134`](https://github.com/zcash/halo2/blob/261faaccd5a30c19bb8468600841a0dac305adf5/halo2_proofs/src/plonk/verifier.rs#L134) — i.e. `input₀, table₀, input₁, table₁, …`. The two orders differ whenever `numLookups ≥ 2` (Orchard has `numLookups = 3`), so `deriveChallenges` did not reproduce the deployed transcript.

The fix adds `absorbLookupPermuted` (interleave per proof, per lookup: input then table) and uses it in the θ→β step.

**Scope.** Only the Fiat–Shamir schedule (`deriveChallenges` / `nonInteractiveFingerprint` / `FixtureFiatShamir`) is affected. `Fixture.fingerprint_matches` uses the *captured* challenges and is unchanged, so this was latent (the assumption `deriveChallenges fs init ps = ch` is what was wrong, undetectable while `fsHash` is abstract). This is **D1** from the transcript cross-reference posted on #11 — the concrete, self-contained instance of that issue's point 2 ("match the deployed transcript exactly"). D2 (challenge self-absorption) and D3 (domain-separation prefixes) remain part of the broader #11 work.

Builds: `lake build Zcash.Snark.Verifier.FiatShamir` green.

🤖 Claude Opus 4.8
