### PR TITLE
fv: permutation & lookup argument soundness + permutation construction (towards #14)

### DIFF
--- a/Zcash/Snark.lean
+++ b/Zcash/Snark.lean
@@ -15,6 +15,7 @@ import Zcash.Snark.Verifier.Expressions
 import Zcash.Snark.Verifier.Assemble
 import Zcash.Snark.Verifier.FiatShamir
 import Zcash.Snark.Fingerprint.Match
+import Zcash.Snark.Soundness.GrandProduct
 import Zcash.Snark.Soundness.InnerProduct
 import Zcash.Snark.Soundness.Extraction
 import Zcash.Snark.Soundness.Constraints

--- a/Zcash/Snark.lean
+++ b/Zcash/Snark.lean
@@ -18,6 +18,7 @@ import Zcash.Snark.Fingerprint.Match
 import Zcash.Snark.Soundness.GrandProduct
 import Zcash.Snark.Soundness.Lookup
 import Zcash.Snark.Soundness.Permutation
+import Zcash.Snark.Soundness.PermutationConstruction
 import Zcash.Snark.Soundness.InnerProduct
 import Zcash.Snark.Soundness.Extraction
 import Zcash.Snark.Soundness.Constraints

--- a/Zcash/Snark.lean
+++ b/Zcash/Snark.lean
@@ -16,6 +16,7 @@ import Zcash.Snark.Verifier.Assemble
 import Zcash.Snark.Verifier.FiatShamir
 import Zcash.Snark.Fingerprint.Match
 import Zcash.Snark.Soundness.GrandProduct
+import Zcash.Snark.Soundness.Lookup
 import Zcash.Snark.Soundness.InnerProduct
 import Zcash.Snark.Soundness.Extraction
 import Zcash.Snark.Soundness.Constraints

--- a/Zcash/Snark.lean
+++ b/Zcash/Snark.lean
@@ -17,6 +17,7 @@ import Zcash.Snark.Verifier.FiatShamir
 import Zcash.Snark.Fingerprint.Match
 import Zcash.Snark.Soundness.GrandProduct
 import Zcash.Snark.Soundness.Lookup
+import Zcash.Snark.Soundness.Permutation
 import Zcash.Snark.Soundness.InnerProduct
 import Zcash.Snark.Soundness.Extraction
 import Zcash.Snark.Soundness.Constraints

--- a/Zcash/Snark/Soundness/GrandProduct.lean
+++ b/Zcash/Snark/Soundness/GrandProduct.lean
@@ -1,0 +1,131 @@
+import Mathlib
+
+/-!
+# The grand-product → multiset kernel (permutation & lookup soundness)
+
+The shared algebraic core that both halo2's permutation and lookup *argument* soundness reduce to
+(tracking issue #14). Both arguments enforce their relation by a **grand product of factors linear in
+the challenges**, and the soundness step is the same: such a product, equal at the random challenge,
+forces the underlying multiset identity.
+
+This file isolates that core over Mathlib `Polynomial`. Nothing here needs computability. The proof
+leans on Mathlib's roots / unique-factorization theory:
+
+* `prod_X_add_u_inj` (**products can represent multisets**): `∏ (X + uᵢ) = ∏ (X + wᵢ)` over an
+  integral domain ⟹ `{uᵢ} = {wᵢ}`; that is, the function representing multisets as products is
+  injective. A product of linear factors is determined by its roots (`{-uᵢ}`); equal products ⟹
+  equal root multisets ⟹ (negation injective) equal multisets.
+* `card_eval_prod_eq_le` (**univariate Schwartz–Zippel at a point**): for `s ≠ t` over a finite field,
+  the challenges `β` where the *field* products `∏ (xᵢ + β)` collide are roots of the (nonzero, by
+  `prod_X_add_u_inj`) difference polynomial — a "bad set" of size `≤ max |s| |t|`.
+* `prod_pair_inj` (**products can represent multisets of pairs**):
+  `∏ (vᵢ + nᵢ·β + γ) = ∏ (cⱼ + dⱼ·β + γ) ⟹ {(vᵢ,nᵢ)} = {(cⱼ,dⱼ)}`, by running `prod_X_add_u_inj`
+  over `R = F[β]` (variable `γ`) and reading off the two coefficients of each linear factor.
+  This is what the permutation argument needs (matching `(value, name)` *pairs*, not just sums);
+  the lookup argument uses `prod_X_add_u_inj` twice with independent `β`, `γ`.
+
+The per-argument wrappers — telescoping the running product over the domain, the boundary / blinding-row
+rules, and (for lookup) the permuted-column structure — build on this and will live alongside in
+`Permutation.lean` / `Lookup.lean`.
+-/
+
+namespace Zcash.Snark
+
+open Polynomial
+
+/-- Helper to view `X + u` terms as `X - (-u)`, so that Mathlib lemmas apply. -/
+theorem map_X_add_u_eq {R : Type*} [CommRing R] (m : Multiset R) :
+    m.map (fun u => X + C u) = (m.map (fun u => -u)).map (fun a => X - C a) := by
+  rw [Multiset.map_map]
+  exact Multiset.map_congr rfl (fun u _ => by simp [Function.comp, sub_neg_eq_add])
+
+/-- The roots of `∏ (X + uᵢ)` are the negated elements `{-uᵢ}` (over a domain). -/
+theorem roots_prod_X_add_u {R : Type*} [CommRing R] [IsDomain R] (m : Multiset R) :
+    (m.map (fun u => X + C u)).prod.roots = m.map (fun u => -u) := by
+  rw [map_X_add_u_eq, roots_multiset_prod_X_sub_C]
+
+/-- Evaluating the polynomial product at `β` gives the field product of the shifted factors:
+`(∏ (X + uᵢ)).eval β = ∏ (β + uᵢ)`. The bridge from the polynomial world (where `prod_X_add_u_inj`
+lives) to the verifier's field-element products. -/
+theorem eval_prod_X_add_u {R : Type*} [CommRing R] (m : Multiset R) (β : R) :
+    ((m.map (fun u => X + C u)).prod).eval β = (m.map (fun x => β + x)).prod := by
+  rw [eval_multiset_prod, Multiset.map_map]
+  exact congrArg Multiset.prod
+    (Multiset.map_congr rfl (fun u _ => by simp [Function.comp, eval_add, eval_X, eval_C]))
+
+/-- `∏ (X + uᵢ)` has degree `|m|` (a product of `|m|` monic linear factors). -/
+theorem natDegree_prod_X_add_u {R : Type*} [CommRing R] [IsDomain R] (m : Multiset R) :
+    ((m.map (fun u => X + C u)).prod).natDegree = Multiset.card m := by
+  rw [map_X_add_u_eq, natDegree_multiset_prod_X_sub_C_eq_card, Multiset.card_map]
+
+/-- **Multiset-from-product, over an integral domain.**
+Products of the monic linear factors `X + uᵢ` are equal iff the multisets of the `uᵢ` agree.
+The reusable kernel behind both the permutation and lookup soundness arguments.
+
+Idea: over a domain a product of linear factors is determined by its roots, which here are `{-uᵢ}`;
+equal products ⟹ equal root multisets ⟹ (negation is injective) equal multisets. -/
+theorem prod_X_add_u_inj {R : Type*} [CommRing R] [IsDomain R] {s t : Multiset R}
+    (h : (s.map (fun u => X + C u)).prod = (t.map (fun u => X + C u)).prod) : s = t := by
+  have heq : s.map (fun u => -u) = t.map (fun u => -u) := by
+    rw [← roots_prod_X_add_u s, ← roots_prod_X_add_u t, h]
+  exact Multiset.map_injective neg_injective heq
+
+/-- **Univariate Schwartz–Zippel at a point.** For `s ≠ t` over a finite field, the challenges `β`
+at which the shifted-factor products `∏ (xᵢ + β)` agree form a "bad set" of size `≤ max |s| |t|` —
+the roots of the (nonzero, by `prod_X_add_u_inj`) difference polynomial. That is, product-equality
+at a random `β` forces the multiset identity except on a negligible bad set. -/
+theorem card_eval_prod_eq_le {F : Type*} [Field F] [Fintype F] [DecidableEq F]
+    {s t : Multiset F} (hst : s ≠ t) :
+    (Finset.univ.filter
+      (fun β => (s.map (fun x => β + x)).prod = (t.map (fun x => β + x)).prod)).card
+      ≤ max (Multiset.card s) (Multiset.card t) := by
+  -- the difference polynomial is nonzero, since `s ≠ t` (`prod_X_add_u_inj` contrapositive)
+  have hD : (s.map (fun u => X + C u)).prod - (t.map (fun u => X + C u)).prod ≠ 0 :=
+    fun h0 => hst (prod_X_add_u_inj (sub_eq_zero.mp h0))
+  calc (Finset.univ.filter
+          (fun β => (s.map (fun x => β + x)).prod = (t.map (fun x => β + x)).prod)).card
+      ≤ ((s.map (fun u => X + C u)).prod
+          - (t.map (fun u => X + C u)).prod).roots.toFinset.card := by
+        -- every "bad" β is a root of the difference polynomial
+        apply Finset.card_le_card
+        intro β hβ
+        simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hβ
+        rw [Multiset.mem_toFinset, mem_roots']
+        refine ⟨hD, ?_⟩
+        show ((s.map (fun u => X + C u)).prod - (t.map (fun u => X + C u)).prod).eval β = 0
+        rw [eval_sub, eval_prod_X_add_u s β, eval_prod_X_add_u t β, hβ, sub_self]
+    _ ≤ Multiset.card ((s.map (fun u => X + C u)).prod
+          - (t.map (fun u => X + C u)).prod).roots := Multiset.toFinset_card_le _
+    _ ≤ ((s.map (fun u => X + C u)).prod - (t.map (fun u => X + C u)).prod).natDegree :=
+          card_roots' _
+    _ ≤ max ((s.map (fun u => X + C u)).prod).natDegree
+            ((t.map (fun u => X + C u)).prod).natDegree := natDegree_sub_le _ _
+    _ = max (Multiset.card s) (Multiset.card t) := by
+          rw [natDegree_prod_X_add_u s, natDegree_prod_X_add_u t]
+
+/-- Encode a pair `(v, n)` as the `F[β]`-element `v + n·β` (here `β = X` in `Polynomial F`).
+Injective, since `v` and `n` are its degree-0 and degree-1 coefficients. -/
+noncomputable def encPair {F : Type*} [Field F] (p : F × F) : Polynomial F := C p.1 + C p.2 * X
+
+theorem encPair_injective {F : Type*} [Field F] : Function.Injective (encPair (F := F)) := by
+  intro p q hpq
+  refine Prod.ext_iff.mpr ⟨?_, ?_⟩
+  · simpa [encPair, coeff_add, coeff_C, coeff_C_mul, coeff_X_zero] using
+      congrArg (Polynomial.coeff · 0) hpq
+  · simpa [encPair, coeff_add, coeff_C, coeff_C_mul, coeff_X_one] using
+      congrArg (Polynomial.coeff · 1) hpq
+
+/-- **Multisets of pairs.** `∏ (vᵢ + nᵢ·β + γ) = ∏ (cⱼ + dⱼ·β + γ) ⟹ {(vᵢ,nᵢ)} = {(cⱼ,dⱼ)}`.
+The factor `vᵢ + nᵢ·β + γ` is `X + C (encPair (vᵢ,nᵢ))` over `R = F[β]` (variable `X = γ`), so this is
+just `prod_X_add_u_inj` over the domain `F[β]` followed by `encPair`-injectivity. This is the multiset
+identity the permutation argument needs (pairs of `(value, name)`, not just sums). -/
+theorem prod_pair_inj {F : Type*} [Field F] {sp tp : Multiset (F × F)}
+    (h : (sp.map (fun p => X + C (encPair p))).prod
+       = (tp.map (fun p => X + C (encPair p))).prod) : sp = tp := by
+  have conv : ∀ (m : Multiset (F × F)),
+      (m.map (fun p => X + C (encPair p))).prod = ((m.map encPair).map (fun u => X + C u)).prod := by
+    intro m; simp only [Multiset.map_map, Function.comp_def]
+  rw [conv sp, conv tp] at h
+  exact Multiset.map_injective encPair_injective (prod_X_add_u_inj h)
+
+end Zcash.Snark

--- a/Zcash/Snark/Soundness/GrandProduct.lean
+++ b/Zcash/Snark/Soundness/GrandProduct.lean
@@ -3,10 +3,10 @@ import Mathlib
 /-!
 # The grand-product → multiset kernel (permutation & lookup soundness)
 
-The shared algebraic core that both halo2's permutation and lookup *argument* soundness reduce to
-(tracking issue #14). Both arguments enforce their relation by a **grand product of factors linear in
-the challenges**, and the soundness step is the same: such a product, equal at the random challenge,
-forces the underlying multiset identity.
+The shared algebraic core that both halo2's permutation and lookup *argument* soundness reduce to.
+Both arguments enforce their relation by a **grand product of factors linear in the challenges**, and
+the soundness step is the same: such a product, equal at the random challenge, forces the underlying
+multiset identity.
 
 This file isolates that core over Mathlib `Polynomial`. Nothing here needs computability. The proof
 leans on Mathlib's roots / unique-factorization theory:

--- a/Zcash/Snark/Soundness/Lookup.lean
+++ b/Zcash/Snark/Soundness/Lookup.lean
@@ -1,0 +1,58 @@
+import Mathlib
+import Zcash.Snark.Soundness.GrandProduct
+
+/-!
+# Lookup argument soundness
+
+(Towards #14.) The [lookup argument](https://zcash.github.io/halo2/design/proving-system/lookup.html)
+proves multiset inclusion {input} ⊆ {table}. Its soundness combines the grand-product → multiset kernel
+(`GrandProduct.lean`, giving {A′} = {input} and {S′} = {table}) with the **permuted-column run-structure**
+proved here: the verifier's ℓ_0·(A′ − S′) and active·(A′ − S′)·(A′ − A′_prev) constraints force every A′
+value to coincide with some S′ value, which together with the multiset equalities yields {input} ⊆ {table}.
+
+This file currently provides `run_structure` (the run-structure step over the usable rows); the
+grand-product ⟹ multiset equalities and the final assembly will follow.
+-/
+
+namespace Zcash.Snark
+
+/-- **Run-structure for the lookup argument**. This verifies part of the abstract argument, not yet
+the mapping to constraints.
+
+We allow the prover to supply permutation columns of A and S — called A′, S′ in the Halo 2 book, and
+`a`, `s` here. As in the book, ℓ_i evaluates to 1 at row i and 0 otherwise, and the running-product
+constraint refers to the previous row A′_prev = A′(ω⁻¹·), which at row 0 wraps cyclically to the last
+blinding row, an arbitrary value `aPrev`.
+
+The constraints checked by the verifier are:
+
+* `a_0 = s_0`, from ℓ_0·(A′ - S′) = 0.
+* `a_0 = s_0 ∨ a_0 = aPrev`, from active·(A′ - S′)·(A′ - A′_prev) = 0 at row 0, with `aPrev` arbitrary.
+* `a_{i+1} = s_{i+1} ∨ a_{i+1} = a_i`, the later-row instances of the same constraint.
+
+The first two together are equivalent to just `a_0 = s_0` for any `aPrev` (the wrapped predecessor is
+harmless), so row 0 is matched. With every later row matched or A′ repeating its predecessor, every
+`a_i` equals some `s_j`. So the permuted-input column A′ is elementwise contained in the permuted
+table S′ — the membership the lookup argument needs.
+
+Indices are `Fin (n + 1)` so the index set is nonempty (row 0 always exists), and the proof uses
+`Fin.induction` so the `succ` case's hypothesis is exactly the predecessor row `i.castSucc`. -/
+theorem run_structure {F : Type*} {n : ℕ} (a s : Fin (n + 1) → F) (aPrev : F)
+    (h0 : a 0 = s 0)
+    (hstep0 : a 0 = s 0 ∨ a 0 = aPrev)
+    (hstep : ∀ i : Fin n, a i.succ = s i.succ ∨ a i.succ = a i.castSucc) :
+    ∀ i, ∃ j, a i = s j := by
+  intro i
+  induction i using Fin.induction with
+  | zero =>
+    -- the row-0 running constraint with the arbitrary wrapped predecessor is subsumed by `a 0 = s 0`
+    rcases hstep0 with h | _
+    · exact ⟨0, h⟩
+    · exact ⟨0, h0⟩
+  | succ i ih =>
+    rcases hstep i with hm | hr
+    · exact ⟨i.succ, hm⟩
+    · obtain ⟨j, hj⟩ := ih
+      exact ⟨j, hr.trans hj⟩
+
+end Zcash.Snark

--- a/Zcash/Snark/Soundness/Lookup.lean
+++ b/Zcash/Snark/Soundness/Lookup.lean
@@ -4,11 +4,12 @@ import Zcash.Snark.Soundness.GrandProduct
 /-!
 # Lookup argument soundness
 
-(Towards #14.) The [lookup argument](https://zcash.github.io/halo2/design/proving-system/lookup.html)
-proves multiset inclusion {input} ⊆ {table}. Its soundness combines the grand-product → multiset kernel
-(`GrandProduct.lean`, giving {A′} = {input} and {S′} = {table}) with the **permuted-column run-structure**
-proved here: the verifier's ℓ_0·(A′ − S′) and active·(A′ − S′)·(A′ − A′_prev) constraints force every A′
-value to coincide with some S′ value, which together with the multiset equalities yields {input} ⊆ {table}.
+The [lookup argument](https://zcash.github.io/halo2/design/proving-system/lookup.html) proves that
+every input value occurs in the table — set inclusion {input} ⊆ {table}, ignoring multiplicity. Its
+soundness combines the grand-product → multiset kernel (`GrandProduct.lean`, giving {A′} = {input} and
+{S′} = {table} as multisets) with the **permuted-column run-structure** proved here: the verifier's
+ℓ_0·(A′ − S′) and active·(A′ − S′)·(A′ − A′_prev) constraints force every A′ value to coincide with some
+S′ value, which together with the multiset equalities yields {input} ⊆ {table} as sets.
 
 This file currently provides `run_structure` (the run-structure step over the usable rows); the
 grand-product ⟹ multiset equalities and the final assembly will follow.

--- a/Zcash/Snark/Soundness/Permutation.lean
+++ b/Zcash/Snark/Soundness/Permutation.lean
@@ -4,7 +4,7 @@ import Zcash.Snark.Soundness.GrandProduct
 /-!
 # Permutation argument soundness
 
-(Towards #14.) The [permutation argument](https://zcash.github.io/halo2/design/proving-system/permutation.html)
+The [permutation argument](https://zcash.github.io/halo2/design/proving-system/permutation.html)
 proves the copy constraints: cells in the same cycle of the permutation `σ` hold equal values.
 
 Its soundness relies on the grand-product → multiset-of-pairs kernel (`GrandProduct.lean`, `prod_pair_inj`,

--- a/Zcash/Snark/Soundness/Permutation.lean
+++ b/Zcash/Snark/Soundness/Permutation.lean
@@ -67,8 +67,8 @@ theorem perm_values_eq_iff {ι L V : Type*} [Fintype ι] (σ : Equiv.Perm ι)
     obtain ⟨e, _, he⟩ := Multiset.mem_map.mp hmem
     -- `he : (value e, label (σ e)) = (value (σ c), label (σ c))`
     have hee : e = c := σ.injective (hlabel (congrArg Prod.snd he))
-    have hve : value e = value (σ c) := congrArg Prod.fst he
-    rwa [hee] at hve
+    have hval : value e = value (σ c) := congrArg Prod.fst he
+    rwa [hee] at hval
   · intro h
     -- value-invariance rewrites the right pairs to `(value (σ c), label (σ c))` …
     have hRHS : Finset.univ.val.map (fun c => (value c, label (σ c)))

--- a/Zcash/Snark/Soundness/Permutation.lean
+++ b/Zcash/Snark/Soundness/Permutation.lean
@@ -1,0 +1,125 @@
+import Mathlib
+import Zcash.Snark.Soundness.GrandProduct
+
+/-!
+# Permutation argument soundness
+
+(Towards #14.) The [permutation argument](https://zcash.github.io/halo2/design/proving-system/permutation.html)
+proves the copy constraints: cells in the same cycle of the permutation `σ` hold equal values.
+
+Its soundness relies on the grand-product → multiset-of-pairs kernel (`GrandProduct.lean`, `prod_pair_inj`,
+giving `{(value c, label c)} = {(value c, label (σ c))}`), and also on the **structural step** proved here,
+which turns that multiset identity into the per-cell relation `value c = value (σ c)`.
+
+Here `label c` is the cell's name `δ^j·ω^i` and `σ` is the permutation built from the cycles of
+copy-constrained cells. Name distinctness — δ-coset disjointness in the keygen — is exactly the
+injectivity of `label` that this step relies on. We do not prove here that the `δ^j·ω^i` encoding
+preserves distinctness.
+
+The per-cell relation `value c = value (σ c)` (invariance under *one* step of `σ`) is then lifted to
+the full copy-constraint statement — *all cells in a cycle of `σ` are equal* — by
+`value_const_on_sameCycle`, which iterates the one-step invariance over the whole orbit.
+
+This file provides `perm_values_eq_iff` (the structural step) and `value_const_on_sameCycle` (the lift
+to cycles), composed in `perm_copy_constraints`: from the multiset-of-pairs identity, with `label`
+injective, cells in the same σ-cycle hold equal values. What remains for full soundness is the
+grand-product ⟹ multiset identity (telescoping the running product over the usable rows, with the
+boundary / blinding-row rules) feeding the `h` hypothesis, and the final assembly.
+-/
+
+namespace Zcash.Snark
+
+open Finset
+
+/-- Mapping a permutation over the universal multiset leaves it unchanged (`σ` is a bijection of the
+index type, so it just reindexes `univ`). -/
+theorem univ_val_map_perm {ι : Type*} [Fintype ι] (σ : Equiv.Perm ι) :
+    Finset.univ.val.map (⇑σ) = Finset.univ.val := by
+  simp
+
+/-- **Structural step for the permutation argument.** Cells `ι` carry a `value` and an injective name
+`label`. The multiset of `(value, label)` pairs is unchanged by permuting the labels through `σ` if and
+only if `value` is constant on each σ-cycle (`value c = value (σ c)` for all `c`) — i.e. the copy
+constraints hold.
+
+The grand-product kernel (`prod_pair_inj`) delivers the multiset equality on the left; `label`
+injectivity (δ-coset name distinctness) is what turns it into the per-cell relation. This is the
+permutation analogue of `Lookup.run_structure`.
+
+* (⟸) value-invariance lets us rewrite each right-hand pair to `(value (σ c), label (σ c))`, which is
+  the left-hand map precomposed with `σ`; reindexing `univ` by the bijection `σ` leaves it unchanged.
+* (⟹) the pair `(value (σ c), label (σ c))` sits in the left multiset (index `σ c`); the equality
+  moves it to the right, where `Multiset.mem_map` yields an index `e` with `label (σ e) = label (σ c)`
+  and `value e = value (σ c)`; injectivity of `label` and of `σ` forces `e = c`. -/
+theorem perm_values_eq_iff {ι L V : Type*} [Fintype ι] (σ : Equiv.Perm ι)
+    {label : ι → L} (hlabel : Function.Injective label) (value : ι → V) :
+    Finset.univ.val.map (fun c => (value c, label c))
+      = Finset.univ.val.map (fun c => (value c, label (σ c)))
+    ↔ ∀ c, value c = value (σ c) := by
+  constructor
+  · intro h c
+    -- the index `σ c` puts `(value (σ c), label (σ c))` in the left multiset
+    have hmem : (value (σ c), label (σ c)) ∈
+        Finset.univ.val.map (fun c => (value c, label c)) :=
+      Multiset.mem_map.mpr ⟨σ c, by simp, rfl⟩
+    -- transport it to the right multiset and read off a matching index `e`
+    rw [h] at hmem
+    obtain ⟨e, _, he⟩ := Multiset.mem_map.mp hmem
+    -- `he : (value e, label (σ e)) = (value (σ c), label (σ c))`
+    have hee : e = c := σ.injective (hlabel (congrArg Prod.snd he))
+    have hve : value e = value (σ c) := congrArg Prod.fst he
+    rwa [hee] at hve
+  · intro h
+    -- value-invariance rewrites the right pairs to `(value (σ c), label (σ c))` …
+    have hRHS : Finset.univ.val.map (fun c => (value c, label (σ c)))
+        = Finset.univ.val.map (fun c => (value (σ c), label (σ c))) :=
+      Multiset.map_congr rfl (fun c _ => by rw [h c])
+    -- … which is `(fun c => (value c, label c)) ∘ σ`, so reindexing by `σ` over `univ` closes it
+    rw [hRHS, show (fun c => (value (σ c), label (σ c)))
+          = (fun c => (value c, label c)) ∘ σ from rfl,
+        ← Multiset.map_map, univ_val_map_perm]
+
+/-- A `value` invariant under one application of `σ` is invariant under every integer power of `σ`.
+By induction on the exponent: the `value c = value (σ c)` hypothesis also gives invariance under `σ⁻¹`
+(`value (σ⁻¹ x) = value (σ (σ⁻¹ x)) = value x`), and the two extend to all of ℤ. (ℕ is logically
+sufficient since the permutation is finite, but Mathlib's definition of `SameCycle` uses ℤ to cater
+for infinite cases.) -/
+theorem value_zpow {ι V : Type*} (σ : Equiv.Perm ι) (value : ι → V)
+    (h : ∀ c, value c = value (σ c)) : ∀ (n : ℤ) (x : ι), value ((σ ^ n) x) = value x := by
+  have hinv : ∀ x, value (σ⁻¹ x) = value x := by
+    intro x; rw [h (σ⁻¹ x)]; simp
+  intro n
+  induction n using Int.induction_on with
+  | zero => intro x; simp
+  | succ i ih =>
+      intro x
+      rw [zpow_add, zpow_one, Equiv.Perm.mul_apply, ih (σ x), ← h x]
+  | pred i ih =>
+      intro x
+      rw [zpow_sub, zpow_one, Equiv.Perm.mul_apply, ih (σ⁻¹ x), hinv x]
+
+/-- **Values are constant on σ-cycles** — the copy-constraint relation in full.
+
+Given the per-cell one-step invariance `value c = value (σ c)` (e.g. from `perm_values_eq_iff`), any two
+cells in the same cycle of `σ` (`σ.SameCycle c d`, i.e. `d = σⁱ c` for some `i : ℤ`) hold equal values. -/
+theorem value_const_on_sameCycle {ι V : Type*} (σ : Equiv.Perm ι) (value : ι → V)
+    (h : ∀ c, value c = value (σ c)) {c d : ι} (hcd : σ.SameCycle c d) :
+    value c = value d := by
+  obtain ⟨n, rfl⟩ := hcd
+  exact (value_zpow σ value h n c).symm
+
+/-- **Soundness of the permutation argument — structural step lifted to cycles** (modulo the
+grand-product ⟹ multiset-identity step).
+
+This composes `perm_values_eq_iff` with `value_const_on_sameCycle`: from the multiset-of-pairs identity
+delivered by the kernel (`prod_pair_inj`), with `label` injective, any two cells in the same cycle of
+`σ` hold equal values — exactly the copy constraints `σ` encodes. -/
+theorem perm_copy_constraints {ι L V : Type*} [Fintype ι] (σ : Equiv.Perm ι)
+    {label : ι → L} (hlabel : Function.Injective label) (value : ι → V)
+    (h : Finset.univ.val.map (fun c => (value c, label c))
+       = Finset.univ.val.map (fun c => (value c, label (σ c))))
+    {c d : ι} (hcd : σ.SameCycle c d) :
+    value c = value d :=
+  value_const_on_sameCycle σ value ((perm_values_eq_iff σ hlabel value).mp h) hcd
+
+end Zcash.Snark

--- a/Zcash/Snark/Soundness/PermutationConstruction.lean
+++ b/Zcash/Snark/Soundness/PermutationConstruction.lean
@@ -1,0 +1,328 @@
+import Mathlib
+import Zcash.Snark.Soundness.Permutation
+
+/-!
+# Correctness of the halo2 permutation construction
+
+(Towards #14.) The permutation `σ` that the permutation argument (`Permutation.lean`) operates on is
+*built* by halo2 from the circuit's copy constraints, so that its cycles are exactly the
+equality-constraint classes. This file verifies that construction.
+
+The algorithm is implemented by
+[`Assembly::copy`](https://github.com/zcash/halo2/blob/261faaccd5a30c19bb8468600841a0dac305adf5/halo2_proofs/src/plonk/permutation/keygen.rs#L45-L100)
+in `plonk/permutation/keygen.rs`; its design is described in section
+[Constructing the permutation](https://zcash.github.io/halo2/design/proving-system/permutation.html#constructing-the-permutation)
+of the Halo 2 book. It processes the copy constraints one at a time, maintaining a permutation `mapping`.
+
+To add `left ≡ right`:
+
+* if `left` and `right` are already in the same cycle, do nothing;
+* otherwise swap `mapping(left)` and `mapping(right)`, i.e. replace the permutation `π` by
+  `π * (left right)`.
+
+We model this as `build`, a fold of `step` over the constraint list starting from the identity. The
+halo2 `aux` / `sizes` arrays are a [disjoint-set](https://en.wikipedia.org/wiki/Disjoint-set_data_structure)
+structure that makes the same-cycle test and the cycle-walk efficient. How the same-cycle test is
+implemented —as long as it is correct— does not affect the resulting permutation, so we model the test
+by `SameCycle` directly. The size comparison (union by size) only chooses which cycle to relabel —a
+performance optimization that also does not affect the resulting permutation— so it is elided.
+
+The mathematical heart is `sameCycle_mul_swap`: composing `π` with the transposition `(a b)` **merges**
+the cycles of `a` and `b` when they are in different cycles (and would **split** a cycle if they were
+already in the same one — which is precisely why the "already in the same cycle" check is essential;
+cf. the design doc's "Broken alternatives"). The main result `build_correct` then says the cycles of the
+built permutation are exactly the equality-constraint classes (the `Relation.EqvGen` closure of the
+constraint pairs). Composed with `Permutation.perm_copy_constraints`, this closes the loop: the verifier
+enforces equality on exactly the cells the circuit declared equal.
+
+`value_eq_of_constraints` performs that composition: the verifier-accepting multiset identity for
+`σ = build cs`, together with the copy constraints forcing `x ≡ y`, gives `value x = value y`.
+
+Formalization gap relative to the Halo 2 implementation: the `aux` and `sizes` arrays are not modelled.
+A bug in updating `aux`, or failing to map through `aux` in the same-cycle check, could affect
+soundness. The use of `sizes` is only a performance optimization.
+-/
+
+open Equiv Equiv.Perm
+
+namespace Zcash.Snark.PermConstruction
+
+variable {α : Type*} [DecidableEq α]
+
+/-- The relation obtained from `π`'s cycle relation by merging the cycle of `a` with the cycle of `b`
+(see `mergeRel_equivalence`: it is an equivalence relation). -/
+def MergeRel (π : Perm α) (a b x y : α) : Prop :=
+  π.SameCycle x y ∨ (π.SameCycle x a ∧ π.SameCycle y b) ∨ (π.SameCycle x b ∧ π.SameCycle y a)
+
+omit [DecidableEq α] in
+theorem mergeRel_refl (π : Perm α) (a b x : α) : MergeRel π a b x x :=
+  Or.inl (SameCycle.refl π x)
+
+omit [DecidableEq α] in
+theorem mergeRel_symm {π : Perm α} {a b x y : α} (h : MergeRel π a b x y) :
+    MergeRel π a b y x := by
+  rcases h with h | ⟨h1, h2⟩ | ⟨h1, h2⟩
+  · exact Or.inl h.symm
+  · exact Or.inr (Or.inr ⟨h2, h1⟩)
+  · exact Or.inr (Or.inl ⟨h2, h1⟩)
+
+omit [DecidableEq α] in
+theorem mergeRel_trans {π : Perm α} {a b x y z : α}
+    (hxy : MergeRel π a b x y) (hyz : MergeRel π a b y z) : MergeRel π a b x z := by
+  rcases hxy with hxy | ⟨hxa, hyb⟩ | ⟨hxb, hya⟩
+  · rcases hyz with hyz | ⟨hya, hzb⟩ | ⟨hyb, hza⟩
+    · exact Or.inl (hxy.trans hyz)
+    · exact Or.inr (Or.inl ⟨hxy.trans hya, hzb⟩)
+    · exact Or.inr (Or.inr ⟨hxy.trans hyb, hza⟩)
+  · rcases hyz with hyz | ⟨hya, hzb⟩ | ⟨_, hza⟩
+    · exact Or.inr (Or.inl ⟨hxa, hyz.symm.trans hyb⟩)
+    · exact Or.inl (hxa.trans ((hya.symm.trans hyb).trans hzb.symm))
+    · exact Or.inl (hxa.trans hza.symm)
+  · rcases hyz with hyz | ⟨_, hzb⟩ | ⟨hyb, hza⟩
+    · exact Or.inr (Or.inr ⟨hxb, hyz.symm.trans hya⟩)
+    · exact Or.inl (hxb.trans hzb.symm)
+    · exact Or.inl (hxb.trans ((hya.symm.trans hyb).symm.trans hza.symm))
+
+omit [DecidableEq α] in
+theorem mergeRel_equivalence (π : Perm α) (a b : α) : Equivalence (MergeRel π a b) :=
+  ⟨mergeRel_refl π a b, mergeRel_symm, mergeRel_trans⟩
+
+/-- One step of `π * swap a b` stays within the merged relation. -/
+theorem mergeRel_step (π : Perm α) (a b x : α) :
+    MergeRel π a b x ((π * swap a b) x) := by
+  have fwd : ∀ z : α, π.SameCycle z (π z) := fun z => ⟨1, by simp⟩
+  rw [Perm.mul_apply]
+  rcases eq_or_ne x a with rfl | hxa
+  · rw [swap_apply_left]
+    exact Or.inr (Or.inl ⟨SameCycle.refl π x, (fwd b).symm⟩)
+  · rcases eq_or_ne x b with rfl | hxb
+    · rw [swap_apply_right]
+      exact Or.inr (Or.inr ⟨SameCycle.refl π x, (fwd a).symm⟩)
+    · rw [swap_apply_of_ne_of_ne hxa hxb]
+      exact Or.inl (fwd x)
+
+/-- **Subset direction (unconditional).** Every `π * swap a b` cycle is contained in the merge of
+`π`'s cycles at `a` and `b`: the new permutation never connects more than the merge allows. Proved by
+showing the merged relation is closed along the `π * swap a b` orbit (it is an equivalence containing
+each one-step pair, `mergeRel_step`). -/
+theorem sameCycle_mul_swap_subset {π : Perm α} {a b x y : α}
+    (h : (π * swap a b).SameCycle x y) : MergeRel π a b x y := by
+  have key : ∀ (n : ℤ) (x : α), MergeRel π a b x (((π * swap a b) ^ n) x) := by
+    intro n
+    induction n using Int.induction_on with
+    | zero => intro x; simpa using mergeRel_refl π a b x
+    | succ i ih =>
+        intro x
+        have hstep : ((π * swap a b) ^ ((i : ℤ) + 1)) x
+            = ((π * swap a b) ^ (i : ℤ)) ((π * swap a b) x) := by
+          rw [zpow_add, zpow_one, Perm.mul_apply]
+        rw [hstep]
+        exact mergeRel_trans (mergeRel_step π a b x) (ih ((π * swap a b) x))
+    | pred i ih =>
+        intro x
+        have hstep : ((π * swap a b) ^ (-(i : ℤ) - 1)) x
+            = ((π * swap a b) ^ (-(i : ℤ))) (((π * swap a b)⁻¹) x) := by
+          rw [show (-(i : ℤ) - 1) = (-(i : ℤ)) + (-1) from by ring, zpow_add, zpow_neg_one,
+            Perm.mul_apply]
+        rw [hstep]
+        have hb := mergeRel_step π a b (((π * swap a b)⁻¹) x)
+        have hpiv : (π * swap a b) (((π * swap a b)⁻¹) x) = x := by simp
+        rw [hpiv] at hb
+        exact mergeRel_trans (mergeRel_symm hb) (ih ((π * swap a b)⁻¹ x))
+  obtain ⟨n, rfl⟩ := h
+  exact key n x
+
+/-- **The orbit walk.** Under `g = π * swap a b`, iterating from `a` follows `b`'s `π`-cycle: as long
+as we stay strictly inside the first `p` steps of `b`'s orbit — where `π^k b` avoids both `a` (it is in
+`b`'s orbit, disjoint from `a`'s, hypothesis `hnotA`) and `b` itself (not yet returned, hypothesis
+`hltb`) — the transposition is invisible and `g^[k+1] a = π^[k+1] b`. Pure orbit arithmetic; no
+finiteness needed. -/
+theorem walk {π : Perm α} {a b : α} {p : ℕ}
+    (hnotA : ∀ k : ℕ, (⇑π)^[k] b ≠ a)
+    (hltb : ∀ k : ℕ, 0 < k → k < p → (⇑π)^[k] b ≠ b) :
+    ∀ k : ℕ, k < p → (⇑(π * swap a b))^[k + 1] a = (⇑π)^[k + 1] b := by
+  have hga : (⇑(π * swap a b)) a = (⇑π) b := by rw [Perm.mul_apply, swap_apply_left]
+  have hgz : ∀ z : α, z ≠ a → z ≠ b → (⇑(π * swap a b)) z = (⇑π) z := by
+    intro z hza hzb; rw [Perm.mul_apply, swap_apply_of_ne_of_ne hza hzb]
+  intro k
+  induction k with
+  | zero =>
+      intro _
+      simp only [zero_add, Function.iterate_one]
+      exact hga
+  | succ k ih =>
+      intro hkp
+      have hk : k < p := Nat.lt_of_succ_lt hkp
+      have hA : (⇑π)^[k + 1] b ≠ a := hnotA (k + 1)
+      have hB : (⇑π)^[k + 1] b ≠ b := hltb (k + 1) (Nat.succ_pos k) hkp
+      calc (⇑(π * swap a b))^[k + 1 + 1] a
+          = (⇑(π * swap a b)) ((⇑(π * swap a b))^[k + 1] a) := Function.iterate_succ_apply' _ _ _
+        _ = (⇑(π * swap a b)) ((⇑π)^[k + 1] b) := by rw [ih hk]
+        _ = (⇑π) ((⇑π)^[k + 1] b) := hgz _ hA hB
+        _ = (⇑π)^[k + 1 + 1] b := (Function.iterate_succ_apply' _ _ _).symm
+
+/-- **The merge witness (the one finiteness-using fact).** If `a` and `b` lie in different cycles of
+`π`, then composing with the transposition `(a b)` puts them in the same cycle. We walk `b`'s `π`-cycle
+(`walk`) for its full period `p = minimalPeriod π b`, reaching `π^[p] b = b` from `a` in `p` steps. -/
+theorem sameCycle_mul_swap_self [Fintype α] {π : Perm α} {a b : α} (hab : ¬ π.SameCycle a b) :
+    (π * swap a b).SameCycle a b := by
+  -- `π^[k] b` is never `a` (same cycle as `b`, which differs from `a`'s cycle)
+  have hnotA : ∀ k : ℕ, (⇑π)^[k] b ≠ a := by
+    intro k hk
+    have hsc : π.SameCycle b a := ⟨(k : ℤ), by rw [zpow_natCast, Equiv.Perm.coe_pow]; exact hk⟩
+    exact hab hsc.symm
+  set p := Function.minimalPeriod (⇑π) b with hp
+  -- `b` is a periodic point (finite group), with minimal period `p`
+  have hper : Function.IsPeriodicPt (⇑π) (orderOf π) b := by
+    show (⇑π)^[orderOf π] b = b
+    rw [← Equiv.Perm.coe_pow, pow_orderOf_eq_one]; rfl
+  have hpb : (⇑π)^[p] b = b := Function.iterate_minimalPeriod
+  have hppos : 0 < p := Function.IsPeriodicPt.minimalPeriod_pos (orderOf_pos π) hper
+  have hltb : ∀ k : ℕ, 0 < k → k < p → (⇑π)^[k] b ≠ b := by
+    intro k hk0 hkp h0
+    exact Function.not_isPeriodicPt_of_pos_of_lt_minimalPeriod hk0.ne' hkp h0
+  -- walk `b`'s cycle for a full period: `g^[p] a = π^[p] b = b`
+  have hreach : (⇑(π * swap a b))^[p] a = b := by
+    have hw := walk hnotA hltb (p - 1) (by omega)
+    have hp1 : p - 1 + 1 = p := by omega
+    rw [hp1] at hw
+    rw [hw, hpb]
+  exact ⟨(p : ℤ), by rw [zpow_natCast, Equiv.Perm.coe_pow]; exact hreach⟩
+
+/-- **Monotonicity.** When `a`, `b` are in different `π`-cycles, composing with `(a b)` only *merges*
+cycles — it never splits one — so every `π`-cycle relation survives in `π * swap a b`. Proved by
+running the (unconditional) subset lemma backwards through `π = (π * swap a b) * swap a b`. -/
+theorem sameCycle_mul_swap_mono [Fintype α] {π : Perm α} {a b : α} (hab : ¬ π.SameCycle a b)
+    {u v : α} (huv : π.SameCycle u v) : (π * swap a b).SameCycle u v := by
+  have hab' : (π * swap a b).SameCycle a b := sameCycle_mul_swap_self hab
+  have hsub : ((π * swap a b) * swap a b).SameCycle u v := by
+    rwa [mul_assoc, swap_mul_self, mul_one]
+  rcases sameCycle_mul_swap_subset hsub with h1 | ⟨h1, h2⟩ | ⟨h1, h2⟩
+  · exact h1
+  · exact h1.trans (hab'.trans h2.symm)
+  · exact h1.trans (hab'.symm.trans h2.symm)
+
+/-- **Cycle-merge lemma.** Composing `π` with the transposition `(a b)`, when `a` and `b` are in
+different `π`-cycles, merges those two cycles and leaves all others unchanged:
+`(π * swap a b).SameCycle x y ↔ MergeRel π a b x y`. (If `a`, `b` were in the *same* cycle, the same
+composition would split it — this is the "Broken alternatives" of the design doc.) -/
+theorem sameCycle_mul_swap [Fintype α] {π : Perm α} {a b : α} (hab : ¬ π.SameCycle a b)
+    (x y : α) :
+    (π * swap a b).SameCycle x y ↔ MergeRel π a b x y := by
+  refine ⟨sameCycle_mul_swap_subset, fun h => ?_⟩
+  have hab' : (π * swap a b).SameCycle a b := sameCycle_mul_swap_self hab
+  rcases h with h | ⟨h1, h2⟩ | ⟨h1, h2⟩
+  · exact sameCycle_mul_swap_mono hab h
+  · exact (sameCycle_mul_swap_mono hab h1).trans (hab'.trans (sameCycle_mul_swap_mono hab h2).symm)
+  · exact (sameCycle_mul_swap_mono hab h1).trans
+      (hab'.symm.trans (sameCycle_mul_swap_mono hab h2).symm)
+
+/-! ## The construction algorithm (union-find fold over copy constraints) -/
+
+variable [Fintype α]
+
+/-- One copy constraint `(a, b)`: merge the cycles of `a` and `b`, unless they are already in the same
+cycle (the disjoint-set "already connected" check — essential: composing with `(a b)` when `a`, `b` are
+already in one cycle would *split* it, undoing constraints). -/
+def step (π : Perm α) (ab : α × α) : Perm α :=
+  if π.SameCycle ab.1 ab.2 then π else π * swap ab.1 ab.2
+
+/-- Run the algorithm over a list of copy constraints, starting from the identity permutation (every
+cell its own 1-cycle). The halo2 implementation keeps the cycle partition in a disjoint-set structure
+(`aux` / `sizes`) purely to make the `SameCycle` test and the merge efficient; the resulting
+permutation — hence its cycle partition — is exactly this. The order in which constraints are processed
+does not affect the final cycle partition (it is the equivalence closure either way; `build_correct`). -/
+def build : List (α × α) → Perm α
+  | [] => 1
+  | ab :: rest => step (build rest) ab
+
+/-- **Every declared copy constraint ends up in one cycle.** (The soundness-relevant direction: each
+`a ≡ b` the circuit asked for is enforced by `σ`.) -/
+theorem pair_linked (cs : List (α × α)) : ∀ p ∈ cs, (build cs).SameCycle p.1 p.2 := by
+  induction cs with
+  | nil => intro p hp; simp at hp
+  | cons ab rest ih =>
+      obtain ⟨a, b⟩ := ab
+      intro p hp
+      show (step (build rest) (a, b)).SameCycle p.1 p.2
+      unfold step
+      rcases List.mem_cons.mp hp with rfl | hpr
+      · by_cases hsc : (build rest).SameCycle a b
+        · rw [if_pos hsc]; exact hsc
+        · rw [if_neg hsc]; exact sameCycle_mul_swap_self hsc
+      · have hp' := ih p hpr
+        by_cases hsc : (build rest).SameCycle a b
+        · rw [if_pos hsc]; exact hp'
+        · rw [if_neg hsc]; exact sameCycle_mul_swap_mono hsc hp'
+
+/-- **No spurious merges.** Two cells share a `build cs` cycle only if the copy constraints force it. -/
+theorem build_subset : ∀ (cs : List (α × α)) {x y : α},
+    (build cs).SameCycle x y → Relation.EqvGen (fun u v => (u, v) ∈ cs) x y := by
+  intro cs
+  induction cs with
+  | nil =>
+      intro x y h
+      have h1 : (1 : Perm α).SameCycle x y := h
+      rw [sameCycle_one] at h1
+      subst h1
+      exact Relation.EqvGen.refl x
+  | cons ab rest ih =>
+      obtain ⟨a, b⟩ := ab
+      intro x y h
+      have mono : ∀ {u v : α}, Relation.EqvGen (fun u v => (u, v) ∈ rest) u v →
+          Relation.EqvGen (fun u v => (u, v) ∈ (a, b) :: rest) u v :=
+        fun huv => Relation.EqvGen.mono (fun _ _ hm => List.mem_cons_of_mem _ hm) huv
+      have hab_link : Relation.EqvGen (fun u v => (u, v) ∈ (a, b) :: rest) a b :=
+        Relation.EqvGen.rel a b List.mem_cons_self
+      have E : Equivalence (Relation.EqvGen (fun u v => (u, v) ∈ (a, b) :: rest)) :=
+        Relation.EqvGen.is_equivalence _
+      change (step (build rest) (a, b)).SameCycle x y at h
+      unfold step at h
+      by_cases hsc : (build rest).SameCycle a b
+      · rw [if_pos hsc] at h
+        exact mono (ih h)
+      · rw [if_neg hsc] at h
+        rcases (sameCycle_mul_swap hsc x y).mp h with h1 | ⟨h1, h2⟩ | ⟨h1, h2⟩
+        · exact mono (ih h1)
+        · exact E.trans (mono (ih h1)) (E.trans hab_link (E.symm (mono (ih h2))))
+        · exact E.trans (mono (ih h1)) (E.trans (E.symm hab_link) (E.symm (mono (ih h2))))
+
+/-- **Correctness of the construction.** The cycles of the permutation built from a list of copy
+constraints are exactly the equality-constraint classes: two cells are in the same cycle iff the
+constraints (reflexively, symmetrically, transitively) force them equal. -/
+theorem build_correct (cs : List (α × α)) (x y : α) :
+    (build cs).SameCycle x y ↔ Relation.EqvGen (fun u v => (u, v) ∈ cs) x y := by
+  refine ⟨build_subset cs, fun h => ?_⟩
+  -- `SameCycle (build cs)` is an equivalence containing every constraint pair (`pair_linked`), and
+  -- `EqvGen` is the least such, so it is contained in `SameCycle (build cs)`.
+  induction h with
+  | rel u v huv => exact pair_linked cs (u, v) huv
+  | refl u => exact SameCycle.refl _ u
+  | symm u v _ ih => exact ih.symm
+  | trans u v w _ _ ih1 ih2 => exact ih1.trans ih2
+
+/-! ## Closing the loop with the permutation-argument soundness -/
+
+/-- **Declared equalities are enforced.** If the verifier accepts — yielding the permutation-argument
+multiset identity `h` for the constructed permutation `σ = build cs` (see `Permutation.lean`) — and the
+copy constraints force `x` and `y` equal (the `Relation.EqvGen` closure), then their witnessed values
+coincide. Combines `build_correct` (σ's cycles are exactly the constraint classes) with
+`Permutation.perm_copy_constraints` (cells in a cycle hold equal values). -/
+theorem value_eq_of_constraints {ι L V : Type*} [Fintype ι] [DecidableEq ι]
+    (cs : List (ι × ι)) {label : ι → L} (hlabel : Function.Injective label) (value : ι → V)
+    (h : Finset.univ.val.map (fun c => (value c, label c))
+       = Finset.univ.val.map (fun c => (value c, label ((build cs) c))))
+    {x y : ι} (hxy : Relation.EqvGen (fun u v => (u, v) ∈ cs) x y) :
+    value x = value y :=
+  perm_copy_constraints (build cs) hlabel value h ((build_correct cs x y).mpr hxy)
+
+/-- Specialization to a directly declared copy constraint `(c, d) ∈ cs`. -/
+theorem value_eq_of_mem {ι L V : Type*} [Fintype ι] [DecidableEq ι]
+    (cs : List (ι × ι)) {label : ι → L} (hlabel : Function.Injective label) (value : ι → V)
+    (h : Finset.univ.val.map (fun c => (value c, label c))
+       = Finset.univ.val.map (fun c => (value c, label ((build cs) c))))
+    {c d : ι} (hcd : (c, d) ∈ cs) :
+    value c = value d :=
+  value_eq_of_constraints cs hlabel value h (Relation.EqvGen.rel c d hcd)
+
+end Zcash.Snark.PermConstruction

--- a/Zcash/Snark/Soundness/PermutationConstruction.lean
+++ b/Zcash/Snark/Soundness/PermutationConstruction.lean
@@ -4,9 +4,9 @@ import Zcash.Snark.Soundness.Permutation
 /-!
 # Correctness of the halo2 permutation construction
 
-(Towards #14.) The permutation `σ` that the permutation argument (`Permutation.lean`) operates on is
-*built* by halo2 from the circuit's copy constraints, so that its cycles are exactly the
-equality-constraint classes. This file verifies that construction.
+The permutation `σ` that the permutation argument (`Permutation.lean`) operates on is *built* by halo2
+from the circuit's copy constraints, so that its cycles are exactly the equality-constraint classes.
+This file verifies that construction.
 
 The algorithm is implemented by
 [`Assembly::copy`](https://github.com/zcash/halo2/blob/261faaccd5a30c19bb8468600841a0dac305adf5/halo2_proofs/src/plonk/permutation/keygen.rs#L45-L100)
@@ -38,9 +38,14 @@ enforces equality on exactly the cells the circuit declared equal.
 `value_eq_of_constraints` performs that composition: the verifier-accepting multiset identity for
 `σ = build cs`, together with the copy constraints forcing `x ≡ y`, gives `value x = value y`.
 
-Formalization gap relative to the Halo 2 implementation: the `aux` and `sizes` arrays are not modelled.
-A bug in updating `aux`, or failing to map through `aux` in the same-cycle check, could affect
-soundness. The use of `sizes` is only a performance optimization.
+Formalization gaps relative to the Halo 2 implementation:
+* The `aux` and `sizes` arrays are not modelled. A bug in updating `aux`, or failing to map through
+  `aux` in the same-cycle check, could affect soundness. The use of `sizes` is only a performance
+  optimization.
+* `build` reproduces the cycle *partition* exactly — which is all the copy-constraint soundness needs —
+  but not necessarily halo2's exact *permutation*. The order in which `copy` calls are made determines
+  the order of each cycle up to rotation, and hence the permutation-polynomial commitments in the
+  verifying key; reproducing the deployed commitments would additionally require modelling that order.
 -/
 
 open Equiv Equiv.Perm
@@ -229,9 +234,10 @@ def step (π : Perm α) (ab : α × α) : Perm α :=
 
 /-- Run the algorithm over a list of copy constraints, starting from the identity permutation (every
 cell its own 1-cycle). The halo2 implementation keeps the cycle partition in a disjoint-set structure
-(`aux` / `sizes`) purely to make the `SameCycle` test and the merge efficient; the resulting
-permutation — hence its cycle partition — is exactly this. The order in which constraints are processed
-does not affect the final cycle partition (it is the equivalence closure either way; `build_correct`). -/
+(`aux` / `sizes`) purely to make the `SameCycle` test and the merge efficient. The order in which
+constraints are processed does not affect the final cycle *partition* (it is the equivalence closure
+either way; `build_correct`), though it does affect the exact permutation — see the module docstring's
+formalization gaps. -/
 def build : List (α × α) → Perm α
   | [] => 1
   | ab :: rest => step (build rest) ab

--- a/_typos.toml
+++ b/_typos.toml
@@ -11,6 +11,8 @@ extend-exclude = [
   "target/",
 ]
 
-[default.extend-words]
-# `hae` is a Lean hypothesis name (hypothesis about `a`'s evaluation), not a misspelling of "have".
-hae = "hae"
+[default]
+# Lean proofs use many short hypothesis names (`hae`, `hve`, `hb`, `ih`, etc.) that the spell-checker
+# misreads as typos. Skip identifiers of three or fewer characters rather than whitelisting each one;
+# genuine typos that short are vanishingly rare and not worth the steady stream of false positives.
+extend-ignore-identifiers-re = ["^[A-Za-z0-9_]{1,3}$"]


### PR DESCRIPTION
Towards #14 — soundness of the permutation and lookup *arguments* (the gates-only gap left open by #9), plus correctness of the permutation *construction*. All proofs are complete: no `sorry`, no new `axiom`; builds green.

## The idea

Both the permutation and lookup arguments enforce their relation by a **grand product of factors linear in the challenges**, and the soundness step is identical: *such a product, equal at the random challenge, forces the underlying multiset identity*. So rather than tackle the two arguments' machinery separately, this PR isolates that shared core as a reusable kernel, then builds each argument's structural step on top, and finally verifies (up to order within each cycle) the construction that produces the permutation in the first place.

## What's here

### `Soundness/GrandProduct.lean` — the shared kernel
Over Mathlib `Polynomial` (these are soundness facts — nothing computes — leaning on Mathlib's roots / unique-factorization theory):
- `prod_X_add_u_inj` — `∏ (X + uᵢ) = ∏ (X + wᵢ)` over an integral domain ⟹ `{uᵢ} = {wᵢ}`. Products represent multisets *injectively* (factor theorem over a domain). The load-bearing fact.
- `card_eval_prod_eq_le` — univariate Schwartz–Zippel at a point: for `s ≠ t`, the challenges `β` where the *field* products `∏ (xᵢ + β)` collide are roots of the (nonzero) difference polynomial — a bad set of size `≤ max |s| |t|`.
- `prod_pair_inj` — the **pair** version `∏ (vᵢ + nᵢ·β + γ) = … ⟹ {(vᵢ,nᵢ)} = {(cⱼ,dⱼ)}`, obtained by running `prod_X_add_u_inj` over `R = F[β]` (variable `γ`) and reading off the two coefficients. This is what the permutation argument needs (matching `(value, name)` *pairs*); the lookup argument uses `prod_X_add_u_inj` twice with independent `β`, `γ`.

### `Soundness/Lookup.lean` — lookup run-structure
`run_structure`: the permuted-column step toward `{input} ⊆ {table}`. Faithful to the constraint system — `a₀ = s₀`, the row-0 instance `a₀ = s₀ ∨ a₀ = aPrev` with the wrapped predecessor `aPrev` arbitrary, and `a_{i+1} = s_{i+1} ∨ a_{i+1} = a_i` — so every `A′` value coincides with some `S′` value.

### `Soundness/Permutation.lean` — permutation argument structural soundness
- `perm_values_eq_iff` — the multiset of `(value, label)` pairs is invariant under permuting labels by `σ` iff `value c = value (σ c)` for all `c`. With `label` injective (δ-coset name distinctness), this turns the kernel's multiset-of-pairs identity (`prod_pair_inj`) into the per-cell relation.
- `value_const_on_sameCycle` — lifts that one-step invariance to all cells in a `σ`-cycle (`value c = value (σ c)` is *not* the same as "constant on cycles"; the orbit lift iterates over `σ.SameCycle`).
- `perm_copy_constraints` — composes the two: multiset-of-pairs identity + injective `label` + `σ.SameCycle c d` ⟹ `value c = value d`, the copy-constraint relation.

### `Soundness/PermutationConstruction.lean` — correctness of the construction
Verifies the union-find algorithm in halo2's `plonk/permutation/keygen.rs` (`Assembly::copy`) that builds `σ` from the circuit's copy constraints.
- `sameCycle_mul_swap` (the crux — **no Mathlib equivalent**): composing `π` with the transposition `(a b)` *merges* the cycles of `a` and `b` when they're in different cycles, and would *split* a cycle otherwise — which is exactly why the algorithm's "already in the same cycle" skip is essential (cf. the design doc's "Broken alternatives"). The whole combinatorial content reduces to one orbit-walk fact (`sameCycle_mul_swap_self`, via `minimalPeriod`); the rest is relational algebra (`MergeRel` equivalence, zpow-closure subset, monotonicity).
- `build_correct`: two cells share a `σ`-cycle iff the copy constraints force them equal (the `Relation.EqvGen` closure of the pairs).
- `value_eq_of_constraints` / `value_eq_of_mem` close the loop: a verifier-accepting multiset identity for `σ = build cs` plus a copy constraint forcing `x ≡ y` gives `value x = value y` — the verifier enforces equality on exactly the cells the circuit declared equal.

## Known gaps

* In `PermutationConstruction.lean`, the disjoint-set `aux` / `sizes` arrays are modelled abstractly: the "same cycle?" test is modelled by `SameCycle` directly. A bug in updating `aux`, or in failing to map through `aux` in that test, could affect soundness; proving the imperative `aux`-walk maintains `aux(x) = aux(y) ↔ SameCycle x y` is separate loop-invariant reasoning, not yet done. The `sizes` (union-by-size) choice is a performance optimization that does not affect the resulting partition.
* `build` reproduces the cycle *partition* exactly — which is all the copy-constraint soundness needs — but not necessarily halo2's exact *permutation*. The order in which `copy` calls are made determines the order of each cycle up to rotation, and hence the permutation-polynomial commitments in the verifying key; reproducing the deployed commitments would additionally require modelling that order.

## Still to come (the remaining wrappers)

- The **grand-product ⟹ multiset identity** step for both arguments: telescoping the running product over the usable rows, with the boundary / blinding-row rules (`l₀(1−z)`, `z²−z`, inter-chunk linking), feeding the multiset identity that `prod_pair_inj` / `prod_X_add_u_inj` consume.
- The **lookup final assembly** (`{input} ⊆ {table}` from the kernel ×2 + `run_structure`).
- The **Schwartz–Zippel bridge** from these polynomial identities to the verifier's actual field-element product check (`card_eval_prod_eq_le` is the univariate seed; the multivariate version reuses `Fingerprint/SchwartzZippel.lean`), tying into the FS / good-challenge work in #11/#12.

🤖 Claude Opus 4.8
