### PR TITLE
feat(fv): formalize Fiat-Shamir under RO and round-by-round soundness

### DIFF
--- a/Zcash/Snark.lean
+++ b/Zcash/Snark.lean
@@ -48,8 +48,9 @@ import Zcash.Snark.Soundness.Deployed.Ipa
 import Zcash.Snark.Soundness.Deployed.IpaPeel
 import Zcash.Snark.Soundness.Deployed.TrustBoundary
 import Zcash.Snark.Soundness.Deployed.Verification
--- Fiat–Shamir forking development: random-oracle discharge of the forked transcript tree, and
--- round-by-round soundness by tying each IPA round challenge to the transcript prefix that commits it.
+-- The Fiat–Shamir forking development: discharges the forked transcript tree in the random-oracle
+-- model, and proves round-by-round soundness by tying each IPA round challenge to the transcript
+-- prefix that commits it.
 import Zcash.Snark.Soundness.Forking.Oracle
 import Zcash.Snark.Soundness.Forking.Tree
 import Zcash.Snark.Soundness.Forking.Probability

--- a/Zcash/Snark.lean
+++ b/Zcash/Snark.lean
@@ -55,5 +55,7 @@ import Zcash.Snark.Soundness.Forking.Tree
 import Zcash.Snark.Soundness.Forking.Probability
 import Zcash.Snark.Soundness.Forking.Extractor
 import Zcash.Snark.Soundness.Forking.Assembly
+import Zcash.Snark.Soundness.Forking.Ordering
 import Zcash.Snark.Soundness.Main
+import Zcash.Snark.Soundness.Forking.Rewind
 import Zcash.Snark.Soundness.Vesta

--- a/Zcash/Snark.lean
+++ b/Zcash/Snark.lean
@@ -53,5 +53,7 @@ import Zcash.Snark.Soundness.Deployed.Verification
 import Zcash.Snark.Soundness.Forking.Oracle
 import Zcash.Snark.Soundness.Forking.Tree
 import Zcash.Snark.Soundness.Forking.Probability
+import Zcash.Snark.Soundness.Forking.Extractor
+import Zcash.Snark.Soundness.Forking.Assembly
 import Zcash.Snark.Soundness.Main
 import Zcash.Snark.Soundness.Vesta

--- a/Zcash/Snark.lean
+++ b/Zcash/Snark.lean
@@ -48,5 +48,10 @@ import Zcash.Snark.Soundness.Deployed.Ipa
 import Zcash.Snark.Soundness.Deployed.IpaPeel
 import Zcash.Snark.Soundness.Deployed.TrustBoundary
 import Zcash.Snark.Soundness.Deployed.Verification
+-- Fiat–Shamir forking development: random-oracle discharge of the forked transcript tree, and
+-- round-by-round soundness by tying each IPA round challenge to the transcript prefix that commits it.
+import Zcash.Snark.Soundness.Forking.Oracle
+import Zcash.Snark.Soundness.Forking.Tree
+import Zcash.Snark.Soundness.Forking.Probability
 import Zcash.Snark.Soundness.Main
 import Zcash.Snark.Soundness.Vesta

--- a/Zcash/Snark/Core/Field.lean
+++ b/Zcash/Snark/Core/Field.lean
@@ -12,8 +12,8 @@ the Pallas *base* order, not the Pallas *scalar* order of the value commitment.
 The development stays generic over `[Field F]`; this module pins the instantiation `F_p = ZMod p`
 and records `|F_p| = p` (`card_Fp`), the cardinality the Schwartz–Zippel bound divides by. The
 Pasta construction itself is not needed for soundness; the one curve-level fact that is — the
-Vesta group order — is derived from the Hasse bound in `Zcash.Snark.Soundness.Vesta`, not
-assumed.
+Vesta group order — is proven unconditionally in `Zcash.Snark.Soundness.Vesta` (`vestaOrder`, from
+CompElliptic's `Pasta.Vesta.card_eq`), no longer an assumption.
 -/
 
 namespace Zcash.Snark

--- a/Zcash/Snark/Core/Field.lean
+++ b/Zcash/Snark/Core/Field.lean
@@ -4,27 +4,20 @@ import CompElliptic.Fields.Pasta
 /-!
 # The verifier's scalar field `F_p`
 
-An Orchard proof is a halo2 proof over the Vesta curve (the verifier group `E_q`): commitments are
-Vesta points; challenges and evaluations live in Vesta's scalar field `F_p`. By the Pasta
-construction `F_p = vesta::Scalar = pallas::Base = ZMod p` with `p = PALLAS_BASE_CARD ≈ 2²⁵⁴` —
-the Pallas *base* order, not the Pallas *scalar* order of the value commitment.
+Orchard commitments are Vesta points; challenges and evaluations use Vesta's scalar field `F_p`.
+For the Pasta curves, this is `pallas::Base = ZMod PALLAS_BASE_CARD`.
 
-The development stays generic over `[Field F]`; this module pins the instantiation `F_p = ZMod p`
-and records `|F_p| = p` (`card_Fp`), the cardinality the Schwartz–Zippel bound divides by. The
-Pasta construction itself is not needed for soundness; the one curve-level fact that is — the
-Vesta group order — is proven unconditionally in `Zcash.Snark.Soundness.Vesta` (`vestaOrder`, from
-CompElliptic's `Pasta.Vesta.card_eq`), no longer an assumption.
+Most proofs remain generic over `[Field F]`. This module fixes the deployed field and proves its
+cardinality, which appears in the Schwartz–Zippel bounds. `Soundness.Vesta` proves the Vesta group
+order separately.
 -/
 
 namespace Zcash.Snark
 
-/-- The verifier's scalar field order `p = |E_q|` — the Vesta scalar order, equal to the Pallas
-base order `PALLAS_BASE_CARD`. Imported from `CompElliptic.Fields.Pasta` with a machine-checked
-Lucas/Pratt primality certificate. -/
+/-- The Vesta scalar-field order, equal to the Pallas base-field order. -/
 @[reducible] def scalarFieldOrder : ℕ := CompElliptic.Fields.Pasta.PALLAS_BASE_CARD
 
-/-- The verifier's scalar field `F_p = ZMod p` (the Vesta scalar field); a field, since `p` is
-prime (CompElliptic's instance). -/
+/-- The verifier's scalar field `F_p = ZMod p`. -/
 abbrev Fp := ZMod scalarFieldOrder
 
 instance : Fact (Nat.Prime scalarFieldOrder) :=

--- a/Zcash/Snark/Fixtures/MaxShape.lean
+++ b/Zcash/Snark/Fixtures/MaxShape.lean
@@ -95,21 +95,21 @@ theorem deriveChallenges_at_captured_shape (n : ℕ) (fs : FiatShamir Fp G)
     (init : List (TranscriptElt Fp G)) (ps : ProofString (shape n) Fp G) :
     deriveChallenges fs init ps =
       let t := init ++ subProofBlocks (fun p : Fin (shape n).numProofs =>
-        absorbPoints (ps.adviceCommitments p))
+        absorbPoints (ps.adviceCommitments p)) ++ [.challenge]
       let theta := fs.squeeze t
-      let t := t ++ [.scalar theta] ++ subProofBlocks (fun p : Fin (shape n).numProofs =>
+      let t := t ++ subProofBlocks (fun p : Fin (shape n).numProofs =>
         subProofBlocks (fun l : Fin (shape n).numLookups =>
           [TranscriptElt.point (ps.lookupPermutedInput p l),
-           TranscriptElt.point (ps.lookupPermutedTable p l)]))
+           TranscriptElt.point (ps.lookupPermutedTable p l)])) ++ [.challenge]
       let beta := fs.squeeze t
-      let t := t ++ [.scalar beta]
+      let t := t ++ [.challenge]
       let gamma := fs.squeeze t
-      let t := t ++ [.scalar gamma]
+      let t := t
         ++ subProofBlocks (fun p : Fin (shape n).numProofs => absorbPoints (ps.permutationProduct p))
         ++ subProofBlocks (fun p : Fin (shape n).numProofs => absorbPoints (ps.lookupProduct p))
-        ++ [TranscriptElt.point ps.vanishingRandom]
+        ++ [TranscriptElt.point ps.vanishingRandom] ++ [.challenge]
       let y := fs.squeeze t
-      let t := t ++ [.scalar y] ++ absorbPoints ps.hPieces
+      let t := t ++ absorbPoints ps.hPieces ++ [.challenge]
       let x := fs.squeeze t
       let evalElts := subProofBlocks (fun p : Fin (shape n).numProofs =>
         absorbScalars (ps.instanceEvals p))
@@ -121,25 +121,24 @@ theorem deriveChallenges_at_captured_shape (n : ℕ) (fs : FiatShamir Fp G)
             absorbPermSet (ps.permutationSetEvals p s)))
         ++ subProofBlocks (fun p : Fin (shape n).numProofs =>
           subProofBlocks (fun l : Fin (shape n).numLookups => absorbLookup (ps.lookupEvals p l)))
-      let t := t ++ [.scalar x] ++ evalElts
+      let t := t ++ evalElts ++ [.challenge]
       let x1 := fs.squeeze t
-      let t := t ++ [.scalar x1]
+      let t := t ++ [.challenge]
       let x2 := fs.squeeze t
-      let t := t ++ [.scalar x2] ++ [TranscriptElt.point ps.multiopenQPrime]
+      let t := t ++ [TranscriptElt.point ps.multiopenQPrime] ++ [.challenge]
       let x3 := fs.squeeze t
-      let t := t ++ [.scalar x3] ++ absorbScalars ps.multiopenU
+      let t := t ++ absorbScalars ps.multiopenU ++ [.challenge]
       let x4 := fs.squeeze t
-      let t := t ++ [.scalar x4] ++ [TranscriptElt.point ps.ipaS]
+      let t := t ++ [TranscriptElt.point ps.ipaS] ++ [.challenge]
       let xi := fs.squeeze t
-      let t := t ++ [.scalar xi]
+      let t := t ++ [.challenge]
       let z := fs.squeeze t
-      let t := t ++ [.scalar z]
       let ipaRes := (List.finRange (shape n).k).foldl
         (fun (st : List (TranscriptElt Fp G) × List Fp) j =>
           let t := st.1 ++ [TranscriptElt.point (ps.ipaRounds j).1,
-            TranscriptElt.point (ps.ipaRounds j).2]
+            TranscriptElt.point (ps.ipaRounds j).2, TranscriptElt.challenge]
           let uj := fs.squeeze t
-          (t ++ [TranscriptElt.scalar uj], st.2 ++ [uj])) (t, [])
+          (t, st.2 ++ [uj])) (t, [])
       { theta := theta, beta := beta, gamma := gamma, y := y, x := x,
         x1 := x1, x2 := x2, x3 := x3, x4 := x4, xi := xi, z := z,
         ipaRound := fun j => ipaRes.2.getD j.val 0 } :=

--- a/Zcash/Snark/Fixtures/MaxShape.lean
+++ b/Zcash/Snark/Fixtures/MaxShape.lean
@@ -3,19 +3,12 @@ import Zcash.Snark
 /-!
 # Verifier-shape fixture: the captured Orchard shape at any action count
 
-The parametric verifier obligations of `Zcash.Snark.Verifier.Parametric`, specialized to the captured
-Orchard verifier shape (`Fixture`/`Fixture2`) with the action count `numProofs` a free parameter `n`. The
-verifying key, proof string, and challenges stay universally quantified — nothing is evaluated at a
-concrete `n`. What is pinned: the per-sub-proof folds elaborate at the captured Orchard column/query
-dimensions for every `n`, so drift in a parametric statement fails to elaborate here.
+This specializes `Verifier.Parametric` to the captured Orchard column and query dimensions while
+leaving the action count `n` free. The verifying key, proof, and challenges remain arbitrary.
 
-Not a Rust/Halo2 capture, and no Rust/Lean MSM match: a real max-action fixture would need a
-65,535-action Rust capture, and the single- and multi-action captures remain the empirical regressions for
-that boundary.
-
-Every consensus-valid bundle has `n ≤ orchardConsensusMaxProofs` (see that definition for the protocol
-spec §7.1.2 rule); `shape_hasConsensusNumProofs` records that each such `n` — the maximum included —
-instantiates this shape, and the folds hold for arbitrary `n` regardless.
+This is not a Rust capture or an MSM match. The single- and multi-action fixtures test that boundary.
+`shape_hasConsensusNumProofs` records that every consensus-valid action count, including the maximum,
+instantiates this shape.
 -/
 
 namespace Zcash.Snark.FixtureMax
@@ -24,8 +17,7 @@ open Zcash.Snark
 
 abbrev G := ℕ
 
-/-- The captured Orchard verifier shape (`Fixture`/`Fixture2`), with the action count `numProofs` left
-as the parameter `n`. Every other dimension is the captured Orchard column/query layout. -/
+/-- The captured Orchard verifier shape with `numProofs` left as the parameter `n`. -/
 def shape (n : ℕ) : Shape := {
   k := 11,
   numProofs := n,
@@ -43,9 +35,7 @@ def shape (n : ℕ) : Shape := {
 theorem shape_numProofs (n : ℕ) : (shape n).numProofs = n :=
   rfl
 
-/-- `n ≤ orchardConsensusMaxProofs` gives `(shape n).hasConsensusNumProofs`, so every consensus-valid
-action count instantiates the captured shape. (The bound is the protocol-spec consensus rule; see
-`orchardConsensusMaxProofs`.) -/
+/-- Every action count within the consensus bound instantiates the captured shape. -/
 theorem shape_hasConsensusNumProofs {n : ℕ} (hn : n ≤ orchardConsensusMaxProofs) :
     (shape n).hasConsensusNumProofs :=
   hn

--- a/Zcash/Snark/Fixtures/MultiAction/FiatShamir.lean
+++ b/Zcash/Snark/Fixtures/MultiAction/FiatShamir.lean
@@ -4,28 +4,13 @@ import Zcash.Snark.Fixtures.ScheduleMarker
 /-!
 # Fiat–Shamir schedule check for the multi-action capture
 
-Checks the deployed Fiat–Shamir absorb/squeeze order against the multi-action Rust capture, then connects
-the resulting FS-derived fingerprint (`nonInteractiveFingerprint`, i.e. `assemble` at `deriveChallenges`)
-to the captured multi-action MSM. The multi-action analog of `Zcash.Snark.Fixtures.SingleAction.FiatShamir`,
-with the challenge schedule made concrete for this capture: Blake2b is taken at the random-oracle boundary,
-and `capturedFs` acts as a fixture oracle over Rust-captured transcript events, returning each captured
-challenge only when `deriveChallenges` presents the captured prefix (re-encoded to the challenge-marker
-transcript by `markerSchedule`).
+This file checks the deployed absorb/squeeze order against a multi-action Rust capture and then
+matches `nonInteractiveFingerprint` to the captured MSM. `capturedFs` returns a captured challenge
+only at its captured transcript prefix, converted by `markerSchedule` to the model's marker encoding.
 
-With `numProofs = 2` this check reaches the schedule's *per-sub-proof absorb interleavings* — all
-proofs' advice commitments before `θ`, per-proof-per-lookup permuted pairs before `β`/`γ`, per-proof
-evaluation blocks before `x₁`, and so on — which the single-action fixture exercises only at length 1.
-A mis-ordered multi-proof absorb changes the transcript prefix presented to `capturedFs`, so the
-`deriveChallenges_matches_captured_schedule` check fails.
-
-This remains a fixture-oracle check over typed transcript events: generated `capturedInit` contains the
-verifier-key transcript scalar and instance commitment events before the first proof-derived read, and
-generated `capturedScheduleEntries` records the Rust verifier prefixes, including that captured prefix.
-
-As with the generated fingerprint fixtures, the Rust capture/dumper boundary is trusted to emit the
-typed proof fields, verifier-key transcript scalar, instance commitments, transcript-event trace, and
-captured challenges corresponding to the deployed transcript; this file does not replay transcript
-bytes.
+With `numProofs = 2`, the check covers the per-proof absorb order that the single-action fixture cannot
+distinguish. The Rust capture is trusted to provide the typed proof data, transcript events, and
+challenges. This file does not replay transcript bytes.
 
 TODO: once a general transcript-ordering theorem lands, either point this oracle at it or keep it as
 a concrete regression for the captured proof.
@@ -54,10 +39,7 @@ def missingChallenge : Fp := 0
 theorem missingChallenge_not_captured : missingChallenge ∉ capturedChallengeValues := by
   native_decide
 
-/-- The captured challenges are pairwise distinct, so the schedule check's record equality also detects
-output-field wiring mistakes in `deriveChallenges`: swapping two challenge assignments would equate two
-distinct captured values. (Without this, a swap between two accidentally-equal captured challenges
-would pass silently.) -/
+/-- The captured challenges are distinct, so record equality also detects swapped output fields. -/
 theorem capturedChallengeValues_nodup : capturedChallengeValues.Nodup := by
   native_decide
 
@@ -68,15 +50,11 @@ def capturedScheduleIncludesInit : Bool :=
 theorem capturedScheduleIncludesInit_eq_true : capturedScheduleIncludesInit = true := by
   native_decide
 
-/-- The captured schedule re-encoded to `deriveChallenges`'s challenge-marker transcript
-(`markerSchedule`): the capture records re-absorption prefixes, the model writes a `challenge` marker
-per squeeze and never feeds the challenge back — same absorb events, same challenge values. -/
+/-- The captured schedule converted from challenge re-absorption to challenge-marker encoding. -/
 def markerScheduleEntries : List (List (TranscriptElt Fp G) × Fp) :=
   markerSchedule capturedScheduleEntries
 
-/-- Fixture Fiat–Shamir oracle: returns a captured challenge only at a Rust-captured transcript prefix,
-re-encoded to the challenge-marker transcript (`markerScheduleEntries`). Unknown prefixes return
-`missingChallenge`, which is checked above not to be one of the captured challenges. -/
+/-- Return a captured challenge at its recorded prefix and `missingChallenge` elsewhere. -/
 def capturedFs : FiatShamir Fp G := {
   squeeze := fun t =>
     match markerScheduleEntries.find? (fun e => decide (e.1 = t)) with
@@ -84,8 +62,7 @@ def capturedFs : FiatShamir Fp G := {
     | none => missingChallenge
 }
 
-/-- Concrete check that the Lean Fiat–Shamir schedule reaches the captured challenges in the captured
-multi-action proof. This is the theorem that fails if a proof-derived absorb is reordered or omitted. -/
+/-- The Lean schedule reaches every captured challenge for the multi-action proof. -/
 theorem deriveChallenges_matches_captured_schedule :
     deriveChallenges capturedFs capturedInit ps = ch := by native_decide
 

--- a/Zcash/Snark/Fixtures/MultiAction/FiatShamir.lean
+++ b/Zcash/Snark/Fixtures/MultiAction/FiatShamir.lean
@@ -1,4 +1,5 @@
 import Zcash.Snark.Fixtures.MultiAction.Fixture
+import Zcash.Snark.Fixtures.ScheduleMarker
 
 /-!
 # Fiat–Shamir schedule check for the multi-action capture
@@ -6,7 +7,8 @@ import Zcash.Snark.Fixtures.MultiAction.Fixture
 The multi-action analog of `Zcash.Snark.Fixtures.SingleAction.FiatShamir`, but with the challenge schedule
 made concrete for this capture. Blake2b is intentionally taken at the random-oracle boundary; here
 `capturedFs` acts as a fixture oracle over Rust-captured transcript events, returning each captured
-challenge only when `deriveChallenges` presents the captured transcript prefix. This checks the
+challenge only when `deriveChallenges` presents the captured transcript prefix (re-encoded to the
+challenge-marker transcript by `markerSchedule`). This checks the
 absorb/squeeze order for the typed verifier transcript after Blake2b initialization, then connects
 the resulting FS-derived fingerprint (`nonInteractiveFingerprint`, i.e. `assemble` at
 `deriveChallenges`) to the captured multi-action MSM.
@@ -67,12 +69,18 @@ def capturedScheduleIncludesInit : Bool :=
 theorem capturedScheduleIncludesInit_eq_true : capturedScheduleIncludesInit = true := by
   native_decide
 
-/-- Fixture Fiat–Shamir oracle: returns a captured challenge only at a Rust-captured transcript prefix.
-Unknown prefixes return `missingChallenge`, which is checked above not to be one of the captured
-challenges. -/
+/-- The captured schedule re-encoded to `deriveChallenges`'s challenge-marker transcript
+(`markerSchedule`): the capture records re-absorption prefixes, the model writes a `challenge` marker
+per squeeze and never feeds the challenge back — same absorb events, same challenge values. -/
+def markerScheduleEntries : List (List (TranscriptElt Fp G) × Fp) :=
+  markerSchedule capturedScheduleEntries
+
+/-- Fixture Fiat–Shamir oracle: returns a captured challenge only at a Rust-captured transcript prefix,
+re-encoded to the challenge-marker transcript (`markerScheduleEntries`). Unknown prefixes return
+`missingChallenge`, which is checked above not to be one of the captured challenges. -/
 def capturedFs : FiatShamir Fp G := {
   squeeze := fun t =>
-    match capturedScheduleEntries.find? (fun e => decide (e.1 = t)) with
+    match markerScheduleEntries.find? (fun e => decide (e.1 = t)) with
     | some e => e.2
     | none => missingChallenge
 }

--- a/Zcash/Snark/Fixtures/MultiAction/FiatShamir.lean
+++ b/Zcash/Snark/Fixtures/MultiAction/FiatShamir.lean
@@ -4,14 +4,13 @@ import Zcash.Snark.Fixtures.ScheduleMarker
 /-!
 # Fiat–Shamir schedule check for the multi-action capture
 
-The multi-action analog of `Zcash.Snark.Fixtures.SingleAction.FiatShamir`, but with the challenge schedule
-made concrete for this capture. Blake2b is intentionally taken at the random-oracle boundary; here
-`capturedFs` acts as a fixture oracle over Rust-captured transcript events, returning each captured
-challenge only when `deriveChallenges` presents the captured transcript prefix (re-encoded to the
-challenge-marker transcript by `markerSchedule`). This checks the
-absorb/squeeze order for the typed verifier transcript after Blake2b initialization, then connects
-the resulting FS-derived fingerprint (`nonInteractiveFingerprint`, i.e. `assemble` at
-`deriveChallenges`) to the captured multi-action MSM.
+Checks the deployed Fiat–Shamir absorb/squeeze order against the multi-action Rust capture, then connects
+the resulting FS-derived fingerprint (`nonInteractiveFingerprint`, i.e. `assemble` at `deriveChallenges`)
+to the captured multi-action MSM. The multi-action analog of `Zcash.Snark.Fixtures.SingleAction.FiatShamir`,
+with the challenge schedule made concrete for this capture: Blake2b is taken at the random-oracle boundary,
+and `capturedFs` acts as a fixture oracle over Rust-captured transcript events, returning each captured
+challenge only when `deriveChallenges` presents the captured prefix (re-encoded to the challenge-marker
+transcript by `markerSchedule`).
 
 With `numProofs = 2` this check reaches the schedule's *per-sub-proof absorb interleavings* — all
 proofs' advice commitments before `θ`, per-proof-per-lookup permuted pairs before `β`/`γ`, per-proof

--- a/Zcash/Snark/Fixtures/ScheduleMarker.lean
+++ b/Zcash/Snark/Fixtures/ScheduleMarker.lean
@@ -3,7 +3,7 @@ import Zcash.Snark.Verifier.FiatShamir
 /-!
 # Captured Fiat–Shamir schedules, re-encoded to the challenge-marker transcript
 
-The Rust `ChallengeRecorder` captures record each squeeze's transcript prefix in the *re-absorption*
+The Rust `ChallengeRecorder` captures each squeeze's transcript prefix in the *re-absorption*
 encoding: after a squeeze, the challenge value is fed back into the running transcript as a `.scalar`,
 and no marker is written. `deriveChallenges` instead models the deployed transcript with the
 `TranscriptElt.challenge` domain marker — halo2 writes the `BLAKE2B_PREFIX_CHALLENGE` byte before each
@@ -21,7 +21,7 @@ variable {F G : Type*}
 
 /-- The fold behind `markerSchedule`: `prev` is the previous entry already re-encoded (its prefix ends
 with the `challenge` marker), `oldLen` the previous entry's prefix length in the captured encoding.
-Each step drops the one re-absorbed challenge that opens every post-squeeze block of the captured
+Each iteration drops the one re-absorbed challenge that opens every post-squeeze block of the captured
 encoding, keeps the block's absorbs, and appends the marker. -/
 def markerSchedule.go (prev : List (TranscriptElt F G) × F) (oldLen : ℕ) :
     List (List (TranscriptElt F G) × F) → List (List (TranscriptElt F G) × F)

--- a/Zcash/Snark/Fixtures/ScheduleMarker.lean
+++ b/Zcash/Snark/Fixtures/ScheduleMarker.lean
@@ -1,39 +1,27 @@
 import Zcash.Snark.Verifier.FiatShamir
 
 /-!
-# Captured Fiat–Shamir schedules, re-encoded to the challenge-marker transcript
+# Re-encode captured Fiat–Shamir schedules
 
-The Rust `ChallengeRecorder` captures each squeeze's transcript prefix in the *re-absorption*
-encoding: after a squeeze, the challenge value is fed back into the running transcript as a `.scalar`,
-and no marker is written. `deriveChallenges` instead models the deployed transcript with the
-`TranscriptElt.challenge` domain marker — halo2 writes the `BLAKE2B_PREFIX_CHALLENGE` byte before each
-squeeze and never feeds the challenge value back (`Zcash.Snark.Verifier.FiatShamir`).
+Rust captures a squeezed challenge by feeding its value back as `.scalar`. `deriveChallenges`
+instead records halo2's challenge-domain marker before the squeeze.
 
-The two encodings record the same absorb events, so they are interconvertible: `markerSchedule`
-re-encodes a captured schedule into the marker form, and the per-capture schedule checks
-(`deriveChallenges_matches_captured_schedule`) re-verify the converted schedule against
-`deriveChallenges` by `native_decide` — a conversion mistake surfaces there, not silently.
+`markerSchedule` converts the captured form to the marker form. Fixture checks then compare the
+result with `deriveChallenges` using `native_decide`.
 -/
 
 namespace Zcash.Snark
 
 variable {F G : Type*}
 
-/-- The fold behind `markerSchedule`: `prev` is the previous entry already re-encoded (its prefix ends
-with the `challenge` marker), `oldLen` the previous entry's prefix length in the captured encoding.
-Each iteration drops the one re-absorbed challenge that opens every post-squeeze block of the captured
-encoding, keeps the block's absorbs, and appends the marker. -/
+/-- Convert one captured schedule step by dropping the reabsorbed challenge and appending its marker. -/
 def markerSchedule.go (prev : List (TranscriptElt F G) × F) (oldLen : ℕ) :
     List (List (TranscriptElt F G) × F) → List (List (TranscriptElt F G) × F)
   | [] => [prev]
   | e :: es =>
       prev :: markerSchedule.go (prev.1 ++ e.1.drop (oldLen + 1) ++ [.challenge], e.2) e.1.length es
 
-/-- Re-encode a captured Fiat–Shamir schedule from the capture's re-absorption encoding (each squeezed
-challenge fed back as a `.scalar`, no marker) to `deriveChallenges`'s challenge-marker encoding: entry
-`i`'s prefix becomes entry `i−1`'s re-encoded prefix, then entry `i`'s new absorbs — its captured
-prefix past entry `i−1`'s, minus the single re-absorbed challenge — then the `challenge` marker. The
-challenge values are unchanged. -/
+/-- Convert a captured reabsorption schedule to `deriveChallenges`'s marker encoding. -/
 def markerSchedule : List (List (TranscriptElt F G) × F) → List (List (TranscriptElt F G) × F)
   | [] => []
   | e :: es => markerSchedule.go (e.1 ++ [.challenge], e.2) e.1.length es

--- a/Zcash/Snark/Fixtures/ScheduleMarker.lean
+++ b/Zcash/Snark/Fixtures/ScheduleMarker.lean
@@ -1,0 +1,41 @@
+import Zcash.Snark.Verifier.FiatShamir
+
+/-!
+# Captured Fiat–Shamir schedules, re-encoded to the challenge-marker transcript
+
+The Rust `ChallengeRecorder` captures record each squeeze's transcript prefix in the *re-absorption*
+encoding: after a squeeze, the challenge value is fed back into the running transcript as a `.scalar`,
+and no marker is written. `deriveChallenges` instead models the deployed transcript with the
+`TranscriptElt.challenge` domain marker — halo2 writes the `BLAKE2B_PREFIX_CHALLENGE` byte before each
+squeeze and never feeds the challenge value back (`Zcash.Snark.Verifier.FiatShamir`).
+
+The two encodings record the same absorb events, so they are interconvertible: `markerSchedule`
+re-encodes a captured schedule into the marker form, and the per-capture schedule checks
+(`deriveChallenges_matches_captured_schedule`) re-verify the converted schedule against
+`deriveChallenges` by `native_decide` — a conversion mistake surfaces there, not silently.
+-/
+
+namespace Zcash.Snark
+
+variable {F G : Type*}
+
+/-- The fold behind `markerSchedule`: `prev` is the previous entry already re-encoded (its prefix ends
+with the `challenge` marker), `oldLen` the previous entry's prefix length in the captured encoding.
+Each step drops the one re-absorbed challenge that opens every post-squeeze block of the captured
+encoding, keeps the block's absorbs, and appends the marker. -/
+def markerSchedule.go (prev : List (TranscriptElt F G) × F) (oldLen : ℕ) :
+    List (List (TranscriptElt F G) × F) → List (List (TranscriptElt F G) × F)
+  | [] => [prev]
+  | e :: es =>
+      prev :: markerSchedule.go (prev.1 ++ e.1.drop (oldLen + 1) ++ [.challenge], e.2) e.1.length es
+
+/-- Re-encode a captured Fiat–Shamir schedule from the capture's re-absorption encoding (each squeezed
+challenge fed back as a `.scalar`, no marker) to `deriveChallenges`'s challenge-marker encoding: entry
+`i`'s prefix becomes entry `i−1`'s re-encoded prefix, then entry `i`'s new absorbs — its captured
+prefix past entry `i−1`'s, minus the single re-absorbed challenge — then the `challenge` marker. The
+challenge values are unchanged. -/
+def markerSchedule : List (List (TranscriptElt F G) × F) → List (List (TranscriptElt F G) × F)
+  | [] => []
+  | e :: es => markerSchedule.go (e.1 ++ [.challenge], e.2) e.1.length es
+
+end Zcash.Snark

--- a/Zcash/Snark/Fixtures/SingleAction/FiatShamir.lean
+++ b/Zcash/Snark/Fixtures/SingleAction/FiatShamir.lean
@@ -1,4 +1,5 @@
 import Zcash.Snark.Fixtures.SingleAction.Fixture
+import Zcash.Snark.Fixtures.ScheduleMarker
 
 /-!
 # Fiat–Shamir schedule check for the single-action capture
@@ -6,7 +7,8 @@ import Zcash.Snark.Fixtures.SingleAction.Fixture
 The single-action analog of `Zcash.Snark.Fixtures.MultiAction.FiatShamir`, on the same design: Blake2b
 is intentionally taken at the random-oracle boundary; here `capturedFs` acts as a fixture oracle over
 Rust-captured transcript events, returning each captured challenge only when `deriveChallenges`
-presents the captured transcript prefix. This checks the absorb/squeeze order for the typed verifier
+presents the captured transcript prefix (re-encoded to the challenge-marker transcript by
+`markerSchedule`). This checks the absorb/squeeze order for the typed verifier
 transcript after Blake2b initialization, and then connects the resulting FS-derived fingerprint
 (`nonInteractiveFingerprint`, i.e. `assemble` at `deriveChallenges`) to the captured single-action MSM.
 The per-sub-proof absorb interleavings are exercised at length 1 here; the multi-action coverage is
@@ -57,12 +59,18 @@ def capturedScheduleIncludesInit : Bool :=
 theorem capturedScheduleIncludesInit_eq_true : capturedScheduleIncludesInit = true := by
   native_decide
 
-/-- Fixture Fiat–Shamir oracle: returns a captured challenge only at a Rust-captured transcript prefix.
-Unknown prefixes return `missingChallenge`, which is checked above not to be one of the captured
-challenges. -/
+/-- The captured schedule re-encoded to `deriveChallenges`'s challenge-marker transcript
+(`markerSchedule`): the capture records re-absorption prefixes, the model writes a `challenge` marker
+per squeeze and never feeds the challenge back — same absorb events, same challenge values. -/
+def markerScheduleEntries : List (List (TranscriptElt Fp G) × Fp) :=
+  markerSchedule capturedScheduleEntries
+
+/-- Fixture Fiat–Shamir oracle: returns a captured challenge only at a Rust-captured transcript prefix,
+re-encoded to the challenge-marker transcript (`markerScheduleEntries`). Unknown prefixes return
+`missingChallenge`, which is checked above not to be one of the captured challenges. -/
 def capturedFs : FiatShamir Fp G := {
   squeeze := fun t =>
-    match capturedScheduleEntries.find? (fun e => decide (e.1 = t)) with
+    match markerScheduleEntries.find? (fun e => decide (e.1 = t)) with
     | some e => e.2
     | none => missingChallenge
 }

--- a/Zcash/Snark/Fixtures/SingleAction/FiatShamir.lean
+++ b/Zcash/Snark/Fixtures/SingleAction/FiatShamir.lean
@@ -4,13 +4,12 @@ import Zcash.Snark.Fixtures.ScheduleMarker
 /-!
 # Fiat–Shamir schedule check for the single-action capture
 
-The single-action analog of `Zcash.Snark.Fixtures.MultiAction.FiatShamir`, on the same design: Blake2b
-is intentionally taken at the random-oracle boundary; here `capturedFs` acts as a fixture oracle over
-Rust-captured transcript events, returning each captured challenge only when `deriveChallenges`
-presents the captured transcript prefix (re-encoded to the challenge-marker transcript by
-`markerSchedule`). This checks the absorb/squeeze order for the typed verifier
-transcript after Blake2b initialization, and then connects the resulting FS-derived fingerprint
-(`nonInteractiveFingerprint`, i.e. `assemble` at `deriveChallenges`) to the captured single-action MSM.
+Checks the deployed Fiat–Shamir absorb/squeeze order against the single-action Rust capture, then connects
+the resulting FS-derived fingerprint (`nonInteractiveFingerprint`, i.e. `assemble` at `deriveChallenges`)
+to the captured single-action MSM. The single-action analog of `Zcash.Snark.Fixtures.MultiAction.FiatShamir`,
+on the same design: Blake2b is taken at the random-oracle boundary, and `capturedFs` acts as a fixture oracle
+over Rust-captured transcript events, returning each captured challenge only when `deriveChallenges` presents
+the captured prefix (re-encoded to the challenge-marker transcript by `markerSchedule`).
 The per-sub-proof absorb interleavings are exercised at length 1 here; the multi-action coverage is
 `Zcash.Snark.Fixtures.MultiAction.FiatShamir`.
 

--- a/Zcash/Snark/Fixtures/SingleAction/FiatShamir.lean
+++ b/Zcash/Snark/Fixtures/SingleAction/FiatShamir.lean
@@ -4,19 +4,12 @@ import Zcash.Snark.Fixtures.ScheduleMarker
 /-!
 # Fiat–Shamir schedule check for the single-action capture
 
-Checks the deployed Fiat–Shamir absorb/squeeze order against the single-action Rust capture, then connects
-the resulting FS-derived fingerprint (`nonInteractiveFingerprint`, i.e. `assemble` at `deriveChallenges`)
-to the captured single-action MSM. The single-action analog of `Zcash.Snark.Fixtures.MultiAction.FiatShamir`,
-on the same design: Blake2b is taken at the random-oracle boundary, and `capturedFs` acts as a fixture oracle
-over Rust-captured transcript events, returning each captured challenge only when `deriveChallenges` presents
-the captured prefix (re-encoded to the challenge-marker transcript by `markerSchedule`).
-The per-sub-proof absorb interleavings are exercised at length 1 here; the multi-action coverage is
-`Zcash.Snark.Fixtures.MultiAction.FiatShamir`.
+This file checks the deployed absorb/squeeze order against a single-action Rust capture and then
+matches `nonInteractiveFingerprint` to the captured MSM. `capturedFs` returns a captured challenge
+only at its captured transcript prefix, converted by `markerSchedule` to the model's marker encoding.
 
-As with the generated fingerprint fixtures, the Rust capture/dumper boundary is trusted to emit the
-typed proof fields, verifier-key transcript scalar, instance commitments, transcript-event trace, and
-captured challenges corresponding to the deployed transcript; this file does not replay transcript
-bytes.
+The Rust capture is trusted to provide the typed proof data, transcript events, and challenges. This
+file does not replay transcript bytes. The multi-action fixture checks the per-proof interleaving.
 
 TODO: once a general transcript-ordering theorem lands, either point this oracle at it or keep it as
 a concrete regression for the captured proof.
@@ -45,9 +38,7 @@ def missingChallenge : Fp := 0
 theorem missingChallenge_not_captured : missingChallenge ∉ capturedChallengeValues := by
   native_decide
 
-/-- The captured challenges are pairwise distinct, so the schedule check's record equality also detects
-output-field wiring mistakes in `deriveChallenges`: swapping two challenge assignments would equate two
-distinct captured values. -/
+/-- The captured challenges are distinct, so record equality also detects swapped output fields. -/
 theorem capturedChallengeValues_nodup : capturedChallengeValues.Nodup := by
   native_decide
 
@@ -58,15 +49,11 @@ def capturedScheduleIncludesInit : Bool :=
 theorem capturedScheduleIncludesInit_eq_true : capturedScheduleIncludesInit = true := by
   native_decide
 
-/-- The captured schedule re-encoded to `deriveChallenges`'s challenge-marker transcript
-(`markerSchedule`): the capture records re-absorption prefixes, the model writes a `challenge` marker
-per squeeze and never feeds the challenge back — same absorb events, same challenge values. -/
+/-- The captured schedule converted from challenge re-absorption to challenge-marker encoding. -/
 def markerScheduleEntries : List (List (TranscriptElt Fp G) × Fp) :=
   markerSchedule capturedScheduleEntries
 
-/-- Fixture Fiat–Shamir oracle: returns a captured challenge only at a Rust-captured transcript prefix,
-re-encoded to the challenge-marker transcript (`markerScheduleEntries`). Unknown prefixes return
-`missingChallenge`, which is checked above not to be one of the captured challenges. -/
+/-- Return a captured challenge at its recorded prefix and `missingChallenge` elsewhere. -/
 def capturedFs : FiatShamir Fp G := {
   squeeze := fun t =>
     match markerScheduleEntries.find? (fun e => decide (e.1 = t)) with
@@ -74,9 +61,7 @@ def capturedFs : FiatShamir Fp G := {
     | none => missingChallenge
 }
 
-/-- Concrete check that the Lean Fiat–Shamir schedule reaches the captured challenges in the captured
-single-action proof. This is the theorem that fails if a proof-derived absorb is reordered or
-omitted. -/
+/-- The Lean schedule reaches every captured challenge for the single-action proof. -/
 theorem deriveChallenges_matches_captured_schedule :
     deriveChallenges capturedFs capturedInit ps = ch := by native_decide
 

--- a/Zcash/Snark/Soundness/Deployed/TrustBoundary.lean
+++ b/Zcash/Snark/Soundness/Deployed/TrustBoundary.lean
@@ -4,25 +4,16 @@ import Mathlib.Util.AssertNoSorry
 /-!
 # Checked trust boundary of the deployed binding-reduction breaks
 
-Build-time enforcement of the breaks-as-computed-data discipline (see
-`Zcash.Security.RandomOracle`), following `Zcash.Security.Ledger.TrustBoundary`. The reductions'
-computability is compiler-enforced — they are plain `def`s, so a `noncomputable` dependency
-fails the build. What a build does not otherwise pin down is a `sorry` reached through some
-dependency, or an unexpected axiom; both checks below follow the elaborated dependency graph.
+This file checks that the binding reductions return computed data. They are plain `def`s, so Lean
+rejects noncomputable dependencies. The checks below also reject `sorry` and pin their axiom sets.
 
-The pinned sets include `Classical.choice`, entering only through Mathlib lemmas cited by the
-erased `Prop` certificate fields (`nontrivial`/`relation`) — harmless per the convention: had
-choice touched the break *data*, the definitions could not have compiled as plain `def`s. The
-Vesta specialization additionally pins CompElliptic's one `native_decide` fact (the prime-order
-witness `p_nsmul_Gpt` behind the curve order), likewise reached only through `Prop` positions.
+`Classical.choice` enters only through erased `Prop` certificate fields; it cannot affect the returned
+data because the reductions are computable. The Vesta result also depends on CompElliptic's
+`native_decide` proof of the curve-order witness.
 
-The same two checks cover the deployed forking reductions that return their result as *computed
-data* — `ipa_extractV` (the IPA opening witness), `ipaRelation_extract`, `produceDeployed`/
-`deployed_forking_tree` (the root-consistent tree extraction), `deployed_forking_relation` (the
-end-to-end multiopen opening). Their non-vacuity *is* their computability — the witness cannot be
-produced without the certificate — so a `sorry` or a `noncomputable` dependency would defeat them,
-and these pins freeze that. Their axiom sets are the standard classical trio, `Classical.choice`
-again reaching only erased `Prop` positions.
+The same checks cover the forking reductions `ipa_extractV`, `ipaRelation_extract`, `produceDeployed`,
+`deployed_forking_tree`, and `deployed_forking_relation`. Each computes its witness from an explicit
+certificate; an existential proof alone cannot produce that data.
 -/
 
 open Zcash.Snark

--- a/Zcash/Snark/Soundness/Deployed/TrustBoundary.lean
+++ b/Zcash/Snark/Soundness/Deployed/TrustBoundary.lean
@@ -15,6 +15,14 @@ erased `Prop` certificate fields (`nontrivial`/`relation`) — harmless per the 
 choice touched the break *data*, the definitions could not have compiled as plain `def`s. The
 Vesta specialization additionally pins CompElliptic's one `native_decide` fact (the prime-order
 witness `p_nsmul_Gpt` behind the curve order), likewise reached only through `Prop` positions.
+
+The same two checks cover the deployed forking reductions that return their result as *computed
+data*: `ipa_extractV` (the IPA opening witness), `ipaRelation_extract`, `produceDeployed` and
+`deployed_forking_tree` (the root-consistent tree extraction), and `deployed_forking_relation`
+(the end-to-end multiopen opening). Their non-vacuity is exactly that they are computable — the
+witness cannot be produced without the certificate — so a `sorry` or a `noncomputable` dependency
+would defeat them, and the pins freeze that. Their axiom sets are the standard classical trio,
+`Classical.choice` again reaching only erased `Prop` positions.
 -/
 
 open Zcash.Snark
@@ -25,6 +33,13 @@ assert_no_sorry NontrivialRelation.ofLeafPeel
 assert_no_sorry NontrivialRelation.ofDeployedTree
 assert_no_sorry NontrivialRelation.ofUnopenedFork
 assert_no_sorry NontrivialRelation.ofUnopenedForkVesta
+
+-- The computed-data forking reductions (opening/relation returned as `Σ'` data, not `∃`).
+assert_no_sorry ipa_extractV
+assert_no_sorry ipaRelation_extract
+assert_no_sorry produceDeployed
+assert_no_sorry deployed_forking_tree
+assert_no_sorry deployed_forking_relation
 
 /-- info: 'Zcash.Snark.NontrivialRelation.ofCombinationCollision' depends on axioms: [propext,
 Classical.choice, Quot.sound] -/
@@ -57,3 +72,23 @@ Quot.sound,
 CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt._native.native_decide.ax_1_1] -/
 #guard_msgs (whitespace := lax) in
 #print axioms NontrivialRelation.ofUnopenedForkVesta
+
+/-- info: 'Zcash.Snark.ipa_extractV' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs (whitespace := lax) in
+#print axioms ipa_extractV
+
+/-- info: 'Zcash.Snark.ipaRelation_extract' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs (whitespace := lax) in
+#print axioms ipaRelation_extract
+
+/-- info: 'Zcash.Snark.produceDeployed' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs (whitespace := lax) in
+#print axioms produceDeployed
+
+/-- info: 'Zcash.Snark.deployed_forking_tree' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs (whitespace := lax) in
+#print axioms deployed_forking_tree
+
+/-- info: 'Zcash.Snark.deployed_forking_relation' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs (whitespace := lax) in
+#print axioms deployed_forking_relation

--- a/Zcash/Snark/Soundness/Deployed/TrustBoundary.lean
+++ b/Zcash/Snark/Soundness/Deployed/TrustBoundary.lean
@@ -17,12 +17,12 @@ Vesta specialization additionally pins CompElliptic's one `native_decide` fact (
 witness `p_nsmul_Gpt` behind the curve order), likewise reached only through `Prop` positions.
 
 The same two checks cover the deployed forking reductions that return their result as *computed
-data*: `ipa_extractV` (the IPA opening witness), `ipaRelation_extract`, `produceDeployed` and
-`deployed_forking_tree` (the root-consistent tree extraction), and `deployed_forking_relation`
-(the end-to-end multiopen opening). Their non-vacuity is exactly that they are computable — the
-witness cannot be produced without the certificate — so a `sorry` or a `noncomputable` dependency
-would defeat them, and the pins freeze that. Their axiom sets are the standard classical trio,
-`Classical.choice` again reaching only erased `Prop` positions.
+data* — `ipa_extractV` (the IPA opening witness), `ipaRelation_extract`, `produceDeployed`/
+`deployed_forking_tree` (the root-consistent tree extraction), `deployed_forking_relation` (the
+end-to-end multiopen opening). Their non-vacuity *is* their computability — the witness cannot be
+produced without the certificate — so a `sorry` or a `noncomputable` dependency would defeat them,
+and these pins freeze that. Their axiom sets are the standard classical trio, `Classical.choice`
+again reaching only erased `Prop` positions.
 -/
 
 open Zcash.Snark

--- a/Zcash/Snark/Soundness/Deployed/Verification.lean
+++ b/Zcash/Snark/Soundness/Deployed/Verification.lean
@@ -2,23 +2,20 @@ import Zcash.Snark.Verifier.Assemble
 import Zcash.Snark.Soundness.Deployed.Fold
 
 /-!
-# The deployed accept entails halo2's explicit IPA verifier equation (structural faithfulness)
+# Deployed acceptance implies the explicit IPA verifier equation
 
-`eval_assembleFinalMsm` evaluates the assembled fingerprint MSM in closed form;
-`deployed_gterm_foldAll` identifies its `g`-term as `[-c]·G'₀`. This module welds them into
-halo2's published IPA verification equation and ties it to the deployed accept condition, pinning
-the opened object `P`/`v` to the proof:
+This module combines `eval_assembleFinalMsm` and `deployed_gterm_foldAll` into halo2's IPA equation
+and ties that equation to the deployed accept condition:
 
 * `multiopenCommitment` / `multiopenValue` — the `P` and `v` halo2's IPA verifier opens, read off the
   multiopen assembly on `(vk, ps, ch)`.
-* `deployed_verification_eq` — `(assembleFinalMsm …).eval` *is* the explicit equation
+* `deployed_verification_eq` — `(assembleFinalMsm …).eval` is the explicit equation
   `P + [-v]g₀ + [ξ]S + Σ(rounds) + [-c·b·z]U + [-f]W + [-c]G'₀`.
 * `DeployedIpaVerifierEq` — that equation set to the identity.
-* the `…?_eq_some` reconciliation — the deployed accept uses the *rejecting* `assemble?`; when it
+* the `…?_eq_some` lemmas — deployed acceptance uses the rejecting `assemble?`; when it
   returns `some m`, `m` is the non-rejecting `assembleFinalMsm`, so the equation transfers.
 
-This discharges the assembly↔equation correspondence separately from the bridge; what the bridge
-still covers is inventoried at `FiatShamirTree` (`Zcash.Snark.Soundness.Main`).
+The remaining bridge obligations are listed at `FiatShamirTree` in `Soundness.Main`.
 -/
 
 namespace Zcash.Snark

--- a/Zcash/Snark/Soundness/Deployed/Verification.lean
+++ b/Zcash/Snark/Soundness/Deployed/Verification.lean
@@ -136,10 +136,10 @@ computes the same thing — halo2 batch-inverts the round challenges with ff's `
 which leaves a zero challenge at zero — so at `uⱼ = 0` the equation and the Rust agree
 term for term. The corner is faithful in both directions: nothing about acceptance can be
 shown from this form that the deployed verifier would not exhibit. The forking *extractor*, by
-contrast, requires the three sibling challenges at each node to be nonzero (the Vandermonde
-recovery and `u⁻¹` fold need cancellable challenges), and pays that extra bad challenge per round
-in the knowledge-error count `Soundness.Forking.Tree.kerr` — so this totality is only about the
-equation's definedness, not the extractor's admissible challenges. -/
+contrast, needs the three sibling challenges at each node to be nonzero (the Vandermonde recovery
+and `u⁻¹` fold need cancellable challenges), paying for that extra bad challenge per round in the
+knowledge-error count `Soundness.Forking.Tree.kerr` — so this totality concerns only the equation's
+definedness, not the extractor's admissible challenges. -/
 def DeployedIpaVerifierEq {shape : Shape} [DecidableEq F] [DecidableEq G] [Inhabited G]
     (g : Fin (2 ^ shape.k) → G) (w u : G)
     (vk : VerifyingKey shape F G) (ps : ProofString shape F G) (ch : Challenges shape.k F) : Prop :=

--- a/Zcash/Snark/Soundness/Deployed/Verification.lean
+++ b/Zcash/Snark/Soundness/Deployed/Verification.lean
@@ -135,7 +135,11 @@ Totality note: the closed form uses Lean's total inverse (`0⁻¹ = 0`), and the
 computes the same thing — halo2 batch-inverts the round challenges with ff's `batch_invert`,
 which leaves a zero challenge at zero — so at `uⱼ = 0` the equation and the Rust agree
 term for term. The corner is faithful in both directions: nothing about acceptance can be
-shown from this form that the deployed verifier would not exhibit. -/
+shown from this form that the deployed verifier would not exhibit. The forking *extractor*, by
+contrast, requires the three sibling challenges at each node to be nonzero (the Vandermonde
+recovery and `u⁻¹` fold need cancellable challenges), and pays that extra bad challenge per round
+in the knowledge-error count `Soundness.Forking.Tree.kerr` — so this totality is only about the
+equation's definedness, not the extractor's admissible challenges. -/
 def DeployedIpaVerifierEq {shape : Shape} [DecidableEq F] [DecidableEq G] [Inhabited G]
     (g : Fin (2 ^ shape.k) → G) (w u : G)
     (vk : VerifyingKey shape F G) (ps : ProofString shape F G) (ch : Challenges shape.k F) : Prop :=

--- a/Zcash/Snark/Soundness/Forking/Assembly.lean
+++ b/Zcash/Snark/Soundness/Forking/Assembly.lean
@@ -2,52 +2,26 @@ import Zcash.Snark.Soundness.Deployed.Verification
 import Zcash.Snark.Soundness.Deployed.IpaPeel
 
 /-!
-# Structural special-soundness assembly (eliminating the monolithic `FiatShamirTree`)
+# Assemble forked transcripts into the deployed IPA tree
 
-`FiatShamirTree` currently assumes, as one opaque bundle, that an accepting deployed verifier equation yields a
-`DeployedIpaTreeV` with `DeployedIpaAcceptV`. That bundles (i) the random-oracle / rewinding *forking* — a
-cryptographic assumption that genuinely cannot be discharged in Lean — with (ii) a purely **structural**
-bridge from accepting transcripts to the recursive ternary IPA tree, which is a proof-engineering problem,
-not handwaving. This module builds (ii), so the residual shrinks to (i) alone.
+The old `FiatShamirTree` assumption combined two jobs: producing forked transcripts by random-oracle
+rewinding, and converting those transcripts into `DeployedIpaAcceptV`. This module proves the second
+job.
 
-## Roadmap (the structural bridge, built on the existing fold foundations)
+The flat verifier equation folds one IPA round at a time. `roundSum_cons`, `computeB_cons`, and
+`CF_cons` match that fold to the recursive commitment, generator, value, and blinding updates.
+`CF_leaf_to_acceptV` identifies the final closed-form equation with the deployed leaf check, and
+`forkAccept_to_acceptV` assembles the full tree.
 
-The flat verifier equation `DeployedIpaVerifierEq` is `(closed form) = 0`, where the closed form
-(`deployed_verification_eq`) is `P' + roundSum + [-c·b·z]U + [-f]W + [-c]·G'₀` with `P' = multiopen − [v]g₀ +
-[ξ]S` the adjusted commitment. The recursive `DeployedIpaAcceptV` folds `P` by `(L,R,u)` per round down to a
-leaf check. Bridging them:
-
-1. **round-sum recursion** (`roundSum_cons`) — `roundSum` peels one `([uⱼ⁻¹]Lⱼ + [uⱼ]Rⱼ)` term per round.
-2. **generator/value fold recursion** — `foldAll`, `foldGens`, `computeS_cons` already give the `g`/`b`
-   one-round fold (`Soundness.Deployed.Fold`, `Soundness.IpaSoundness`).
-3. **`computeB` one-round recursion** (`computeB_cons`) — the `b`-value fold (the `[-c·b·z]U` coefficient).
-4. **one-round closed-form fold** (`CF_cons`) — combine 1–3: with the round point in its `(g,U,W)`
-   representation, the closed form at challenge `u₀` equals the closed form of the folded instance
-   `(foldGens g u₀⁻¹, P + u₀⁻¹Lg + u₀Rg, …)` over the remaining rounds, the value/blinding coefficients
-   folding additively. The eval-vector fold telescopes to `computeB` (`foldAll_evalVector`, the value bridge).
-5. **leaf reconciliation** (`CF_leaf_to_acceptV`) — at depth 0 (single generator) the closed form `= 0` gives
-   the `DeployedIpaAcceptV` leaf, with the folded commitment in its `(g,U,W)` representation and the value
-   carried on `U` via `z` (the form `NontrivialRelation.ofLeafPeel` then peels, sound for `z ≠ 0`).
-6. **ternary assembly** — three transcripts diverging at distinct nonzero `u` (the forking output) give a
-   `DeployedIpaTreeV` node via Vandermonde (`vandermonde3`, `ipa_round_commit_sound`), recursed to the tree.
-
-Parts 1–5 are proven below: the closed-form verifier equation folds round by round into the recursive tree
-structure and reconciles to the `DeployedIpaAcceptV` leaf. The ternary assembly's special-soundness
-*extraction* is now likewise proven on the live flat path — `Soundness.Forking.Extractor.produceDeployed` /
-`deployed_forking_tree` recover the round points' `(g,U,W)` representation by Vandermonde from
-decomposition-free `DeployedForkValid` certificates; the *posited* node decomposition survives only on the
-legacy `ForkAccept`/`FiatShamirForking` route (`Soundness.Main`). What stays the irreducible residual is the
-random-oracle rewinding that *produces* the forked transcripts (with its query loss) — the honest floor; the
-structural fold this module proves is the part downstream of having the transcripts.
+`Soundness.Forking.Extractor` separately recovers each round point's `(g, U, W)` coefficients from
+three forks. Random-oracle rewinding and its query loss remain outside this structural step.
 -/
 
 namespace Zcash.Snark
 
 variable {F G : Type*} [Field F] [AddCommGroup G] [Module F G]
 
-/-- The IPA rounds' contribution to the verifier equation: `Σⱼ ([uⱼ⁻¹] Lⱼ + [uⱼ] Rⱼ)`, pairing each prover
-round `(Lⱼ, Rⱼ)` with its challenge `uⱼ`. This is the `roundSum` term of `deployed_verification_eq`'s closed
-form, named so the per-round closed-form fold (`CF_cons`, below) can peel it. -/
+/-- The sum `Σⱼ ([uⱼ⁻¹]Lⱼ + [uⱼ]Rⱼ)` contributed by the IPA rounds. -/
 def roundSum (rounds : List (G × G)) (u : List F) : G :=
   ((rounds.zip u).map (fun p => p.2⁻¹ • p.1.1 + p.2 • p.1.2)).sum
 
@@ -57,17 +31,14 @@ def roundSum (rounds : List (G × G)) (u : List F) : G :=
 @[simp] theorem roundSum_nil_challenges (rounds : List (G × G)) : roundSum rounds ([] : List F) = 0 := by
   simp [roundSum, List.zip_nil_right]
 
-/-- One round peels off the head of the round-sum: `roundSum ((L,R) :: rounds) (u₀ :: u) = ([u₀⁻¹]L + [u₀]R)
-+ roundSum rounds u`. The keystone of the per-round closed-form fold — the head term folds into the
-commitment, the tail is the folded instance's round-sum. -/
+/-- Split the first round's contribution from `roundSum`. -/
 theorem roundSum_cons (L R : G) (rounds : List (G × G)) (u₀ : F) (u : List F) :
     roundSum ((L, R) :: rounds) (u₀ :: u) = (u₀⁻¹ • L + u₀ • R) + roundSum rounds u := by
   simp [roundSum]
 
 /-! ## The `computeB` round recursion (the `b`-value fold) -/
 
-/-- The `computeB` fold's running point after `|u|` rounds is `x ^ (2 ^ |u|)` (it squares each round). The
-auxiliary tracking the second fold component, needed to peel `computeB`'s leading round. -/
+/-- The second `computeB` accumulator after `|u|` rounds is `x ^ (2 ^ |u|)`. -/
 theorem computeB_pt {F : Type*} [CommRing F] (x : F) (u : List F) :
     (u.reverse.foldl (fun acc uⱼ => (acc.1 * (1 + uⱼ * acc.2), acc.2 * acc.2)) ((1 : F), x)).2
       = x ^ (2 ^ u.length) := by
@@ -77,9 +48,7 @@ theorem computeB_pt {F : Type*} [CommRing F] (x : F) (u : List F) :
     rw [List.reverse_cons, List.foldl_append, List.foldl_cons, List.foldl_nil, ih,
       List.length_cons, ← pow_add, pow_succ, Nat.mul_two]
 
-/-- One round of `computeB`: the leading challenge `u₀` contributes the factor `1 + u₀ · x ^ (2 ^ |tail|)` to
-the product over the remaining challenges. The `b`-value fold underlying the deployed IPA's `[-c·b·z]U`
-coefficient, peeled alongside the generators and the round-sum. -/
+/-- Split the leading challenge's factor from `computeB`. -/
 theorem computeB_cons {F : Type*} [CommRing F] (x u₀ : F) (tail : List F) :
     computeB x (u₀ :: tail) = computeB x tail * (1 + u₀ * x ^ (2 ^ tail.length)) := by
   rw [computeB, computeB, List.reverse_cons, List.foldl_append, List.foldl_cons, List.foldl_nil,
@@ -87,20 +56,14 @@ theorem computeB_cons {F : Type*} [CommRing F] (x u₀ : F) (tail : List F) :
 
 /-! ## The commitment/generator side of the closed-form equation folds per round
 
-The closed-form verifier equation (`deployed_verification_eq`) is `gPart + [-c·b·z]·U + [-f]·W`, where the
-`gPart` collects the adjusted commitment, the round-sum, and the folded generator. The `U`/`W` terms do not
-fold per round (the `computeB` value is global, `computeB_cons`); the `gPart` does, and that fold is the
-commitment/generator recursion the deployed tree (`DeployedIpaAcceptV`) runs on. -/
+`gPart` contains the adjusted commitment, round sum, and folded generator. It follows the same
+per-round commitment and generator recursion as `DeployedIpaAcceptV`. -/
 
-/-- The commitment/generator side of the deployed verifier equation: the adjusted commitment `P'`, plus the
-round-sum, plus `[-c]` times the folded generator `foldAll`. (The `U`/`W`/value terms are handled separately
-at the leaf.) -/
+/-- The adjusted commitment, IPA round sum, and final folded-generator term. -/
 def gPart (rounds : List (G × G)) (u : List F) (g : Fin (2 ^ u.length) → G) (P' : G) (c : F) : G :=
   P' + roundSum rounds u + (-c) • foldAll u g 0
 
-/-- One round of the commitment/generator fold: the leading round `(L₀, R₀)` folds into the commitment
-(`P' ↦ P' + [u₀⁻¹]L₀ + [u₀]R₀`) and the generators by `foldGens g u₀⁻¹`, leaving the remaining-rounds
-`gPart`. This is exactly the deployed tree's per-node commitment/generator fold. -/
+/-- Fold the first round point into the commitment and generators. -/
 theorem gPart_cons (L R : G) (rounds : List (G × G)) (u₀ : F) (u : List F)
     (g : Fin (2 ^ (u₀ :: u).length) → G) (P' : G) (c : F) :
     gPart ((L, R) :: rounds) (u₀ :: u) g P' c
@@ -110,15 +73,11 @@ theorem gPart_cons (L R : G) (rounds : List (G × G)) (u₀ : F) (u : List F)
 
 /-! ## The eval-vector fold telescopes to `computeB`
 
-The deployed tree (`DeployedIpaAcceptV`) folds the eval vector `b = (1, x, x², …)` by `foldGens b uᵢ` per
-round and reads the single leaf value `b₀`. The flat verifier equation's `U`-coefficient is the global
-product `computeB`. Folding `evalVector` one round multiplies it by the scalar `1 + u⁻¹·x^(2^k)` and halves
-its length, so folding through all rounds telescopes the leaf `b₀` to a `computeB`-shaped product — the
-bridge between the recursive `b`-fold and the flat `computeB`. -/
+The recursive verifier folds `b = (1, x, x², …)` to one value. The lemmas below show that this value
+is the flat verifier's `computeB x u`.
+-/
 
-/-- One round of the eval-vector fold: folding `evalVector (k+1) x` by `foldGens · u` scales it by the factor
-`1 + u⁻¹·x^(2^k)` and drops to `evalVector k x`. (The same fold the generators undergo, on the value side.)
-This is the per-round factor whose product over all rounds is `computeB`. -/
+/-- One eval-vector fold produces a shorter eval vector and one scalar factor. -/
 theorem foldGens_evalVector {F : Type*} [Field F] (k : ℕ) (x u : F) :
     foldGens (evalVector (k + 1) x) u = (1 + u⁻¹ * x ^ (2 ^ k)) • evalVector k x := by
   funext i
@@ -126,27 +85,21 @@ theorem foldGens_evalVector {F : Type*} [Field F] (k : ℕ) (x u : F) :
   rw [pow_add]
   ring
 
-/-- `foldGens` is linear in the vector: folding a scaled vector scales the fold. The eval-vector fold picks
-up a scalar factor each round (`foldGens_evalVector`), and this carries that factor out through the
-remaining rounds. -/
+/-- `foldGens` commutes with scalar multiplication. -/
 theorem foldGens_smul {F : Type*} [Field F] {k : ℕ} (c : F) (b : Fin (2 ^ (k + 1)) → F) (v : F) :
     foldGens (c • b) v = c • foldGens b v := by
   funext i
   simp only [foldGens, Pi.add_apply, Pi.smul_apply, loHalf, hiHalf, smul_eq_mul]
   ring
 
-/-- `foldAll` is linear in the vector (it is iterated `foldGens`): the per-round scalar factors the
-eval-vector fold accumulates pull out to a single scalar on the fully-folded value. -/
+/-- `foldAll` commutes with scalar multiplication. -/
 theorem foldAll_smul {F : Type*} [Field F] (c : F) (u : List F) (b : Fin (2 ^ u.length) → F) :
     foldAll (G := F) u (c • b) = c • foldAll (G := F) u b := by
   induction u with
   | nil => rfl
   | cons u₀ rest ih => rw [foldAll, foldGens_smul, ih, foldAll]
 
-/-- **The value bridge.** Folding the eval vector `b = (1, x, x², …)` through challenges `u` by `foldAll`
-(the inverse-convention fold, `foldGens · uⱼ⁻¹`) telescopes its single leaf value to exactly the flat
-`computeB x u`. This identifies the deployed tree's recursive `b`-fold (read at the leaf as `b₀`) with the
-flat verifier equation's global `U`-coefficient, the keystone of the closed-form↔tree bridge. -/
+/-- Folding the eval vector through all challenges gives `computeB x u`. -/
 theorem foldAll_evalVector {F : Type*} [Field F] (x : F) (u : List F) :
     foldAll (G := F) u (evalVector u.length x) (0 : Fin (2 ^ 0)) = computeB x u := by
   induction u with
@@ -159,32 +112,17 @@ theorem foldAll_evalVector {F : Type*} [Field F] (x : F) (u : List F) :
 
 /-! ## The closed-form verifier equation folds one round (the keystone)
 
-`CF` is the closed-form verifier equation's left-hand side, abstracted over the value/blinding coefficients:
-`gPart` (the commitment/generator side) plus `[Uc]·U + [Wc]·W`. For the deployed equation the coefficients
-are `Uc = -c·computeB·z` and `Wc = -f`.
+`CF` is the flat verifier equation with abstract `U` and `W` coefficients. `CF_cons` shows that a
+round point represented over `(g, U, W)` folds the commitment, value, and blinding exactly as the
+deployed tree does.
+-/
 
-The keystone `CF_cons` folds it one round, given the prover's round point `L`/`R` in their **`(g, U, W)`
-representation** `L = Lg + [Lv]·U + [Lw]·W`, `R = Rg + [Rv]·U + [Rw]·W` (the decomposition the extractor
-recovers from the forked transcripts). The commitment/generator side folds by `gPart_cons`; the value
-coefficient `Uc` and blinding coefficient `Wc` fold **additively** — `Uc ↦ Uc + u₀⁻¹·Lv + u₀·Rv`,
-`Wc ↦ Wc + u₀⁻¹·Lw + u₀·Rw` — because the `U`/`W` parts of `[u₀⁻¹]L + [u₀]R` peel out of the commitment slot.
-This is exactly the deployed tree's per-node fold of `(P, v, blind)`, with `Uc` tracking `z·v` and `Wc`
-tracking the blinding. The structural fold is unconditional; the cryptographic content (which `Lv`/`Rv`/… the
-prover is committed to) lives in the extractor that supplies the representation. -/
-
-/-- The closed-form verifier equation's left-hand side, abstracted over the value/blinding coefficients:
-the commitment/generator side `gPart` plus `[Uc]·U + [Wc]·W`. The deployed equation is `CF … = 0` with
-`Uc = -c·computeB·z`, `Wc = -f`. -/
+/-- The flat verifier equation with abstract coefficients for `U` and `W`. -/
 def CF (rounds : List (G × G)) (u : List F) (g : Fin (2 ^ u.length) → G) (P : G) (c : F)
     (Uc : F) (U : G) (Wc : F) (W : G) : G :=
   gPart rounds u g P c + Uc • U + Wc • W
 
-/-- **The closed-form one-round fold.** Given the leading round point in its `(g, U, W)` representation
-`L = Lg + [Lv]U + [Lw]W`, `R = Rg + [Rv]U + [Rw]W`, one round of the closed-form equation folds to the
-remaining-rounds closed form of the folded instance: the generators fold by `foldGens g u₀⁻¹`, the
-commitment by its `g`-part `P + [u₀⁻¹]Lg + [u₀]Rg`, and the value/blinding coefficients fold additively
-(`Uc ↦ Uc + u₀⁻¹·Lv + u₀·Rv`, `Wc ↦ Wc + u₀⁻¹·Lw + u₀·Rw`). The deployed tree's per-node fold of `P`, `v`,
-`blind` in one identity. -/
+/-- Fold one represented round point through the flat verifier equation. -/
 theorem CF_cons (Lg Rg U W : G) (Lv Lw Rv Rw : F) (rounds : List (G × G)) (u₀ : F) (u : List F)
     (g : Fin (2 ^ (u₀ :: u).length) → G) (P : G) (c Uc Wc : F) :
     CF ((Lg + Lv • U + Lw • W, Rg + Rv • U + Rw • W) :: rounds) (u₀ :: u) g P c Uc U Wc W
@@ -197,18 +135,11 @@ theorem CF_cons (Lg Rg U W : G) (Lv Lw Rv Rw : F) (rounds : List (G × G)) (u₀
 
 /-! ## Leaf reconciliation: the depth-0 closed form is the deployed tree's leaf check
 
-At depth 0 the generators are a single point `g 0` and the closed form has folded all rounds. With the value
-coefficient set to the deployed reference `Uc = -(z · b₀)` (where `b₀ = commitGen b (·↦c)` is the folded eval
-value, `foldAll_evalVector`) and `Wc = -f`, and the folded commitment given in its `(g, U, W)` representation
-`P = ⟨aP, g⟩ + [z·v]U + [blind]W`, the closed-form equation `CF [] [] g P c Uc U Wc W = 0` rearranges to
-exactly halo2's reformulated leaf relation — the `DeployedIpaAcceptV` leaf. This is where `z ≠ 0` is needed
-downstream (`NontrivialRelation.ofLeafPeel`) to cancel the `U`-side; here the reconciliation is the pure
-rearrangement. -/
+At depth zero, the flat equation rearranges to the deployed IPA leaf check. This step is pure group
+algebra; the later peel uses `z ≠ 0`.
+-/
 
-/-- **Leaf reconciliation.** The depth-0 closed-form equation, with the folded commitment in its `(g, U, W)`
-representation `P = ⟨aP, g⟩ + [z·v]U + [blind]W` and value coefficient `-(z·b₀)`, is the deployed tree's
-reformulated leaf check `DeployedIpaAcceptV g b U W z ⟨aP,g⟩ v blind (leaf c f)`: the closed form rearranges
-to `⟨aP,g⟩ + [z·v]U + [blind]W = ⟨c,g⟩ + [z·c·b₀]U + [f]W`. -/
+/-- Convert the depth-zero flat equation to the deployed IPA leaf check. -/
 theorem CF_leaf_to_acceptV (g : Fin (2 ^ 0) → G) (b : Fin (2 ^ 0) → F) (U W : G) (z : F)
     (aP : Fin (2 ^ 0) → F) (v blind c f : F)
     (hCF : CF [] [] g (commitGen g aP + (z * v) • U + blind • W) c
@@ -222,24 +153,11 @@ theorem CF_leaf_to_acceptV (g : Fin (2 ^ 0) → G) (b : Fin (2 ^ 0) → F) (U W 
 
 /-! ## The tree assembly: the forking output yields `DeployedIpaAcceptV`
 
-`DeployedIpaTreeV` is a 3-ary special-soundness object, so it cannot come from a single accepting transcript:
-the forking procedure supplies, at each IPA round, three accepting continuations with a shared prefix and
-distinct nonzero challenges. `ForkAccept` packages exactly that forking output — the same recursion as
-`DeployedIpaAcceptV` (the verifier's per-round fold of `g`, `b`, `P`, the value and the blinding) but with
-the *flat closed-form equation* at each leaf (an accepting transcript) in place of the reformulated check.
+`ForkAccept` records three accepting continuations at each round and a flat verifier equation at each
+leaf. `forkAccept_to_acceptV` converts those leaves and assembles `DeployedIpaAcceptV`.
+-/
 
-`forkAccept_to_acceptV` is the deterministic assembly: it threads the recursion down to the leaves and
-reconciles each via `CF_leaf_to_acceptV`, turning the forking output into `DeployedIpaAcceptV` — from which
-`NontrivialRelation.ofDeployedTree` and `ipa_soundV` extract a witness. This discharges the tree-assembly
-content of the Fiat–Shamir bridge: what stays is supplying `ForkAccept` itself (the rewinding that produces
-the distinct-challenge transcripts and pins each round point's `(g,U,W)` representation), the random-oracle
-floor. -/
-
-/-- The forking procedure's output, recursive over the special-soundness tree: the same per-round fold as
-`DeployedIpaAcceptV`, but each leaf carries the *flat closed-form verifier equation* (`CF … = 0`, an
-accepting transcript) with its commitment opening `aP`, rather than the reformulated leaf check. A node
-records three accepting continuations at distinct nonzero challenges `u₁, u₂, u₃` (the 3-special-soundness
-forking). -/
+/-- A ternary fork tree with the flat verifier equation at each leaf. -/
 def ForkAccept : {d : ℕ} → (Fin (2 ^ d) → G) → (Fin (2 ^ d) → F) → G → G → F → G → F → F →
     DeployedIpaTreeV F G d → Prop
   | 0, g, b, U, W, z, P, v, blind, .leaf c f aP =>
@@ -254,12 +172,7 @@ def ForkAccept : {d : ℕ} → (Fin (2 ^ d) → G) → (Fin (2 ^ d) → F) → G
         ForkAccept (foldGens g u₃) (foldGens b u₃) U W z
           (P + u₃⁻¹ • L + u₃ • R) (v + u₃⁻¹ • Lv + u₃ • Rv) (blind + u₃⁻¹ • Lw + u₃ • Rw) t₃
 
-/-- **The tree assembly.** The forking output `ForkAccept` yields the deployed accept predicate
-`DeployedIpaAcceptV`. By induction on the tree: each node's per-round fold is identical, and each leaf's flat
-closed-form equation is reconciled to the reformulated leaf check by `CF_leaf_to_acceptV`. This is the
-deterministic, `sorry`/`axiom`-free discharge of the tree-assembly handwave: the forking *output* is the
-input, and `DeployedIpaAcceptV` is the proven consequence — from which `NontrivialRelation.ofDeployedTree`
-and `ipa_soundV` extract an opening. -/
+/-- Convert a `ForkAccept` tree to the deployed recursive acceptance predicate. -/
 theorem forkAccept_to_acceptV {U W : G} {z : F} :
     {d : ℕ} → (g : Fin (2 ^ d) → G) → (b : Fin (2 ^ d) → F) → (P : G) → (v blind : F) →
       (t : DeployedIpaTreeV F G d) → ForkAccept g b U W z P v blind t →
@@ -277,17 +190,11 @@ theorem forkAccept_to_acceptV {U W : G} {z : F} :
 
 /-! ## The adjusted-commitment connection: halo2's verifier equation is the closed form
 
-The forking development runs on the closed form `CF`. To tie it to halo2's actual deployed verifier equation
-`DeployedIpaVerifierEq`, this identifies the two: the verifier equation *is* `CF = 0` with the
-**adjusted commitment** `P' = multiopen + [-v]g₀ + [ξ]S` (the value term `[-v]g₀` and the blinding poly `[ξ]S`
-folded into the commitment slot), `Uc = -c·b·z`, `Wc = -f`, over the proof's round points and IPA challenges.
-It is a pure reordering of the same seven group terms (`abel`). -/
+The forking proof uses `CF`. The theorem below shows that halo2's deployed verifier equation is the
+same expression with its adjusted commitment and concrete coefficients.
+-/
 
-/-- **halo2's verifier equation is the closed form.** `DeployedIpaVerifierEq` holds iff the closed-form
-equation `CF = 0` does, with the adjusted commitment `P' = multiopen + [-v]g₀ + [ξ]S`, `Uc = -c·b·z`,
-`Wc = -f`, on the proof's IPA rounds and challenges. The two are the same seven-term sum reordered — the
-deterministic bridge putting the forking machinery (`CF_cons`, the value bridge, leaf reconciliation) onto
-halo2's actual equation. -/
+/-- Halo2's deployed IPA verifier equation is the closed form `CF = 0`. -/
 theorem deployedVerifierEq_cf {shape : Shape} [DecidableEq F] [DecidableEq G] [Inhabited G]
     (g : Fin (2 ^ shape.k) → G) (w u : G)
     (vk : VerifyingKey shape F G) (ps : ProofString shape F G) (ch : Challenges shape.k F) :

--- a/Zcash/Snark/Soundness/Forking/Assembly.lean
+++ b/Zcash/Snark/Soundness/Forking/Assembly.lean
@@ -1,0 +1,301 @@
+import Zcash.Snark.Soundness.Deployed.Verification
+import Zcash.Snark.Soundness.Deployed.IpaPeel
+
+/-!
+# Structural special-soundness assembly (eliminating the monolithic `FiatShamirTree`)
+
+`FiatShamirTree` currently assumes, in one opaque step, that an accepting deployed verifier equation yields a
+`DeployedIpaTreeV` with `DeployedIpaAcceptV`. That bundles (i) the random-oracle / rewinding *forking* — a
+cryptographic assumption that genuinely cannot be discharged in Lean — with (ii) a purely **structural**
+bridge from accepting transcripts to the recursive ternary IPA tree, which is a proof-engineering problem,
+not handwaving. This module builds (ii), so the residual shrinks to (i) alone.
+
+## Roadmap (the structural bridge, built on the existing fold foundations)
+
+The flat verifier equation `DeployedIpaVerifierEq` is `(closed form) = 0`, where the closed form
+(`deployed_verification_eq`) is `P' + roundSum + [-c·b·z]U + [-f]W + [-c]·G'₀` with `P' = multiopen − [v]g₀ +
+[ξ]S` the adjusted commitment. The recursive `DeployedIpaAcceptV` folds `P` by `(L,R,u)` per round down to a
+leaf check. Bridging them:
+
+1. **round-sum recursion** (`roundSum_cons`) — `roundSum` peels one `([uⱼ⁻¹]Lⱼ + [uⱼ]Rⱼ)` term per round.
+2. **generator/value fold recursion** — `foldAll`, `foldGens`, `computeS_cons` already give the `g`/`b`
+   one-round fold (`Soundness.Deployed.Fold`, `Soundness.IpaSoundness`).
+3. **`computeB` one-round recursion** (`computeB_cons`) — the `b`-value fold (the `[-c·b·z]U` coefficient).
+4. **one-round closed-form fold** (`CF_cons`) — combine 1–3: with the round point in its `(g,U,W)`
+   representation, the closed form at challenge `u₀` equals the closed form of the folded instance
+   `(foldGens g u₀⁻¹, P + u₀⁻¹Lg + u₀Rg, …)` over the remaining rounds, the value/blinding coefficients
+   folding additively. The eval-vector fold telescopes to `computeB` (`foldAll_evalVector`, the value bridge).
+5. **leaf reconciliation** (`CF_leaf_to_acceptV`) — at depth 0 (single generator) the closed form `= 0` gives
+   the `DeployedIpaAcceptV` leaf, with the folded commitment in its `(g,U,W)` representation and the value
+   carried on `U` via `z` (the form `NontrivialRelation.ofLeafPeel` then peels, sound for `z ≠ 0`).
+6. **ternary assembly** — three transcripts diverging at distinct nonzero `u` (the forking output) give a
+   `DeployedIpaTreeV` node via Vandermonde (`vandermonde3`, `ipa_round_commit_sound`), recursed to the tree.
+
+Steps 1–5 are proven below: the closed-form verifier equation folds round by round into the recursive tree
+structure and reconciles to the `DeployedIpaAcceptV` leaf. Step 6's special-soundness *extraction* is now
+likewise proven on the live flat path — `Soundness.Forking.Extractor.produceDeployed` /
+`deployed_forking_tree` recover the round points' `(g,U,W)` representation by Vandermonde from
+decomposition-free `DeployedForkValid` certificates; the *posited* node decomposition survives only on the
+legacy `ForkAccept`/`FiatShamirForking` route (`Soundness.Main`). What stays the irreducible residual is
+the random-oracle rewinding that *produces* the forked transcripts (with its query loss) — the honest
+floor; the structural fold this module proves is the part downstream of having the transcripts.
+-/
+
+namespace Zcash.Snark
+
+variable {F G : Type*} [Field F] [AddCommGroup G] [Module F G]
+
+/-- The IPA rounds' contribution to the verifier equation: `Σⱼ ([uⱼ⁻¹] Lⱼ + [uⱼ] Rⱼ)`, pairing each prover
+round `(Lⱼ, Rⱼ)` with its challenge `uⱼ`. This is the `roundSum` term of `deployed_verification_eq`'s closed
+form, named so the per-round fold (step 4 of the roadmap) can peel it. -/
+def roundSum (rounds : List (G × G)) (u : List F) : G :=
+  ((rounds.zip u).map (fun p => p.2⁻¹ • p.1.1 + p.2 • p.1.2)).sum
+
+@[simp] theorem roundSum_nil_rounds (u : List F) : roundSum ([] : List (G × G)) u = 0 := by
+  simp [roundSum]
+
+@[simp] theorem roundSum_nil_challenges (rounds : List (G × G)) : roundSum rounds ([] : List F) = 0 := by
+  simp [roundSum, List.zip_nil_right]
+
+/-- One round peels off the head of the round-sum: `roundSum ((L,R) :: rounds) (u₀ :: u) = ([u₀⁻¹]L + [u₀]R)
++ roundSum rounds u`. The keystone of the per-round closed-form fold — the head term folds into the
+commitment, the tail is the folded instance's round-sum. -/
+theorem roundSum_cons (L R : G) (rounds : List (G × G)) (u₀ : F) (u : List F) :
+    roundSum ((L, R) :: rounds) (u₀ :: u) = (u₀⁻¹ • L + u₀ • R) + roundSum rounds u := by
+  simp [roundSum]
+
+/-! ## Step 3 — the `computeB` round recursion (the `b`-value fold) -/
+
+/-- The `computeB` fold's running point after `|u|` rounds is `x ^ (2 ^ |u|)` (it squares each round). The
+auxiliary tracking the second fold component, needed to peel `computeB`'s leading round. -/
+theorem computeB_pt {F : Type*} [CommRing F] (x : F) (u : List F) :
+    (u.reverse.foldl (fun acc uⱼ => (acc.1 * (1 + uⱼ * acc.2), acc.2 * acc.2)) ((1 : F), x)).2
+      = x ^ (2 ^ u.length) := by
+  induction u with
+  | nil => simp
+  | cons u₀ tail ih =>
+    rw [List.reverse_cons, List.foldl_append, List.foldl_cons, List.foldl_nil, ih,
+      List.length_cons, ← pow_add, pow_succ, Nat.mul_two]
+
+/-- One round of `computeB`: the leading challenge `u₀` contributes the factor `1 + u₀ · x ^ (2 ^ |tail|)` to
+the product over the remaining challenges. The `b`-value fold underlying the deployed IPA's `[-c·b·z]U`
+coefficient, peeled in step with the generators and the round-sum. -/
+theorem computeB_cons {F : Type*} [CommRing F] (x u₀ : F) (tail : List F) :
+    computeB x (u₀ :: tail) = computeB x tail * (1 + u₀ * x ^ (2 ^ tail.length)) := by
+  rw [computeB, computeB, List.reverse_cons, List.foldl_append, List.foldl_cons, List.foldl_nil,
+    ← computeB_pt x tail]
+
+/-! ## Step 4a — the commitment/generator side of the closed-form equation folds per round
+
+The closed-form verifier equation (`deployed_verification_eq`) is `gPart + [-c·b·z]·U + [-f]·W`, where the
+`gPart` collects the adjusted commitment, the round-sum, and the folded generator. The `U`/`W` terms do not
+fold per round (the `computeB` value is global, `computeB_cons`); the `gPart` does, and that fold is the
+commitment/generator recursion the deployed tree (`DeployedIpaAcceptV`) runs on. -/
+
+/-- The commitment/generator side of the deployed verifier equation: the adjusted commitment `P'`, plus the
+round-sum, plus `[-c]` times the folded generator `foldAll`. (The `U`/`W`/value terms are handled separately
+at the leaf.) -/
+def gPart (rounds : List (G × G)) (u : List F) (g : Fin (2 ^ u.length) → G) (P' : G) (c : F) : G :=
+  P' + roundSum rounds u + (-c) • foldAll u g 0
+
+/-- One round of the commitment/generator fold: the leading round `(L₀, R₀)` folds into the commitment
+(`P' ↦ P' + [u₀⁻¹]L₀ + [u₀]R₀`) and the generators by `foldGens g u₀⁻¹`, leaving the remaining-rounds
+`gPart`. This is exactly the deployed tree's per-node commitment/generator fold. -/
+theorem gPart_cons (L R : G) (rounds : List (G × G)) (u₀ : F) (u : List F)
+    (g : Fin (2 ^ (u₀ :: u).length) → G) (P' : G) (c : F) :
+    gPart ((L, R) :: rounds) (u₀ :: u) g P' c
+      = gPart rounds u (foldGens g u₀⁻¹) (P' + u₀⁻¹ • L + u₀ • R) c := by
+  simp only [gPart, roundSum_cons, foldAll]
+  abel
+
+/-! ## Step 4b — the eval-vector fold telescopes to `computeB`
+
+The deployed tree (`DeployedIpaAcceptV`) folds the eval vector `b = (1, x, x², …)` by `foldGens b uᵢ` per
+round and reads the single leaf value `b₀`. The flat verifier equation's `U`-coefficient is the global
+product `computeB`. Folding `evalVector` one round multiplies it by the scalar `1 + u⁻¹·x^(2^k)` and halves
+its length, so folding through all rounds telescopes the leaf `b₀` to a `computeB`-shaped product — the
+bridge between the recursive `b`-fold and the flat `computeB`. -/
+
+/-- One round of the eval-vector fold: folding `evalVector (k+1) x` by `foldGens · u` scales it by the factor
+`1 + u⁻¹·x^(2^k)` and drops to `evalVector k x`. (The same fold the generators undergo, on the value side.)
+This is the per-round step whose product over all rounds is `computeB`. -/
+theorem foldGens_evalVector {F : Type*} [Field F] (k : ℕ) (x u : F) :
+    foldGens (evalVector (k + 1) x) u = (1 + u⁻¹ * x ^ (2 ^ k)) • evalVector k x := by
+  funext i
+  simp only [foldGens, Pi.add_apply, Pi.smul_apply, loHalf, hiHalf, evalVector, smul_eq_mul]
+  rw [pow_add]
+  ring
+
+/-- `foldGens` is linear in the vector: folding a scaled vector scales the fold. The eval-vector fold picks
+up a scalar factor each round (`foldGens_evalVector`), and this carries that factor out through the
+remaining rounds. -/
+theorem foldGens_smul {F : Type*} [Field F] {k : ℕ} (c : F) (b : Fin (2 ^ (k + 1)) → F) (v : F) :
+    foldGens (c • b) v = c • foldGens b v := by
+  funext i
+  simp only [foldGens, Pi.add_apply, Pi.smul_apply, loHalf, hiHalf, smul_eq_mul]
+  ring
+
+/-- `foldAll` is linear in the vector (it is iterated `foldGens`): the per-round scalar factors the
+eval-vector fold accumulates pull out to a single scalar on the fully-folded value. -/
+theorem foldAll_smul {F : Type*} [Field F] (c : F) (u : List F) (b : Fin (2 ^ u.length) → F) :
+    foldAll (G := F) u (c • b) = c • foldAll (G := F) u b := by
+  induction u with
+  | nil => rfl
+  | cons u₀ rest ih => rw [foldAll, foldGens_smul, ih, foldAll]
+
+/-- **The value bridge.** Folding the eval vector `b = (1, x, x², …)` through challenges `u` by `foldAll`
+(the inverse-convention fold, `foldGens · uⱼ⁻¹`) telescopes its single leaf value to exactly the flat
+`computeB x u`. This identifies the deployed tree's recursive `b`-fold (read at the leaf as `b₀`) with the
+flat verifier equation's global `U`-coefficient, the keystone of the closed-form↔tree bridge. -/
+theorem foldAll_evalVector {F : Type*} [Field F] (x : F) (u : List F) :
+    foldAll (G := F) u (evalVector u.length x) (0 : Fin (2 ^ 0)) = computeB x u := by
+  induction u with
+  | nil => simp [foldAll, evalVector, computeB]
+  | cons u₀ rest ih =>
+    rw [foldAll]
+    simp only [List.length_cons]
+    rw [foldGens_evalVector, inv_inv, foldAll_smul, Pi.smul_apply, ih, smul_eq_mul, computeB_cons]
+    ring
+
+/-! ## Step 4 — the closed-form verifier equation folds one round (the keystone)
+
+`CF` is the closed-form verifier equation's left-hand side, abstracted over the value/blinding coefficients:
+`gPart` (the commitment/generator side) plus `[Uc]·U + [Wc]·W`. For the deployed equation the coefficients
+are `Uc = -c·computeB·z` and `Wc = -f`.
+
+The keystone `CF_cons` folds it one round, given the prover's round point `L`/`R` in their **`(g, U, W)`
+representation** `L = Lg + [Lv]·U + [Lw]·W`, `R = Rg + [Rv]·U + [Rw]·W` (the decomposition the extractor
+recovers from the forked transcripts). The commitment/generator side folds by `gPart_cons`; the value
+coefficient `Uc` and blinding coefficient `Wc` fold **additively** — `Uc ↦ Uc + u₀⁻¹·Lv + u₀·Rv`,
+`Wc ↦ Wc + u₀⁻¹·Lw + u₀·Rw` — because the `U`/`W` parts of `[u₀⁻¹]L + [u₀]R` peel out of the commitment slot.
+This is exactly the deployed tree's per-node fold of `(P, v, blind)`, with `Uc` tracking `z·v` and `Wc`
+tracking the blinding. The structural fold is unconditional; the cryptographic content (which `Lv`/`Rv`/… the
+prover is committed to) lives in the extractor that supplies the representation. -/
+
+/-- The closed-form verifier equation's left-hand side, abstracted over the value/blinding coefficients:
+the commitment/generator side `gPart` plus `[Uc]·U + [Wc]·W`. The deployed equation is `CF … = 0` with
+`Uc = -c·computeB·z`, `Wc = -f`. -/
+def CF (rounds : List (G × G)) (u : List F) (g : Fin (2 ^ u.length) → G) (P : G) (c : F)
+    (Uc : F) (U : G) (Wc : F) (W : G) : G :=
+  gPart rounds u g P c + Uc • U + Wc • W
+
+/-- **The closed-form one-round fold.** Given the leading round point in its `(g, U, W)` representation
+`L = Lg + [Lv]U + [Lw]W`, `R = Rg + [Rv]U + [Rw]W`, one round of the closed-form equation folds to the
+remaining-rounds closed form of the folded instance: the generators fold by `foldGens g u₀⁻¹`, the
+commitment by its `g`-part `P + [u₀⁻¹]Lg + [u₀]Rg`, and the value/blinding coefficients fold additively
+(`Uc ↦ Uc + u₀⁻¹·Lv + u₀·Rv`, `Wc ↦ Wc + u₀⁻¹·Lw + u₀·Rw`). The deployed tree's per-node fold of `P`, `v`,
+`blind` in one identity. -/
+theorem CF_cons (Lg Rg U W : G) (Lv Lw Rv Rw : F) (rounds : List (G × G)) (u₀ : F) (u : List F)
+    (g : Fin (2 ^ (u₀ :: u).length) → G) (P : G) (c Uc Wc : F) :
+    CF ((Lg + Lv • U + Lw • W, Rg + Rv • U + Rw • W) :: rounds) (u₀ :: u) g P c Uc U Wc W
+      = CF rounds u (foldGens g u₀⁻¹) (P + u₀⁻¹ • Lg + u₀ • Rg) c
+          (Uc + u₀⁻¹ * Lv + u₀ * Rv) U (Wc + u₀⁻¹ * Lw + u₀ * Rw) W := by
+  simp only [CF]
+  rw [gPart_cons]
+  simp only [gPart]
+  module
+
+/-! ## Step 5 — leaf reconciliation: the depth-0 closed form is the deployed tree's leaf check
+
+At depth 0 the generators are a single point `g 0` and the closed form has folded all rounds. With the value
+coefficient set to the deployed reference `Uc = -(z · b₀)` (where `b₀ = commitGen b (·↦c)` is the folded eval
+value, `foldAll_evalVector`) and `Wc = -f`, and the folded commitment given in its `(g, U, W)` representation
+`P = ⟨aP, g⟩ + [z·v]U + [blind]W`, the closed-form equation `CF [] [] g P c Uc U Wc W = 0` rearranges to
+exactly halo2's reformulated leaf relation — the `DeployedIpaAcceptV` leaf. This is where `z ≠ 0` is needed
+downstream (`NontrivialRelation.ofLeafPeel`) to cancel the `U`-side; here the reconciliation is the pure rearrangement. -/
+
+/-- **Leaf reconciliation.** The depth-0 closed-form equation, with the folded commitment in its `(g, U, W)`
+representation `P = ⟨aP, g⟩ + [z·v]U + [blind]W` and value coefficient `-(z·b₀)`, is the deployed tree's
+reformulated leaf check `DeployedIpaAcceptV g b U W z ⟨aP,g⟩ v blind (leaf c f)`: the closed form rearranges
+to `⟨aP,g⟩ + [z·v]U + [blind]W = ⟨c,g⟩ + [z·c·b₀]U + [f]W`. -/
+theorem CF_leaf_to_acceptV (g : Fin (2 ^ 0) → G) (b : Fin (2 ^ 0) → F) (U W : G) (z : F)
+    (aP : Fin (2 ^ 0) → F) (v blind c f : F)
+    (hCF : CF [] [] g (commitGen g aP + (z * v) • U + blind • W) c
+              (-(z * commitGen b (fun _ => c))) U (-f) W = 0) :
+    DeployedIpaAcceptV g b U W z (commitGen g aP) v blind (.leaf c f aP) := by
+  refine ⟨rfl, ?_⟩
+  have hg : commitGen g (fun _ => c) = c • g 0 := by simp [commitGen]
+  rw [hg, ← sub_eq_zero, ← hCF]
+  simp only [CF, gPart, roundSum, foldAll, List.zip_nil_left, List.map_nil, List.sum_nil, add_zero]
+  module
+
+/-! ## Step 6 — the tree assembly: the forking output yields `DeployedIpaAcceptV`
+
+`DeployedIpaTreeV` is a 3-ary special-soundness object, so it cannot come from a single accepting transcript:
+the forking procedure supplies, at each IPA round, three accepting continuations with a shared prefix and
+distinct nonzero challenges. `ForkAccept` packages exactly that forking output — the same recursion as
+`DeployedIpaAcceptV` (the verifier's per-round fold of `g`, `b`, `P`, the value and the blinding) but with
+the *flat closed-form equation* at each leaf (an accepting transcript) in place of the reformulated check.
+
+`forkAccept_to_acceptV` is the deterministic assembly: it threads the recursion down to the leaves and
+reconciles each via `CF_leaf_to_acceptV`, turning the forking output into `DeployedIpaAcceptV` — which
+`NontrivialRelation.ofDeployedTree` + `ipa_soundV` then extract a witness from. This discharges the tree-assembly content
+of the Fiat–Shamir bridge: what stays is supplying `ForkAccept` itself (the rewinding that produces the
+distinct-challenge transcripts and pins each round point's `(g,U,W)` representation), the random-oracle floor. -/
+
+/-- The forking procedure's output, recursive over the special-soundness tree: the same per-round fold as
+`DeployedIpaAcceptV`, but each leaf carries the *flat closed-form verifier equation* (`CF … = 0`, an
+accepting transcript) with its commitment opening `aP`, rather than the reformulated leaf check. A node
+records three accepting continuations at distinct nonzero challenges `u₁, u₂, u₃` (the 3-special-soundness
+forking). -/
+def ForkAccept : {d : ℕ} → (Fin (2 ^ d) → G) → (Fin (2 ^ d) → F) → G → G → F → G → F → F →
+    DeployedIpaTreeV F G d → Prop
+  | 0, g, b, U, W, z, P, v, blind, .leaf c f aP =>
+      P = commitGen g aP ∧
+        CF [] [] g (P + (z * v) • U + blind • W) c (-(z * commitGen b (fun _ => c))) U (-f) W = 0
+  | _ + 1, g, b, U, W, z, P, v, blind, .node L R Lv Rv Lw Rw u₁ u₂ u₃ t₁ t₂ t₃ =>
+      u₁ ≠ u₂ ∧ u₁ ≠ u₃ ∧ u₂ ≠ u₃ ∧ u₁ ≠ 0 ∧ u₂ ≠ 0 ∧ u₃ ≠ 0 ∧
+        ForkAccept (foldGens g u₁) (foldGens b u₁) U W z
+          (P + u₁⁻¹ • L + u₁ • R) (v + u₁⁻¹ • Lv + u₁ • Rv) (blind + u₁⁻¹ • Lw + u₁ • Rw) t₁ ∧
+        ForkAccept (foldGens g u₂) (foldGens b u₂) U W z
+          (P + u₂⁻¹ • L + u₂ • R) (v + u₂⁻¹ • Lv + u₂ • Rv) (blind + u₂⁻¹ • Lw + u₂ • Rw) t₂ ∧
+        ForkAccept (foldGens g u₃) (foldGens b u₃) U W z
+          (P + u₃⁻¹ • L + u₃ • R) (v + u₃⁻¹ • Lv + u₃ • Rv) (blind + u₃⁻¹ • Lw + u₃ • Rw) t₃
+
+/-- **The tree assembly.** The forking output `ForkAccept` yields the deployed accept predicate
+`DeployedIpaAcceptV`. By induction on the tree: each node's per-round fold is identical, and each leaf's flat
+closed-form equation is reconciled to the reformulated leaf check by `CF_leaf_to_acceptV`. This is the
+deterministic, `sorry`/`axiom`-free discharge of the tree-assembly handwave — the forking *output* is the
+input, and the recursive `DeployedIpaAcceptV` (hence, via `NontrivialRelation.ofDeployedTree`/`ipa_soundV`, an opening) is
+the proven consequence. -/
+theorem forkAccept_to_acceptV {U W : G} {z : F} :
+    {d : ℕ} → (g : Fin (2 ^ d) → G) → (b : Fin (2 ^ d) → F) → (P : G) → (v blind : F) →
+      (t : DeployedIpaTreeV F G d) → ForkAccept g b U W z P v blind t →
+      DeployedIpaAcceptV g b U W z P v blind t
+  | 0, g, b, P, v, blind, .leaf c f aP, h => by
+      obtain ⟨hP, hCF⟩ := h
+      rw [hP] at hCF ⊢
+      exact CF_leaf_to_acceptV g b U W z aP v blind c f hCF
+  | _ + 1, g, b, P, v, blind, .node L R Lv Rv Lw Rw u₁ u₂ u₃ t₁ t₂ t₃, h => by
+      obtain ⟨h12, h13, h23, hu₁, hu₂, hu₃, ha₁, ha₂, ha₃⟩ := h
+      exact ⟨h12, h13, h23, hu₁, hu₂, hu₃,
+        forkAccept_to_acceptV _ _ _ _ _ t₁ ha₁,
+        forkAccept_to_acceptV _ _ _ _ _ t₂ ha₂,
+        forkAccept_to_acceptV _ _ _ _ _ t₃ ha₃⟩
+
+/-! ## The adjusted-commitment connection: halo2's verifier equation is the closed form
+
+The forking development runs on the closed form `CF`. To tie it to halo2's actual deployed verifier equation
+`DeployedIpaVerifierEq`, this step identifies the two: the verifier equation *is* `CF = 0` with the
+**adjusted commitment** `P' = multiopen + [-v]g₀ + [ξ]S` (the value term `[-v]g₀` and the blinding poly `[ξ]S`
+folded into the commitment slot), `Uc = -c·b·z`, `Wc = -f`, over the proof's round points and IPA challenges.
+It is a pure reordering of the same seven group terms (`abel`). -/
+
+/-- **halo2's verifier equation is the closed form.** `DeployedIpaVerifierEq` holds iff the closed-form
+equation `CF = 0` does, with the adjusted commitment `P' = multiopen + [-v]g₀ + [ξ]S`, `Uc = -c·b·z`,
+`Wc = -f`, on the proof's IPA rounds and challenges. The two are the same seven-term sum reordered — the
+deterministic bridge putting the forking machinery (`CF_cons`, the value bridge, leaf reconciliation) onto
+halo2's actual equation. -/
+theorem deployedVerifierEq_cf {shape : Shape} [DecidableEq F] [DecidableEq G] [Inhabited G]
+    (g : Fin (2 ^ shape.k) → G) (w u : G)
+    (vk : VerifyingKey shape F G) (ps : ProofString shape F G) (ch : Challenges shape.k F) :
+    DeployedIpaVerifierEq g w u vk ps ch ↔
+      CF (List.ofFn ps.ipaRounds) (List.ofFn ch.ipaRound)
+          (fun j => g (Fin.cast (congrArg (2 ^ ·) List.length_ofFn) j))
+          (multiopenCommitment g w u vk ps ch
+            + (∑ i, ([-(multiopenValue vk ps ch)].getD i.val 0) • g i) + ch.xi • ps.ipaS)
+          ps.ipaC (-ps.ipaC * computeB ch.x3 (List.ofFn ch.ipaRound) * ch.z) u (-ps.ipaF) w = 0 := by
+  unfold DeployedIpaVerifierEq CF gPart roundSum multiopenCommitment multiopenValue
+  constructor <;> intro h <;> linear_combination (norm := abel) h
+
+end Zcash.Snark

--- a/Zcash/Snark/Soundness/Forking/Assembly.lean
+++ b/Zcash/Snark/Soundness/Forking/Assembly.lean
@@ -4,7 +4,7 @@ import Zcash.Snark.Soundness.Deployed.IpaPeel
 /-!
 # Structural special-soundness assembly (eliminating the monolithic `FiatShamirTree`)
 
-`FiatShamirTree` currently assumes, in one opaque step, that an accepting deployed verifier equation yields a
+`FiatShamirTree` currently assumes, as one opaque bundle, that an accepting deployed verifier equation yields a
 `DeployedIpaTreeV` with `DeployedIpaAcceptV`. That bundles (i) the random-oracle / rewinding *forking* — a
 cryptographic assumption that genuinely cannot be discharged in Lean — with (ii) a purely **structural**
 bridge from accepting transcripts to the recursive ternary IPA tree, which is a proof-engineering problem,
@@ -31,14 +31,14 @@ leaf check. Bridging them:
 6. **ternary assembly** — three transcripts diverging at distinct nonzero `u` (the forking output) give a
    `DeployedIpaTreeV` node via Vandermonde (`vandermonde3`, `ipa_round_commit_sound`), recursed to the tree.
 
-Steps 1–5 are proven below: the closed-form verifier equation folds round by round into the recursive tree
-structure and reconciles to the `DeployedIpaAcceptV` leaf. Step 6's special-soundness *extraction* is now
-likewise proven on the live flat path — `Soundness.Forking.Extractor.produceDeployed` /
+Parts 1–5 are proven below: the closed-form verifier equation folds round by round into the recursive tree
+structure and reconciles to the `DeployedIpaAcceptV` leaf. The ternary assembly's special-soundness
+*extraction* is now likewise proven on the live flat path — `Soundness.Forking.Extractor.produceDeployed` /
 `deployed_forking_tree` recover the round points' `(g,U,W)` representation by Vandermonde from
 decomposition-free `DeployedForkValid` certificates; the *posited* node decomposition survives only on the
-legacy `ForkAccept`/`FiatShamirForking` route (`Soundness.Main`). What stays the irreducible residual is
-the random-oracle rewinding that *produces* the forked transcripts (with its query loss) — the honest
-floor; the structural fold this module proves is the part downstream of having the transcripts.
+legacy `ForkAccept`/`FiatShamirForking` route (`Soundness.Main`). What stays the irreducible residual is the
+random-oracle rewinding that *produces* the forked transcripts (with its query loss) — the honest floor; the
+structural fold this module proves is the part downstream of having the transcripts.
 -/
 
 namespace Zcash.Snark
@@ -47,7 +47,7 @@ variable {F G : Type*} [Field F] [AddCommGroup G] [Module F G]
 
 /-- The IPA rounds' contribution to the verifier equation: `Σⱼ ([uⱼ⁻¹] Lⱼ + [uⱼ] Rⱼ)`, pairing each prover
 round `(Lⱼ, Rⱼ)` with its challenge `uⱼ`. This is the `roundSum` term of `deployed_verification_eq`'s closed
-form, named so the per-round fold (step 4 of the roadmap) can peel it. -/
+form, named so the per-round closed-form fold (`CF_cons`, below) can peel it. -/
 def roundSum (rounds : List (G × G)) (u : List F) : G :=
   ((rounds.zip u).map (fun p => p.2⁻¹ • p.1.1 + p.2 • p.1.2)).sum
 
@@ -64,7 +64,7 @@ theorem roundSum_cons (L R : G) (rounds : List (G × G)) (u₀ : F) (u : List F)
     roundSum ((L, R) :: rounds) (u₀ :: u) = (u₀⁻¹ • L + u₀ • R) + roundSum rounds u := by
   simp [roundSum]
 
-/-! ## Step 3 — the `computeB` round recursion (the `b`-value fold) -/
+/-! ## The `computeB` round recursion (the `b`-value fold) -/
 
 /-- The `computeB` fold's running point after `|u|` rounds is `x ^ (2 ^ |u|)` (it squares each round). The
 auxiliary tracking the second fold component, needed to peel `computeB`'s leading round. -/
@@ -79,13 +79,13 @@ theorem computeB_pt {F : Type*} [CommRing F] (x : F) (u : List F) :
 
 /-- One round of `computeB`: the leading challenge `u₀` contributes the factor `1 + u₀ · x ^ (2 ^ |tail|)` to
 the product over the remaining challenges. The `b`-value fold underlying the deployed IPA's `[-c·b·z]U`
-coefficient, peeled in step with the generators and the round-sum. -/
+coefficient, peeled alongside the generators and the round-sum. -/
 theorem computeB_cons {F : Type*} [CommRing F] (x u₀ : F) (tail : List F) :
     computeB x (u₀ :: tail) = computeB x tail * (1 + u₀ * x ^ (2 ^ tail.length)) := by
   rw [computeB, computeB, List.reverse_cons, List.foldl_append, List.foldl_cons, List.foldl_nil,
     ← computeB_pt x tail]
 
-/-! ## Step 4a — the commitment/generator side of the closed-form equation folds per round
+/-! ## The commitment/generator side of the closed-form equation folds per round
 
 The closed-form verifier equation (`deployed_verification_eq`) is `gPart + [-c·b·z]·U + [-f]·W`, where the
 `gPart` collects the adjusted commitment, the round-sum, and the folded generator. The `U`/`W` terms do not
@@ -108,7 +108,7 @@ theorem gPart_cons (L R : G) (rounds : List (G × G)) (u₀ : F) (u : List F)
   simp only [gPart, roundSum_cons, foldAll]
   abel
 
-/-! ## Step 4b — the eval-vector fold telescopes to `computeB`
+/-! ## The eval-vector fold telescopes to `computeB`
 
 The deployed tree (`DeployedIpaAcceptV`) folds the eval vector `b = (1, x, x², …)` by `foldGens b uᵢ` per
 round and reads the single leaf value `b₀`. The flat verifier equation's `U`-coefficient is the global
@@ -118,7 +118,7 @@ bridge between the recursive `b`-fold and the flat `computeB`. -/
 
 /-- One round of the eval-vector fold: folding `evalVector (k+1) x` by `foldGens · u` scales it by the factor
 `1 + u⁻¹·x^(2^k)` and drops to `evalVector k x`. (The same fold the generators undergo, on the value side.)
-This is the per-round step whose product over all rounds is `computeB`. -/
+This is the per-round factor whose product over all rounds is `computeB`. -/
 theorem foldGens_evalVector {F : Type*} [Field F] (k : ℕ) (x u : F) :
     foldGens (evalVector (k + 1) x) u = (1 + u⁻¹ * x ^ (2 ^ k)) • evalVector k x := by
   funext i
@@ -157,7 +157,7 @@ theorem foldAll_evalVector {F : Type*} [Field F] (x : F) (u : List F) :
     rw [foldGens_evalVector, inv_inv, foldAll_smul, Pi.smul_apply, ih, smul_eq_mul, computeB_cons]
     ring
 
-/-! ## Step 4 — the closed-form verifier equation folds one round (the keystone)
+/-! ## The closed-form verifier equation folds one round (the keystone)
 
 `CF` is the closed-form verifier equation's left-hand side, abstracted over the value/blinding coefficients:
 `gPart` (the commitment/generator side) plus `[Uc]·U + [Wc]·W`. For the deployed equation the coefficients
@@ -195,14 +195,15 @@ theorem CF_cons (Lg Rg U W : G) (Lv Lw Rv Rw : F) (rounds : List (G × G)) (u₀
   simp only [gPart]
   module
 
-/-! ## Step 5 — leaf reconciliation: the depth-0 closed form is the deployed tree's leaf check
+/-! ## Leaf reconciliation: the depth-0 closed form is the deployed tree's leaf check
 
 At depth 0 the generators are a single point `g 0` and the closed form has folded all rounds. With the value
 coefficient set to the deployed reference `Uc = -(z · b₀)` (where `b₀ = commitGen b (·↦c)` is the folded eval
 value, `foldAll_evalVector`) and `Wc = -f`, and the folded commitment given in its `(g, U, W)` representation
 `P = ⟨aP, g⟩ + [z·v]U + [blind]W`, the closed-form equation `CF [] [] g P c Uc U Wc W = 0` rearranges to
 exactly halo2's reformulated leaf relation — the `DeployedIpaAcceptV` leaf. This is where `z ≠ 0` is needed
-downstream (`NontrivialRelation.ofLeafPeel`) to cancel the `U`-side; here the reconciliation is the pure rearrangement. -/
+downstream (`NontrivialRelation.ofLeafPeel`) to cancel the `U`-side; here the reconciliation is the pure
+rearrangement. -/
 
 /-- **Leaf reconciliation.** The depth-0 closed-form equation, with the folded commitment in its `(g, U, W)`
 representation `P = ⟨aP, g⟩ + [z·v]U + [blind]W` and value coefficient `-(z·b₀)`, is the deployed tree's
@@ -219,7 +220,7 @@ theorem CF_leaf_to_acceptV (g : Fin (2 ^ 0) → G) (b : Fin (2 ^ 0) → F) (U W 
   simp only [CF, gPart, roundSum, foldAll, List.zip_nil_left, List.map_nil, List.sum_nil, add_zero]
   module
 
-/-! ## Step 6 — the tree assembly: the forking output yields `DeployedIpaAcceptV`
+/-! ## The tree assembly: the forking output yields `DeployedIpaAcceptV`
 
 `DeployedIpaTreeV` is a 3-ary special-soundness object, so it cannot come from a single accepting transcript:
 the forking procedure supplies, at each IPA round, three accepting continuations with a shared prefix and
@@ -228,10 +229,11 @@ distinct nonzero challenges. `ForkAccept` packages exactly that forking output �
 the *flat closed-form equation* at each leaf (an accepting transcript) in place of the reformulated check.
 
 `forkAccept_to_acceptV` is the deterministic assembly: it threads the recursion down to the leaves and
-reconciles each via `CF_leaf_to_acceptV`, turning the forking output into `DeployedIpaAcceptV` — which
-`NontrivialRelation.ofDeployedTree` + `ipa_soundV` then extract a witness from. This discharges the tree-assembly content
-of the Fiat–Shamir bridge: what stays is supplying `ForkAccept` itself (the rewinding that produces the
-distinct-challenge transcripts and pins each round point's `(g,U,W)` representation), the random-oracle floor. -/
+reconciles each via `CF_leaf_to_acceptV`, turning the forking output into `DeployedIpaAcceptV` — from which
+`NontrivialRelation.ofDeployedTree` and `ipa_soundV` extract a witness. This discharges the tree-assembly
+content of the Fiat–Shamir bridge: what stays is supplying `ForkAccept` itself (the rewinding that produces
+the distinct-challenge transcripts and pins each round point's `(g,U,W)` representation), the random-oracle
+floor. -/
 
 /-- The forking procedure's output, recursive over the special-soundness tree: the same per-round fold as
 `DeployedIpaAcceptV`, but each leaf carries the *flat closed-form verifier equation* (`CF … = 0`, an
@@ -255,9 +257,9 @@ def ForkAccept : {d : ℕ} → (Fin (2 ^ d) → G) → (Fin (2 ^ d) → F) → G
 /-- **The tree assembly.** The forking output `ForkAccept` yields the deployed accept predicate
 `DeployedIpaAcceptV`. By induction on the tree: each node's per-round fold is identical, and each leaf's flat
 closed-form equation is reconciled to the reformulated leaf check by `CF_leaf_to_acceptV`. This is the
-deterministic, `sorry`/`axiom`-free discharge of the tree-assembly handwave — the forking *output* is the
-input, and the recursive `DeployedIpaAcceptV` (hence, via `NontrivialRelation.ofDeployedTree`/`ipa_soundV`, an opening) is
-the proven consequence. -/
+deterministic, `sorry`/`axiom`-free discharge of the tree-assembly handwave: the forking *output* is the
+input, and `DeployedIpaAcceptV` is the proven consequence — from which `NontrivialRelation.ofDeployedTree`
+and `ipa_soundV` extract an opening. -/
 theorem forkAccept_to_acceptV {U W : G} {z : F} :
     {d : ℕ} → (g : Fin (2 ^ d) → G) → (b : Fin (2 ^ d) → F) → (P : G) → (v blind : F) →
       (t : DeployedIpaTreeV F G d) → ForkAccept g b U W z P v blind t →
@@ -276,7 +278,7 @@ theorem forkAccept_to_acceptV {U W : G} {z : F} :
 /-! ## The adjusted-commitment connection: halo2's verifier equation is the closed form
 
 The forking development runs on the closed form `CF`. To tie it to halo2's actual deployed verifier equation
-`DeployedIpaVerifierEq`, this step identifies the two: the verifier equation *is* `CF = 0` with the
+`DeployedIpaVerifierEq`, this identifies the two: the verifier equation *is* `CF = 0` with the
 **adjusted commitment** `P' = multiopen + [-v]g₀ + [ξ]S` (the value term `[-v]g₀` and the blinding poly `[ξ]S`
 folded into the commitment slot), `Uc = -c·b·z`, `Wc = -f`, over the proof's round points and IPA challenges.
 It is a pure reordering of the same seven group terms (`abel`). -/

--- a/Zcash/Snark/Soundness/Forking/Extractor.lean
+++ b/Zcash/Snark/Soundness/Forking/Extractor.lean
@@ -4,17 +4,11 @@ import Zcash.Snark.Soundness.Forking.Tree
 import Zcash.Snark.Soundness.Forking.Probability
 
 /-!
-# The deployed special-soundness extractor (Fiat–Shamir forking, part 2)
+# Recover a deployed IPA tree from three forks
 
-Building `ForkAccept` from the forking output needs each node's value/blinding cross-terms `Lv/Rv/Lw/Rw`
-recovered from the three accepting continuations. `ipa_round_commit_with_coeffs` already *cancels* arbitrary
-`L`/`R` cross-terms by Vandermonde and recovers the parent commitment; this module supplies the *recovery*
-counterpart for the scalar value/blinding fold: given the three folded scalars at distinct nonzero
-challenges, the parent scalar and its two cross-terms exist and fold back to them.
-
-`vandermonde3_recover` is the scalar 3-special-soundness recovery: the linear map
-`(v, Lv, Rv) ↦ (v + uᵢ⁻¹·Lv + uᵢ·Rv)ᵢ` is injective at three distinct nonzero challenges (a quadratic with
-three roots is zero), hence surjective, so any triple of folded values is hit.
+Three accepting continuations determine a parent commitment and its two round terms. The same
+Vandermonde calculation recovers the parent value, blinding, and their round terms. This module uses
+those recoveries to build a root-consistent deployed IPA tree.
 -/
 
 namespace Zcash.Snark
@@ -22,11 +16,7 @@ namespace Zcash.Snark
 variable {F : Type*} [Field F]
 variable {G : Type*} [AddCommGroup G] [Module F G]
 
-/-- **Group 3-special-soundness recovery.** Given target folded commitments `P₁,P₂,P₃ : G` at three distinct
-nonzero challenges, there is a parent commitment `P` and cross-terms `L, R : G` with `P + uᵢ⁻¹•L + uᵢ•R = Pᵢ`.
-The commitment counterpart of `vandermonde3_recover`: the bottom-up extractor recovers each node's commitment
-and its two cross-terms from the three accepting continuations (the explicit Lagrange combination of the
-`Pᵢ`, with the same coefficients as the scalar recovery). -/
+/-- Recover a parent commitment and round terms from three folded commitments. -/
 def vandermonde3_recover_group {u₁ u₂ u₃ : F}
     (h12 : u₁ ≠ u₂) (h13 : u₁ ≠ u₃) (h23 : u₂ ≠ u₃) (hu₁ : u₁ ≠ 0) (hu₂ : u₂ ≠ 0) (hu₃ : u₃ ≠ 0)
     (P₁ P₂ P₃ : G) :
@@ -49,10 +39,7 @@ def vandermonde3_recover_group {u₁ u₂ u₃ : F}
             + (u₃ / ((u₃ - u₁) * (u₃ - u₂))) • P₃, ?_, ?_, ?_⟩ <;>
     match_scalars <;> field_simp <;> ring
 
-/-- **Uniqueness of the per-round recovery.** The fold map `(P, L, R) ↦ (P + uᵢ⁻¹•L + uᵢ•R)ᵢ` is injective at
-three distinct nonzero challenges: two roots folding to the same three children are equal. (A degree-≤2 system
-with an invertible Vandermonde matrix has a unique solution.) This pins the bottom-up recovered root — it is
-*the* instance consistent with the children, so it matches whatever the deployed verifier equation pins. -/
+/-- Three distinct nonzero challenges uniquely determine the parent and round terms. -/
 theorem fold_inj {u₁ u₂ u₃ : F} (h12 : u₁ ≠ u₂) (h13 : u₁ ≠ u₃) (h23 : u₂ ≠ u₃)
     (hu₁ : u₁ ≠ 0) (hu₂ : u₂ ≠ 0) (hu₃ : u₃ ≠ 0) {P L R P' L' R' : G}
     (e₁ : P + u₁⁻¹ • L + u₁ • R = P' + u₁⁻¹ • L' + u₁ • R')
@@ -89,10 +76,7 @@ theorem fold_inj {u₁ u₂ u₃ : F} (h12 : u₁ ≠ u₂) (h13 : u₁ ≠ u₃
   have hL : L - L' = 0 := by linear_combination (norm := module) f₁ - u₁ • hP - (u₁ * u₁) • hR
   exact ⟨sub_eq_zero.mp hP, sub_eq_zero.mp hL, sub_eq_zero.mp hR⟩
 
-/-- **Scalar 3-special-soundness recovery.** Given target folded values `t₁, t₂, t₃` at three distinct
-nonzero challenges, there is a parent value `v` and cross-terms `Lv, Rv` with `v + uᵢ⁻¹·Lv + uᵢ·Rv = tᵢ`.
-The value/blinding counterpart of `ipa_round_commit_with_coeffs`: the deployed tree's per-node `Lv/Rv`
-(resp. `Lw/Rw`) are pinned by the three accepting continuations. -/
+/-- Recover a parent scalar and round terms from three folded scalars. -/
 def vandermonde3_recover {u₁ u₂ u₃ : F}
     (h12 : u₁ ≠ u₂) (h13 : u₁ ≠ u₃) (h23 : u₂ ≠ u₃) (hu₁ : u₁ ≠ 0) (hu₂ : u₂ ≠ 0) (hu₃ : u₃ ≠ 0)
     (t₁ t₂ t₃ : F) :
@@ -117,28 +101,18 @@ def vandermonde3_recover {u₁ u₂ u₃ : F}
 
 /-! ## The root-consistent producer: threading the deployed commitment
 
-To pin the extracted root to the deployed commitment — rather than a *free* root, disconnected from the
-deployed instance — we thread the deployed commitment-*whole* `Pwhole = P + [z·v]U + [blind]W` top-down.
-`DForkCert`/`DeployedForkValid` carry, at each node, the prover's round point `(L, R)` (the rewound
-transcript's commitment) so the whole folds by it; at each leaf they assert the flat verifier leaf equation
-for the folded whole. The producer `produceDeployed` recovers the cross-terms bottom-up by Vandermonde and
-additionally proves the recovered root whole *equals* `Pwhole`: the recovered whole and `Pwhole` fold to the
-same three child wholes, so `fold_inj` forces them equal. This is root consistency — the residual collapses to
-supplying `DeployedForkValid` (the rewinding) and Blake2b. -/
+`DForkCert` stores the prover's round points and three challenges at each node. `DeployedForkValid`
+threads the deployed commitment through every path. `produceDeployed` recovers the tree bottom-up and
+uses `fold_inj` to prove that its root is the original deployed commitment.
+-/
 
-/-- A deployed forking certificate: the prover's round point `(L, R)` at each node (the rewound transcript's
-commitment), the three challenges, and the final opening `(c, f)` at each leaf. It carries the round points,
-so the deployed commitment-whole can be folded by them top-down rather than recovered. -/
+/-- A fork tree containing each round point, three challenges, and each leaf opening. -/
 inductive DForkCert (F G : Type*) : ℕ → Type _ where
   | leaf : F → F → DForkCert F G 0
   | node {d : ℕ} : G → G → F → F → F →
       DForkCert F G d → DForkCert F G d → DForkCert F G d → DForkCert F G (d + 1)
 
-/-- The deployed forking acceptance condition: the deployed commitment-whole `Pwhole`, folded by the prover's
-round points `(L, R)` down each path, satisfies the flat verifier leaf equation
-`Pwhole = ⟨c,g⟩ + [z·⟨c,b⟩]U + [f]W` at every leaf (with distinct nonzero challenges at each node). The forking
-output stated *about the deployed instance* — the rewound transcripts accept against the threaded deployed
-commitment, with no decomposition posited. -/
+/-- Every path in a fork certificate satisfies the deployed flat verifier equation. -/
 def DeployedForkValid : {d : ℕ} → (Fin (2 ^ d) → G) → (Fin (2 ^ d) → F) → (U W : G) → (z : F) → G →
     DForkCert F G d → Prop
   | 0, g, b, U, W, z, Pwhole, .leaf c f =>
@@ -149,12 +123,7 @@ def DeployedForkValid : {d : ℕ} → (Fin (2 ^ d) → G) → (Fin (2 ^ d) → F
         DeployedForkValid (foldGens g u₂) (foldGens b u₂) U W z (Pwhole + u₂⁻¹ • L + u₂ • R) c₂ ∧
         DeployedForkValid (foldGens g u₃) (foldGens b u₃) U W z (Pwhole + u₃⁻¹ • L + u₃ • R) c₃
 
-/-- **The root-consistent deployed producer.** Threading the deployed commitment-whole `Pwhole`, a valid
-deployed forking output yields a transcript tree with `DeployedIpaAcceptV` whose recovered root whole
-`P + [z·v]U + [blind]W` is *exactly* `Pwhole`. The cross-terms are recovered bottom-up by Vandermonde; the
-root whole is pinned by `fold_inj` — it and `Pwhole` fold to the same three child
-wholes (the recursion's invariant), so they coincide. No posited decomposition, and the root is the deployed
-commitment, not a free one: root consistency, proven. -/
+/-- Build an accepting deployed IPA tree whose recovered root equals `Pwhole`. -/
 def produceDeployed {U W : G} {z : F} : {d : ℕ} → (g : Fin (2 ^ d) → G) → (b : Fin (2 ^ d) → F) →
     (Pwhole : G) → (cert : DForkCert F G d) → DeployedForkValid g b U W z Pwhole cert →
     Σ' (P : G) (v blind : F) (t : DeployedIpaTreeV F G d),
@@ -190,16 +159,9 @@ def produceDeployed {U W : G} {z : F} : {d : ℕ} → (g : Fin (2 ^ d) → G) �
           (key u₁ P₁ v₁ bl₁ eP₁ ev₁ eb₁ hw₁) (key u₂ P₂ v₂ bl₂ eP₂ ev₂ eb₂ hw₂)
           (key u₃ P₃ v₃ bl₃ eP₃ ev₃ eb₃ hw₃)).1
 
-/-- **Root-consistent extraction (the deployed `FiatShamirTree`), as a computable reduction.** Threading the
-deployed commitment-whole `⟨aDep, g⟩ + [z·vDep]U + [blindDep]W`, a valid deployed forking output *computes*
-either the deployed accept predicate for the deployed commitment `⟨aDep, g⟩` / value `vDep`, or a nontrivial
-`(g, U, W)` relation. `produceDeployed` gives a tree whose recovered root whole equals the deployed whole;
-`ipa_extractV` *computes* that root's opening witness (not the vacuous `∃`), and matching it against the
-deployed whole (`NontrivialRelation.ofCombinationCollision` — the binding branch) forces the recovered
-`(P, v)` to *be* the deployed `(⟨aDep,g⟩, vDep)`. Genuinely non-vacuous: this is a computable `def`
-(decidable `if`, no `Classical.choose`), so neither branch's *data* can be fabricated without the `cert` —
-the discrete-log preimage a prime-order vacuity witness would need is not computable. The residual is
-supplying `DeployedForkValid` (the rewinding) and the DLR/Blake2b hardness floor. -/
+/-- Compute either an accepting deployed IPA tree or a nontrivial `(g, U, W)` relation.
+
+The input certificate is explicit, and this definition uses no `Classical.choose`. -/
 def deployed_forking_tree [DecidableEq F] [DecidableEq G] {U W : G} {z : F} (hz : z ≠ 0)
     {d : ℕ} (g : Fin (2 ^ d) → G) (b : Fin (2 ^ d) → F) (aDep : Fin (2 ^ d) → F) (vDep blindDep : F)
     (cert : DForkCert F G d)
@@ -225,34 +187,18 @@ def deployed_forking_tree [DecidableEq F] [DecidableEq G] {U W : G} {z : F} (hz 
 
 /-! ## The prover-as-oracle-function model: from the abstract forking tree to `DeployedForkValid`
 
-`extractable_of_prob` (`Soundness.Forking.Probability`) gives a *bare* `(3,…,3)` challenge tree (`Extractable`)
-once the accept probability beats the knowledge error. To feed `produceDeployed`/`deployed_forking_tree`, that
-abstract tree must be filled with the prover's round points and openings — the data a `DForkCert` records.
+`extractable_of_prob` returns only a challenge tree. `Prover` supplies the round points and leaf
+openings chosen along each prefix. `proverAccept_forkValid` combines them into a `DForkCert`.
 
-`Prover` is the prover's strategy as a tree: at each round the cross-commitment `(L, R)` it sends *before* the
-challenge, then a continuation per challenge; at the leaf its final opening `(c, f)`. The tree shape enforces
-that the round point depends only on the prefix (the challenges already sent) — exactly the Fiat–Shamir
-prover-as-oracle-function structure, with the round point committed before the next challenge is squeezed.
+Connecting a real Fiat–Shamir adversary to this strategy type remains outside this module.
+-/
 
-`proverAccept` reads off the deployed accept condition along one challenge path: fold the deployed
-commitment-whole by the prover's round points down the path and check the flat verifier leaf equation.
-`proverAccept_forkValid` is the assembly: any `Extractable` tree for that accept predicate *is* a valid
-`DeployedForkValid` certificate — zip the prover's round points/openings with the tree's challenges. This is
-the deterministic bridge from the probabilistic forking tree to the deployed forking output; what stays the
-floor is that the *deployed* prover realizes this `Prover`/`proverAccept` shape (the faithful transcript
-model) and Blake2b-as-random-oracle. -/
-
-/-- A prover's strategy tree for the `d`-round IPA: at each round the cross-commitment `(L, R)` it sends
-*before* the challenge, then a continuation per challenge; at the leaf its final opening `(c, f)`. The tree
-shape enforces the Fiat–Shamir prefix-determination — the round point is fixed before the challenge. -/
+/-- A prefix-determined IPA prover strategy with round points and leaf openings. -/
 inductive Prover (F G : Type*) : ℕ → Type _ where
   | leaf : F → F → Prover F G 0
   | node {d : ℕ} : G → G → (F → Prover F G d) → Prover F G (d + 1)
 
-/-- The deployed accept condition along one challenge path `χ`: fold the deployed commitment-whole `Pwhole` by
-the prover's round points down `χ` (and the generators/eval-vector accordingly), then check the flat verifier
-leaf equation `Pwhole = ⟨c,g⟩ + [z·⟨c,b⟩]U + [f]W` at the bottom. The single-path version of
-`DeployedForkValid`, indexed by the prover strategy. -/
+/-- The deployed accept condition along one challenge path through a prover strategy. -/
 def proverAccept : {d : ℕ} → Prover F G d → (Fin (2 ^ d) → G) → (Fin (2 ^ d) → F) → (U W : G) → (z : F) → G →
     (Fin d → F) → Prop
   | 0, .leaf c f, g, b, U, W, z, Pwhole, _ =>
@@ -261,12 +207,7 @@ def proverAccept : {d : ℕ} → Prover F G d → (Fin (2 ^ d) → G) → (Fin (
       proverAccept (cont (χ 0)) (foldGens g (χ 0)) (foldGens b (χ 0)) U W z
         (Pwhole + (χ 0)⁻¹ • L + (χ 0) • R) (Fin.tail χ)
 
-/-- **The prover-as-oracle assembly.** A `(3,…,3)` `Extractable` tree for the prover's accept predicate yields
-a valid `DeployedForkValid` certificate: zip the prover's round points and openings with the tree's distinct
-challenges. By recursion on the prover/tree — each node takes its round point from the prover and its three
-challenges from `Extractable`, each leaf its opening from the prover, and the per-leaf accept conditions are
-exactly `Extractable`'s. This bridges the probabilistic forking tree (`extractable_of_prob`) to the deployed
-forking output that `deployed_forking_tree` consumes. -/
+/-- Combine an `Extractable` challenge tree with a prover strategy to obtain a valid fork certificate. -/
 theorem proverAccept_forkValid {U W : G} {z : F} : {d : ℕ} → (P : Prover F G d) → (g : Fin (2 ^ d) → G) →
     (b : Fin (2 ^ d) → F) → (Pwhole : G) → Extractable (proverAccept P g b U W z Pwhole) →
     ∃ cert : DForkCert F G d, DeployedForkValid g b U W z Pwhole cert

--- a/Zcash/Snark/Soundness/Forking/Extractor.lean
+++ b/Zcash/Snark/Soundness/Forking/Extractor.lean
@@ -10,9 +10,9 @@ Building `ForkAccept` from the forking output needs each node's value/blinding c
 recovered from the three accepting continuations. `ipa_round_commit_with_coeffs` already *cancels* arbitrary
 `L`/`R` cross-terms by Vandermonde and recovers the parent commitment; this module supplies the *recovery*
 counterpart for the scalar value/blinding fold: given the three folded scalars at distinct nonzero
-challenges, the parent scalar and its two cross-terms exist and interpolate them.
+challenges, the parent scalar and its two cross-terms exist and fold back to them.
 
-`vandermonde3_recover` is the scalar 3-special-soundness step: the linear map
+`vandermonde3_recover` is the scalar 3-special-soundness recovery: the linear map
 `(v, Lv, Rv) ↦ (v + uᵢ⁻¹·Lv + uᵢ·Rv)ᵢ` is injective at three distinct nonzero challenges (a quadratic with
 three roots is zero), hence surjective, so any triple of folded values is hit.
 -/
@@ -198,7 +198,7 @@ either the deployed accept predicate for the deployed commitment `⟨aDep, g⟩`
 deployed whole (`NontrivialRelation.ofCombinationCollision` — the binding branch) forces the recovered
 `(P, v)` to *be* the deployed `(⟨aDep,g⟩, vDep)`. Genuinely non-vacuous: this is a computable `def`
 (decidable `if`, no `Classical.choose`), so neither branch's *data* can be fabricated without the `cert` —
-the discrete-log preimage the reviewer's prime-order vacuity witness needs is not computable. The residual is
+the discrete-log preimage a prime-order vacuity witness would need is not computable. The residual is
 supplying `DeployedForkValid` (the rewinding) and the DLR/Blake2b hardness floor. -/
 def deployed_forking_tree [DecidableEq F] [DecidableEq G] {U W : G} {z : F} (hz : z ≠ 0)
     {d : ℕ} (g : Fin (2 ^ d) → G) (b : Fin (2 ^ d) → F) (aDep : Fin (2 ^ d) → F) (vDep blindDep : F)

--- a/Zcash/Snark/Soundness/Forking/Extractor.lean
+++ b/Zcash/Snark/Soundness/Forking/Extractor.lean
@@ -1,0 +1,285 @@
+import Zcash.Snark.Soundness.IpaSoundness
+import Zcash.Snark.Soundness.Deployed.IpaPeel
+import Zcash.Snark.Soundness.Forking.Tree
+import Zcash.Snark.Soundness.Forking.Probability
+
+/-!
+# The deployed special-soundness extractor (Fiat–Shamir forking, part 2)
+
+Building `ForkAccept` from the forking output needs each node's value/blinding cross-terms `Lv/Rv/Lw/Rw`
+recovered from the three accepting continuations. `ipa_round_commit_with_coeffs` already *cancels* arbitrary
+`L`/`R` cross-terms by Vandermonde and recovers the parent commitment; this module supplies the *recovery*
+counterpart for the scalar value/blinding fold: given the three folded scalars at distinct nonzero
+challenges, the parent scalar and its two cross-terms exist and interpolate them.
+
+`vandermonde3_recover` is the scalar 3-special-soundness step: the linear map
+`(v, Lv, Rv) ↦ (v + uᵢ⁻¹·Lv + uᵢ·Rv)ᵢ` is injective at three distinct nonzero challenges (a quadratic with
+three roots is zero), hence surjective, so any triple of folded values is hit.
+-/
+
+namespace Zcash.Snark
+
+variable {F : Type*} [Field F]
+variable {G : Type*} [AddCommGroup G] [Module F G]
+
+/-- **Group 3-special-soundness recovery.** Given target folded commitments `P₁,P₂,P₃ : G` at three distinct
+nonzero challenges, there is a parent commitment `P` and cross-terms `L, R : G` with `P + uᵢ⁻¹•L + uᵢ•R = Pᵢ`.
+The commitment counterpart of `vandermonde3_recover`: the bottom-up extractor recovers each node's commitment
+and its two cross-terms from the three accepting continuations (the explicit Lagrange combination of the
+`Pᵢ`, with the same coefficients as the scalar recovery). -/
+def vandermonde3_recover_group {u₁ u₂ u₃ : F}
+    (h12 : u₁ ≠ u₂) (h13 : u₁ ≠ u₃) (h23 : u₂ ≠ u₃) (hu₁ : u₁ ≠ 0) (hu₂ : u₂ ≠ 0) (hu₃ : u₃ ≠ 0)
+    (P₁ P₂ P₃ : G) :
+    Σ' (P L R : G), P + u₁⁻¹ • L + u₁ • R = P₁ ∧ P + u₂⁻¹ • L + u₂ • R = P₂
+      ∧ P + u₃⁻¹ • L + u₃ • R = P₃ := by
+  have d12 : u₁ - u₂ ≠ 0 := sub_ne_zero.mpr h12
+  have d13 : u₁ - u₃ ≠ 0 := sub_ne_zero.mpr h13
+  have d23 : u₂ - u₃ ≠ 0 := sub_ne_zero.mpr h23
+  have d21 : u₂ - u₁ ≠ 0 := sub_ne_zero.mpr h12.symm
+  have d31 : u₃ - u₁ ≠ 0 := sub_ne_zero.mpr h13.symm
+  have d32 : u₃ - u₂ ≠ 0 := sub_ne_zero.mpr h23.symm
+  refine ⟨(-(u₁ * (u₂ + u₃) / ((u₁ - u₂) * (u₁ - u₃)))) • P₁
+            + (-(u₂ * (u₁ + u₃) / ((u₂ - u₁) * (u₂ - u₃)))) • P₂
+            + (-(u₃ * (u₁ + u₂) / ((u₃ - u₁) * (u₃ - u₂)))) • P₃,
+          (u₁ * (u₂ * u₃) / ((u₁ - u₂) * (u₁ - u₃))) • P₁
+            + (u₂ * (u₁ * u₃) / ((u₂ - u₁) * (u₂ - u₃))) • P₂
+            + (u₃ * (u₁ * u₂) / ((u₃ - u₁) * (u₃ - u₂))) • P₃,
+          (u₁ / ((u₁ - u₂) * (u₁ - u₃))) • P₁
+            + (u₂ / ((u₂ - u₁) * (u₂ - u₃))) • P₂
+            + (u₃ / ((u₃ - u₁) * (u₃ - u₂))) • P₃, ?_, ?_, ?_⟩ <;>
+    match_scalars <;> field_simp <;> ring
+
+/-- **Uniqueness of the per-round recovery.** The fold map `(P, L, R) ↦ (P + uᵢ⁻¹•L + uᵢ•R)ᵢ` is injective at
+three distinct nonzero challenges: two roots folding to the same three children are equal. (A degree-≤2 system
+with an invertible Vandermonde matrix has a unique solution.) This pins the bottom-up recovered root — it is
+*the* instance consistent with the children, so it matches whatever the deployed verifier equation pins. -/
+theorem fold_inj {u₁ u₂ u₃ : F} (h12 : u₁ ≠ u₂) (h13 : u₁ ≠ u₃) (h23 : u₂ ≠ u₃)
+    (hu₁ : u₁ ≠ 0) (hu₂ : u₂ ≠ 0) (hu₃ : u₃ ≠ 0) {P L R P' L' R' : G}
+    (e₁ : P + u₁⁻¹ • L + u₁ • R = P' + u₁⁻¹ • L' + u₁ • R')
+    (e₂ : P + u₂⁻¹ • L + u₂ • R = P' + u₂⁻¹ • L' + u₂ • R')
+    (e₃ : P + u₃⁻¹ • L + u₃ • R = P' + u₃⁻¹ • L' + u₃ • R') :
+    P = P' ∧ L = L' ∧ R = R' := by
+  -- clear the inverses: fᵢ : uᵢ•(P-P') + (L-L') + (uᵢ*uᵢ)•(R-R') = 0
+  have f : ∀ u : F, u ≠ 0 → (P + u⁻¹ • L + u • R = P' + u⁻¹ • L' + u • R') →
+      u • (P - P') + (L - L') + (u * u) • (R - R') = 0 := by
+    intro u hu e
+    have h := congrArg (u • ·) (sub_eq_zero.mpr e)
+    simp only [smul_zero, smul_sub, smul_add, smul_smul, mul_inv_cancel₀ hu, one_smul] at h
+    rw [← h]; module
+  have f₁ := f u₁ hu₁ e₁
+  have f₂ := f u₂ hu₂ e₂
+  have f₃ := f u₃ hu₃ e₃
+  -- eliminate (L-L'): subtract pairs and factor out the nonzero difference
+  have g : ∀ u v : F, u ≠ v →
+      u • (P - P') + (u * u) • (R - R') = v • (P - P') + (v * v) • (R - R') →
+      (P - P') + (u + v) • (R - R') = 0 := by
+    intro u v huv e
+    have hd : u - v ≠ 0 := sub_ne_zero.mpr huv
+    have : (u - v) • ((P - P') + (u + v) • (R - R')) = 0 := by
+      rw [← sub_eq_zero] at e; rw [← e]; module
+    exact (smul_eq_zero.mp this).resolve_left hd
+  have g12 : (P - P') + (u₁ + u₂) • (R - R') = 0 := g u₁ u₂ h12 (by linear_combination (norm := module) f₁ - f₂)
+  have g13 : (P - P') + (u₁ + u₃) • (R - R') = 0 := g u₁ u₃ h13 (by linear_combination (norm := module) f₁ - f₃)
+  -- (u₂ - u₃)•(R-R') = 0 ⟹ R = R'
+  have hR : R - R' = 0 := by
+    have hd : u₂ - u₃ ≠ 0 := sub_ne_zero.mpr h23
+    have : (u₂ - u₃) • (R - R') = 0 := by linear_combination (norm := module) g12 - g13
+    exact (smul_eq_zero.mp this).resolve_left hd
+  have hP : P - P' = 0 := by linear_combination (norm := module) g12 - (u₁ + u₂) • hR
+  have hL : L - L' = 0 := by linear_combination (norm := module) f₁ - u₁ • hP - (u₁ * u₁) • hR
+  exact ⟨sub_eq_zero.mp hP, sub_eq_zero.mp hL, sub_eq_zero.mp hR⟩
+
+/-- **Scalar 3-special-soundness recovery.** Given target folded values `t₁, t₂, t₃` at three distinct
+nonzero challenges, there is a parent value `v` and cross-terms `Lv, Rv` with `v + uᵢ⁻¹·Lv + uᵢ·Rv = tᵢ`.
+The value/blinding counterpart of `ipa_round_commit_with_coeffs`: the deployed tree's per-node `Lv/Rv`
+(resp. `Lw/Rw`) are pinned by the three accepting continuations. -/
+def vandermonde3_recover {u₁ u₂ u₃ : F}
+    (h12 : u₁ ≠ u₂) (h13 : u₁ ≠ u₃) (h23 : u₂ ≠ u₃) (hu₁ : u₁ ≠ 0) (hu₂ : u₂ ≠ 0) (hu₃ : u₃ ≠ 0)
+    (t₁ t₂ t₃ : F) :
+    Σ' (v Lv Rv : F), v + u₁⁻¹ * Lv + u₁ * Rv = t₁ ∧ v + u₂⁻¹ * Lv + u₂ * Rv = t₂
+      ∧ v + u₃⁻¹ * Lv + u₃ * Rv = t₃ := by
+  have d12 : u₁ - u₂ ≠ 0 := sub_ne_zero.mpr h12
+  have d13 : u₁ - u₃ ≠ 0 := sub_ne_zero.mpr h13
+  have d23 : u₂ - u₃ ≠ 0 := sub_ne_zero.mpr h23
+  have d21 : u₂ - u₁ ≠ 0 := sub_ne_zero.mpr h12.symm
+  have d31 : u₃ - u₁ ≠ 0 := sub_ne_zero.mpr h13.symm
+  have d32 : u₃ - u₂ ≠ 0 := sub_ne_zero.mpr h23.symm
+  refine ⟨-(u₁ * t₁ * (u₂ + u₃) / ((u₁ - u₂) * (u₁ - u₃))
+            + u₂ * t₂ * (u₁ + u₃) / ((u₂ - u₁) * (u₂ - u₃))
+            + u₃ * t₃ * (u₁ + u₂) / ((u₃ - u₁) * (u₃ - u₂))),
+          u₁ * t₁ * (u₂ * u₃) / ((u₁ - u₂) * (u₁ - u₃))
+            + u₂ * t₂ * (u₁ * u₃) / ((u₂ - u₁) * (u₂ - u₃))
+            + u₃ * t₃ * (u₁ * u₂) / ((u₃ - u₁) * (u₃ - u₂)),
+          u₁ * t₁ / ((u₁ - u₂) * (u₁ - u₃))
+            + u₂ * t₂ / ((u₂ - u₁) * (u₂ - u₃))
+            + u₃ * t₃ / ((u₃ - u₁) * (u₃ - u₂)), ?_, ?_, ?_⟩ <;>
+    field_simp <;> ring
+
+/-! ## The root-consistent producer: threading the deployed commitment
+
+To pin the extracted root to the deployed commitment — rather than a *free* root, disconnected from the
+deployed instance — we thread the deployed commitment-*whole* `Pwhole = P + [z·v]U + [blind]W` top-down.
+`DForkCert`/`DeployedForkValid` carry, at each node, the prover's round point `(L, R)` (the rewound
+transcript's commitment) so the whole folds by it; at each leaf they assert the flat verifier leaf equation
+for the folded whole. The producer `produceDeployed` recovers the cross-terms bottom-up by Vandermonde and
+additionally proves the recovered root whole *equals* `Pwhole`: the recovered whole and `Pwhole` fold to the
+same three child wholes, so `fold_inj` forces them equal. This is root consistency — the residual collapses to
+supplying `DeployedForkValid` (the rewinding) and Blake2b. -/
+
+/-- A deployed forking certificate: the prover's round point `(L, R)` at each node (the rewound transcript's
+commitment), the three challenges, and the final opening `(c, f)` at each leaf. It carries the round points,
+so the deployed commitment-whole can be folded by them top-down rather than recovered. -/
+inductive DForkCert (F G : Type*) : ℕ → Type _ where
+  | leaf : F → F → DForkCert F G 0
+  | node {d : ℕ} : G → G → F → F → F →
+      DForkCert F G d → DForkCert F G d → DForkCert F G d → DForkCert F G (d + 1)
+
+/-- The deployed forking acceptance condition: the deployed commitment-whole `Pwhole`, folded by the prover's
+round points `(L, R)` down each path, satisfies the flat verifier leaf equation
+`Pwhole = ⟨c,g⟩ + [z·⟨c,b⟩]U + [f]W` at every leaf (with distinct nonzero challenges at each node). The forking
+output stated *about the deployed instance* — the rewound transcripts accept against the threaded deployed
+commitment, with no decomposition posited. -/
+def DeployedForkValid : {d : ℕ} → (Fin (2 ^ d) → G) → (Fin (2 ^ d) → F) → (U W : G) → (z : F) → G →
+    DForkCert F G d → Prop
+  | 0, g, b, U, W, z, Pwhole, .leaf c f =>
+      Pwhole = commitGen g (fun _ => c) + (z * commitGen b (fun _ => c)) • U + f • W
+  | _ + 1, g, b, U, W, z, Pwhole, .node L R u₁ u₂ u₃ c₁ c₂ c₃ =>
+      u₁ ≠ u₂ ∧ u₁ ≠ u₃ ∧ u₂ ≠ u₃ ∧ u₁ ≠ 0 ∧ u₂ ≠ 0 ∧ u₃ ≠ 0 ∧
+        DeployedForkValid (foldGens g u₁) (foldGens b u₁) U W z (Pwhole + u₁⁻¹ • L + u₁ • R) c₁ ∧
+        DeployedForkValid (foldGens g u₂) (foldGens b u₂) U W z (Pwhole + u₂⁻¹ • L + u₂ • R) c₂ ∧
+        DeployedForkValid (foldGens g u₃) (foldGens b u₃) U W z (Pwhole + u₃⁻¹ • L + u₃ • R) c₃
+
+/-- **The root-consistent deployed producer.** Threading the deployed commitment-whole `Pwhole`, a valid
+deployed forking output yields a transcript tree with `DeployedIpaAcceptV` whose recovered root whole
+`P + [z·v]U + [blind]W` is *exactly* `Pwhole`. The cross-terms are recovered bottom-up by Vandermonde; the
+root whole is pinned by `fold_inj` — it and `Pwhole` fold to the same three child
+wholes (the recursion's invariant), so they coincide. No posited decomposition, and the root is the deployed
+commitment, not a free one: root consistency, proven. -/
+def produceDeployed {U W : G} {z : F} : {d : ℕ} → (g : Fin (2 ^ d) → G) → (b : Fin (2 ^ d) → F) →
+    (Pwhole : G) → (cert : DForkCert F G d) → DeployedForkValid g b U W z Pwhole cert →
+    Σ' (P : G) (v blind : F) (t : DeployedIpaTreeV F G d),
+      DeployedIpaAcceptV g b U W z P v blind t ∧ P + (z * v) • U + blind • W = Pwhole
+  | 0, g, b, Pwhole, .leaf c f, hv =>
+      ⟨commitGen g (fun _ => c), commitGen b (fun _ => c), f, .leaf c f (fun _ => c), ⟨rfl, rfl⟩, hv.symm⟩
+  | d + 1, g, b, Pwhole, .node L R u₁ u₂ u₃ c₁ c₂ c₃, hv => by
+      obtain ⟨h12, h13, h23, hu₁, hu₂, hu₃, hv₁, hv₂, hv₃⟩ := hv
+      obtain ⟨P₁, v₁, bl₁, t₁, ha₁, hw₁⟩ := produceDeployed (foldGens g u₁) (foldGens b u₁) _ c₁ hv₁
+      obtain ⟨P₂, v₂, bl₂, t₂, ha₂, hw₂⟩ := produceDeployed (foldGens g u₂) (foldGens b u₂) _ c₂ hv₂
+      obtain ⟨P₃, v₃, bl₃, t₃, ha₃, hw₃⟩ := produceDeployed (foldGens g u₃) (foldGens b u₃) _ c₃ hv₃
+      obtain ⟨P, L', R', eP₁, eP₂, eP₃⟩ := vandermonde3_recover_group h12 h13 h23 hu₁ hu₂ hu₃ P₁ P₂ P₃
+      obtain ⟨v, Lv, Rv, ev₁, ev₂, ev₃⟩ := vandermonde3_recover h12 h13 h23 hu₁ hu₂ hu₃ v₁ v₂ v₃
+      obtain ⟨blind, Lw, Rw, eb₁, eb₂, eb₃⟩ := vandermonde3_recover h12 h13 h23 hu₁ hu₂ hu₃ bl₁ bl₂ bl₃
+      refine ⟨P, v, blind, .node L' R' Lv Rv Lw Rw u₁ u₂ u₃ t₁ t₂ t₃,
+        ⟨h12, h13, h23, hu₁, hu₂, hu₃, ?_, ?_, ?_⟩, ?_⟩
+      · simp only [smul_eq_mul]; rw [eP₁, ev₁, eb₁]; exact ha₁
+      · simp only [smul_eq_mul]; rw [eP₂, ev₂, eb₂]; exact ha₂
+      · simp only [smul_eq_mul]; rw [eP₃, ev₃, eb₃]; exact ha₃
+      · -- the recovered root whole and `Pwhole` fold to the same three child wholes ⇒ equal (`fold_inj`)
+        have key : ∀ (uu : F) (Pi : G) (vi bli : F),
+            P + uu⁻¹ • L' + uu • R' = Pi → v + uu⁻¹ * Lv + uu * Rv = vi →
+            blind + uu⁻¹ * Lw + uu * Rw = bli → Pi + (z * vi) • U + bli • W = Pwhole + uu⁻¹ • L + uu • R →
+            (P + (z * v) • U + blind • W) + uu⁻¹ • (L' + (z * Lv) • U + Lw • W)
+                + uu • (R' + (z * Rv) • U + Rw • W) = Pwhole + uu⁻¹ • L + uu • R := by
+          intro uu Pi vi bli hP hvv hb hw
+          rw [show (P + (z * v) • U + blind • W) + uu⁻¹ • (L' + (z * Lv) • U + Lw • W)
+                + uu • (R' + (z * Rv) • U + Rw • W)
+              = (P + uu⁻¹ • L' + uu • R') + (z * (v + uu⁻¹ * Lv + uu * Rv)) • U
+                + (blind + uu⁻¹ * Lw + uu * Rw) • W from by match_scalars <;> ring,
+            hP, hvv, hb, hw]
+        exact (fold_inj h12 h13 h23 hu₁ hu₂ hu₃
+          (key u₁ P₁ v₁ bl₁ eP₁ ev₁ eb₁ hw₁) (key u₂ P₂ v₂ bl₂ eP₂ ev₂ eb₂ hw₂)
+          (key u₃ P₃ v₃ bl₃ eP₃ ev₃ eb₃ hw₃)).1
+
+/-- **Root-consistent extraction (the deployed `FiatShamirTree`), as a computable reduction.** Threading the
+deployed commitment-whole `⟨aDep, g⟩ + [z·vDep]U + [blindDep]W`, a valid deployed forking output *computes*
+either the deployed accept predicate for the deployed commitment `⟨aDep, g⟩` / value `vDep`, or a nontrivial
+`(g, U, W)` relation. `produceDeployed` gives a tree whose recovered root whole equals the deployed whole;
+`ipa_extractV` *computes* that root's opening witness (not the vacuous `∃`), and matching it against the
+deployed whole (`NontrivialRelation.ofCombinationCollision` — the binding branch) forces the recovered
+`(P, v)` to *be* the deployed `(⟨aDep,g⟩, vDep)`. Genuinely non-vacuous: this is a computable `def`
+(decidable `if`, no `Classical.choose`), so neither branch's *data* can be fabricated without the `cert` —
+the discrete-log preimage the reviewer's prime-order vacuity witness needs is not computable. The residual is
+supplying `DeployedForkValid` (the rewinding) and the DLR/Blake2b hardness floor. -/
+def deployed_forking_tree [DecidableEq F] [DecidableEq G] {U W : G} {z : F} (hz : z ≠ 0)
+    {d : ℕ} (g : Fin (2 ^ d) → G) (b : Fin (2 ^ d) → F) (aDep : Fin (2 ^ d) → F) (vDep blindDep : F)
+    (cert : DForkCert F G d)
+    (hv : DeployedForkValid g b U W z (commitGen g aDep + (z * vDep) • U + blindDep • W) cert) :
+    (Σ' (blind : F) (t : DeployedIpaTreeV F G d),
+        DeployedIpaAcceptV g b U W z (commitGen g aDep) vDep blind t)
+      ⊕' NontrivialRelation (F := F) g U W :=
+  match produceDeployed g b _ cert hv with
+  | ⟨P, v, blind, t, ha, hw⟩ =>
+    if hclean : IpaAcceptV g b P v (projTree t) then
+      match ipa_extractV g b P v (projTree t) hclean with
+      | ⟨a, hPa, _hva⟩ =>
+        if hcoord : a = aDep ∧ (z * v) = (z * vDep) ∧ blind = blindDep then
+          PSum.inl ⟨blind, t, by
+            obtain ⟨haa, hU, _⟩ := hcoord
+            have hPP : P = commitGen g aDep := by rw [← hPa, haa]
+            have hvv : v = vDep := mul_left_cancel₀ hz hU
+            rw [hPP, hvv] at ha; exact ha⟩
+        else
+          PSum.inr (NontrivialRelation.ofCombinationCollision (by rw [← hPa] at hw; exact hw) hcoord)
+    else
+      PSum.inr (NontrivialRelation.ofDeployedTree hz g b P v blind t ha hclean)
+
+/-! ## The prover-as-oracle-function model: from the abstract forking tree to `DeployedForkValid`
+
+`extractable_of_prob` (`Soundness.Forking.Probability`) gives a *bare* `(3,…,3)` challenge tree (`Extractable`)
+once the accept probability beats the knowledge error. To feed `produceDeployed`/`deployed_forking_tree`, that
+abstract tree must be filled with the prover's round points and openings — the data a `DForkCert` records.
+
+`Prover` is the prover's strategy as a tree: at each round the cross-commitment `(L, R)` it sends *before* the
+challenge, then a continuation per challenge; at the leaf its final opening `(c, f)`. The tree shape enforces
+that the round point depends only on the prefix (the challenges already sent) — exactly the Fiat–Shamir
+prover-as-oracle-function structure, with the round point committed before the next challenge is squeezed.
+
+`proverAccept` reads off the deployed accept condition along one challenge path: fold the deployed
+commitment-whole by the prover's round points down the path and check the flat verifier leaf equation.
+`proverAccept_forkValid` is the assembly: any `Extractable` tree for that accept predicate *is* a valid
+`DeployedForkValid` certificate — zip the prover's round points/openings with the tree's challenges. This is
+the deterministic bridge from the probabilistic forking tree to the deployed forking output; what stays the
+floor is that the *deployed* prover realizes this `Prover`/`proverAccept` shape (the faithful transcript
+model) and Blake2b-as-random-oracle. -/
+
+/-- A prover's strategy tree for the `d`-round IPA: at each round the cross-commitment `(L, R)` it sends
+*before* the challenge, then a continuation per challenge; at the leaf its final opening `(c, f)`. The tree
+shape enforces the Fiat–Shamir prefix-determination — the round point is fixed before the challenge. -/
+inductive Prover (F G : Type*) : ℕ → Type _ where
+  | leaf : F → F → Prover F G 0
+  | node {d : ℕ} : G → G → (F → Prover F G d) → Prover F G (d + 1)
+
+/-- The deployed accept condition along one challenge path `χ`: fold the deployed commitment-whole `Pwhole` by
+the prover's round points down `χ` (and the generators/eval-vector accordingly), then check the flat verifier
+leaf equation `Pwhole = ⟨c,g⟩ + [z·⟨c,b⟩]U + [f]W` at the bottom. The single-path version of
+`DeployedForkValid`, indexed by the prover strategy. -/
+def proverAccept : {d : ℕ} → Prover F G d → (Fin (2 ^ d) → G) → (Fin (2 ^ d) → F) → (U W : G) → (z : F) → G →
+    (Fin d → F) → Prop
+  | 0, .leaf c f, g, b, U, W, z, Pwhole, _ =>
+      Pwhole = commitGen g (fun _ => c) + (z * commitGen b (fun _ => c)) • U + f • W
+  | _ + 1, .node L R cont, g, b, U, W, z, Pwhole, χ =>
+      proverAccept (cont (χ 0)) (foldGens g (χ 0)) (foldGens b (χ 0)) U W z
+        (Pwhole + (χ 0)⁻¹ • L + (χ 0) • R) (Fin.tail χ)
+
+/-- **The prover-as-oracle assembly.** A `(3,…,3)` `Extractable` tree for the prover's accept predicate yields
+a valid `DeployedForkValid` certificate: zip the prover's round points and openings with the tree's distinct
+challenges. By recursion on the prover/tree — each node takes its round point from the prover and its three
+challenges from `Extractable`, each leaf its opening from the prover, and the per-leaf accept conditions are
+exactly `Extractable`'s. This bridges the probabilistic forking tree (`extractable_of_prob`) to the deployed
+forking output that `deployed_forking_tree` consumes. -/
+theorem proverAccept_forkValid {U W : G} {z : F} : {d : ℕ} → (P : Prover F G d) → (g : Fin (2 ^ d) → G) →
+    (b : Fin (2 ^ d) → F) → (Pwhole : G) → Extractable (proverAccept P g b U W z Pwhole) →
+    ∃ cert : DForkCert F G d, DeployedForkValid g b U W z Pwhole cert
+  | 0, .leaf c f, g, b, Pwhole, hext => ⟨.leaf c f, hext⟩
+  | d + 1, .node L R cont, g, b, Pwhole, hext => by
+      obtain ⟨u₁, u₂, u₃, h12, h13, h23, hu₁, hu₂, hu₃, e₁, e₂, e₃⟩ := hext
+      obtain ⟨cert₁, hv₁⟩ := proverAccept_forkValid (cont u₁) (foldGens g u₁) (foldGens b u₁)
+        (Pwhole + u₁⁻¹ • L + u₁ • R) e₁
+      obtain ⟨cert₂, hv₂⟩ := proverAccept_forkValid (cont u₂) (foldGens g u₂) (foldGens b u₂)
+        (Pwhole + u₂⁻¹ • L + u₂ • R) e₂
+      obtain ⟨cert₃, hv₃⟩ := proverAccept_forkValid (cont u₃) (foldGens g u₃) (foldGens b u₃)
+        (Pwhole + u₃⁻¹ • L + u₃ • R) e₃
+      exact ⟨.node L R u₁ u₂ u₃ cert₁ cert₂ cert₃,
+        h12, h13, h23, hu₁, hu₂, hu₃, hv₁, hv₂, hv₃⟩
+
+end Zcash.Snark

--- a/Zcash/Snark/Soundness/Forking/Oracle.lean
+++ b/Zcash/Snark/Soundness/Forking/Oracle.lean
@@ -7,8 +7,8 @@ import Zcash.Snark.Core.Field
 
 `Verifier.FiatShamir` derives challenges through an opaque `squeeze : List (TranscriptElt F G) → F`. The
 deployed verifier instantiates it with Blake2b; discharging the Fiat–Shamir assumption models
-that hash as a **random oracle** — a function whose answers are uniform and that we can **reprogram** at a
-single query (the rewinding primitive the forking argument needs).
+that hash as a random oracle — a function whose answers are uniform and that we can reprogram at a
+single query (`reprogram`; the rewinding primitive the forking argument needs).
 
 This module supplies the random-oracle primitives the forking development is framed with:
 
@@ -19,7 +19,7 @@ This module supplies the random-oracle primitives the forking development is fra
   `Fp`, hence lands in a finite "bad" set of size `d` with probability `d / p`. This is the Schwartz–Zippel
   exclusion budget and the source of the forking-collision bounds.
 
-## The distributional model: `hprob`'s measure is justified standalone; the adversary experiment is the floor
+## The measure of `hprob` is justified standalone
 
 The forking probability (`Soundness.Forking.Probability`, `Soundness.Forking.Tree`) is stated over the uniform
 measure `PMF.uniformOfFintype (Fin k → Fp)` on the IPA round-challenge vector. That a uniform random oracle
@@ -35,15 +35,16 @@ independent-uniform. Reprogramming (`reprogram`) resamples one prefix's answer �
 idealizations are part of "`O` is a uniform random function", not extra assumptions: the transcript encoding is
 injective / self-delimiting, so distinct `TranscriptElt` sequences hit distinct Blake2b inputs (halo2 writes
 fixed-width points and scalars behind domain-prefix bytes, so absorb-order collisions cannot occur); and the
-`Challenge255 → F_p` decoding is taken as exactly uniform. halo2 reduces 64 hash bytes with
-`FromUniformBytes<64>`, whose reduction bias is ≈ `p/2⁵¹² < 2⁻²⁵⁶` per squeeze — negligible but nonzero, and
-not composed into any stated bound.
+`Challenge255 → F_p` decoding is taken as exactly uniform (`uniformChallenge`, whose residual reduction bias
+is negligible but nonzero and uncomposed).
 
 So the uniform measure of `hprob` is justified standalone, not posited — no `axiom`, no `sorry` — and its own
 input, that `O` is a random oracle, is the standard Fiat–Shamir/ROM assumption (no concrete hash is provably a
 random oracle).
 
-The distributional floor left is the **adversary experiment above `hprob`**, not its measure. A full
+## The floor above `hprob`: the adversary experiment
+
+The distributional floor left is the *adversary experiment above `hprob`*, not its measure. A full
 knowledge-soundness reduction would model the Fiat–Shamir forger as a machine querying `O` and *derive* the
 accept probability of `hprob` from its advantage `ε`, paying the query-loss `ε → ε/Q`. That is not modeled:
 `hprob` is the hypothesis — the adversary's accept probability over the (now provably uniform, reprogrammable)
@@ -58,11 +59,13 @@ that out-of-Lean floor; see the quantifier-shape caveats there.) `uniformChallen
 directly-consumed uniformity consequence — it supplies the `1/p` `ξ`-randomization budget
 (`blinder_shift_badSet_measure`, `Soundness.Vesta.blinder_value_recovery_badSet`).
 
-Two scope notes, both part of that floor, not the derived uniformity. **Existence-only:** beating `kerr` proves
-the extracted witness *exists* (a counting argument over the challenge space), not that an expected-polynomial-time
-extractor computes it. **Uncomposed budgets:** the per-hypothesis exclusions (`z ≠ 0`, the `ξ`-recovery, `1/p`
-each) and the `3k/p` tree threshold are stated separately, not composed into one end-to-end bound — the
-composition belongs with the query-loss accounting.
+Two scope notes, both part of that floor, not the derived uniformity:
+
+* **Existence-only.** Beating `kerr` proves the extracted witness *exists* (a counting argument over the
+  challenge space), not that an expected-polynomial-time extractor computes it.
+* **Uncomposed budgets.** The per-hypothesis exclusions (`z ≠ 0`, the `ξ`-recovery, `1/p` each) and the
+  `3k/p` tree threshold are stated separately, not composed into one end-to-end bound — the composition
+  belongs with the query-loss accounting.
 -/
 
 namespace Zcash.Snark
@@ -91,7 +94,10 @@ theorem reprogram_ne {O : List (TranscriptElt F G) → F} {t t' : List (Transcri
 
 /-! ## The uniform-challenge idealization -/
 
-/-- The random-oracle idealization of a fresh squeeze: a uniform field challenge over `Fp`. -/
+/-- The random-oracle idealization of a fresh squeeze: a uniform field challenge over `Fp`. This idealizes
+halo2's `Challenge255 → F_p` decoding as exactly uniform; halo2 reduces 64 hash bytes with
+`FromUniformBytes<64>`, whose reduction bias is ≈ `p/2⁵¹² < 2⁻²⁵⁶` per squeeze — negligible but nonzero, and
+not composed into any stated bound. -/
 noncomputable def uniformChallenge : PMF Fp := PMF.uniformOfFintype Fp
 
 /-- A fresh squeeze lands in a finite bad set of size `d` with probability `d / p` (`p = card Fp`) — the

--- a/Zcash/Snark/Soundness/Forking/Oracle.lean
+++ b/Zcash/Snark/Soundness/Forking/Oracle.lean
@@ -11,10 +11,11 @@ at one query.
 
 This module supplies the random-oracle primitives the forking development is framed with:
 
-* `reprogram` changes the answer at one transcript prefix. Rewinding reruns the prover with that
-  changed answer.
 * `uniformChallenge` and `uniformChallenge_badSet` model a fresh field challenge and its probability
   of landing in a finite bad set.
+
+Reprogramming — the rewinding primitive itself — is `reprogramRounds` in
+`Soundness.Forking.Rewind`, which replaces the whole IPA round vector at once.
 
 ## Challenge-vector distribution
 
@@ -49,24 +50,6 @@ Two scope notes, both part of that floor, not the derived uniformity:
 namespace Zcash.Snark
 
 open scoped ENNReal
-
-variable {F G : Type*}
-
-/-! ## Reprogramming — the rewinding primitive -/
-
-open Classical in
-/-- Change the oracle's answer at `t` to `c`, leaving all other answers unchanged. -/
-noncomputable def reprogram (O : List (TranscriptElt F G) → F) (t : List (TranscriptElt F G)) (c : F) :
-    List (TranscriptElt F G) → F :=
-  fun t' => if t' = t then c else O t'
-
-@[simp] theorem reprogram_self (O : List (TranscriptElt F G) → F) (t : List (TranscriptElt F G)) (c : F) :
-    reprogram O t c t = c := by
-  simp [reprogram]
-
-theorem reprogram_ne {O : List (TranscriptElt F G) → F} {t t' : List (TranscriptElt F G)} {c : F}
-    (h : t' ≠ t) : reprogram O t c t' = O t' := by
-  simp [reprogram, h]
 
 /-! ## The uniform-challenge idealization -/
 

--- a/Zcash/Snark/Soundness/Forking/Oracle.lean
+++ b/Zcash/Snark/Soundness/Forking/Oracle.lean
@@ -19,48 +19,50 @@ This module supplies the random-oracle primitives the forking development is fra
   `Fp`, hence lands in a finite "bad" set of size `d` with probability `d / p`. This is the Schwartz–Zippel
   exclusion budget and the source of the forking-collision bounds.
 
-## The distributional floor: the random-oracle uniformity axiom (accepted, not proved)
+## The distributional model: `hprob`'s measure is justified standalone; the adversary experiment is the floor
 
 The forking probability (`Soundness.Forking.Probability`, `Soundness.Forking.Tree`) is stated over the uniform
-measure `PMF.uniformOfFintype (Fin k → Fp)` on the IPA round-challenge *vector*. What licenses that measure is
-**the one accepted axiom of the Fiat–Shamir discharge**:
+measure `PMF.uniformOfFintype (Fin k → Fp)` on the IPA round-challenge vector. That a uniform random oracle
+induces this measure is a theorem (`Soundness.Forking.Rewind.roChallenges_ipaRound_uniform`), replacing the old
+uniformity axiom. It is a *standalone* justification — consumed by no capstone, over the fixed-`ps` marginal;
+its precise scope is in that theorem's section — downstream of one standard assumption:
 
-> **Random-oracle uniformity.** Idealizing the Blake2b squeeze as a random oracle, the round-challenge vector
-> `roChallenges O init ps = deriveChallenges (ofOracle O) init ps` that an oracle `O` induces is distributed as
-> `PMF.uniformOfFintype (Fin k → Fp)`: each fresh squeeze is uniform on `Fp` (`uniformChallenge`), the `k`
-> distinct round prefixes squeeze independently, and rewinding (`reprogram`) resamples a fresh independent
-> challenge. This models the oracle over the structured `List (TranscriptElt Fp G)` rather than the deployed
-> byte stream, so it additionally assumes the transcript encoding is **injective / self-delimiting** — that
-> distinct `TranscriptElt` sequences serialize to distinct Blake2b inputs (true in halo2: fixed-width point
-> and scalar writes, each behind its domain-prefix byte), so absorb-order collisions cannot occur. The
-> `Challenge255 → F_p` decoding (a 512-bit hash output reduced into `F_p`) is likewise idealized as exactly
-> uniform; the reduction bias ≈ `p/2⁵¹² < 2⁻²⁵⁶` is absorbed into this axiom.
+> **Random oracle.** The Blake2b squeeze is idealized as a *uniform random function* `O` over its query domain.
 
-This is **accepted, not proved** — it is the standard random-oracle-model assumption (no concrete hash,
-Blake2b included, is provably a random oracle), and it is the *only* distributional assumption the Fiat–Shamir
-development rests on. It is deliberately **not** introduced as a Lean `axiom`: this development declares no
-`axiom` of its own and uses no `sorry`, so the assumption is carried *explicitly in the theorem statements* —
-as the uniform measure of the forking-probability hypothesis `hprob`
-(`Soundness.Forking.Rewind.deployed_forking_soundness` and the Vesta `_rewind`/`_adaptive_rewind` capstones) plus
-the explicit prover-as-oracle/execution-semantics bridge hypotheses around
-`deployed_forking_soundness_of_bridge`. Every soundness result that consumes the uniform challenge measure is
-therefore conditional on this axiom and says so in its own signature; nothing hides it. (Scope note: the
-`_deployed` capstones instantiate the prover as the *fixed* proof string, so their `hprob` is that proof's
-accept measure over the whole challenge space — the static dichotomy — while the adaptive rewinding reduction
-connecting a Fiat–Shamir forger to such a measure — the execution-semantics identification with its query
-loss — is an out-of-Lean floor additional to this axiom; see the quantifier-shape caveats on those
-capstones.)
-`uniformChallenge_badSet` is the one directly-consumed consequence — it
-supplies the `1/p` `ξ`-randomization budget in `Soundness.Forking.Rewind` (`blinder_shift_badSet_measure`,
-`Soundness.Vesta.blinder_value_recovery_badSet`).
+From that, challenge-vector uniformity follows (derivation in `Soundness.Forking.Rewind`): each round challenge
+is `O` read at that round's transcript prefix, the `k` prefixes are distinct, so the `k` answers are
+independent-uniform. Reprogramming (`reprogram`) resamples one prefix's answer — the rewinding primitive. Two
+idealizations are part of "`O` is a uniform random function", not extra assumptions: the transcript encoding is
+injective / self-delimiting, so distinct `TranscriptElt` sequences hit distinct Blake2b inputs (halo2 writes
+fixed-width points and scalars behind domain-prefix bytes, so absorb-order collisions cannot occur); and the
+`Challenge255 → F_p` decoding is taken as exactly uniform. halo2 reduces 64 hash bytes with
+`FromUniformBytes<64>`, whose reduction bias is ≈ `p/2⁵¹² < 2⁻²⁵⁶` per squeeze — negligible but nonzero, and
+not composed into any stated bound.
 
-Two further scope notes. **Existence-only:** beating `kerr` proves the extracted witness *exists* — a
-counting argument over the challenge space (`Soundness.Forking.Tree`, `Soundness.Forking.Probability`) —
-not that an expected-polynomial-time extractor computes it; the runtime/emulation half of literature
-knowledge soundness is not modeled, a gap distinct from the query-count factor above. **Uncomposed
-budgets:** the per-hypothesis exclusions (`z ≠ 0` and the `ξ`-recovery, `1/p` each) and the `3k/p` tree
-threshold are stated separately, not yet composed into one end-to-end bound — the composition belongs with
-the query-loss accounting, part of the same out-of-Lean floor.
+So the uniform measure of `hprob` is justified standalone, not posited — no `axiom`, no `sorry` — and its own
+input, that `O` is a random oracle, is the standard Fiat–Shamir/ROM assumption (no concrete hash is provably a
+random oracle).
+
+The distributional floor left is the **adversary experiment above `hprob`**, not its measure. A full
+knowledge-soundness reduction would model the Fiat–Shamir forger as a machine querying `O` and *derive* the
+accept probability of `hprob` from its advantage `ε`, paying the query-loss `ε → ε/Q`. That is not modeled:
+`hprob` is the hypothesis — the adversary's accept probability over the (now provably uniform, reprogrammable)
+challenges — as any knowledge-soundness statement is conditional on the adversary succeeding. `hprob` cannot be
+discharged outright (a soundness theorem with no accept-probability hypothesis is false); reducing it to a
+querying adversary's advantage needs a probabilistic-oracle-machine, a lazily-sampled oracle, and a
+forking-lemma-with-query-loss — foundations Mathlib does not provide. This is the out-of-Lean floor, with the
+prover-as-oracle bridge (`deployed_forking_soundness_of_bridge`) and Blake2b-as-random-oracle. (Scope note: the
+`_deployed` capstones instantiate the *fixed* proof string, so their `hprob` is that proof's accept measure over
+the whole challenge space — the static dichotomy — while connecting a Fiat–Shamir forger to such a measure is
+that out-of-Lean floor; see the quantifier-shape caveats there.) `uniformChallenge_badSet` is the one
+directly-consumed uniformity consequence — it supplies the `1/p` `ξ`-randomization budget
+(`blinder_shift_badSet_measure`, `Soundness.Vesta.blinder_value_recovery_badSet`).
+
+Two scope notes, both part of that floor, not the derived uniformity. **Existence-only:** beating `kerr` proves
+the extracted witness *exists* (a counting argument over the challenge space), not that an expected-polynomial-time
+extractor computes it. **Uncomposed budgets:** the per-hypothesis exclusions (`z ≠ 0`, the `ξ`-recovery, `1/p`
+each) and the `3k/p` tree threshold are stated separately, not composed into one end-to-end bound — the
+composition belongs with the query-loss accounting.
 -/
 
 namespace Zcash.Snark

--- a/Zcash/Snark/Soundness/Forking/Oracle.lean
+++ b/Zcash/Snark/Soundness/Forking/Oracle.lean
@@ -1,0 +1,103 @@
+import Mathlib.Probability.Distributions.Uniform
+import Zcash.Snark.Verifier.FiatShamir
+import Zcash.Snark.Core.Field
+
+/-!
+# Random-oracle model for the Fiat–Shamir squeeze
+
+`Verifier.FiatShamir` derives challenges through an opaque `squeeze : List (TranscriptElt F G) → F`. The
+deployed verifier instantiates it with Blake2b; discharging the Fiat–Shamir assumption models
+that hash as a **random oracle** — a function whose answers are uniform and that we can **reprogram** at a
+single query (the rewinding primitive the forking argument needs).
+
+This module supplies the random-oracle primitives the forking development is framed with:
+
+* `reprogram` — replace the oracle's answer at one transcript prefix, with `reprogram_self`/`reprogram_ne`.
+  Rewinding re-runs the (oracle-deterministic) prover under `reprogram O t c`, diverging exactly at the
+  forked query `t`.
+* `uniformChallenge` / `uniformChallenge_badSet` — the idealization that a fresh squeeze is uniform over
+  `Fp`, hence lands in a finite "bad" set of size `d` with probability `d / p`. This is the Schwartz–Zippel
+  exclusion budget and the source of the forking-collision bounds.
+
+## The distributional floor: the random-oracle uniformity axiom (accepted, not proved)
+
+The forking probability (`Soundness.Forking.Probability`, `Soundness.Forking.Tree`) is stated over the uniform
+measure `PMF.uniformOfFintype (Fin k → Fp)` on the IPA round-challenge *vector*. What licenses that measure is
+**the one accepted axiom of the Fiat–Shamir discharge**:
+
+> **Random-oracle uniformity.** Idealizing the Blake2b squeeze as a random oracle, the round-challenge vector
+> `roChallenges O init ps = deriveChallenges (ofOracle O) init ps` that an oracle `O` induces is distributed as
+> `PMF.uniformOfFintype (Fin k → Fp)`: each fresh squeeze is uniform on `Fp` (`uniformChallenge`), the `k`
+> distinct round prefixes squeeze independently, and rewinding (`reprogram`) resamples a fresh independent
+> challenge. This models the oracle over the structured `List (TranscriptElt Fp G)` rather than the deployed
+> byte stream, so it additionally assumes the transcript encoding is **injective / self-delimiting** — that
+> distinct `TranscriptElt` sequences serialize to distinct Blake2b inputs (true in halo2: fixed-width point
+> and scalar writes, each behind its domain-prefix byte), so absorb-order collisions cannot occur. The
+> `Challenge255 → F_p` decoding (a 512-bit hash output reduced into `F_p`) is likewise idealized as exactly
+> uniform; the reduction bias ≈ `p/2⁵¹² < 2⁻²⁵⁶` is absorbed into this axiom.
+
+This is **accepted, not proved** — it is the standard random-oracle-model assumption (no concrete hash,
+Blake2b included, is provably a random oracle), and it is the *only* distributional assumption the Fiat–Shamir
+development rests on. It is deliberately **not** introduced as a Lean `axiom`: this development declares no
+`axiom` of its own and uses no `sorry`, so the assumption is carried *explicitly in the theorem statements* —
+as the uniform measure of the forking-probability hypothesis `hprob`
+(`Soundness.Forking.Rewind.deployed_forking_soundness` and the Vesta `_rewind`/`_adaptive_rewind` capstones) plus
+the explicit prover-as-oracle/execution-semantics bridge hypotheses around
+`deployed_forking_soundness_of_bridge`. Every soundness result that consumes the uniform challenge measure is
+therefore conditional on this axiom and says so in its own signature; nothing hides it. (Scope note: the
+`_deployed` capstones instantiate the prover as the *fixed* proof string, so their `hprob` is that proof's
+accept measure over the whole challenge space — the static dichotomy — while the adaptive rewinding reduction
+connecting a Fiat–Shamir forger to such a measure — the execution-semantics identification with its query
+loss — is an out-of-Lean floor additional to this axiom; see the quantifier-shape caveats on those
+capstones.)
+`uniformChallenge_badSet` is the one directly-consumed consequence — it
+supplies the `1/p` `ξ`-randomization budget in `Soundness.Forking.Rewind` (`blinder_shift_badSet_measure`,
+`Soundness.Vesta.blinder_value_recovery_badSet`).
+
+Two further scope notes. **Existence-only:** beating `kerr` proves the extracted witness *exists* — a
+counting argument over the challenge space (`Soundness.Forking.Tree`, `Soundness.Forking.Probability`) —
+not that an expected-polynomial-time extractor computes it; the runtime/emulation half of literature
+knowledge soundness is not modeled, a gap distinct from the query-count factor above. **Uncomposed
+budgets:** the per-hypothesis exclusions (`z ≠ 0` and the `ξ`-recovery, `1/p` each) and the `3k/p` tree
+threshold are stated separately, not yet composed into one end-to-end bound — the composition belongs with
+the query-loss accounting, part of the same out-of-Lean floor.
+-/
+
+namespace Zcash.Snark
+
+open scoped ENNReal
+
+variable {F G : Type*}
+
+/-! ## Reprogramming — the rewinding primitive -/
+
+open Classical in
+/-- Reprogram a Fiat–Shamir oracle at one transcript prefix `t`: answer `c` there, `O` everywhere else.
+Forking reprograms the oracle at the forked round's query and re-runs the prover, producing a transcript
+that agrees with the original on the prefix and diverges at `t`. -/
+noncomputable def reprogram (O : List (TranscriptElt F G) → F) (t : List (TranscriptElt F G)) (c : F) :
+    List (TranscriptElt F G) → F :=
+  fun t' => if t' = t then c else O t'
+
+@[simp] theorem reprogram_self (O : List (TranscriptElt F G) → F) (t : List (TranscriptElt F G)) (c : F) :
+    reprogram O t c t = c := by
+  simp [reprogram]
+
+theorem reprogram_ne {O : List (TranscriptElt F G) → F} {t t' : List (TranscriptElt F G)} {c : F}
+    (h : t' ≠ t) : reprogram O t c t' = O t' := by
+  simp [reprogram, h]
+
+/-! ## The uniform-challenge idealization -/
+
+/-- The random-oracle idealization of a fresh squeeze: a uniform field challenge over `Fp`. -/
+noncomputable def uniformChallenge : PMF Fp := PMF.uniformOfFintype Fp
+
+/-- A fresh squeeze lands in a finite bad set of size `d` with probability `d / p` (`p = card Fp`) — the
+Schwartz–Zippel exclusion budget the good-challenge arguments and the forking-collision bounds
+draw on. -/
+theorem uniformChallenge_badSet (bad : Finset Fp) :
+    uniformChallenge.toOuterMeasure bad = (bad.card : ℝ≥0∞) / Fintype.card Fp := by
+  rw [uniformChallenge, PMF.toOuterMeasure_apply_finset]
+  simp only [PMF.uniformOfFintype_apply, Finset.sum_const, nsmul_eq_mul, div_eq_mul_inv]
+
+end Zcash.Snark

--- a/Zcash/Snark/Soundness/Forking/Oracle.lean
+++ b/Zcash/Snark/Soundness/Forking/Oracle.lean
@@ -3,69 +3,47 @@ import Zcash.Snark.Verifier.FiatShamir
 import Zcash.Snark.Core.Field
 
 /-!
-# Random-oracle model for the Fiat–Shamir squeeze
+# Random-oracle model for Fiat–Shamir
 
-`Verifier.FiatShamir` derives challenges through an opaque `squeeze : List (TranscriptElt F G) → F`. The
-deployed verifier instantiates it with Blake2b; discharging the Fiat–Shamir assumption models
-that hash as a random oracle — a function whose answers are uniform and that we can reprogram at a
-single query (`reprogram`; the rewinding primitive the forking argument needs).
+`Verifier.FiatShamir` derives challenges with an abstract `squeeze`. The deployed verifier uses
+Blake2b. The soundness proof models it as a random function with uniform answers that can be changed
+at one query.
 
 This module supplies the random-oracle primitives the forking development is framed with:
 
-* `reprogram` — replace the oracle's answer at one transcript prefix, with `reprogram_self`/`reprogram_ne`.
-  Rewinding re-runs the (oracle-deterministic) prover under `reprogram O t c`, diverging exactly at the
-  forked query `t`.
-* `uniformChallenge` / `uniformChallenge_badSet` — the idealization that a fresh squeeze is uniform over
-  `Fp`, hence lands in a finite "bad" set of size `d` with probability `d / p`. This is the Schwartz–Zippel
-  exclusion budget and the source of the forking-collision bounds.
+* `reprogram` changes the answer at one transcript prefix. Rewinding reruns the prover with that
+  changed answer.
+* `uniformChallenge` and `uniformChallenge_badSet` model a fresh field challenge and its probability
+  of landing in a finite bad set.
 
-## The measure of `hprob` is justified standalone
+## Challenge-vector distribution
 
-The forking probability (`Soundness.Forking.Probability`, `Soundness.Forking.Tree`) is stated over the uniform
-measure `PMF.uniformOfFintype (Fin k → Fp)` on the IPA round-challenge vector. That a uniform random oracle
-induces this measure is a theorem (`Soundness.Forking.Rewind.roChallenges_ipaRound_uniform`), replacing the old
-uniformity axiom. It is a *standalone* justification — consumed by no capstone, over the fixed-`ps` marginal;
-its precise scope is in that theorem's section — downstream of one standard assumption:
+The forking proof uses the uniform distribution on IPA challenge vectors.
+`Soundness.Forking.Rewind.roChallenges_ipaRound_uniform` derives that distribution for a fixed proof
+from one assumption:
 
 > **Random oracle.** The Blake2b squeeze is idealized as a *uniform random function* `O` over its query domain.
 
-From that, challenge-vector uniformity follows (derivation in `Soundness.Forking.Rewind`): each round challenge
-is `O` read at that round's transcript prefix, the `k` prefixes are distinct, so the `k` answers are
-independent-uniform. Reprogramming (`reprogram`) resamples one prefix's answer — the rewinding primitive. Two
-idealizations are part of "`O` is a uniform random function", not extra assumptions: the transcript encoding is
-injective / self-delimiting, so distinct `TranscriptElt` sequences hit distinct Blake2b inputs (halo2 writes
-fixed-width points and scalars behind domain-prefix bytes, so absorb-order collisions cannot occur); and the
-`Challenge255 → F_p` decoding is taken as exactly uniform (`uniformChallenge`, whose residual reduction bias
-is negligible but nonzero and uncomposed).
+Each round reads `O` at a distinct transcript prefix, so the answers are independent and uniform.
+This also assumes that transcript encoding is injective and that halo2's `Challenge255 → Fp`
+conversion is exactly uniform. The real conversion has a negligible, unaccounted reduction bias.
 
-So the uniform measure of `hprob` is justified standalone, not posited — no `axiom`, no `sorry` — and its own
-input, that `O` is a random oracle, is the standard Fiat–Shamir/ROM assumption (no concrete hash is provably a
-random oracle).
+Thus the challenge distribution is proved inside the random-oracle model, while the model itself
+remains an assumption about Blake2b.
 
-## The floor above `hprob`: the adversary experiment
+## Remaining adversary model
 
-The distributional floor left is the *adversary experiment above `hprob`*, not its measure. A full
-knowledge-soundness reduction would model the Fiat–Shamir forger as a machine querying `O` and *derive* the
-accept probability of `hprob` from its advantage `ε`, paying the query-loss `ε → ε/Q`. That is not modeled:
-`hprob` is the hypothesis — the adversary's accept probability over the (now provably uniform, reprogrammable)
-challenges — as any knowledge-soundness statement is conditional on the adversary succeeding. `hprob` cannot be
-discharged outright (a soundness theorem with no accept-probability hypothesis is false); reducing it to a
-querying adversary's advantage needs a probabilistic-oracle-machine, a lazily-sampled oracle, and a
-forking-lemma-with-query-loss — foundations Mathlib does not provide. This is the out-of-Lean floor, with the
-prover-as-oracle bridge (`deployed_forking_soundness_of_bridge`) and Blake2b-as-random-oracle. (Scope note: the
-`_deployed` capstones instantiate the *fixed* proof string, so their `hprob` is that proof's accept measure over
-the whole challenge space — the static dichotomy — while connecting a Fiat–Shamir forger to such a measure is
-that out-of-Lean floor; see the quantifier-shape caveats there.) `uniformChallenge_badSet` is the one
-directly-consumed uniformity consequence — it supplies the `1/p` `ξ`-randomization budget
-(`blinder_shift_badSet_measure`, `Soundness.Vesta.blinder_value_recovery_badSet`).
+A full reduction must model a forger that queries `O`, derive `hprob` from its advantage, and pay the
+random-oracle query loss. That adversary experiment is outside this PR. The fixed-proof endpoints
+measure one proof over all challenges; they do not yet measure a real Fiat–Shamir attack.
+
+`uniformChallenge_badSet` is used directly for the `1/p` blinding budget.
 
 Two scope notes, both part of that floor, not the derived uniformity:
 
-* **Existence-only.** Beating `kerr` proves the extracted witness *exists* (a counting argument over the
-  challenge space), not that an expected-polynomial-time extractor computes it.
-* **Uncomposed budgets.** The per-hypothesis exclusions (`z ≠ 0`, the `ξ`-recovery, `1/p` each) and the
-  `3k/p` tree threshold are stated separately, not composed into one end-to-end bound — the composition
-  belongs with the query-loss accounting.
+* Beating `kerr` proves that a witness exists; it does not implement an expected-polynomial-time
+  extractor.
+* The `z ≠ 0`, `ξ`-recovery, tree, and query-loss budgets are not yet combined into one bound.
 -/
 
 namespace Zcash.Snark
@@ -77,9 +55,7 @@ variable {F G : Type*}
 /-! ## Reprogramming — the rewinding primitive -/
 
 open Classical in
-/-- Reprogram a Fiat–Shamir oracle at one transcript prefix `t`: answer `c` there, `O` everywhere else.
-Forking reprograms the oracle at the forked round's query and re-runs the prover, producing a transcript
-that agrees with the original on the prefix and diverges at `t`. -/
+/-- Change the oracle's answer at `t` to `c`, leaving all other answers unchanged. -/
 noncomputable def reprogram (O : List (TranscriptElt F G) → F) (t : List (TranscriptElt F G)) (c : F) :
     List (TranscriptElt F G) → F :=
   fun t' => if t' = t then c else O t'
@@ -94,15 +70,12 @@ theorem reprogram_ne {O : List (TranscriptElt F G) → F} {t t' : List (Transcri
 
 /-! ## The uniform-challenge idealization -/
 
-/-- The random-oracle idealization of a fresh squeeze: a uniform field challenge over `Fp`. This idealizes
-halo2's `Challenge255 → F_p` decoding as exactly uniform; halo2 reduces 64 hash bytes with
-`FromUniformBytes<64>`, whose reduction bias is ≈ `p/2⁵¹² < 2⁻²⁵⁶` per squeeze — negligible but nonzero, and
-not composed into any stated bound. -/
+/-- A fresh random-oracle squeeze, modeled as uniform over `Fp`.
+
+Halo2's real field conversion has negligible reduction bias that is not included in the bounds. -/
 noncomputable def uniformChallenge : PMF Fp := PMF.uniformOfFintype Fp
 
-/-- A fresh squeeze lands in a finite bad set of size `d` with probability `d / p` (`p = card Fp`) — the
-Schwartz–Zippel exclusion budget the good-challenge arguments and the forking-collision bounds
-draw on. -/
+/-- A uniform challenge lands in `bad` with probability `|bad| / |Fp|`. -/
 theorem uniformChallenge_badSet (bad : Finset Fp) :
     uniformChallenge.toOuterMeasure bad = (bad.card : ℝ≥0∞) / Fintype.card Fp := by
   rw [uniformChallenge, PMF.toOuterMeasure_apply_finset]

--- a/Zcash/Snark/Soundness/Forking/Ordering.lean
+++ b/Zcash/Snark/Soundness/Forking/Ordering.lean
@@ -15,7 +15,7 @@ This module makes the online ordering that `foldl` enforces explicit and proves 
 half of the prover-as-oracle bridge (`Soundness.Forking.Rewind`): the deployed schedule's own derivation
 has the dependency structure the `Prover`/rewinding tree (`Soundness.Forking.Extractor.Prover`) assumes.
 
-* `roundTranscript` — the transcript prefix `uⱼ` is squeezed from (the running `t` above, at step `j`).
+* `roundTranscript` — the transcript prefix `uⱼ` is squeezed from (the running `t` above, at round `j`).
 * `roundTranscript_succ` — round `j+1`'s transcript is round `j`'s extended by exactly `(L_{j+1}, R_{j+1})`
   and the challenge marker: each round point is absorbed *before* that round's challenge and *after* every
   earlier round's challenge.
@@ -25,21 +25,21 @@ has the dependency structure the `Prover`/rewinding tree (`Soundness.Forking.Ext
 * `roundTranscript_prefix_mono` — the base transcript `t₀` (through `z`) is a prefix of every round's
   transcript, and round transcripts grow monotonically, so no round's squeeze can see a *later* round's point.
 
-`(L, R)` and the challenge marker not depending on `uⱼ` is a *structural* fact of the derivation
-(`roundTranscript` is a function of `t₀` and the round points only — the squeezed `uⱼ` never re-enters it,
-matching halo2's no-self-absorption). Tying the round points themselves to a challenge-prefix-respecting
-`Prover` strategy — that `Lⱼ, Rⱼ` are chosen from `u₀ … u_{j-1}` but not `uⱼ` — is `Prover`/`proverAccept`'s
-node/continuation shape; this module supplies the transcript side that shape mirrors.
+That `(Lⱼ, Rⱼ)` and the challenge marker do not depend on `uⱼ` is *structural*: `roundTranscript` is a
+function of `t₀` and the round points alone, and the squeezed `uⱼ` never re-enters it (halo2's
+no-self-absorption). Tying the round points themselves to a challenge-prefix-respecting `Prover` strategy —
+`Lⱼ, Rⱼ` chosen from `u₀ … u_{j-1}` but not `uⱼ` — is `Prover`/`proverAccept`'s node/continuation shape; this
+module supplies the transcript side that shape mirrors.
 -/
 
 namespace Zcash.Snark
 
 variable {F G : Type*}
 
-/-- The transcript prefix from which the round-`j` IPA challenge `uⱼ` is squeezed, given the base transcript
-`t₀` (everything absorbed through `z`) and the round points `rounds i = (Lᵢ, Rᵢ)`. Structurally the running
-`t` in `deriveChallenges`'s IPA `foldl` at step `j`: `t₀` followed by `[.point Lᵢ, .point Rᵢ, .challenge]`
-for every `i ≤ j`. -/
+/-- The transcript prefix the round-`j` IPA challenge `uⱼ` is squeezed from, given the base transcript `t₀`
+(everything absorbed through `z`) and the round points `rounds i = (Lᵢ, Rᵢ)`: it is the running `t` in
+`deriveChallenges`'s IPA `foldl` at round `j` — `t₀` followed by `[.point Lᵢ, .point Rᵢ, .challenge]` for
+every `i ≤ j`. -/
 def roundTranscript (t₀ : List (TranscriptElt F G)) (rounds : ℕ → G × G) :
     ℕ → List (TranscriptElt F G)
   | 0 => t₀ ++ [.point (rounds 0).1, .point (rounds 0).2, .challenge]
@@ -67,9 +67,9 @@ theorem roundTranscript_prefix_mono (t₀ : List (TranscriptElt F G)) (rounds : 
     | succ j ih => exact ih.trans ⟨_, (roundTranscript_succ t₀ rounds j).symm⟩
   · exact ⟨_, (roundTranscript_succ t₀ rounds j).symm⟩
 
-/-- **The round point is fixed before its challenge.** `(Lⱼ, Rⱼ)` occurs in `roundTranscript t₀ rounds j`,
-the prefix `uⱼ = squeeze (roundTranscript t₀ rounds j)` is squeezed from. So `uⱼ` is a function of a
-transcript containing the round point: `(Lⱼ, Rⱼ)` is determined before `uⱼ` and cannot depend on it. -/
+/-- **The round point is fixed before its challenge.** `(Lⱼ, Rⱼ)` occurs in the prefix
+`uⱼ = squeeze (roundTranscript t₀ rounds j)` is squeezed from, so `uⱼ` is a function of a transcript already
+containing the round point — which therefore cannot depend on its own challenge. -/
 theorem roundPoint_mem_roundTranscript (t₀ : List (TranscriptElt F G)) (rounds : ℕ → G × G) (j : ℕ) :
     TranscriptElt.point (rounds j).1 ∈ roundTranscript t₀ rounds j ∧
       TranscriptElt.point (rounds j).2 ∈ roundTranscript t₀ rounds j := by
@@ -86,13 +86,12 @@ def roundChallenge (fs : FiatShamir F G) (t₀ : List (TranscriptElt F G)) (roun
 `L` — at each `i`, appending `[.point Lᵢ, .point Rᵢ, .challenge]` to the running transcript and squeezing —
 the final transcript is the base `t₀` followed by every round's point-pair and challenge marker, in order.
 
-This lambda matches the IPA `foldl` of `Verifier.FiatShamir.deriveChallenges` (with `rp = ps.ipaRounds` and
-`L = List.finRange shape.k`); the *instantiation* against the actual derivation is carried by the
-challenge-side companion `ipaFold_challenges` inside the seal `deriveChallenges_ipaRound_eq` — which a
-schedule refactor would break — with this transcript-side form documenting the same fold: the deployed
-verifier absorbs the round points sequentially, each `(Lᵢ, Rᵢ)` before its own challenge is squeezed and
-after every earlier round's, with the squeezed challenges never re-entering the transcript (halo2's
-no-self-absorption). -/
+This lambda matches the IPA `foldl` of `Verifier.FiatShamir.deriveChallenges` (`rp = ps.ipaRounds`,
+`L = List.finRange shape.k`). It documents the transcript side of that fold: the deployed verifier absorbs
+the round points sequentially — each `(Lᵢ, Rᵢ)` before its own challenge is squeezed and after every earlier
+round's — and the squeezed challenges never re-enter the transcript (halo2's no-self-absorption). The
+instantiation against the actual derivation is carried by the challenge-side companion `ipaFold_challenges`,
+inside the seal `deriveChallenges_ipaRound_eq` that a schedule refactor would break. -/
 theorem ipaFold_transcript {ι : Type*} (fs : FiatShamir F G) (rp : ι → G × G)
     (L : List ι) (t₀ : List (TranscriptElt F G)) (us₀ : List F) :
     (L.foldl (fun st i =>

--- a/Zcash/Snark/Soundness/Forking/Ordering.lean
+++ b/Zcash/Snark/Soundness/Forking/Ordering.lean
@@ -2,62 +2,44 @@ import Zcash.Snark.Verifier.FiatShamir
 import Zcash.Snark.Soundness.Forking.Extractor
 
 /-!
-# Round-by-round Fiat–Shamir transcript ordering
+# Fiat–Shamir round ordering
 
-`Verifier.FiatShamir.deriveChallenges` squeezes the IPA round challenges with a `foldl` over the rounds that,
-at round `j`, appends the round point `(Lⱼ, Rⱼ)` to the running transcript and *then* squeezes `uⱼ` from it:
+`deriveChallenges` appends each IPA round point `(Lⱼ, Rⱼ)` before squeezing its challenge `uⱼ`:
 
     (List.finRange shape.k).foldl (fun (t, us) j =>
         let t := t ++ [.point Lⱼ, .point Rⱼ, .challenge]
         (t, us ++ [squeeze t])) (t₀, [])
 
-This module makes the online ordering that `foldl` enforces explicit and proves it — the transcript-ordering
-half of the prover-as-oracle bridge (`Soundness.Forking.Rewind`): the deployed schedule's own derivation
-has the dependency structure the `Prover`/rewinding tree (`Soundness.Forking.Extractor.Prover`) assumes.
+This module proves that the deployed schedule has the prefix ordering assumed by the prover strategy
+and rewinding proofs.
 
-* `roundTranscript` — the transcript prefix `uⱼ` is squeezed from (the running `t` above, at round `j`).
-* `roundTranscript_succ` — round `j+1`'s transcript is round `j`'s extended by exactly `(L_{j+1}, R_{j+1})`
-  and the challenge marker: each round point is absorbed *before* that round's challenge and *after* every
-  earlier round's challenge.
-* `roundPoint_mem_roundTranscript` — `(Lⱼ, Rⱼ)` lies in the prefix `uⱼ` is squeezed from, so `uⱼ` is a
-  function of a transcript containing `(Lⱼ, Rⱼ)`: the round point is fixed before its challenge and cannot
-  depend on it (while later points, appended after, may depend on `uⱼ`).
-* `roundTranscript_prefix_mono` — the base transcript `t₀` (through `z`) is a prefix of every round's
-  transcript, and round transcripts grow monotonically, so no round's squeeze can see a *later* round's point.
+* `roundTranscript` is the prefix used to squeeze one round challenge.
+* `roundTranscript_succ` and `roundTranscript_prefix_mono` show how those prefixes grow.
+* `roundPoint_mem_roundTranscript` shows that the current point is present before its challenge.
 
-That `(Lⱼ, Rⱼ)` and the challenge marker do not depend on `uⱼ` is *structural*: `roundTranscript` is a
-function of `t₀` and the round points alone, and the squeezed `uⱼ` never re-enters it (halo2's
-no-self-absorption). Tying the round points themselves to a challenge-prefix-respecting `Prover` strategy —
-`Lⱼ, Rⱼ` chosen from `u₀ … u_{j-1}` but not `uⱼ` — is `Prover`/`proverAccept`'s node/continuation shape; this
-module supplies the transcript side that shape mirrors.
+Halo2 does not reabsorb squeezed challenges. The `Prover` type separately ensures that each round
+point depends only on earlier challenges.
 -/
 
 namespace Zcash.Snark
 
 variable {F G : Type*}
 
-/-- The transcript prefix the round-`j` IPA challenge `uⱼ` is squeezed from, given the base transcript `t₀`
-(everything absorbed through `z`) and the round points `rounds i = (Lᵢ, Rᵢ)`: it is the running `t` in
-`deriveChallenges`'s IPA `foldl` at round `j` — `t₀` followed by `[.point Lᵢ, .point Rᵢ, .challenge]` for
-every `i ≤ j`. -/
+/-- The transcript prefix used to squeeze the round-`j` IPA challenge. -/
 def roundTranscript (t₀ : List (TranscriptElt F G)) (rounds : ℕ → G × G) :
     ℕ → List (TranscriptElt F G)
   | 0 => t₀ ++ [.point (rounds 0).1, .point (rounds 0).2, .challenge]
   | j + 1 =>
       roundTranscript t₀ rounds j ++ [.point (rounds (j + 1)).1, .point (rounds (j + 1)).2, .challenge]
 
-/-- **Each round point is absorbed before its challenge, after all earlier challenges.** Round `j+1`'s
-transcript is round `j`'s extended by exactly `(L_{j+1}, R_{j+1})` and the challenge marker — so `(Lⱼ, Rⱼ)`
-enters the transcript strictly between `u_{j-1}`'s squeeze and `uⱼ`'s. -/
+/-- Extend a round transcript with the next point and challenge marker. -/
 theorem roundTranscript_succ (t₀ : List (TranscriptElt F G)) (rounds : ℕ → G × G) (j : ℕ) :
     roundTranscript t₀ rounds (j + 1)
       = roundTranscript t₀ rounds j
         ++ [.point (rounds (j + 1)).1, .point (rounds (j + 1)).2, .challenge] :=
   rfl
 
-/-- **Monotone growth from the base transcript.** `t₀` (everything through `z`) is a prefix of every round's
-transcript, and round `j`'s transcript is a prefix of round `j+1`'s — so no round's squeeze can see a later
-round's point. -/
+/-- The base and earlier round transcripts are prefixes of every later round transcript. -/
 theorem roundTranscript_prefix_mono (t₀ : List (TranscriptElt F G)) (rounds : ℕ → G × G) (j : ℕ) :
     t₀ <+: roundTranscript t₀ rounds j
       ∧ roundTranscript t₀ rounds j <+: roundTranscript t₀ rounds (j + 1) := by
@@ -67,31 +49,18 @@ theorem roundTranscript_prefix_mono (t₀ : List (TranscriptElt F G)) (rounds : 
     | succ j ih => exact ih.trans ⟨_, (roundTranscript_succ t₀ rounds j).symm⟩
   · exact ⟨_, (roundTranscript_succ t₀ rounds j).symm⟩
 
-/-- **The round point is fixed before its challenge.** `(Lⱼ, Rⱼ)` occurs in the prefix
-`uⱼ = squeeze (roundTranscript t₀ rounds j)` is squeezed from, so `uⱼ` is a function of a transcript already
-containing the round point — which therefore cannot depend on its own challenge. -/
+/-- The round-`j` point is present in the transcript before `uⱼ` is squeezed. -/
 theorem roundPoint_mem_roundTranscript (t₀ : List (TranscriptElt F G)) (rounds : ℕ → G × G) (j : ℕ) :
     TranscriptElt.point (rounds j).1 ∈ roundTranscript t₀ rounds j ∧
       TranscriptElt.point (rounds j).2 ∈ roundTranscript t₀ rounds j := by
   cases j <;> exact ⟨by simp [roundTranscript], by simp [roundTranscript]⟩
 
-/-- The round-`j` IPA challenge as the deployed schedule squeezes it: from the round-`j` transcript, which
-contains `(Lⱼ, Rⱼ)` (`roundPoint_mem_roundTranscript`) and never the challenge `uⱼ` itself.
-`deriveChallenges_ipaRound_eq_roundChallenge` pins the deployed derivation to this form. -/
+/-- Squeeze the round-`j` IPA challenge from its round transcript. -/
 def roundChallenge (fs : FiatShamir F G) (t₀ : List (TranscriptElt F G)) (rounds : ℕ → G × G)
     (j : ℕ) : F :=
   fs.squeeze (roundTranscript t₀ rounds j)
 
-/-- **The deployed schedule's IPA `foldl` builds the round-by-round transcript.** Folding the round points in
-`L` — at each `i`, appending `[.point Lᵢ, .point Rᵢ, .challenge]` to the running transcript and squeezing —
-the final transcript is the base `t₀` followed by every round's point-pair and challenge marker, in order.
-
-This lambda matches the IPA `foldl` of `Verifier.FiatShamir.deriveChallenges` (`rp = ps.ipaRounds`,
-`L = List.finRange shape.k`). It documents the transcript side of that fold: the deployed verifier absorbs
-the round points sequentially — each `(Lᵢ, Rᵢ)` before its own challenge is squeezed and after every earlier
-round's — and the squeezed challenges never re-enter the transcript (halo2's no-self-absorption). The
-instantiation against the actual derivation is carried by the challenge-side companion `ipaFold_challenges`,
-inside the seal `deriveChallenges_ipaRound_eq` that a schedule refactor would break. -/
+/-- The transcript part of the deployed IPA `foldl` is the base followed by each round's absorb block. -/
 theorem ipaFold_transcript {ι : Type*} (fs : FiatShamir F G) (rp : ι → G × G)
     (L : List ι) (t₀ : List (TranscriptElt F G)) (us₀ : List F) :
     (L.foldl (fun st i =>
@@ -106,25 +75,17 @@ theorem ipaFold_transcript {ι : Type*} (fs : FiatShamir F G) (rp : ι → G × 
 
 /-! ## The Prover-tree side: each round point is prefix-determined
 
-`Soundness.Forking.Extractor.Prover` is `node (L R : G) (cont : F → Prover d)`: the round point `(L, R)` is a
-field of the node — fixed — while `cont` takes the round challenge. So the *type* already forbids `(Lⱼ, Rⱼ)`
-depending on `uⱼ`; below we read that off as a theorem, matching the transcript ordering above.
+In `Prover.node`, the round point is fixed before the challenge selects a continuation. The theorem
+below states that two paths with the same prefix therefore have the same next round point.
 -/
 
-/-- The round point `(Lⱼ, Rⱼ)` the prover strategy `P` commits at depth `j` down the challenge path `χ`:
-descend `j` nodes following the earlier challenges `χ 0, …, χ (j-1)`, then read the reached node's fixed
-`(L, R)` (`none` past the leaf). -/
+/-- The prover's round point at depth `j` along challenge path `χ`. -/
 def proverRoundPoint : {d : ℕ} → Prover F G d → (Fin d → F) → ℕ → Option (G × G)
   | 0, _, _, _ => none
   | _ + 1, .node L R _, _, 0 => some (L, R)
   | _ + 1, .node _ _ cont, χ, j + 1 => proverRoundPoint (cont (χ 0)) (Fin.tail χ) j
 
-/-- **The Prover tree fixes each round point before its challenge.** The depth-`j` round
-point depends only on the earlier challenges `χ 0, …, χ (j-1)` — the path descended to reach the node — not on
-that round's own challenge `χ j` or any later one: two paths agreeing on their first `j` entries yield the same
-depth-`j` round point. This is the tree side of the transcript ordering (`roundPoint_mem_roundTranscript`):
-`(Lⱼ, Rⱼ)` is prefix-determined, so the modeled prover commits it before seeing `uⱼ`, exactly as the deployed
-transcript absorbs `(Lⱼ, Rⱼ)` before squeezing `uⱼ`. -/
+/-- The round point at depth `j` depends only on the first `j` challenges. -/
 theorem proverRoundPoint_prefix : {d : ℕ} → (P : Prover F G d) → (χ χ' : Fin d → F) → (j : ℕ) →
     (∀ i : Fin d, (i : ℕ) < j → χ i = χ' i) →
     proverRoundPoint P χ j = proverRoundPoint P χ' j
@@ -139,19 +100,11 @@ theorem proverRoundPoint_prefix : {d : ℕ} → (P : Prover F G d) → (χ χ' :
 
 /-! ## Sealing the module to the deployed derivation
 
-The lemmas above are stated over `roundTranscript`, a *reconstruction* of `deriveChallenges`'s IPA fold. To
-rule out drift between the reconstruction and the deployed schedule, `deriveChallenges_ipaRound_eq` proves
-the deployed round challenges *are* the round-by-round squeezes: `(deriveChallenges fs init ps).ipaRound j`
-is `fs.squeeze` of the round-`j` transcript over the named base `preIpaTranscript init ps` and the proof's
-own round points, and `roundTranscriptFin_eq_roundTranscript` / `deriveChallenges_ipaRound_eq_roundChallenge`
-identify the sealed object with the reconstruction — so the ordering trio transports to the deployed
-derivation rather than holding only of a mirror. Any refactor of `deriveChallenges` that changes the IPA
-absorb order breaks the seal. -/
+The earlier lemmas use a reconstructed round transcript. `deriveChallenges_ipaRound_eq` proves that
+the deployed schedule uses exactly that transcript, so any ordering change breaks the theorem.
+-/
 
-/-- The transcript `deriveChallenges` has absorbed when its IPA fold starts: `init`, then every pre-IPA
-absorb block with its challenge markers, through the `z` marker. The chain never re-absorbs a squeezed
-challenge (halo2's no-self-absorption), so it is a function of `init` and the proof string alone — no
-`FiatShamir` argument. `deriveChallenges_ipaRound_eq` pins this to the deployed derivation. -/
+/-- The transcript prefix before the deployed IPA round fold begins. -/
 def preIpaTranscript {shape : Shape} (init : List (TranscriptElt F G)) (ps : ProofString shape F G) :
     List (TranscriptElt F G) :=
   let t := init ++ absorbPoints2 ps.adviceCommitments ++ [.challenge]
@@ -173,9 +126,7 @@ def preIpaTranscript {shape : Shape} (init : List (TranscriptElt F G)) (ps : Pro
   let t := t ++ [.challenge]
   t
 
-/-- The challenge side of the IPA `foldl` (companion of `ipaFold_transcript`, which characterizes the
-transcript side): the accumulated challenge list is `us₀` extended by, for each round position `m`, the
-squeeze of the base extended by the first `m + 1` rounds' absorb blocks. -/
+/-- The challenges produced by the deployed IPA `foldl`. -/
 theorem ipaFold_challenges {ι : Type*} (fs : FiatShamir F G) (rp : ι → G × G)
     (L : List ι) (t₀ : List (TranscriptElt F G)) (us₀ : List F) :
     (L.foldl (fun st i =>
@@ -194,8 +145,7 @@ theorem ipaFold_challenges {ι : Type*} (fs : FiatShamir F G) (rp : ι → G × 
         List.flatten_cons, List.flatten_nil, Function.comp_def, List.append_assoc,
         List.cons_append, List.nil_append]
 
-/-- `roundTranscript` in take-and-flatten form: the base followed by the first `j + 1` rounds' absorb
-blocks — the shape `ipaFold_challenges` produces, bridging the fold to the recursion. -/
+/-- Express `roundTranscript` as the base followed by the first `j + 1` absorb blocks. -/
 theorem roundTranscript_eq_take (t₀ : List (TranscriptElt F G)) (rounds : ℕ → G × G) (j : ℕ) :
     roundTranscript t₀ rounds j
       = t₀ ++ ((List.range (j + 1)).map (fun i =>
@@ -208,8 +158,7 @@ theorem roundTranscript_eq_take (t₀ : List (TranscriptElt F G)) (rounds : ℕ 
         List.flatten_append, List.append_assoc]
       simp
 
-/-- The round-`j` transcript over `Fin`-indexed round points — the form the deployed schedule's
-`Fin shape.k → G × G` rounds produce directly. -/
+/-- The round-`j` transcript for a `Fin`-indexed round vector. -/
 def roundTranscriptFin {k : ℕ} (t₀ : List (TranscriptElt F G)) (rounds : Fin k → G × G) (j : Fin k) :
     List (TranscriptElt F G) :=
   t₀ ++ (((List.finRange k).take (j.val + 1)).map (fun i =>
@@ -224,8 +173,7 @@ private theorem length_flatten_map_triple {ι : Type*} (f g h : ι → Transcrip
         List.length_nil, length_flatten_map_triple f g h l]
       omega
 
-/-- Each round's absorb block has three elements, so the round-`j` transcript extends the base by exactly
-`3 · (j + 1)` — the length arithmetic behind "distinct rounds have distinct transcripts". -/
+/-- The round-`j` transcript extends the base by `3 · (j + 1)` elements. -/
 theorem roundTranscriptFin_length {k : ℕ} (t₀ : List (TranscriptElt F G)) (rounds : Fin k → G × G)
     (j : Fin k) :
     (roundTranscriptFin t₀ rounds j).length = t₀.length + 3 * (j.val + 1) := by
@@ -236,8 +184,7 @@ theorem roundTranscriptFin_length {k : ℕ} (t₀ : List (TranscriptElt F G)) (r
     List.length_take, List.length_finRange]
   omega
 
-/-- Distinct rounds squeeze from distinct transcripts (their lengths differ by `3 · |j − j'|`) — the fact
-that lets the oracle be reprogrammed at one round's prefix without touching any other round's challenge. -/
+/-- Distinct rounds squeeze from distinct transcript prefixes. -/
 theorem roundTranscriptFin_injective {k : ℕ} (t₀ : List (TranscriptElt F G))
     (rounds : Fin k → G × G) :
     Function.Injective (roundTranscriptFin t₀ rounds) := by
@@ -246,10 +193,7 @@ theorem roundTranscriptFin_injective {k : ℕ} (t₀ : List (TranscriptElt F G))
   rw [roundTranscriptFin_length, roundTranscriptFin_length] at hlen
   exact Fin.ext (by omega)
 
-/-- **The mirror↔seal identification.** The `Fin`-indexed round transcript — the sealed object — is
-`roundTranscript` at (any `ℕ`-extension of) the same round points: below `j` the wrap-around never fires.
-This is what transports the ordering lemmas (`roundTranscript_succ` / `roundPoint_mem_roundTranscript` /
-`roundTranscript_prefix_mono`) to the deployed derivation through the seal. -/
+/-- The `Fin`-indexed round transcript equals the recursive `roundTranscript`. -/
 theorem roundTranscriptFin_eq_roundTranscript {k : ℕ} (t₀ : List (TranscriptElt F G))
     (rounds : Fin k → G × G) (j : Fin k) :
     roundTranscriptFin t₀ rounds j
@@ -268,14 +212,9 @@ theorem roundTranscriptFin_eq_roundTranscript {k : ℕ} (t₀ : List (Transcript
       TranscriptElt.challenge]) (Fin.ext ?_)
     simp [Nat.mod_eq_of_lt hn]
 
-/-- **The anti-drift seal: the deployed schedule's IPA challenges are the round-by-round squeezes.**
-`(deriveChallenges fs init ps).ipaRound j` is exactly `fs.squeeze` of the round-`j` transcript over the
-named base `preIpaTranscript init ps` and the proof's own round points `ps.ipaRounds`. Through the
-identification `roundTranscriptFin_eq_roundTranscript` (and the `roundChallenge` form below),
-`roundTranscript_succ` / `roundPoint_mem_roundTranscript` / `roundTranscript_prefix_mono` then hold *of the
-deployed derivation itself*: each `(Lⱼ, Rⱼ)` is absorbed before `uⱼ` is squeezed, and
-`uⱼ` is sampled from the prefix containing it. A refactor of `deriveChallenges` that changes the IPA
-absorb order breaks this theorem. -/
+/-- The deployed round challenge is squeezed from the corresponding `roundTranscriptFin`.
+
+This theorem pins the ordering model to `deriveChallenges`. -/
 theorem deriveChallenges_ipaRound_eq {shape : Shape} [Zero F] (fs : FiatShamir F G)
     (init : List (TranscriptElt F G)) (ps : ProofString shape F G) (j : Fin shape.k) :
     (deriveChallenges fs init ps).ipaRound j
@@ -285,9 +224,7 @@ theorem deriveChallenges_ipaRound_eq {shape : Shape} [Zero F] (fs : FiatShamir F
     List.getElem?_range (by simp)]
   rfl
 
-/-- The seal in `roundChallenge` form: the deployed round-`j` challenge is `roundChallenge` at the deployed
-base `preIpaTranscript` and (any `ℕ`-extension of) the proof's round points — so the ordering trio above
-holds verbatim of the transcripts the deployed schedule actually squeezes. -/
+/-- Restate `deriveChallenges_ipaRound_eq` using `roundChallenge`. -/
 theorem deriveChallenges_ipaRound_eq_roundChallenge {shape : Shape} [Zero F] (fs : FiatShamir F G)
     (init : List (TranscriptElt F G)) (ps : ProofString shape F G) (j : Fin shape.k) :
     (deriveChallenges fs init ps).ipaRound j

--- a/Zcash/Snark/Soundness/Forking/Ordering.lean
+++ b/Zcash/Snark/Soundness/Forking/Ordering.lean
@@ -1,0 +1,299 @@
+import Zcash.Snark.Verifier.FiatShamir
+import Zcash.Snark.Soundness.Forking.Extractor
+
+/-!
+# Round-by-round Fiat–Shamir transcript ordering
+
+`Verifier.FiatShamir.deriveChallenges` squeezes the IPA round challenges with a `foldl` over the rounds that,
+at round `j`, appends the round point `(Lⱼ, Rⱼ)` to the running transcript and *then* squeezes `uⱼ` from it:
+
+    (List.finRange shape.k).foldl (fun (t, us) j =>
+        let t := t ++ [.point Lⱼ, .point Rⱼ, .challenge]
+        (t, us ++ [squeeze t])) (t₀, [])
+
+This module makes the online ordering that `foldl` enforces explicit and proves it — the transcript-ordering
+half of the prover-as-oracle bridge (`Soundness.Forking.Rewind`): the deployed schedule's own derivation
+has the dependency structure the `Prover`/rewinding tree (`Soundness.Forking.Extractor.Prover`) assumes.
+
+* `roundTranscript` — the transcript prefix `uⱼ` is squeezed from (the running `t` above, at step `j`).
+* `roundTranscript_succ` — round `j+1`'s transcript is round `j`'s extended by exactly `(L_{j+1}, R_{j+1})`
+  and the challenge marker: each round point is absorbed *before* that round's challenge and *after* every
+  earlier round's challenge.
+* `roundPoint_mem_roundTranscript` — `(Lⱼ, Rⱼ)` lies in the prefix `uⱼ` is squeezed from, so `uⱼ` is a
+  function of a transcript containing `(Lⱼ, Rⱼ)`: the round point is fixed before its challenge and cannot
+  depend on it (while later points, appended after, may depend on `uⱼ`).
+* `roundTranscript_prefix_mono` — the base transcript `t₀` (through `z`) is a prefix of every round's
+  transcript, and round transcripts grow monotonically, so no round's squeeze can see a *later* round's point.
+
+`(L, R)` and the challenge marker not depending on `uⱼ` is a *structural* fact of the derivation
+(`roundTranscript` is a function of `t₀` and the round points only — the squeezed `uⱼ` never re-enters it,
+matching halo2's no-self-absorption). Tying the round points themselves to a challenge-prefix-respecting
+`Prover` strategy — that `Lⱼ, Rⱼ` are chosen from `u₀ … u_{j-1}` but not `uⱼ` — is `Prover`/`proverAccept`'s
+node/continuation shape; this module supplies the transcript side that shape mirrors.
+-/
+
+namespace Zcash.Snark
+
+variable {F G : Type*}
+
+/-- The transcript prefix from which the round-`j` IPA challenge `uⱼ` is squeezed, given the base transcript
+`t₀` (everything absorbed through `z`) and the round points `rounds i = (Lᵢ, Rᵢ)`. Structurally the running
+`t` in `deriveChallenges`'s IPA `foldl` at step `j`: `t₀` followed by `[.point Lᵢ, .point Rᵢ, .challenge]`
+for every `i ≤ j`. -/
+def roundTranscript (t₀ : List (TranscriptElt F G)) (rounds : ℕ → G × G) :
+    ℕ → List (TranscriptElt F G)
+  | 0 => t₀ ++ [.point (rounds 0).1, .point (rounds 0).2, .challenge]
+  | j + 1 =>
+      roundTranscript t₀ rounds j ++ [.point (rounds (j + 1)).1, .point (rounds (j + 1)).2, .challenge]
+
+/-- **Each round point is absorbed before its challenge, after all earlier challenges.** Round `j+1`'s
+transcript is round `j`'s extended by exactly `(L_{j+1}, R_{j+1})` and the challenge marker — so `(Lⱼ, Rⱼ)`
+enters the transcript strictly between `u_{j-1}`'s squeeze and `uⱼ`'s. -/
+theorem roundTranscript_succ (t₀ : List (TranscriptElt F G)) (rounds : ℕ → G × G) (j : ℕ) :
+    roundTranscript t₀ rounds (j + 1)
+      = roundTranscript t₀ rounds j
+        ++ [.point (rounds (j + 1)).1, .point (rounds (j + 1)).2, .challenge] :=
+  rfl
+
+/-- **Monotone growth from the base transcript.** `t₀` (everything through `z`) is a prefix of every round's
+transcript, and round `j`'s transcript is a prefix of round `j+1`'s — so no round's squeeze can see a later
+round's point. -/
+theorem roundTranscript_prefix_mono (t₀ : List (TranscriptElt F G)) (rounds : ℕ → G × G) (j : ℕ) :
+    t₀ <+: roundTranscript t₀ rounds j
+      ∧ roundTranscript t₀ rounds j <+: roundTranscript t₀ rounds (j + 1) := by
+  constructor
+  · induction j with
+    | zero => exact ⟨_, rfl⟩
+    | succ j ih => exact ih.trans ⟨_, (roundTranscript_succ t₀ rounds j).symm⟩
+  · exact ⟨_, (roundTranscript_succ t₀ rounds j).symm⟩
+
+/-- **The round point is fixed before its challenge.** `(Lⱼ, Rⱼ)` occurs in `roundTranscript t₀ rounds j`,
+the prefix `uⱼ = squeeze (roundTranscript t₀ rounds j)` is squeezed from. So `uⱼ` is a function of a
+transcript containing the round point: `(Lⱼ, Rⱼ)` is determined before `uⱼ` and cannot depend on it. -/
+theorem roundPoint_mem_roundTranscript (t₀ : List (TranscriptElt F G)) (rounds : ℕ → G × G) (j : ℕ) :
+    TranscriptElt.point (rounds j).1 ∈ roundTranscript t₀ rounds j ∧
+      TranscriptElt.point (rounds j).2 ∈ roundTranscript t₀ rounds j := by
+  cases j <;> exact ⟨by simp [roundTranscript], by simp [roundTranscript]⟩
+
+/-- The round-`j` IPA challenge as the deployed schedule squeezes it: from the round-`j` transcript, which
+contains `(Lⱼ, Rⱼ)` (`roundPoint_mem_roundTranscript`) and never the challenge `uⱼ` itself.
+`deriveChallenges_ipaRound_eq_roundChallenge` pins the deployed derivation to this form. -/
+def roundChallenge (fs : FiatShamir F G) (t₀ : List (TranscriptElt F G)) (rounds : ℕ → G × G)
+    (j : ℕ) : F :=
+  fs.squeeze (roundTranscript t₀ rounds j)
+
+/-- **The deployed schedule's IPA `foldl` builds the round-by-round transcript.** Folding the round points in
+`L` — at each `i`, appending `[.point Lᵢ, .point Rᵢ, .challenge]` to the running transcript and squeezing —
+the final transcript is the base `t₀` followed by every round's point-pair and challenge marker, in order.
+
+This lambda matches the IPA `foldl` of `Verifier.FiatShamir.deriveChallenges` (with `rp = ps.ipaRounds` and
+`L = List.finRange shape.k`); the *instantiation* against the actual derivation is carried by the
+challenge-side companion `ipaFold_challenges` inside the seal `deriveChallenges_ipaRound_eq` — which a
+schedule refactor would break — with this transcript-side form documenting the same fold: the deployed
+verifier absorbs the round points sequentially, each `(Lᵢ, Rᵢ)` before its own challenge is squeezed and
+after every earlier round's, with the squeezed challenges never re-entering the transcript (halo2's
+no-self-absorption). -/
+theorem ipaFold_transcript {ι : Type*} (fs : FiatShamir F G) (rp : ι → G × G)
+    (L : List ι) (t₀ : List (TranscriptElt F G)) (us₀ : List F) :
+    (L.foldl (fun st i =>
+        (st.1 ++ [TranscriptElt.point (rp i).1, TranscriptElt.point (rp i).2, TranscriptElt.challenge],
+          st.2 ++ [fs.squeeze (st.1 ++ [TranscriptElt.point (rp i).1, TranscriptElt.point (rp i).2,
+            TranscriptElt.challenge])])) (t₀, us₀)).1
+      = t₀ ++ (L.map (fun i =>
+          [TranscriptElt.point (rp i).1, TranscriptElt.point (rp i).2, TranscriptElt.challenge])).flatten := by
+  induction L generalizing t₀ us₀ with
+  | nil => simp
+  | cons i L ih => simp only [List.foldl_cons, ih, List.map_cons, List.flatten_cons, List.append_assoc]
+
+/-! ## The Prover-tree side: each round point is prefix-determined
+
+`Soundness.Forking.Extractor.Prover` is `node (L R : G) (cont : F → Prover d)`: the round point `(L, R)` is a
+field of the node — fixed — while `cont` takes the round challenge. So the *type* already forbids `(Lⱼ, Rⱼ)`
+depending on `uⱼ`; below we read that off as a theorem, matching the transcript ordering above.
+-/
+
+/-- The round point `(Lⱼ, Rⱼ)` the prover strategy `P` commits at depth `j` down the challenge path `χ`:
+descend `j` nodes following the earlier challenges `χ 0, …, χ (j-1)`, then read the reached node's fixed
+`(L, R)` (`none` past the leaf). -/
+def proverRoundPoint : {d : ℕ} → Prover F G d → (Fin d → F) → ℕ → Option (G × G)
+  | 0, _, _, _ => none
+  | _ + 1, .node L R _, _, 0 => some (L, R)
+  | _ + 1, .node _ _ cont, χ, j + 1 => proverRoundPoint (cont (χ 0)) (Fin.tail χ) j
+
+/-- **The Prover tree fixes each round point before its challenge.** The depth-`j` round
+point depends only on the earlier challenges `χ 0, …, χ (j-1)` — the path descended to reach the node — not on
+that round's own challenge `χ j` or any later one: two paths agreeing on their first `j` entries yield the same
+depth-`j` round point. This is the tree side of the transcript ordering (`roundPoint_mem_roundTranscript`):
+`(Lⱼ, Rⱼ)` is prefix-determined, so the modeled prover commits it before seeing `uⱼ`, exactly as the deployed
+transcript absorbs `(Lⱼ, Rⱼ)` before squeezing `uⱼ`. -/
+theorem proverRoundPoint_prefix : {d : ℕ} → (P : Prover F G d) → (χ χ' : Fin d → F) → (j : ℕ) →
+    (∀ i : Fin d, (i : ℕ) < j → χ i = χ' i) →
+    proverRoundPoint P χ j = proverRoundPoint P χ' j
+  | 0, .leaf _ _, _, _, _, _ => rfl
+  | _ + 1, .node _ _ _, _, _, 0, _ => rfl
+  | _ + 1, .node _ _ cont, χ, χ', j + 1, h => by
+      have h0 : χ 0 = χ' 0 := h 0 (Nat.succ_pos j)
+      show proverRoundPoint (cont (χ 0)) (Fin.tail χ) j = proverRoundPoint (cont (χ' 0)) (Fin.tail χ') j
+      rw [h0]
+      exact proverRoundPoint_prefix (cont (χ' 0)) (Fin.tail χ) (Fin.tail χ') j
+        (fun i hi => h i.succ (by simp only [Fin.val_succ]; omega))
+
+/-! ## Sealing the module to the deployed derivation
+
+The lemmas above are stated over `roundTranscript`, a *reconstruction* of `deriveChallenges`'s IPA fold. To
+rule out drift between the reconstruction and the deployed schedule, `deriveChallenges_ipaRound_eq` proves
+the deployed round challenges *are* the round-by-round squeezes: `(deriveChallenges fs init ps).ipaRound j`
+is `fs.squeeze` of the round-`j` transcript over the named base `preIpaTranscript init ps` and the proof's
+own round points, and `roundTranscriptFin_eq_roundTranscript` / `deriveChallenges_ipaRound_eq_roundChallenge`
+identify the sealed object with the reconstruction — so the ordering trio transports to the deployed
+derivation rather than holding only of a mirror. Any refactor of `deriveChallenges` that changes the IPA
+absorb order breaks the seal. -/
+
+/-- The transcript `deriveChallenges` has absorbed when its IPA fold starts: `init`, then every pre-IPA
+absorb block with its challenge markers, through the `z` marker. The chain never re-absorbs a squeezed
+challenge (halo2's no-self-absorption), so it is a function of `init` and the proof string alone — no
+`FiatShamir` argument. `deriveChallenges_ipaRound_eq` pins this to the deployed derivation. -/
+def preIpaTranscript {shape : Shape} (init : List (TranscriptElt F G)) (ps : ProofString shape F G) :
+    List (TranscriptElt F G) :=
+  let t := init ++ absorbPoints2 ps.adviceCommitments ++ [.challenge]
+  let t := t ++ absorbLookupPermuted ps.lookupPermutedInput ps.lookupPermutedTable ++ [.challenge]
+  let t := t ++ [.challenge]
+  let t := t ++ absorbPoints2 ps.permutationProduct ++ absorbPoints2 ps.lookupProduct
+    ++ [TranscriptElt.point ps.vanishingRandom] ++ [.challenge]
+  let t := t ++ absorbPoints ps.hPieces ++ [.challenge]
+  let evalElts := absorbScalars2 ps.instanceEvals ++ absorbScalars2 ps.adviceEvals
+    ++ absorbScalars ps.fixedEvals ++ [TranscriptElt.scalar ps.vanishingRandomEval]
+    ++ absorbScalars ps.permutationCommonEvals
+    ++ (List.ofFn (fun p => (List.ofFn (fun s => absorbPermSet (ps.permutationSetEvals p s))).flatten)).flatten
+    ++ (List.ofFn (fun p => (List.ofFn (fun l => absorbLookup (ps.lookupEvals p l))).flatten)).flatten
+  let t := t ++ evalElts ++ [.challenge]
+  let t := t ++ [.challenge]
+  let t := t ++ [TranscriptElt.point ps.multiopenQPrime] ++ [.challenge]
+  let t := t ++ absorbScalars ps.multiopenU ++ [.challenge]
+  let t := t ++ [TranscriptElt.point ps.ipaS] ++ [.challenge]
+  let t := t ++ [.challenge]
+  t
+
+/-- The challenge side of the IPA `foldl` (companion of `ipaFold_transcript`, which characterizes the
+transcript side): the accumulated challenge list is `us₀` extended by, for each round position `m`, the
+squeeze of the base extended by the first `m + 1` rounds' absorb blocks. -/
+theorem ipaFold_challenges {ι : Type*} (fs : FiatShamir F G) (rp : ι → G × G)
+    (L : List ι) (t₀ : List (TranscriptElt F G)) (us₀ : List F) :
+    (L.foldl (fun st i =>
+        (st.1 ++ [TranscriptElt.point (rp i).1, TranscriptElt.point (rp i).2, TranscriptElt.challenge],
+          st.2 ++ [fs.squeeze (st.1 ++ [TranscriptElt.point (rp i).1, TranscriptElt.point (rp i).2,
+            TranscriptElt.challenge])])) (t₀, us₀)).2
+      = us₀ ++ (List.range L.length).map (fun m =>
+          fs.squeeze (t₀ ++ ((L.take (m + 1)).map (fun i =>
+            [TranscriptElt.point (rp i).1, TranscriptElt.point (rp i).2,
+              TranscriptElt.challenge])).flatten)) := by
+  induction L generalizing t₀ us₀ with
+  | nil => simp
+  | cons i L ih =>
+      rw [List.foldl_cons, ih, List.length_cons, List.range_succ_eq_map]
+      simp only [List.map_cons, List.map_map, List.take_succ_cons, List.take_zero, List.map_nil,
+        List.flatten_cons, List.flatten_nil, Function.comp_def, List.append_assoc,
+        List.cons_append, List.nil_append]
+
+/-- `roundTranscript` in take-and-flatten form: the base followed by the first `j + 1` rounds' absorb
+blocks — the shape `ipaFold_challenges` produces, bridging the fold to the recursion. -/
+theorem roundTranscript_eq_take (t₀ : List (TranscriptElt F G)) (rounds : ℕ → G × G) (j : ℕ) :
+    roundTranscript t₀ rounds j
+      = t₀ ++ ((List.range (j + 1)).map (fun i =>
+          [TranscriptElt.point (rounds i).1, TranscriptElt.point (rounds i).2,
+            TranscriptElt.challenge])).flatten := by
+  induction j with
+  | zero => simp [roundTranscript]
+  | succ j ih =>
+      rw [roundTranscript_succ, ih, List.range_succ (n := j + 1), List.map_append,
+        List.flatten_append, List.append_assoc]
+      simp
+
+/-- The round-`j` transcript over `Fin`-indexed round points — the form the deployed schedule's
+`Fin shape.k → G × G` rounds produce directly. -/
+def roundTranscriptFin {k : ℕ} (t₀ : List (TranscriptElt F G)) (rounds : Fin k → G × G) (j : Fin k) :
+    List (TranscriptElt F G) :=
+  t₀ ++ (((List.finRange k).take (j.val + 1)).map (fun i =>
+    [TranscriptElt.point (rounds i).1, TranscriptElt.point (rounds i).2,
+      TranscriptElt.challenge])).flatten
+
+private theorem length_flatten_map_triple {ι : Type*} (f g h : ι → TranscriptElt F G) :
+    ∀ l : List ι, ((l.map (fun i => [f i, g i, h i])).flatten).length = 3 * l.length
+  | [] => rfl
+  | i :: l => by
+      simp only [List.map_cons, List.flatten_cons, List.length_append, List.length_cons,
+        List.length_nil, length_flatten_map_triple f g h l]
+      omega
+
+/-- Each round's absorb block has three elements, so the round-`j` transcript extends the base by exactly
+`3 · (j + 1)` — the length arithmetic behind "distinct rounds have distinct transcripts". -/
+theorem roundTranscriptFin_length {k : ℕ} (t₀ : List (TranscriptElt F G)) (rounds : Fin k → G × G)
+    (j : Fin k) :
+    (roundTranscriptFin t₀ rounds j).length = t₀.length + 3 * (j.val + 1) := by
+  have hj := j.isLt
+  simp only [roundTranscriptFin, List.length_append,
+    length_flatten_map_triple (fun i => TranscriptElt.point (rounds i).1)
+      (fun i => TranscriptElt.point (rounds i).2) (fun _ => TranscriptElt.challenge),
+    List.length_take, List.length_finRange]
+  omega
+
+/-- Distinct rounds squeeze from distinct transcripts (their lengths differ by `3 · |j − j'|`) — the fact
+that lets the oracle be reprogrammed at one round's prefix without touching any other round's challenge. -/
+theorem roundTranscriptFin_injective {k : ℕ} (t₀ : List (TranscriptElt F G))
+    (rounds : Fin k → G × G) :
+    Function.Injective (roundTranscriptFin t₀ rounds) := by
+  intro a b h
+  have hlen := congrArg List.length h
+  rw [roundTranscriptFin_length, roundTranscriptFin_length] at hlen
+  exact Fin.ext (by omega)
+
+/-- **The mirror↔seal identification.** The `Fin`-indexed round transcript — the sealed object — is
+`roundTranscript` at (any `ℕ`-extension of) the same round points: below `j` the wrap-around never fires.
+This is what transports the ordering lemmas (`roundTranscript_succ` / `roundPoint_mem_roundTranscript` /
+`roundTranscript_prefix_mono`) to the deployed derivation through the seal. -/
+theorem roundTranscriptFin_eq_roundTranscript {k : ℕ} (t₀ : List (TranscriptElt F G))
+    (rounds : Fin k → G × G) (j : Fin k) :
+    roundTranscriptFin t₀ rounds j
+      = roundTranscript t₀ (fun i => rounds ⟨i % k, Nat.mod_lt _ j.pos⟩) j.val := by
+  rw [roundTranscript_eq_take, roundTranscriptFin]
+  congr 2
+  apply List.ext_getElem
+  · simp only [List.length_map, List.length_take, List.length_finRange, List.length_range]
+    have := j.isLt
+    omega
+  · intro n h1 h2
+    simp only [List.length_map, List.length_take, List.length_finRange, List.length_range] at h1 h2
+    have hn : n < k := lt_of_lt_of_le (lt_min_iff.mp h1).1 (Nat.succ_le_of_lt j.isLt)
+    simp only [List.getElem_map, List.getElem_take, List.getElem_finRange, List.getElem_range]
+    refine congrArg (fun x => [TranscriptElt.point (rounds x).1, TranscriptElt.point (rounds x).2,
+      TranscriptElt.challenge]) (Fin.ext ?_)
+    simp [Nat.mod_eq_of_lt hn]
+
+/-- **The anti-drift seal: the deployed schedule's IPA challenges are the round-by-round squeezes.**
+`(deriveChallenges fs init ps).ipaRound j` is exactly `fs.squeeze` of the round-`j` transcript over the
+named base `preIpaTranscript init ps` and the proof's own round points `ps.ipaRounds`. Through the
+identification `roundTranscriptFin_eq_roundTranscript` (and the `roundChallenge` form below),
+`roundTranscript_succ` / `roundPoint_mem_roundTranscript` / `roundTranscript_prefix_mono` then hold *of the
+deployed derivation itself*: each `(Lⱼ, Rⱼ)` is absorbed before `uⱼ` is squeezed, and
+`uⱼ` is sampled from the prefix containing it. A refactor of `deriveChallenges` that changes the IPA
+absorb order breaks this theorem. -/
+theorem deriveChallenges_ipaRound_eq {shape : Shape} [Zero F] (fs : FiatShamir F G)
+    (init : List (TranscriptElt F G)) (ps : ProofString shape F G) (j : Fin shape.k) :
+    (deriveChallenges fs init ps).ipaRound j
+      = fs.squeeze (roundTranscriptFin (preIpaTranscript init ps) ps.ipaRounds j) := by
+  simp only [deriveChallenges, preIpaTranscript, roundTranscriptFin]
+  rw [ipaFold_challenges, List.nil_append, List.getD_eq_getElem?_getD, List.getElem?_map,
+    List.getElem?_range (by simp)]
+  rfl
+
+/-- The seal in `roundChallenge` form: the deployed round-`j` challenge is `roundChallenge` at the deployed
+base `preIpaTranscript` and (any `ℕ`-extension of) the proof's round points — so the ordering trio above
+holds verbatim of the transcripts the deployed schedule actually squeezes. -/
+theorem deriveChallenges_ipaRound_eq_roundChallenge {shape : Shape} [Zero F] (fs : FiatShamir F G)
+    (init : List (TranscriptElt F G)) (ps : ProofString shape F G) (j : Fin shape.k) :
+    (deriveChallenges fs init ps).ipaRound j
+      = roundChallenge fs (preIpaTranscript init ps)
+          (fun i => ps.ipaRounds ⟨i % shape.k, Nat.mod_lt _ j.pos⟩) j.val := by
+  rw [deriveChallenges_ipaRound_eq, roundChallenge, roundTranscriptFin_eq_roundTranscript]
+
+end Zcash.Snark

--- a/Zcash/Snark/Soundness/Forking/Probability.lean
+++ b/Zcash/Snark/Soundness/Forking/Probability.lean
@@ -3,32 +3,20 @@ import Zcash.Snark.Soundness.Forking.Oracle
 import Zcash.Snark.Soundness.Forking.Tree
 
 /-!
-# The forking lemma's probabilistic core (random-oracle model)
+# Probability form of the forking lemma
 
-The deterministic tree assembly (`Soundness.Forking.Assembly.forkAccept_to_acceptV`) turns the *forking
-output* — three accepting continuations per IPA round at distinct nonzero challenges — into the deployed
-accept predicate. What is *not* deterministic is producing that output: a single non-interactive proof gives
-one challenge path, not the three the 3-special-soundness tree needs. The honest statement is probabilistic
-(a rewinding/forking reduction): if the prover makes the verifier accept with probability `ε` over a random
-oracle, beating the knowledge error forces the full `(3,…,3)` forking tree to exist.
+The deterministic assembly consumes three accepting continuations at each IPA round. This module
+proves when such a tree exists: acceptance above the knowledge-error threshold under uniform
+challenges forces a full `(3,…,3)` accepting tree.
 
-This module supplies that probabilistic argument over the uniform challenge of the random-oracle model
-(`Forking.Oracle.uniformChallenge`):
+The main results are:
 
-* `uniformOfFintype_toOuterMeasure_finset` — a finite event has uniform probability `|E| / |domain|`
-  (the general form of `uniformChallenge_badSet`): under the random-oracle model the challenge is uniform, so
-  any "good"/"bad" set's probability is its size over the field size.
-* `extractable_of_prob` — **the multi-round forking lemma.** If, over the random-oracle-uniform challenge
-  *vector* `Fin d → α`, the prover's accept probability exceeds the knowledge error
-  `kerr (card α) d / (card α)^d` (`= 3d/N` as a fraction), a full `(3,…,3)` forking tree of accepting challenge
-  vectors exists (`Extractable`). It composes the uniform-measure identity with the deterministic counting core
-  `Soundness.Forking.Tree.extractable_of_kerr_lt`: beating the error in *probability* is beating the
-  knowledge-error *count*, which forces the tree.
+* `uniformOfFintype_toOuterMeasure_finset`: a finite event under a uniform distribution has
+  probability `|E| / |domain|`.
+* `extractable_of_prob`: if acceptance exceeds `kerr / |domain|`, an `Extractable` tree exists.
 
-The tree existence goes *directly* through the `kerr` count — it does not iterate a per-round `ε³` bound, so
-the catastrophic `ε^{3ᵈ}` composition never arises. The remaining random-oracle floor — the
-prover-as-oracle-function model pinning each round's accepting set, the adaptive RO-query loss, and
-Blake2b-as-random-oracle — is laid out in `Forking.Oracle`.
+The proof uses the multi-round `kerr` count directly. It does not compound a per-round cubic loss.
+`Forking.Oracle` describes the remaining adversary and random-oracle assumptions.
 -/
 
 namespace Zcash.Snark
@@ -37,17 +25,13 @@ open scoped ENNReal
 
 variable {α : Type*}
 
-/-- A finite event `E` has uniform probability `|E| / |α|` (the general form of `uniformChallenge_badSet`:
-the per-round challenge is uniform under the random-oracle model, so any "bad"/"good" set's probability is
-its size over the field size). -/
+/-- A finite event under the uniform distribution has probability `|E| / |α|`. -/
 theorem uniformOfFintype_toOuterMeasure_finset [Fintype α] [Nonempty α] (E : Finset α) :
     (PMF.uniformOfFintype α).toOuterMeasure E = (E.card : ℝ≥0∞) / Fintype.card α := by
   rw [PMF.toOuterMeasure_apply_finset]
   simp only [PMF.uniformOfFintype_apply, Finset.sum_const, nsmul_eq_mul, div_eq_mul_inv]
 
-/-- Pushing the uniform distribution on `A` forward along a bijection `e : A ≃ B` gives the uniform distribution
-on `B`: each `b` has the single preimage `e.symm b`, of uniform mass `(card A)⁻¹ = (card B)⁻¹`. The building block
-for `uniformOfFintype_map_eval_injective`. -/
+/-- A bijection maps the uniform distribution on `A` to the uniform distribution on `B`. -/
 theorem map_uniformOfFintype_equiv {A B : Type*} [Fintype A] [Nonempty A] [Fintype B] [Nonempty B]
     (e : A ≃ B) : (PMF.uniformOfFintype A).map e = PMF.uniformOfFintype B := by
   refine PMF.ext (fun b => ?_)
@@ -57,27 +41,15 @@ theorem map_uniformOfFintype_equiv {A B : Type*} [Fintype A] [Nonempty A] [Finty
     intro hb
     exact ha (e.injective ((e.apply_symm_apply b).symm ▸ hb.symm))
 
-/-- Reading a uniform random function at finitely many distinct points is uniform. For injective `φ : ι → T`,
-sampling the oracle uniformly over its query domain — the finite set `↥(Set.range φ)` of the points `φ i` — and
-reading its answers `i ↦ O (φ i)` is distributed as `PMF.uniformOfFintype (ι → α)`. `Equiv.ofInjective φ hφ`
-reindexes the query cells by `ι`; injectivity is what makes it a bijection, so the reading map is an equivalence
-and `map_uniformOfFintype_equiv` applies. The random-oracle core of challenge-vector uniformity
-(`Soundness.Forking.Rewind.roChallenges_ipaRound_uniform`). -/
+/-- Reading a uniform random function at finitely many distinct points gives independent uniform
+answers. -/
 theorem uniformOfFintype_map_eval_injective {ι T α : Type*} [Fintype ι] [DecidableEq ι] [DecidableEq T]
     [Fintype α] [Nonempty α] (φ : ι → T) (hφ : Function.Injective φ) :
     (PMF.uniformOfFintype (↥(Set.range φ) → α)).map (fun O i => O (Equiv.ofInjective φ hφ i))
       = PMF.uniformOfFintype (ι → α) :=
   map_uniformOfFintype_equiv (Equiv.arrowCongr (Equiv.ofInjective φ hφ).symm (Equiv.refl α))
 
-/-- **The multi-round forking lemma (probabilistic form).** If, over the random-oracle-uniform challenge
-*vector* `Fin d → α`, the prover's accept probability exceeds the knowledge error
-`kerr (card α) d / (card α)^d` (`= 3d/N` as a fraction), then a full `(3,…,3)` forking tree of accepting
-challenge vectors exists (`Extractable acc`). Composing the uniform-measure identity
-(`uniformOfFintype_toOuterMeasure_finset`) with the deterministic counting core (`extractable_of_kerr_lt`):
-beating the error in *probability* is beating the knowledge-error *count*, which forces the tree. This is the
-`acc ⇒ frk` reduction across all `d` rounds — what the random oracle's uniformity buys, once Blake2b is
-modeled as that oracle. The remaining floor — the prover-as-oracle-function model pinning `acc` to the
-deployed verifier, and Blake2b-as-random-oracle — is laid out in `Forking.Oracle`. -/
+/-- If uniform acceptance exceeds the `kerr` probability, a full accepting fork tree exists. -/
 theorem extractable_of_prob [Fintype α] [DecidableEq α] [Zero α] [Nonempty α] {d : ℕ}
     (acc : (Fin d → α) → Prop) [DecidablePred acc]
     (h : (kerr (Fintype.card α) d : ℝ≥0∞) / Fintype.card (Fin d → α)

--- a/Zcash/Snark/Soundness/Forking/Probability.lean
+++ b/Zcash/Snark/Soundness/Forking/Probability.lean
@@ -45,6 +45,30 @@ theorem uniformOfFintype_toOuterMeasure_finset [Fintype α] [Nonempty α] (E : F
   rw [PMF.toOuterMeasure_apply_finset]
   simp only [PMF.uniformOfFintype_apply, Finset.sum_const, nsmul_eq_mul, div_eq_mul_inv]
 
+/-- Pushing the uniform distribution on `A` forward along a bijection `e : A ≃ B` gives the uniform distribution
+on `B`: each `b` has the single preimage `e.symm b`, of uniform mass `(card A)⁻¹ = (card B)⁻¹`. The building block
+for `uniformOfFintype_map_eval_injective`. -/
+theorem map_uniformOfFintype_equiv {A B : Type*} [Fintype A] [Nonempty A] [Fintype B] [Nonempty B]
+    (e : A ≃ B) : (PMF.uniformOfFintype A).map e = PMF.uniformOfFintype B := by
+  refine PMF.ext (fun b => ?_)
+  rw [PMF.map_apply, tsum_eq_single (e.symm b) (fun a ha => ?_)]
+  · simp only [PMF.uniformOfFintype_apply, Equiv.apply_symm_apply, if_pos, Fintype.card_congr e]
+  · rw [if_neg]
+    intro hb
+    exact ha (e.injective ((e.apply_symm_apply b).symm ▸ hb.symm))
+
+/-- Reading a uniform random function at finitely many distinct points is uniform. For injective `φ : ι → T`,
+sampling the oracle uniformly over its query domain — the finite set `↥(Set.range φ)` of the points `φ i` — and
+reading its answers `i ↦ O (φ i)` is distributed as `PMF.uniformOfFintype (ι → α)`. `Equiv.ofInjective φ hφ`
+reindexes the query cells by `ι`; injectivity is what makes it a bijection, so the reading map is an equivalence
+and `map_uniformOfFintype_equiv` applies. The random-oracle core of challenge-vector uniformity
+(`Soundness.Forking.Rewind.roChallenges_ipaRound_uniform`). -/
+theorem uniformOfFintype_map_eval_injective {ι T α : Type*} [Fintype ι] [DecidableEq ι] [DecidableEq T]
+    [Fintype α] [Nonempty α] (φ : ι → T) (hφ : Function.Injective φ) :
+    (PMF.uniformOfFintype (↥(Set.range φ) → α)).map (fun O i => O (Equiv.ofInjective φ hφ i))
+      = PMF.uniformOfFintype (ι → α) :=
+  map_uniformOfFintype_equiv (Equiv.arrowCongr (Equiv.ofInjective φ hφ).symm (Equiv.refl α))
+
 /-- **The multi-round forking lemma (probabilistic form).** If, over the random-oracle-uniform challenge
 *vector* `Fin d → α`, the prover's accept probability exceeds the knowledge error
 `kerr (card α) d / (card α)^d` (`= 3d/N` as a fraction), then a full `(3,…,3)` forking tree of accepting

--- a/Zcash/Snark/Soundness/Forking/Probability.lean
+++ b/Zcash/Snark/Soundness/Forking/Probability.lean
@@ -12,7 +12,7 @@ one challenge path, not the three the 3-special-soundness tree needs. The honest
 (a rewinding/forking reduction): if the prover makes the verifier accept with probability `ε` over a random
 oracle, beating the knowledge error forces the full `(3,…,3)` forking tree to exist.
 
-This module supplies that probabilistic step over the uniform challenge of the random-oracle model
+This module supplies that probabilistic argument over the uniform challenge of the random-oracle model
 (`Forking.Oracle.uniformChallenge`):
 
 * `uniformOfFintype_toOuterMeasure_finset` — a finite event has uniform probability `|E| / |domain|`
@@ -25,10 +25,10 @@ This module supplies that probabilistic step over the uniform challenge of the r
   `Soundness.Forking.Tree.extractable_of_kerr_lt`: beating the error in *probability* is beating the
   knowledge-error *count*, which forces the tree.
 
-The tree existence goes **directly** through the `kerr` count — it does not iterate a per-round `ε³` bound, so
-the catastrophic `ε^{3ᵈ}` composition never arises. What stays the random-oracle floor is the
-prover-as-oracle-function model that pins each round's accepting set (and the adaptive RO-query loss), plus the
-idealization that Blake2b is a random oracle.
+The tree existence goes *directly* through the `kerr` count — it does not iterate a per-round `ε³` bound, so
+the catastrophic `ε^{3ᵈ}` composition never arises. The remaining random-oracle floor — the
+prover-as-oracle-function model pinning each round's accepting set, the adaptive RO-query loss, and
+Blake2b-as-random-oracle — is laid out in `Forking.Oracle`.
 -/
 
 namespace Zcash.Snark
@@ -76,8 +76,8 @@ challenge vectors exists (`Extractable acc`). Composing the uniform-measure iden
 (`uniformOfFintype_toOuterMeasure_finset`) with the deterministic counting core (`extractable_of_kerr_lt`):
 beating the error in *probability* is beating the knowledge-error *count*, which forces the tree. This is the
 `acc ⇒ frk` reduction across all `d` rounds — what the random oracle's uniformity buys, once Blake2b is
-modeled as that oracle. The remaining floor is the prover-as-oracle-function model pinning `acc` to the
-deployed verifier, and Blake2b-as-random-oracle itself. -/
+modeled as that oracle. The remaining floor — the prover-as-oracle-function model pinning `acc` to the
+deployed verifier, and Blake2b-as-random-oracle — is laid out in `Forking.Oracle`. -/
 theorem extractable_of_prob [Fintype α] [DecidableEq α] [Zero α] [Nonempty α] {d : ℕ}
     (acc : (Fin d → α) → Prop) [DecidablePred acc]
     (h : (kerr (Fintype.card α) d : ℝ≥0∞) / Fintype.card (Fin d → α)

--- a/Zcash/Snark/Soundness/Forking/Probability.lean
+++ b/Zcash/Snark/Soundness/Forking/Probability.lean
@@ -1,0 +1,71 @@
+import Mathlib
+import Zcash.Snark.Soundness.Forking.Oracle
+import Zcash.Snark.Soundness.Forking.Tree
+
+/-!
+# The forking lemma's probabilistic core (random-oracle model)
+
+The deterministic tree assembly (`Soundness.Forking.Assembly.forkAccept_to_acceptV`) turns the *forking
+output* — three accepting continuations per IPA round at distinct nonzero challenges — into the deployed
+accept predicate. What is *not* deterministic is producing that output: a single non-interactive proof gives
+one challenge path, not the three the 3-special-soundness tree needs. The honest statement is probabilistic
+(a rewinding/forking reduction): if the prover makes the verifier accept with probability `ε` over a random
+oracle, beating the knowledge error forces the full `(3,…,3)` forking tree to exist.
+
+This module supplies that probabilistic step over the uniform challenge of the random-oracle model
+(`Forking.Oracle.uniformChallenge`):
+
+* `uniformOfFintype_toOuterMeasure_finset` — a finite event has uniform probability `|E| / |domain|`
+  (the general form of `uniformChallenge_badSet`): under the random-oracle model the challenge is uniform, so
+  any "good"/"bad" set's probability is its size over the field size.
+* `extractable_of_prob` — **the multi-round forking lemma.** If, over the random-oracle-uniform challenge
+  *vector* `Fin d → α`, the prover's accept probability exceeds the knowledge error
+  `kerr (card α) d / (card α)^d` (`= 3d/N` as a fraction), a full `(3,…,3)` forking tree of accepting challenge
+  vectors exists (`Extractable`). It composes the uniform-measure identity with the deterministic counting core
+  `Soundness.Forking.Tree.extractable_of_kerr_lt`: beating the error in *probability* is beating the
+  knowledge-error *count*, which forces the tree.
+
+The tree existence goes **directly** through the `kerr` count — it does not iterate a per-round `ε³` bound, so
+the catastrophic `ε^{3ᵈ}` composition never arises. What stays the random-oracle floor is the
+prover-as-oracle-function model that pins each round's accepting set (and the adaptive RO-query loss), plus the
+idealization that Blake2b is a random oracle.
+-/
+
+namespace Zcash.Snark
+
+open scoped ENNReal
+
+variable {α : Type*}
+
+/-- A finite event `E` has uniform probability `|E| / |α|` (the general form of `uniformChallenge_badSet`:
+the per-round challenge is uniform under the random-oracle model, so any "bad"/"good" set's probability is
+its size over the field size). -/
+theorem uniformOfFintype_toOuterMeasure_finset [Fintype α] [Nonempty α] (E : Finset α) :
+    (PMF.uniformOfFintype α).toOuterMeasure E = (E.card : ℝ≥0∞) / Fintype.card α := by
+  rw [PMF.toOuterMeasure_apply_finset]
+  simp only [PMF.uniformOfFintype_apply, Finset.sum_const, nsmul_eq_mul, div_eq_mul_inv]
+
+/-- **The multi-round forking lemma (probabilistic form).** If, over the random-oracle-uniform challenge
+*vector* `Fin d → α`, the prover's accept probability exceeds the knowledge error
+`kerr (card α) d / (card α)^d` (`= 3d/N` as a fraction), then a full `(3,…,3)` forking tree of accepting
+challenge vectors exists (`Extractable acc`). Composing the uniform-measure identity
+(`uniformOfFintype_toOuterMeasure_finset`) with the deterministic counting core (`extractable_of_kerr_lt`):
+beating the error in *probability* is beating the knowledge-error *count*, which forces the tree. This is the
+`acc ⇒ frk` reduction across all `d` rounds — what the random oracle's uniformity buys, once Blake2b is
+modeled as that oracle. The remaining floor is the prover-as-oracle-function model pinning `acc` to the
+deployed verifier, and Blake2b-as-random-oracle itself. -/
+theorem extractable_of_prob [Fintype α] [DecidableEq α] [Zero α] [Nonempty α] {d : ℕ}
+    (acc : (Fin d → α) → Prop) [DecidablePred acc]
+    (h : (kerr (Fintype.card α) d : ℝ≥0∞) / Fintype.card (Fin d → α)
+       < (PMF.uniformOfFintype (Fin d → α)).toOuterMeasure (Finset.univ.filter acc)) :
+    Extractable acc := by
+  apply extractable_of_kerr_lt
+  by_contra hle
+  push_neg at hle
+  have hmono : (PMF.uniformOfFintype (Fin d → α)).toOuterMeasure (Finset.univ.filter acc)
+      ≤ (kerr (Fintype.card α) d : ℝ≥0∞) / Fintype.card (Fin d → α) := by
+    rw [uniformOfFintype_toOuterMeasure_finset]
+    gcongr
+  exact absurd h (not_lt.mpr hmono)
+
+end Zcash.Snark

--- a/Zcash/Snark/Soundness/Forking/Rewind.lean
+++ b/Zcash/Snark/Soundness/Forking/Rewind.lean
@@ -14,14 +14,12 @@ identification is load-bearing in the `_rewind` Vesta capstones.
 Second, the probability chain replaces a posited forked transcript tree by an accept-probability hypothesis:
 `extractable_of_prob` yields an `Extractable` challenge tree, `proverAccept_forkValid` turns it into a
 `DeployedForkValid` certificate, `deployed_forking_relation` extracts the opened value, and
-`deployed_forking_soundness_of_bridge` exposes the remaining prover-as-oracle bridge explicitly. The bridge's
-deterministic content is discharged below (`deployedVerifierEq_iff_flatAccept` and
-`deployedVerifierEq_iff_flatAccept_adaptive`); the remaining floor is the execution-semantics identification
-for a rewound RO adversary — the querying-adversary/query-loss experiment that would *derive* the accept
-probability of `hprob` — plus Blake2b-as-random-oracle. Challenge-vector uniformity is justified separately:
-`roChallenges_ipaRound_uniform` shows `hprob`'s uniform measure is the one a uniform random oracle induces. It
-is a standalone theorem, consumed by no capstone, and covers the fixed proof string only — see its section
-below for the precise scope.
+`deployed_forking_soundness_of_bridge` isolates the remaining prover-as-oracle bridge. Its deterministic
+content is proven below (`deployedVerifierEq_iff_flatAccept`, `deployedVerifierEq_iff_flatAccept_adaptive`).
+The floor left is the execution-semantics identification for a rewound RO adversary — the
+querying-adversary/query-loss experiment that would *derive* `hprob`'s accept probability — plus
+Blake2b-as-random-oracle. The uniform *measure* of `hprob` is justified standalone by
+`roChallenges_ipaRound_uniform` (see its section for the scope).
 -/
 
 namespace Zcash.Snark
@@ -31,8 +29,8 @@ variable {G : Type*} [AddCommGroup G] [Module Fp G]
 /-- A random-oracle-backed Fiat–Shamir instance: the squeeze *is* the oracle `O`. -/
 def ofOracle (O : List (TranscriptElt Fp G) → Fp) : FiatShamir Fp G := ⟨O⟩
 
-/-- The non-interactive challenges a proof induces under random oracle `O` (the deployed verifier's own
-Fiat–Shamir coins): `deriveChallenges` through `ofOracle O`. -/
+/-- The challenges a proof induces under random oracle `O` — the deployed verifier's own Fiat–Shamir coins,
+`deriveChallenges` run through `ofOracle O`. -/
 def roChallenges {shape : Shape} (O : List (TranscriptElt Fp G) → Fp)
     (init : List (TranscriptElt Fp G)) (ps : ProofString shape Fp G) : Challenges shape.k Fp :=
   deriveChallenges (ofOracle O) init ps
@@ -41,13 +39,13 @@ def roChallenges {shape : Shape} (O : List (TranscriptElt Fp G) → Fp)
 
 The forking layer redraws the IPA round-challenge vector `χ` and evaluates the verifier at
 `{ch with ipaRound := χ}`; the random-oracle model rewinds by *reprogramming* the oracle
-(`Soundness.Forking.Oracle.reprogram`) at round prefixes and re-running the schedule. These are the same
-operation, and `roChallenges_reprogramRounds` proves it, consuming the round-by-round transcript ordering
-(`Soundness.Forking.Ordering`): the round prefixes are pairwise distinct and longer than every
-pre-IPA squeeze input (`roundTranscriptFin_length`/`_injective`), so reprogramming them changes exactly the
-round challenges (`deriveChallenges_ipaRound_eq`, the seal) and nothing upstream. This puts the ordering
-module on the Fiat–Shamir path: the `_rewind` capstones (`Soundness.Vesta`) state their accept probability
-over reprogrammed-oracle runs and reach the `_deployed` capstones through this identification. -/
+(`Soundness.Forking.Oracle.reprogram`) at the round prefixes and re-running the schedule. These are the same
+operation, and `roChallenges_reprogramRounds` proves it. The round prefixes are pairwise distinct and longer
+than every pre-IPA squeeze input (`roundTranscriptFin_length`/`_injective`), so reprogramming them changes
+exactly the round challenges (`deriveChallenges_ipaRound_eq`, the seal) and nothing upstream — which is why the
+proof consumes the round-by-round transcript ordering (`Soundness.Forking.Ordering`). This puts the ordering
+module on the Fiat–Shamir path: the `_rewind` capstones (`Soundness.Vesta`) state their accept probability over
+reprogrammed-oracle runs and reach the `_deployed` capstones through this identification. -/
 
 open Classical in
 /-- The `k`-point extension of `reprogram`: reprogram the oracle at *every* IPA round prefix of the fixed
@@ -106,11 +104,10 @@ private theorem Challenges.ext' {k : ℕ} {F : Type*} {c₁ c₂ : Challenges k 
 
 /-- **Redrawing the round vector is reprogramming the deployed oracle.** Running the deployed schedule under
 the oracle reprogrammed at all `k` round prefixes yields exactly the honest run with its IPA round vector
-replaced by `χ`: the pre-IPA challenges are untouched (their squeeze inputs are no longer than the base,
-`reprogramRounds_apply_short`), and round `j`'s challenge is the reprogrammed answer `χ j` — by the
-transcript-ordering seal `deriveChallenges_ipaRound_eq`. This is the vector-semantics ⇔ rewinding
-identification the forking layer's `{ch with ipaRound := χ}` events rest on, and the load-bearing consumer
-of `Soundness.Forking.Ordering`. -/
+replaced by `χ`. The pre-IPA challenges are untouched (their squeeze inputs are no longer than the base,
+`reprogramRounds_apply_short`), and round `j`'s challenge is the reprogrammed answer `χ j` — the
+transcript-ordering seal `deriveChallenges_ipaRound_eq`. This is the identification the forking layer's
+`{ch with ipaRound := χ}` events rest on, and the load-bearing consumer of `Soundness.Forking.Ordering`. -/
 theorem roChallenges_reprogramRounds {shape : Shape} (O : List (TranscriptElt Fp G) → Fp)
     (init : List (TranscriptElt Fp G)) (ps : ProofString shape Fp G) (χ : Fin shape.k → Fp) :
     roChallenges (reprogramRounds O init ps χ) init ps
@@ -135,14 +132,16 @@ vector. That a random oracle induces this distribution was an axiom; it is now a
 * `roChallenges_ipaRound_uniform` — the `k` prefixes are pairwise distinct (`roundTranscriptFin_injective`), so
   reading a uniform random oracle at them (`uniformOfFintype_map_eval_injective`) is the uniform challenge vector.
 
-**Scope.** This is a *standalone* justification, not a step in any capstone: nothing consumes
+**Scope.** This is a *standalone* justification, not a link in any capstone: nothing consumes
 `roChallenges_ipaRound_uniform`, and every `hprob` below is stated directly over `PMF.uniformOfFintype`. The
 theorem shows that measure is what a uniform random oracle induces; it is not substituted into the reduction.
-It has two limits. It samples the oracle only at the `k` round prefixes — the marginal on the round vector, not
-a full query domain. And it is for the fixed proof string `ps`: in the `_adaptive`/`_rewind` events the
-reprogrammed prefixes depend on `χ`, so tying `hprob`'s measure to a rewound-oracle experiment there belongs to
-the execution-semantics floor (a forger querying `O`, with query-loss — `Forking.Oracle`), above `hprob`, not
-this theorem. -/
+It has two limits:
+
+* it samples the oracle only at the `k` round prefixes — the marginal on the round vector, not a full query
+  domain;
+* it is for the fixed proof string `ps`. In the `_adaptive`/`_rewind` events the reprogrammed prefixes depend
+  on `χ`, so tying `hprob`'s measure to a rewound-oracle experiment there belongs to the execution-semantics
+  floor (a forger querying `O`, with query-loss — `Forking.Oracle`), above `hprob`, not this theorem. -/
 
 /-- Each round challenge is the oracle's answer at that round's transcript prefix:
 `(roChallenges O init ps).ipaRound j = O (roundTranscriptFin (preIpaTranscript init ps) ps.ipaRounds j)`.
@@ -177,10 +176,10 @@ open scoped ENNReal in
 open Classical in
 /-- **Accept-measure monotonicity into the capstones' `hprob`.** The deployed accept (`DeployedAccepts`,
 the `assemble?` guards plus the MSM identity) implies the explicit verifier equation pointwise
-(`deployedAccepts_verifierEq`), so a threshold beaten by the *deployed-accept* event is beaten by the
-`DeployedIpaVerifierEq` event the capstones consume — stated over arbitrary proof-string/challenge-record
-families so it covers the constant, `_rewind`, and `_adaptive_rewind` event shapes alike. Use this to feed
-a capstone `hprob` from a genuine deployed-accept probability. -/
+(`deployedAccepts_verifierEq`), so any threshold beaten by the *deployed-accept* event is beaten by the
+`DeployedIpaVerifierEq` event the capstones consume. Stated over arbitrary proof-string/challenge-record
+families, it covers the constant, `_rewind`, and `_adaptive_rewind` event shapes alike — use it to feed a
+capstone `hprob` from a genuine deployed-accept probability. -/
 theorem kerr_lt_verifierEq_of_deployedAccepts [DecidableEq G] [Inhabited G] {shape : Shape}
     (urs : URS G) (hk : shape.k = urs.k) (vk : VerifyingKey shape Fp G)
     (psf : (Fin shape.k → Fp) → ProofString shape Fp G)
@@ -199,12 +198,12 @@ theorem kerr_lt_verifierEq_of_deployedAccepts [DecidableEq G] [Inhabited G] {sha
 
 This closes the deterministic chain. From the flat forking output threading halo2's *adjusted* commitment
 `P' = ⟨aDep,G⟩ = multiopen − [v]g₀ + [ξ]⟨s,G⟩` (the verifier's `add_constant_term(-v)` plus the synthetic
-blinding `[ξ]S`), `deployed_forking_tree` extracts an opening of `P'` to inner product `0`, and the
-adjusted-commitment theorem (`ipaRelation_unshift` on `b₀ = 1`, then `ipaRelation_unblind_value`
-*unconditionally*) lifts it to an opening of the *multiopen* commitment `⟨aMulti,G⟩` to its **true** value
-`v − ξ·⟨s,b⟩`. So every step from the rewinding output to the deployed inner-product relation is a theorem;
-the residual is `DeployedForkValid` (the rewinding itself), the `g`-span/adjusted form, `b₀ = 1`, and
-Blake2b-as-random-oracle. -/
+blinding `[ξ]S`), `deployed_forking_tree` extracts an opening of `P'` to inner product `0`; the
+adjusted-commitment theorems then lift it to an opening of the *multiopen* commitment `⟨aMulti,G⟩` to its
+**true** value `v − ξ·⟨s,b⟩` — `ipaRelation_unshift` (keyed on `b₀ = 1`) restores the value and
+`ipaRelation_unblind_value` strips the blinding *unconditionally*. So every link from the rewinding output to
+the deployed inner-product relation is a theorem; the residual is `DeployedForkValid` (the rewinding itself),
+the `g`-span/adjusted form, `b₀ = 1`, and Blake2b-as-random-oracle. -/
 
 /-- **The deployed forking opening.** A flat forking output (`DeployedForkValid`, no posited decomposition)
 threading halo2's adjusted commitment `⟨aDep,G⟩ = ⟨aMulti,G⟩ − [v]g₀ + [ξ]⟨s,G⟩` yields an inner-product
@@ -214,8 +213,8 @@ opening of the multiopen commitment `⟨aMulti,G⟩` to the value `v − ξ·⟨
 (`deployed_forking_tree`) opens `⟨aDep,G⟩` to inner product `0`; `ipaRelation_unshift`
 (keyed on `b₀ = 1`) restores the value, and `ipaRelation_unblind_value` strips the synthetic blinding
 *unconditionally* — reporting that opened value whatever the prover's blinder `s` is (no `⟨s,b⟩ = 0`
-assumed; the honest case `⟨s,b⟩ = 0` recovers the claimed `v`). Every deterministic tie from rewinding to the
-opening is now proven. As a *computable* `def`, the opening is returned as **computed data**
+assumed; the honest case `⟨s,b⟩ = 0` recovers the claimed `v`). As a *computable* `def`, the opening is
+returned as **computed data**
 (`ipaRelation_extract`), not the prime-order-vacuous `∃ a, …`: neither the opening witness nor the relation
 coefficients can be produced without the `cert` (the discrete-log preimage the reviewer's vacuity witness
 needs is not computable), so this reduction is genuinely non-vacuous. The `deployed_forking_soundness*`
@@ -247,25 +246,24 @@ def deployed_forking_relation [DecidableEq G] [Inhabited G] (urs : URS G)
 
 /-! ## Closing the rewinding gap: the forked transcripts are *produced* by the probability
 
-`deployed_forking_relation` still took `DeployedForkValid` (the forked transcripts) as a hypothesis. This
+`deployed_forking_relation` still took `DeployedForkValid` (the forked transcripts) as a hypothesis; this
 discharges it. In the random-oracle model the challenge vector is uniform, so the prover's accept event is a
 finite set whose measure is its accept *probability*. When that probability exceeds the knowledge error
 `kerr/Nᵏ = 3k/N`, `extractable_of_prob` — the averaging argument that *is* the multi-round forking lemma —
 forces a full `(3,…,3)` forking tree to exist, and `proverAccept_forkValid` reads off the `DeployedForkValid`
-certificate. So the rewinding output is no longer assumed: it is produced by the accept probability beating
-the knowledge error, in the ideal RO model. The residual is exactly Blake2b-as-random-oracle (what makes the
-challenge uniform), the prover-as-strategy `P`, and the standard structural/honest-prover facts. -/
+certificate. So the rewinding output is no longer assumed: the accept probability beating the knowledge error
+produces it, in the ideal RO model. The residual is Blake2b-as-random-oracle (what makes the challenge
+uniform), the prover-as-strategy `P`, and the standard structural/honest-prover facts. -/
 
 open scoped ENNReal in
 open Classical in
 /-- **Challenge inversion is measure-preserving.** Componentwise inversion `χ ↦ (·⁻¹) ∘ χ` is an involution
 on `Fin d → Fp` — a field satisfies `a⁻¹⁻¹ = a` for *every* `a` (including `0`, since `0⁻¹ = 0`) — hence a
-bijection of the uniform random-oracle sample space onto itself. So relabelling the challenge vector by
-inversion leaves any accept event's probability unchanged. This is the probabilistic half of the
-consistency bridge: the deployed verifier folds generators by `foldGens g u⁻¹` (`foldAll`) while the
-extraction tree folds by `foldGens g u`, and the two accept events differ by exactly this inversion — so they
-have the same accept probability, and the soundness hypothesis on the tree predicate is the deployed
-verifier's accept probability. -/
+bijection of the uniform random-oracle sample space onto itself, so inverting the challenge vector leaves any
+accept event's probability unchanged. This is the probabilistic half of the consistency bridge: the deployed
+verifier folds generators by `foldGens g u⁻¹` (`foldAll`) while the extraction tree folds by `foldGens g u`,
+so the two accept events differ by exactly this inversion — equal probability, and the soundness hypothesis on
+the tree predicate is the deployed verifier's accept probability. -/
 theorem uniformOfFintype_measure_inv {d : ℕ} (acc : (Fin d → Fp) → Prop) :
     (PMF.uniformOfFintype (Fin d → Fp)).toOuterMeasure
         (Finset.univ.filter (fun χ : Fin d → Fp => acc (fun i => (χ i)⁻¹)))
@@ -310,10 +308,10 @@ theorem blinder_shift_badSet_measure (δ c : Fp) (hδ : δ ≠ 0) :
 
 /-- The deployed accept condition along one challenge path, in the **flat verifier's** IPA fold convention:
 generators (and eval vector) fold by `foldGens · u⁻¹` — exactly halo2's `foldAll`/`computeS` direction — rather
-than the extraction tree's `foldGens · u` (`proverAccept`). Everything else (the commitment fold `[u⁻¹]L + [u]R`,
-the leaf check) is identical. Its `CF`-fold is intended to match `DeployedIpaVerifierEq` — `deployedVerifierEq_cf`
-identifies the verifier equation with `CF = 0`, and the per-path identification is supplied as the explicit
-`hbridge` of `deployed_forking_soundness_of_bridge`, not proved here. -/
+than the extraction tree's `foldGens · u` (`proverAccept`). Everything else — the commitment fold
+`[u⁻¹]L + [u]R`, the leaf check — is identical. Its `CF`-fold matches `DeployedIpaVerifierEq`
+(`deployedVerifierEq_cf` identifies the verifier equation with `CF = 0`); the per-path identification is the
+explicit `hbridge` of `deployed_forking_soundness_of_bridge`, not proved here. -/
 def flatAccept : {d : ℕ} → Prover Fp G d → (Fin (2 ^ d) → G) → (Fin (2 ^ d) → Fp) → (U W : G) → (z : Fp) →
     G → (Fin d → Fp) → Prop
   | 0, .leaf c f, g, b, U, W, z, Pwhole, _ =>
@@ -385,14 +383,14 @@ open scoped ENNReal in
 /-- **The forking soundness for an abstract prover strategy.** For a strategy tree `P`, if its accept event
 `proverAccept P …` has probability exceeding the knowledge error `kerr (card Fp) k / (card Fp)ᵏ` (`= 3k/N`)
 over the uniform challenge vector, then the multiopen commitment `⟨aMulti,G⟩` opens to its **true** value
-`v − ξ·⟨s,b⟩` — or a nontrivial relation. `extractable_of_prob` (the averaging argument) turns the probability
-into a forking tree, `proverAccept_forkValid` into a `DeployedForkValid` certificate, and
-`deployed_forking_relation` into the opening. This is the **abstract** layer: `P` is an arbitrary strategy and
-the challenge vector is taken uniform. Tying it to the deployed verifier — that the actual proof realizes such
-a `P` whose accept event is `DeployedIpaVerifierEq`, over the random-oracle-derived challenge — is the explicit
-bridge of `deployed_forking_soundness_of_bridge`. The residual is that bridge (the prover-as-oracle / Blake2b
-floor) together with the structural facts (`b₀ = 1`, the adjusted/`g`-span form `hP`); the synthetic blinder is
-stripped unconditionally (no `s(x) = 0` assumed). -/
+`v − ξ·⟨s,b⟩` — or a nontrivial relation. The chain: `extractable_of_prob` (the averaging argument) turns the
+probability into a forking tree, `proverAccept_forkValid` into a `DeployedForkValid` certificate, and
+`deployed_forking_relation` into the opening. This is the **abstract** layer — `P` is an arbitrary strategy,
+the challenge vector uniform. Tying it to the deployed verifier (that the actual proof realizes such a `P`
+whose accept event is `DeployedIpaVerifierEq`, over the RO-derived challenge) is the explicit bridge
+`deployed_forking_soundness_of_bridge`. The residual is that bridge (the prover-as-oracle / Blake2b floor) and
+the structural facts (`b₀ = 1`, the adjusted/`g`-span form `hP`); the synthetic blinder is stripped
+unconditionally (no `s(x) = 0` assumed). -/
 noncomputable def deployed_forking_soundness [DecidableEq G] [Inhabited G] (urs : URS G)
     (b : Fin (2 ^ urs.k) → Fp) (v ξ z blind : Fp) (aMulti aDep s : Fin (2 ^ urs.k) → Fp)
     (P : Prover Fp G urs.k) (hz : z ≠ 0) (hb0 : b 0 = 1)
@@ -418,14 +416,13 @@ noncomputable def deployed_forking_soundness [DecidableEq G] [Inhabited G] (urs 
 
 open scoped ENNReal in
 open Classical in
-/-- **The deployed forking soundness, in the verifier's own fold convention.** Identical to
-`deployed_forking_soundness`, but the accept-probability hypothesis is stated with `flatAccept` — the flat
-verifier predicate folding generators by `foldGens g u⁻¹`, exactly halo2's `foldAll`/`computeS` direction —
-rather than the extraction tree's `proverAccept` (`foldGens g u`). The two have equal accept probability
-(`proverAccept_measure_eq_flatAccept`, via the measure-preserving challenge inversion), so this is a faithful
-restatement in the verifier's own `u⁻¹` fold convention, with the `u`-vs-`u⁻¹` consistency gap discharged by
-theorem. The hypothesis is still the *strategy* predicate `flatAccept Q`; identifying `Q` with the deployed
-proof is the explicit bridge of `deployed_forking_soundness_of_bridge`. -/
+/-- **The deployed forking soundness, in the verifier's own fold convention.** `deployed_forking_soundness`
+with the accept-probability hypothesis stated over `flatAccept` — folding generators by `foldGens g u⁻¹`,
+halo2's `foldAll`/`computeS` direction — instead of the extraction tree's `proverAccept` (`foldGens g u`). The
+two have equal accept probability (`proverAccept_measure_eq_flatAccept`, via the measure-preserving challenge
+inversion), so the `u`-vs-`u⁻¹` consistency gap is discharged by theorem. The hypothesis is still the
+*strategy* predicate `flatAccept Q`; identifying `Q` with the deployed proof is the explicit bridge
+`deployed_forking_soundness_of_bridge`. -/
 noncomputable def deployed_forking_soundness_flat [DecidableEq G] [Inhabited G] (urs : URS G)
     (b : Fin (2 ^ urs.k) → Fp) (v ξ z blind : Fp) (aMulti aDep s : Fin (2 ^ urs.k) → Fp)
     (Q : Prover Fp G urs.k) (hz : z ≠ 0) (hb0 : b 0 = 1)
@@ -690,64 +687,47 @@ theorem deployedVerifierEq_iff_flatAccept_adaptive {shape : Shape} [DecidableEq 
 
 /-! ## The deterministic content of the prover-as-oracle bridge `hbridge` is proven
 
-`hbridge` (the hypothesis of `deployed_forking_soundness_of_bridge` below) says: the deployed verifier's accept
-event, as a function of the challenge vector, is the flat predicate `flatAccept Q` of a prefix-respecting prover
-strategy `Q`. This is a **pointwise** (deterministic) identification — it carries no probability.
+`hbridge` (the hypothesis of `deployed_forking_soundness_of_bridge` below) is the **pointwise**
+identification — it carries no probability — of the deployed verifier's accept event, as a function of the
+challenge vector, with the flat predicate `flatAccept Q` of a prefix-respecting prover strategy `Q`.
 
-Its deterministic content is now **proven**: `deployedVerifierEq_iff_flatAccept` (above) proves halo2's actual
-verifier equation `DeployedIpaVerifierEq` *is* `flatAccept (proverOfRounds ps.ipaRounds ps.ipaC ps.ipaF)` at the
-challenge vector. The earlier "needs a separate round-by-round transcript-semantics layer" is done inside the
-model: the tree is `proverOfRounds` (its round points fixed by the proof string, its leaf the final opening —
-the Fiat–Shamir prefix-determination), and each path's `flatAccept` matches the verifier equation by
-`flatAccept_proverOfRounds` (`flatAccept` ↔ `CF = 0`) composed with `deployedVerifierEq_cf` (`CF = 0` ↔ the
-verifier equation).
+Its deterministic content is a **theorem**: `deployedVerifierEq_iff_flatAccept` (the constant strategy
+`proverOfRounds ps.ipaRounds ps.ipaC ps.ipaF`, round points fixed by the proof string) and
+`deployedVerifierEq_iff_flatAccept_adaptive` (every staged strategy) prove halo2's actual verifier equation
+`DeployedIpaVerifierEq` *is* `flatAccept` at the challenge vector — `flatAccept_proverOfRounds`
+(`flatAccept` ↔ `CF = 0`) composed with `deployedVerifierEq_cf` (`CF = 0` ↔ the equation). The round-by-round
+transcript ordering behind the prefix-respecting shape is likewise proven and sealed to the deployed schedule
+(`Soundness.Forking.Ordering`, `deriveChallenges_ipaRound_eq`; `proverRoundPoint_proverOfRounds` for the tree
+side).
 
-**Status.** `hbridge` is *discharged* in the deployed opening capstone
-`orchard_verifier_vesta_forking_opening_deployed` (`Soundness.Vesta`): that theorem takes halo2's **actual**
-verifier accept `DeployedIpaVerifierEq` (no abstract `hbridge`) and proves the bridge internally via
-`deployedVerifierEq_iff_flatAccept`, at the cost of the `S`-opening witness `commit urs s = ps.ipaS` (and
-the `shape.k`↔`urs.k` transport, discharged by `subst`). **Scope of the discharge:** the `_deployed` pair
-instantiates the *constant* strategy `proverOfRounds` — the fixed proof string — so its `hprob` is that fixed
-proof's accept measure over the whole challenge space (the static dichotomy), *not* the Fiat–Shamir attack
-event. The staged discharge — `deployedVerifierEq_iff_flatAccept_adaptive` and the `_adaptive` capstones
-(`Soundness.Vesta`) — extends the bridge theorem to *every* prefix-respecting strategy (`spliceIpa` /
-`pathData`), so `hprob` there is the accept probability of a round-adaptive adversary, the object rewinding
-produces. What `hbridge` still names beyond that is the execution-semantics identification — that a rewound
-random-oracle adversary *induces* such a staged strategy, with its RO-query loss (the out-of-Lean
-execution-semantics floor). The abstract theorems —
-`deployed_forking_soundness_of_bridge` below, and `orchard_verifier_vesta_forking_opening`/`_constraint` —
-retain `hbridge` as that *modular* hypothesis (they are stated over an abstract `accepts`/`Q`): its
-deterministic content is a theorem for every staged strategy, and the round-by-round transcript ordering
-behind the prefix-respecting shape is likewise proven and sealed to the deployed derivation
-(`Soundness.Forking.Ordering`, `deriveChallenges_ipaRound_eq`; `proverRoundPoint_proverOfRounds` for the
-tree side). Its execution-semantics content is the residual prover-as-oracle floor — that a rewound
-random-oracle adversary *induces* such a staged strategy, with its query-loss, deriving the accept probability
-of `hprob` — alongside Blake2b-as-random-oracle. The uniform *measure* of `hprob` has its own justification:
-`roChallenges_ipaRound_uniform` shows it is what a uniform random oracle induces for the fixed proof string. That
-theorem is standalone (consumed by no capstone; see its section), so it justifies the measure choice without
-itself discharging the floor above. -/
+**Where it is discharged.** The Vesta capstones (`Soundness.Vesta`) take halo2's **actual** accept
+`DeployedIpaVerifierEq` — no abstract `hbridge` — and prove the bridge internally, at the cost of the
+`S`-opening witness `commit urs s = ps.ipaS` (and the `shape.k`↔`urs.k` transport, by `subst`). The `_deployed`
+pair uses the *constant* strategy, so its `hprob` is that fixed proof's accept measure over the whole challenge
+space — the static dichotomy, *not* the Fiat–Shamir attack event; the `_adaptive` pair uses `spliceIpa`/
+`pathData`, so its `hprob` is a round-adaptive adversary's accept probability, the object rewinding produces.
+The abstract theorems (`deployed_forking_soundness_of_bridge` below,
+`orchard_verifier_vesta_forking_opening`/`_constraint`) keep `hbridge` as a *modular* hypothesis over an
+abstract `accepts`/`Q`.
+
+What `hbridge` still names is the execution-semantics floor: a rewound random-oracle adversary *induces* such a
+staged strategy, with its RO-query loss, deriving `hprob`'s accept probability — alongside
+Blake2b-as-random-oracle. The uniform *measure* of `hprob` is justified standalone
+(`roChallenges_ipaRound_uniform`; see its section). -/
 
 open scoped ENNReal in
 open Classical in
-/-- **The deployed forking soundness from an explicit prover-as-oracle bridge.** This is the honest top of the
-forking chain. It takes the deployed verifier's *actual* accept event `accepts χ` — the verifier on the proof
-at challenge vector `χ`, the proof being a function of `χ` is the Fiat–Shamir/random-oracle model — together
-with the **explicit** faithfulness bridge `hbridge` identifying that event with the strategy predicate
-`flatAccept Q`, and concludes the deployed opening from the accept *probability*.
-
-`flatAccept` folds generators by `foldGens g u⁻¹`, exactly halo2's `compute_s` direction, so the verifier
-equation `DeployedIpaVerifierEq` — which `deployedVerifierEq_cf` identifies with the closed form `CF = 0` —
-folds along each challenge path to `flatAccept Q`. The deterministic content of `hbridge` is **proven** by
-`deployedVerifierEq_iff_flatAccept` (the proof string read as the prefix-respecting `Prover`
-`proverOfRounds ps.ipaRounds ps.ipaC ps.ipaF`, whose per-path `flatAccept` *is* the verifier's accept), so
-`hbridge` is *dischargeable* — but this theorem still takes it as an explicit hypothesis (it has not been
-rewired to consume that identity; doing so also needs the `S`-opening fact `commit urs s = ps.ipaS`). With
-`hbridge` supplied, the residual is *only* the random-oracle adversary experiment above `hprob` — a querying
-forger and the rewinding query-loss that would derive its accept probability — plus Blake2b-as-random-oracle.
-Every other link (challenge-vector uniformity, now derived by `roChallenges_ipaRound_uniform`; extraction;
-root-consistency; value placement; the `u`-vs-`u⁻¹` convention) is a theorem, as is the round-by-round transcript
-ordering (`Soundness.Forking.Ordering`, sealed by `deriveChallenges_ipaRound_eq`). This is the granular
-replacement for the monolithic `FiatShamirTree`. -/
+/-- **The deployed forking soundness from an explicit prover-as-oracle bridge.** The honest top of the forking
+chain: from the deployed verifier's *actual* accept event `accepts χ` (the proof a function of `χ` — the
+Fiat–Shamir/random-oracle model), the **explicit** faithfulness bridge `hbridge` identifying it with the
+strategy predicate `flatAccept Q`, and the accept *probability* beating the knowledge error, it concludes the
+deployed opening. `hbridge`'s deterministic content is a theorem (`deployedVerifierEq_iff_flatAccept`; see the
+section above), so it is *dischargeable* — this theorem keeps it as an explicit hypothesis (discharging it in
+place also needs the `S`-opening fact `commit urs s = ps.ipaS`). With `hbridge` supplied, the residual is
+*only* the random-oracle adversary experiment above `hprob` (a querying forger and the rewinding query-loss)
+plus Blake2b-as-random-oracle; every other link — challenge-vector uniformity (`roChallenges_ipaRound_uniform`),
+extraction, root-consistency, value placement, the `u`-vs-`u⁻¹` convention, the transcript ordering — is a
+theorem. The granular replacement for the monolithic `FiatShamirTree`. -/
 noncomputable def deployed_forking_soundness_of_bridge [DecidableEq G] [Inhabited G] (urs : URS G)
     (b : Fin (2 ^ urs.k) → Fp) (v ξ z blind : Fp) (aMulti aDep s : Fin (2 ^ urs.k) → Fp)
     (Q : Prover Fp G urs.k) (accepts : (Fin urs.k → Fp) → Prop)

--- a/Zcash/Snark/Soundness/Forking/Rewind.lean
+++ b/Zcash/Snark/Soundness/Forking/Rewind.lean
@@ -1,0 +1,709 @@
+import Zcash.Snark.Soundness.Main
+import Zcash.Snark.Soundness.Forking.Oracle
+import Zcash.Snark.Soundness.Forking.Extractor
+import Zcash.Snark.Soundness.Forking.Ordering
+
+/-!
+# The deployed verifier under random-oracle rewinding
+
+This module carries the live Fiat–Shamir forking path. First, `ofOracle`/`roChallenges` instantiate
+`deriveChallenges` with a random oracle, and `reprogramRounds` proves that re-running the deployed schedule
+under round-prefix reprogramming is exactly the same as replacing the IPA round-challenge vector. That
+identification is load-bearing in the `_rewind` Vesta capstones.
+
+Second, the probability chain replaces a posited forked transcript tree by an accept-probability hypothesis:
+`extractable_of_prob` yields an `Extractable` challenge tree, `proverAccept_forkValid` turns it into a
+`DeployedForkValid` certificate, `deployed_forking_relation` extracts the opened value, and
+`deployed_forking_soundness_of_bridge` exposes the remaining prover-as-oracle bridge explicitly. The bridge's
+deterministic content is discharged below (`deployedVerifierEq_iff_flatAccept` and
+`deployedVerifierEq_iff_flatAccept_adaptive`); the remaining floor is the execution-semantics identification
+for a rewound RO adversary plus the random-oracle uniformity axiom carried by `hprob`.
+-/
+
+namespace Zcash.Snark
+
+variable {G : Type*} [AddCommGroup G] [Module Fp G]
+
+/-- A random-oracle-backed Fiat–Shamir instance: the squeeze *is* the oracle `O`. -/
+def ofOracle (O : List (TranscriptElt Fp G) → Fp) : FiatShamir Fp G := ⟨O⟩
+
+/-- The non-interactive challenges a proof induces under random oracle `O` (the deployed verifier's own
+Fiat–Shamir coins): `deriveChallenges` through `ofOracle O`. -/
+def roChallenges {shape : Shape} (O : List (TranscriptElt Fp G) → Fp)
+    (init : List (TranscriptElt Fp G)) (ps : ProofString shape Fp G) : Challenges shape.k Fp :=
+  deriveChallenges (ofOracle O) init ps
+
+/-! ## Redrawing the round vector *is* reprogramming the deployed oracle
+
+The forking layer redraws the IPA round-challenge vector `χ` and evaluates the verifier at
+`{ch with ipaRound := χ}`; the random-oracle model rewinds by *reprogramming* the oracle
+(`Soundness.Forking.Oracle.reprogram`) at round prefixes and re-running the schedule. These are the same
+operation, and `roChallenges_reprogramRounds` proves it, consuming the round-by-round transcript ordering
+(`Soundness.Forking.Ordering`): the round prefixes are pairwise distinct and longer than every
+pre-IPA squeeze input (`roundTranscriptFin_length`/`_injective`), so reprogramming them changes exactly the
+round challenges (`deriveChallenges_ipaRound_eq`, the seal) and nothing upstream. This puts the ordering
+module on the Fiat–Shamir path: the `_rewind` capstones (`Soundness.Vesta`) state their accept probability
+over reprogrammed-oracle runs and reach the `_deployed` capstones through this identification. -/
+
+open Classical in
+/-- The `k`-point extension of `reprogram`: reprogram the oracle at *every* IPA round prefix of the fixed
+proof string at once, answering `χ j` at the round-`j` transcript (as `reprogram … (χ j)` would) and `O`
+elsewhere. Redrawing the whole round vector — what the forking probability ranges over — runs the deployed
+schedule under this oracle (`roChallenges_reprogramRounds`). -/
+noncomputable def reprogramRounds {shape : Shape} (O : List (TranscriptElt Fp G) → Fp)
+    (init : List (TranscriptElt Fp G)) (ps : ProofString shape Fp G) (χ : Fin shape.k → Fp) :
+    List (TranscriptElt Fp G) → Fp :=
+  fun t => if h : ∃ j : Fin shape.k,
+      t = roundTranscriptFin (preIpaTranscript init ps) ps.ipaRounds j
+    then χ h.choose else O t
+
+/-- At the round-`j` prefix, the reprogrammed oracle answers `χ j` (well-defined because distinct rounds
+have distinct prefixes, `roundTranscriptFin_injective`). -/
+theorem reprogramRounds_apply_round {shape : Shape} (O : List (TranscriptElt Fp G) → Fp)
+    (init : List (TranscriptElt Fp G)) (ps : ProofString shape Fp G) (χ : Fin shape.k → Fp)
+    (j : Fin shape.k) :
+    reprogramRounds O init ps χ
+      (roundTranscriptFin (preIpaTranscript init ps) ps.ipaRounds j) = χ j := by
+  have hex : ∃ j' : Fin shape.k,
+      roundTranscriptFin (preIpaTranscript init ps) ps.ipaRounds j
+        = roundTranscriptFin (preIpaTranscript init ps) ps.ipaRounds j' := ⟨j, rfl⟩
+  simp only [reprogramRounds]
+  rw [dif_pos hex]
+  exact (congrArg χ (roundTranscriptFin_injective _ _ hex.choose_spec)).symm
+
+/-- Off the round prefixes, the reprogrammed oracle is `O`. -/
+theorem reprogramRounds_apply_ne {shape : Shape} (O : List (TranscriptElt Fp G) → Fp)
+    (init : List (TranscriptElt Fp G)) (ps : ProofString shape Fp G) (χ : Fin shape.k → Fp)
+    {t : List (TranscriptElt Fp G)}
+    (ht : ∀ j : Fin shape.k, t ≠ roundTranscriptFin (preIpaTranscript init ps) ps.ipaRounds j) :
+    reprogramRounds O init ps χ t = O t := by
+  simp only [reprogramRounds]
+  rw [dif_neg]
+  rintro ⟨j, hj⟩
+  exact ht j hj
+
+/-- Every transcript no longer than the pre-IPA base is untouched by the round reprogramming: the round
+prefixes are strictly longer (`roundTranscriptFin_length`). In particular every pre-IPA squeeze input. -/
+theorem reprogramRounds_apply_short {shape : Shape} (O : List (TranscriptElt Fp G) → Fp)
+    (init : List (TranscriptElt Fp G)) (ps : ProofString shape Fp G) (χ : Fin shape.k → Fp)
+    {t : List (TranscriptElt Fp G)} (ht : t.length ≤ (preIpaTranscript init ps).length) :
+    reprogramRounds O init ps χ t = O t :=
+  reprogramRounds_apply_ne O init ps χ (fun j h => by
+    have hlen := congrArg List.length h
+    rw [roundTranscriptFin_length] at hlen
+    omega)
+
+private theorem Challenges.ext' {k : ℕ} {F : Type*} {c₁ c₂ : Challenges k F}
+    (hθ : c₁.theta = c₂.theta) (hβ : c₁.beta = c₂.beta) (hγ : c₁.gamma = c₂.gamma)
+    (hy : c₁.y = c₂.y) (hx : c₁.x = c₂.x) (h1 : c₁.x1 = c₂.x1) (h2 : c₁.x2 = c₂.x2)
+    (h3 : c₁.x3 = c₂.x3) (h4 : c₁.x4 = c₂.x4) (hξ : c₁.xi = c₂.xi) (hz : c₁.z = c₂.z)
+    (hu : c₁.ipaRound = c₂.ipaRound) : c₁ = c₂ := by
+  cases c₁; cases c₂; simp_all
+
+/-- **Redrawing the round vector is reprogramming the deployed oracle.** Running the deployed schedule under
+the oracle reprogrammed at all `k` round prefixes yields exactly the honest run with its IPA round vector
+replaced by `χ`: the pre-IPA challenges are untouched (their squeeze inputs are no longer than the base,
+`reprogramRounds_apply_short`), and round `j`'s challenge is the reprogrammed answer `χ j` — by the
+transcript-ordering seal `deriveChallenges_ipaRound_eq`. This is the vector-semantics ⇔ rewinding
+identification the forking layer's `{ch with ipaRound := χ}` events rest on, and the load-bearing consumer
+of `Soundness.Forking.Ordering`. -/
+theorem roChallenges_reprogramRounds {shape : Shape} (O : List (TranscriptElt Fp G) → Fp)
+    (init : List (TranscriptElt Fp G)) (ps : ProofString shape Fp G) (χ : Fin shape.k → Fp) :
+    roChallenges (reprogramRounds O init ps χ) init ps
+      = { roChallenges O init ps with ipaRound := χ } := by
+  refine Challenges.ext' ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ <;>
+    first
+      | (funext j
+         show (deriveChallenges (ofOracle (reprogramRounds O init ps χ)) init ps).ipaRound j = χ j
+         rw [deriveChallenges_ipaRound_eq]
+         exact reprogramRounds_apply_round O init ps χ j)
+      | exact reprogramRounds_apply_short O init ps χ (by
+          simp only [preIpaTranscript, List.length_append, List.length_cons, List.length_nil]
+          omega)
+
+open scoped ENNReal in
+open Classical in
+/-- **Accept-measure monotonicity into the capstones' `hprob`.** The deployed accept (`DeployedAccepts`,
+the `assemble?` guards plus the MSM identity) implies the explicit verifier equation pointwise
+(`deployedAccepts_verifierEq`), so a threshold beaten by the *deployed-accept* event is beaten by the
+`DeployedIpaVerifierEq` event the capstones consume — stated over arbitrary proof-string/challenge-record
+families so it covers the constant, `_rewind`, and `_adaptive_rewind` event shapes alike. Use this to feed
+a capstone `hprob` from a genuine deployed-accept probability. -/
+theorem kerr_lt_verifierEq_of_deployedAccepts [DecidableEq G] [Inhabited G] {shape : Shape}
+    (urs : URS G) (hk : shape.k = urs.k) (vk : VerifyingKey shape Fp G)
+    (psf : (Fin shape.k → Fp) → ProofString shape Fp G)
+    (chf : (Fin shape.k → Fp) → Challenges shape.k Fp) {ε : ℝ≥0∞}
+    (h : ε < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
+        (Finset.univ.filter (fun χ => DeployedAccepts urs hk vk (psf χ) (chf χ)))) :
+    ε < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
+        (Finset.univ.filter (fun χ =>
+          DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk (psf χ) (chf χ))) := by
+  refine lt_of_lt_of_le h ((PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure.mono ?_)
+  intro χ hχ
+  simp only [Finset.coe_filter, Finset.mem_univ, true_and, Set.mem_setOf_eq] at hχ ⊢
+  exact deployedAccepts_verifierEq urs hk vk (psf χ) (chf χ) hχ
+
+/-! ## The deployed forking opening: the value-placement composed end to end
+
+This closes the deterministic chain. From the flat forking output threading halo2's *adjusted* commitment
+`P' = ⟨aDep,G⟩ = multiopen − [v]g₀ + [ξ]⟨s,G⟩` (the verifier's `add_constant_term(-v)` plus the synthetic
+blinding `[ξ]S`), `deployed_forking_tree` extracts an opening of `P'` to inner product `0`, and the
+adjusted-commitment theorem (`ipaRelation_unshift` on `b₀ = 1`, then `ipaRelation_unblind_value`
+*unconditionally*) lifts it to an opening of the *multiopen* commitment `⟨aMulti,G⟩` to its **true** value
+`v − ξ·⟨s,b⟩`. So every step from the rewinding output to the deployed inner-product relation is a theorem;
+the residual is `DeployedForkValid` (the rewinding itself), the `g`-span/adjusted form, `b₀ = 1`, and
+Blake2b-as-random-oracle. -/
+
+/-- **The deployed forking opening.** A flat forking output (`DeployedForkValid`, no posited decomposition)
+threading halo2's adjusted commitment `⟨aDep,G⟩ = ⟨aMulti,G⟩ − [v]g₀ + [ξ]⟨s,G⟩` yields an inner-product
+opening of the multiopen commitment `⟨aMulti,G⟩` to the value `v − ξ·⟨s,b⟩` for the supplied `S`-opening
+`s` — unique under binding: two distinct openings of `ps.ipaS` shift it by `ξ·⟨Δ,b⟩` while exhibiting a
+`g`-relation, the computed `NontrivialRelation` branch — or the multiopen opening. The extraction
+(`deployed_forking_tree`) opens `⟨aDep,G⟩` to inner product `0`; `ipaRelation_unshift`
+(keyed on `b₀ = 1`) restores the value, and `ipaRelation_unblind_value` strips the synthetic blinding
+*unconditionally* — reporting that opened value whatever the prover's blinder `s` is (no `⟨s,b⟩ = 0`
+assumed; the honest case `⟨s,b⟩ = 0` recovers the claimed `v`). Every deterministic tie from rewinding to the
+opening is now proven. As a *computable* `def`, the opening is returned as **computed data**
+(`ipaRelation_extract`), not the prime-order-vacuous `∃ a, …`: neither the opening witness nor the relation
+coefficients can be produced without the `cert` (the discrete-log preimage the reviewer's vacuity witness
+needs is not computable), so this reduction is genuinely non-vacuous. The `deployed_forking_soundness*`
+capstones that wrap it are the honest floor — they forget the data to `∃` because the `cert` is only
+classically obtained (the random-oracle experiment, `Forking.Oracle`, is unmodeled). -/
+def deployed_forking_relation [DecidableEq G] [Inhabited G] (urs : URS G)
+    (b : Fin (2 ^ urs.k) → Fp) (v ξ z blind : Fp) (aMulti aDep s : Fin (2 ^ urs.k) → Fp)
+    (cert : DForkCert Fp G urs.k) (hz : z ≠ 0) (hb0 : b 0 = 1)
+    (hP : commit urs aDep = commit urs aMulti - v • urs.g 0 + ξ • commit urs s)
+    (hvalid : DeployedForkValid urs.g b urs.u urs.w z
+        (commit urs aDep + (z * 0) • urs.u + blind • urs.w) cert) :
+    (Σ' a, IpaRelation urs (commit urs aMulti) b (v - ξ * innerProduct s b) a)
+      ⊕' NontrivialRelation (F := Fp) urs.g urs.u urs.w :=
+  match deployed_forking_tree hz urs.g b aDep 0 blind cert hvalid with
+  | .inl ⟨blind', t, ht⟩ =>
+      if hclean : IpaAcceptV urs.g b (commit urs aDep) 0 (projTree t) then
+        match ipaRelation_extract urs b (commit urs aDep) 0 (projTree t) hclean with
+        | ⟨a, ha⟩ =>
+            PSum.inl ⟨_, ipaRelation_unblind_value urs (commit urs aMulti) b v ξ s _
+              (by
+                have h1 := ipaRelation_unshift urs (commit urs aDep + v • urs.g 0) b v a hb0
+                  (by rw [add_sub_cancel_right]; exact ha)
+                have h2 : commit urs aDep + v • urs.g 0 = commit urs aMulti + ξ • commit urs s := by
+                  rw [hP]; abel
+                rw [h2] at h1; exact h1)⟩
+      else
+        PSum.inr (NontrivialRelation.ofDeployedTree hz urs.g b (commit urs aDep) 0 blind' t ht hclean)
+  | .inr hrel => PSum.inr hrel
+
+/-! ## Closing the rewinding gap: the forked transcripts are *produced* by the probability
+
+`deployed_forking_relation` still took `DeployedForkValid` (the forked transcripts) as a hypothesis. This
+discharges it. In the random-oracle model the challenge vector is uniform, so the prover's accept event is a
+finite set whose measure is its accept *probability*. When that probability exceeds the knowledge error
+`kerr/Nᵏ = 3k/N`, `extractable_of_prob` — the averaging argument that *is* the multi-round forking lemma —
+forces a full `(3,…,3)` forking tree to exist, and `proverAccept_forkValid` reads off the `DeployedForkValid`
+certificate. So the rewinding output is no longer assumed: it is produced by the accept probability beating
+the knowledge error, in the ideal RO model. The residual is exactly Blake2b-as-random-oracle (what makes the
+challenge uniform), the prover-as-strategy `P`, and the standard structural/honest-prover facts. -/
+
+open scoped ENNReal in
+open Classical in
+/-- **Challenge inversion is measure-preserving.** Componentwise inversion `χ ↦ (·⁻¹) ∘ χ` is an involution
+on `Fin d → Fp` — a field satisfies `a⁻¹⁻¹ = a` for *every* `a` (including `0`, since `0⁻¹ = 0`) — hence a
+bijection of the uniform random-oracle sample space onto itself. So relabelling the challenge vector by
+inversion leaves any accept event's probability unchanged. This is the probabilistic half of the
+consistency bridge: the deployed verifier folds generators by `foldGens g u⁻¹` (`foldAll`) while the
+extraction tree folds by `foldGens g u`, and the two accept events differ by exactly this inversion — so they
+have the same accept probability, and the soundness hypothesis on the tree predicate is the deployed
+verifier's accept probability. -/
+theorem uniformOfFintype_measure_inv {d : ℕ} (acc : (Fin d → Fp) → Prop) :
+    (PMF.uniformOfFintype (Fin d → Fp)).toOuterMeasure
+        (Finset.univ.filter (fun χ : Fin d → Fp => acc (fun i => (χ i)⁻¹)))
+      = (PMF.uniformOfFintype (Fin d → Fp)).toOuterMeasure (Finset.univ.filter acc) := by
+  rw [PMF.toOuterMeasure_apply_finset, PMF.toOuterMeasure_apply_finset]
+  simp only [PMF.uniformOfFintype_apply, Finset.sum_const, nsmul_eq_mul]
+  congr 1
+  norm_cast
+  refine Finset.card_bij' (fun χ _ => (fun i => (χ i)⁻¹)) (fun χ _ => (fun i => (χ i)⁻¹))
+    ?hi ?hj ?li ?ri
+  case hi =>
+    intro χ hχ
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hχ ⊢
+    exact hχ
+  case hj =>
+    intro χ hχ
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hχ ⊢
+    have hχχ : (fun i => ((χ i)⁻¹)⁻¹) = χ := by funext i; rw [inv_inv]
+    rw [hχχ]; exact hχ
+  case li => intro χ _; funext i; simp only [inv_inv]
+  case ri => intro χ _; funext i; simp only [inv_inv]
+
+open scoped ENNReal in
+/-- **The synthetic blinder's soundness budget (ξ-randomization).** A malicious IPA blinder `S = ⟨s,G⟩` with
+`⟨s,b⟩ = δ ≠ 0` shifts the opened value of the multiopen commitment by `−ξδ` (`ipaRelation_unblind_value`):
+the plain commitment opens to `v − ξδ` rather than the claimed `v`. Because the verifier squeezes `ξ` *after*
+the prover has committed `S` (`deriveChallenges`), `δ` is fixed before `ξ`, so the shifted value `v − ξδ`
+hits any fixed target `c` for at most one challenge `ξ = (v−c)/δ` — a set of uniform random-oracle measure
+`≤ 1/p`. This is the `1/p` soundness role of `[ξ]S`: it replaces the honest-prover assumption `⟨s,b⟩ = 0`
+(the `hs` of `ipaRelation_unblind`) by a Schwartz–Zippel exclusion over `ξ`. -/
+theorem blinder_shift_badSet_measure (δ c : Fp) (hδ : δ ≠ 0) :
+    uniformChallenge.toOuterMeasure (Finset.univ.filter (fun ξ : Fp => ξ * δ = c))
+      ≤ 1 / (Fintype.card Fp : ℝ≥0∞) := by
+  rw [uniformChallenge_badSet]
+  have hcard : (Finset.univ.filter (fun ξ : Fp => ξ * δ = c)).card ≤ 1 := by
+    rw [Finset.card_le_one]
+    intro ξ₁ h₁ ξ₂ h₂
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at h₁ h₂
+    exact mul_right_cancel₀ hδ (h₁.trans h₂.symm)
+  gcongr
+  exact_mod_cast hcard
+
+/-- The deployed accept condition along one challenge path, in the **flat verifier's** IPA fold convention:
+generators (and eval vector) fold by `foldGens · u⁻¹` — exactly halo2's `foldAll`/`computeS` direction — rather
+than the extraction tree's `foldGens · u` (`proverAccept`). Everything else (the commitment fold `[u⁻¹]L + [u]R`,
+the leaf check) is identical. Its `CF`-fold is intended to match `DeployedIpaVerifierEq` — `deployedVerifierEq_cf`
+identifies the verifier equation with `CF = 0`, and the per-path identification is supplied as the explicit
+`hbridge` of `deployed_forking_soundness_of_bridge`, not proved here. -/
+def flatAccept : {d : ℕ} → Prover Fp G d → (Fin (2 ^ d) → G) → (Fin (2 ^ d) → Fp) → (U W : G) → (z : Fp) →
+    G → (Fin d → Fp) → Prop
+  | 0, .leaf c f, g, b, U, W, z, Pwhole, _ =>
+      Pwhole = commitGen g (fun _ => c) + (z * commitGen b (fun _ => c)) • U + f • W
+  | _ + 1, .node L R cont, g, b, U, W, z, Pwhole, χ =>
+      flatAccept (cont (χ 0)) (foldGens g (χ 0)⁻¹) (foldGens b (χ 0)⁻¹) U W z
+        (Pwhole + (χ 0)⁻¹ • L + (χ 0) • R) (Fin.tail χ)
+
+/-- The prover strategy re-indexed for the flat convention: swap each round's `(L, R)` and feed every
+continuation the inverted challenge. The involution that, together with challenge inversion, turns the
+extraction tree's fold convention into the flat verifier's. -/
+def invProver : {d : ℕ} → Prover Fp G d → Prover Fp G d
+  | 0, .leaf c f => .leaf c f
+  | _ + 1, .node L R cont => .node R L (fun u => invProver (cont u⁻¹))
+
+/-- `invProver` is an involution. -/
+theorem invProver_invProver : {d : ℕ} → (P : Prover Fp G d) → invProver (invProver P) = P
+  | 0, .leaf _ _ => rfl
+  | _ + 1, .node L R cont => by
+      simp only [invProver]
+      congr 1
+      funext u
+      rw [inv_inv, invProver_invProver (cont u)]
+
+/-- **The convention bridge (pointwise).** The extraction tree's accept predicate `proverAccept` (folding
+generators by `foldGens g u`) at challenge vector `χ` is *exactly* the flat verifier predicate `flatAccept`
+(folding by `foldGens g u⁻¹`) for the re-indexed prover `invProver P` at the inverted challenges `χ⁻¹`. The two
+IPA fold conventions differ only by this challenge inversion and an `L`/`R` swap — both discharged here by
+structural induction (`inv_inv`, `Fin.tail` of an inverted vector, and commutativity of the commitment fold).
+No correctness gap: the tree predicate *is* the flat verifier predicate, relabelled. -/
+theorem proverAccept_iff_flatAccept {U W : G} {z : Fp} : {d : ℕ} → (P : Prover Fp G d) →
+    (g : Fin (2 ^ d) → G) → (b : Fin (2 ^ d) → Fp) → (Pwhole : G) → (χ : Fin d → Fp) →
+    (proverAccept P g b U W z Pwhole χ ↔
+      flatAccept (invProver P) g b U W z Pwhole (fun i => (χ i)⁻¹))
+  | 0, .leaf _ _, _, _, _, _ => Iff.rfl
+  | d + 1, .node L R cont, g, b, Pwhole, χ => by
+      rw [proverAccept, proverAccept_iff_flatAccept (cont (χ 0)) (foldGens g (χ 0)) (foldGens b (χ 0))
+        (Pwhole + (χ 0)⁻¹ • L + (χ 0) • R) (Fin.tail χ), invProver, flatAccept]
+      simp only [inv_inv]
+      have htail : (Fin.tail fun i => (χ i)⁻¹) = (fun i => ((Fin.tail χ) i)⁻¹) := by
+        funext i; rfl
+      rw [htail, show Pwhole + (χ 0) • R + (χ 0)⁻¹ • L = Pwhole + (χ 0)⁻¹ • L + (χ 0) • R from by abel]
+
+open scoped ENNReal in
+open Classical in
+/-- **The convention bridge (probabilistic) — the consistency gap, closed.** The extraction tree's accept
+predicate (`proverAccept`, fold `foldGens g u`) and the flat verifier predicate (`flatAccept`, fold
+`foldGens g u⁻¹` — halo2's actual `foldAll`/`computeS` direction) have *equal* accept probability under the
+uniform random oracle. Pointwise they are the same event up to challenge inversion
+(`proverAccept_iff_flatAccept`), and inversion is measure-preserving (`uniformOfFintype_measure_inv`). So the
+`u`-vs-`u⁻¹` IPA fold convention is not a correctness gap: the tree predicate and the flat-convention
+predicate share an accept probability. (Identifying `flatAccept` itself with the deployed verifier's *actual*
+accept event is the separate prover-as-oracle bridge, `deployed_forking_soundness_of_bridge`.) -/
+theorem proverAccept_measure_eq_flatAccept {d : ℕ} {U W : G} {z : Fp} (P : Prover Fp G d)
+    (g : Fin (2 ^ d) → G) (b : Fin (2 ^ d) → Fp) (Pwhole : G) :
+    (PMF.uniformOfFintype (Fin d → Fp)).toOuterMeasure
+        (Finset.univ.filter (proverAccept P g b U W z Pwhole))
+      = (PMF.uniformOfFintype (Fin d → Fp)).toOuterMeasure
+        (Finset.univ.filter (flatAccept (invProver P) g b U W z Pwhole)) := by
+  have hset : (Finset.univ.filter (proverAccept P g b U W z Pwhole))
+      = Finset.univ.filter
+          (fun χ : Fin d → Fp => flatAccept (invProver P) g b U W z Pwhole (fun i => (χ i)⁻¹)) := by
+    ext χ
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+    exact proverAccept_iff_flatAccept P g b Pwhole χ
+  rw [hset, uniformOfFintype_measure_inv]
+
+open scoped ENNReal in
+/-- **The forking soundness for an abstract prover strategy.** For a strategy tree `P`, if its accept event
+`proverAccept P …` has probability exceeding the knowledge error `kerr (card Fp) k / (card Fp)ᵏ` (`= 3k/N`)
+over the uniform challenge vector, then the multiopen commitment `⟨aMulti,G⟩` opens to its **true** value
+`v − ξ·⟨s,b⟩` — or a nontrivial relation. `extractable_of_prob` (the averaging argument) turns the probability
+into a forking tree, `proverAccept_forkValid` into a `DeployedForkValid` certificate, and
+`deployed_forking_relation` into the opening. This is the **abstract** layer: `P` is an arbitrary strategy and
+the challenge vector is taken uniform. Tying it to the deployed verifier — that the actual proof realizes such
+a `P` whose accept event is `DeployedIpaVerifierEq`, over the random-oracle-derived challenge — is the explicit
+bridge of `deployed_forking_soundness_of_bridge`. The residual is that bridge (the prover-as-oracle / Blake2b
+floor) together with the structural facts (`b₀ = 1`, the adjusted/`g`-span form `hP`); the synthetic blinder is
+stripped unconditionally (no `s(x) = 0` assumed). -/
+noncomputable def deployed_forking_soundness [DecidableEq G] [Inhabited G] (urs : URS G)
+    (b : Fin (2 ^ urs.k) → Fp) (v ξ z blind : Fp) (aMulti aDep s : Fin (2 ^ urs.k) → Fp)
+    (P : Prover Fp G urs.k) (hz : z ≠ 0) (hb0 : b 0 = 1)
+    (hP : commit urs aDep = commit urs aMulti - v • urs.g 0 + ξ • commit urs s)
+    [DecidablePred (proverAccept P urs.g b urs.u urs.w z
+      (commit urs aDep + (z * 0) • urs.u + blind • urs.w))]
+    (hprob : (kerr (Fintype.card Fp) urs.k : ℝ≥0∞) / Fintype.card (Fin urs.k → Fp)
+        < (PMF.uniformOfFintype (Fin urs.k → Fp)).toOuterMeasure
+            (Finset.univ.filter (proverAccept P urs.g b urs.u urs.w z
+              (commit urs aDep + (z * 0) • urs.u + blind • urs.w)))) :
+    (∃ a, IpaRelation urs (commit urs aMulti) b (v - ξ * innerProduct s b) a)
+      ⊕' NontrivialRelation (F := Fp) urs.g urs.u urs.w := by
+  -- `proverAccept_forkValid` yields the certificate behind a `Prop` `∃`; naming it as data (`Classical.choose`)
+  -- is what makes this composition `noncomputable` — the honest random-oracle floor (`Forking.Oracle`). The
+  -- deterministic `deployed_forking_relation` it wraps is a genuine *computed* reduction returning the opening
+  -- as data; here that data is forgotten to `∃` since the certificate itself is only classically obtained.
+  have hpf := proverAccept_forkValid P urs.g b
+    (commit urs aDep + (z * 0) • urs.u + blind • urs.w) (extractable_of_prob _ hprob)
+  rcases deployed_forking_relation urs b v ξ z blind aMulti aDep s hpf.choose hz hb0 hP hpf.choose_spec
+    with ⟨a, ha⟩ | r
+  · exact PSum.inl ⟨a, ha⟩
+  · exact PSum.inr r
+
+open scoped ENNReal in
+open Classical in
+/-- **The deployed forking soundness, in the verifier's own fold convention.** Identical to
+`deployed_forking_soundness`, but the accept-probability hypothesis is stated with `flatAccept` — the flat
+verifier predicate folding generators by `foldGens g u⁻¹`, exactly halo2's `foldAll`/`computeS` direction —
+rather than the extraction tree's `proverAccept` (`foldGens g u`). The two have equal accept probability
+(`proverAccept_measure_eq_flatAccept`, via the measure-preserving challenge inversion), so this is a faithful
+restatement in the verifier's own `u⁻¹` fold convention, with the `u`-vs-`u⁻¹` consistency gap discharged by
+theorem. The hypothesis is still the *strategy* predicate `flatAccept Q`; identifying `Q` with the deployed
+proof is the explicit bridge of `deployed_forking_soundness_of_bridge`. -/
+noncomputable def deployed_forking_soundness_flat [DecidableEq G] [Inhabited G] (urs : URS G)
+    (b : Fin (2 ^ urs.k) → Fp) (v ξ z blind : Fp) (aMulti aDep s : Fin (2 ^ urs.k) → Fp)
+    (Q : Prover Fp G urs.k) (hz : z ≠ 0) (hb0 : b 0 = 1)
+    (hP : commit urs aDep = commit urs aMulti - v • urs.g 0 + ξ • commit urs s)
+    (hprob : (kerr (Fintype.card Fp) urs.k : ℝ≥0∞) / Fintype.card (Fin urs.k → Fp)
+        < (PMF.uniformOfFintype (Fin urs.k → Fp)).toOuterMeasure
+            (Finset.univ.filter (flatAccept Q urs.g b urs.u urs.w z
+              (commit urs aDep + (z * 0) • urs.u + blind • urs.w)))) :
+    (∃ a, IpaRelation urs (commit urs aMulti) b (v - ξ * innerProduct s b) a)
+      ⊕' NontrivialRelation (F := Fp) urs.g urs.u urs.w := by
+  refine deployed_forking_soundness urs b v ξ z blind aMulti aDep s (invProver Q) hz hb0 hP ?_
+  rw [proverAccept_measure_eq_flatAccept (invProver Q) urs.g b
+        (commit urs aDep + (z * 0) • urs.u + blind • urs.w), invProver_invProver Q]
+  exact hprob
+
+/-! ## Discharging the deterministic half of the prover-as-oracle bridge `hbridge`
+
+`hbridge` bundles a deterministic algebra half — the deployed verifier equation folds, along each challenge
+path, to the flat tree predicate `flatAccept` of the proof read as a `Prover` — with the irreducible
+random-oracle half (the accept *probability* is over uniform rewindable challenges). This section discharges
+the **algebra half**: `deployedVerifierEq_iff_flatAccept` proves halo2's actual `DeployedIpaVerifierEq` is
+`flatAccept (proverOfRounds …)` at the challenge vector, so `hbridge` is a *theorem* for the deployed verifier,
+not an assumption. The round-by-round ordering behind the prefix-respecting `Prover` shape is likewise a
+theorem (`Soundness.Forking.Ordering`, sealed to the deployed schedule by `deriveChallenges_ipaRound_eq`;
+`proverRoundPoint_proverOfRounds` below reads the fixed round points off `proverOfRounds` on every challenge
+path). The residual is then only the random-oracle uniformity axiom (`Forking.Oracle`). -/
+
+/-- The prover-strategy tree the deployed non-interactive proof realises: at each IPA round it commits the
+proof's **fixed** round points `(Lⱼ, Rⱼ)` (they are written in the proof string, so the continuation ignores
+the challenge), and the leaf carries the final folded opening scalar `c` and blinding `f`. This is the concrete
+`Prover` object that `hbridge` posits abstractly — here built explicitly from the proof string. -/
+def proverOfRounds : {d : ℕ} → (Fin d → G × G) → Fp → Fp → Prover Fp G d
+  | 0, _, c, f => .leaf c f
+  | _ + 1, R, c, f => .node (R 0).1 (R 0).2 (fun _ => proverOfRounds (Fin.tail R) c f)
+
+/-- The deployed fixed-proof prover commits constant round points: on *every* challenge path,
+`proverRoundPoint` of `proverOfRounds R c f` at depth `j` is `R j` — the degenerate
+(challenge-independent) case of `proverRoundPoint_prefix`, and the prover-tree side of the deployed
+schedule's ordering (`deriveChallenges_ipaRound_eq`). So the tree `hbridge` instantiates satisfies the
+round-by-round prefix-determination by construction. -/
+theorem proverRoundPoint_proverOfRounds : {d : ℕ} → (R : Fin d → G × G) → (c f : Fp) →
+    (χ : Fin d → Fp) → (j : ℕ) → (hj : j < d) →
+    proverRoundPoint (proverOfRounds R c f) χ j = some (R ⟨j, hj⟩)
+  | 0, _, _, _, _, _, hj => absurd hj (Nat.not_lt_zero _)
+  | _ + 1, R, _, _, _, 0, hj => by
+      show some ((R 0).1, (R 0).2) = some (R ⟨0, hj⟩)
+      exact congrArg some (congrArg R (Fin.ext (by simp)))
+  | _ + 1, R, c, f, χ, j + 1, hj => by
+      show proverRoundPoint (proverOfRounds (Fin.tail R) c f) (Fin.tail χ) j = _
+      rw [proverRoundPoint_proverOfRounds (Fin.tail R) c f (Fin.tail χ) j (Nat.lt_of_succ_lt_succ hj)]
+      rfl
+
+/-- `foldGens` commutes with reindexing the generators along a `Fin.cast` (`loHalf`/`hiHalf` read only the
+index value, which `Fin.cast` preserves). The bookkeeping lemma letting the `flatAccept` fold — indexed by the
+round count `d` — meet the closed-form `CF` fold, indexed by the challenge-*list* length `(List.ofFn χ).length`
+(propositionally, not definitionally, `d`). -/
+theorem foldGens_comp_cast {m n : ℕ} (h : n = m) (g : Fin (2 ^ (m + 1)) → G) (u : Fp) :
+    foldGens (fun j : Fin (2 ^ (n + 1)) => g (Fin.cast (by rw [h]) j)) u
+      = fun i : Fin (2 ^ n) => foldGens g u (Fin.cast (by rw [h]) i) := by
+  subst h; rfl
+
+/-- Fin-indexed generator fold: fold `g` by `foldGens · (χ j)⁻¹` down all `d` rounds to a single generator.
+The cast-free counterpart of the deployed list fold `foldAll (List.ofFn χ) …`, matching `flatAccept`'s
+per-round generator fold exactly, so the identity's induction stays cast-free. -/
+def foldAllFin : {d : ℕ} → (Fin d → Fp) → (Fin (2 ^ d) → G) → G
+  | 0, _, g => g 0
+  | _ + 1, χ, g => foldAllFin (Fin.tail χ) (foldGens g (χ 0)⁻¹)
+
+/-- `foldAll` reindexed along a list equality: rewrites the list and the generators' `Fin.cast` together (via
+`subst`), the tool that peels `foldAll (List.ofFn χ)` past the dependent cast that blocks a bare `rw`. -/
+theorem foldAll_congr_cast {u u' : List Fp} (h : u = u') (g : Fin (2 ^ u.length) → G) :
+    foldAll u g = foldAll u' (fun j => g (Fin.cast (by rw [h]) j)) := by
+  subst h; rfl
+
+/-- **The Fin↔list generator-fold bridge.** The cast-free `foldAllFin χ g` equals the deployed list fold
+`foldAll (List.ofFn χ) (g ∘ cast) 0`. Peels one round on each side (`foldAllFin` by definition, `foldAll` via
+`foldAll_congr_cast` past the dependent cast) and reconciles the folded generators by `foldGens_comp_cast`. -/
+theorem foldAllFin_eq : {d : ℕ} → (χ : Fin d → Fp) → (g : Fin (2 ^ d) → G) →
+    foldAllFin χ g = foldAll (List.ofFn χ) (fun j => g (Fin.cast (congrArg (2 ^ ·) List.length_ofFn) j)) 0
+  | 0, _, g => by simp only [foldAllFin]; rfl
+  | d + 1, χ, g => by
+      have hchal : List.ofFn χ = χ 0 :: List.ofFn (Fin.tail χ) := by rw [List.ofFn_succ]; rfl
+      rw [foldAllFin, foldAllFin_eq (Fin.tail χ) (foldGens g (χ 0)⁻¹), foldAll_congr_cast hchal, foldAll]
+      simp only [Fin.cast_cast]
+      exact congrArg (fun gen => foldAll (List.ofFn (Fin.tail χ)) gen 0)
+        (foldGens_comp_cast (List.length_ofFn (f := Fin.tail χ)) g (χ 0)⁻¹).symm
+
+/-- `CF` reindexed along a challenge-list equality: rewrites the challenge list and the generators' `Fin.cast`
+together (via `subst`). -/
+theorem CF_congr_chal {u u' : List Fp} (h : u = u') (rounds : List (G × G))
+    (g : Fin (2 ^ u.length) → G) (P : G) (c Uc Wc : Fp) (U W : G) :
+    CF rounds u g P c Uc U Wc W
+      = CF rounds u' (fun j => g (Fin.cast (by rw [h]) j)) P c Uc U Wc W := by
+  subst h; rfl
+
+/-- **The verifier-fold ↔ tree-fold identity — the deterministic core of `hbridge`.** For the concrete prover
+tree `proverOfRounds R c f` built from a proof's fixed round points, the flat verifier predicate `flatAccept`
+along challenge path `χ` is *exactly* the closed-form verifier equation `CF … = 0` over the round list
+`List.ofFn R` and challenge list `List.ofFn χ`. Proven by induction on the round count: the leaf reconciles the
+final opening (base), and each round folds one `(Lⱼ, Rⱼ)` into the commitment (`CF_cons`, the round point
+undecomposed) while the value coefficient tracks the eval-vector fold `foldAllFin χ b`. No `sorry`/`axiom`. -/
+theorem flatAccept_proverOfRounds :
+    {d : ℕ} → (R : Fin d → G × G) → (c f : Fp) → (g : Fin (2 ^ d) → G) → (b : Fin (2 ^ d) → Fp) →
+    (U W : G) → (z : Fp) → (P : G) → (χ : Fin d → Fp) →
+    (flatAccept (proverOfRounds R c f) g b U W z P χ ↔
+      CF (List.ofFn R) (List.ofFn χ)
+          (fun j => g (Fin.cast (congrArg (2 ^ ·) List.length_ofFn) j)) P c
+          (-(z * c * foldAllFin χ b)) U (-f) W = 0)
+  | 0, R, c, f, g, b, U, W, z, P, χ => by
+      rw [proverOfRounds, flatAccept]
+      simp only [CF, gPart]
+      rw [← foldAllFin_eq]
+      have hg : commitGen g (fun _ : Fin (2 ^ 0) => c) = c • g 0 := by simp [commitGen]
+      have hb : commitGen b (fun _ : Fin (2 ^ 0) => c) = c * b 0 := by simp [commitGen]
+      simp only [roundSum, List.ofFn_zero, List.zip_nil_right, List.map_nil, List.sum_nil, add_zero,
+        foldAllFin, hg, hb]
+      constructor
+      · intro h; rw [h]; module
+      · intro h; linear_combination (norm := module) h
+  | d + 1, R, c, f, g, b, U, W, z, P, χ => by
+      have hchal : List.ofFn χ = χ 0 :: List.ofFn (Fin.tail χ) := by rw [List.ofFn_succ]; rfl
+      have hround : List.ofFn R = ((R 0).1, (R 0).2) :: List.ofFn (Fin.tail R) := by
+        rw [List.ofFn_succ]; rfl
+      rw [proverOfRounds, flatAccept,
+          flatAccept_proverOfRounds (Fin.tail R) c f (foldGens g (χ 0)⁻¹) (foldGens b (χ 0)⁻¹) U W z
+            (P + (χ 0)⁻¹ • (R 0).1 + (χ 0) • (R 0).2) (Fin.tail χ)]
+      rw [hround, CF_congr_chal hchal]
+      rw [show (((R 0).1, (R 0).2) : G × G)
+            = ((R 0).1 + (0 : Fp) • U + (0 : Fp) • W, (R 0).2 + (0 : Fp) • U + (0 : Fp) • W) by simp]
+      rw [CF_cons]
+      simp only [mul_zero, add_zero, Fin.cast_cast]
+      refine iff_of_eq (congrArg (· = (0 : G)) ?_)
+      congr 1
+      exact (foldGens_comp_cast (List.length_ofFn (f := Fin.tail χ)) g (χ 0)⁻¹).symm
+
+/-- The Fin-indexed eval-vector fold is the flat `computeB` (the `b`-value bridge, Fin form): folds the powers
+vector `evalVector d x` down `χ` to `computeB x (List.ofFn χ)`. `foldAllFin_eq` moves to the list fold and
+`foldAll_evalVector` telescopes it. -/
+theorem foldAllFin_evalVector {d : ℕ} (χ : Fin d → Fp) (x : Fp) :
+    foldAllFin χ (evalVector d x) = computeB x (List.ofFn χ) := by
+  rw [foldAllFin_eq]
+  have hev : (fun j => evalVector d x (Fin.cast (congrArg (2 ^ ·) List.length_ofFn) j))
+      = evalVector (List.ofFn χ).length x := by
+    funext j; simp only [evalVector, Fin.val_cast]
+  rw [hev]
+  exact foldAll_evalVector x (List.ofFn χ)
+
+/-- **`hbridge`, discharged for the deployed verifier (the algebra half).** halo2's actual verifier equation
+`DeployedIpaVerifierEq` at any IPA challenge vector `ch.ipaRound` is *exactly* the flat verifier predicate
+`flatAccept` of the concrete prover tree `proverOfRounds ps.ipaRounds ps.ipaC ps.ipaF` read off the proof —
+with the eval vector `evalVector shape.k ch.x3` and the adjusted commitment `multiopen + [-v]g₀ + [ξ]S`. This is
+the deterministic content of the prover-as-oracle bridge, now a **theorem**, not an assumption: chaining
+`deployedVerifierEq_cf` (the verifier equation is `CF = 0`), `flatAccept_proverOfRounds` (`flatAccept` of the
+tree is that same `CF = 0`), and `foldAllFin_evalVector` (the `U`-coefficient is `computeB`). The only residual
+is the random-oracle uniformity axiom on the accept *measure* (`Forking.Oracle`). -/
+theorem deployedVerifierEq_iff_flatAccept {shape : Shape} [DecidableEq Fp] [DecidableEq G] [Inhabited G]
+    (g : Fin (2 ^ shape.k) → G) (w u : G) (vk : VerifyingKey shape Fp G) (ps : ProofString shape Fp G)
+    (ch : Challenges shape.k Fp) :
+    DeployedIpaVerifierEq g w u vk ps ch ↔
+      flatAccept (proverOfRounds ps.ipaRounds ps.ipaC ps.ipaF) g (evalVector shape.k ch.x3) u w ch.z
+        (multiopenCommitment g w u vk ps ch
+          + (∑ i, ([-(multiopenValue vk ps ch)].getD i.val 0) • g i) + ch.xi • ps.ipaS)
+        ch.ipaRound := by
+  rw [deployedVerifierEq_cf, flatAccept_proverOfRounds, foldAllFin_evalVector,
+    show (-ps.ipaC * computeB ch.x3 (List.ofFn ch.ipaRound) * ch.z)
+      = -(ch.z * ps.ipaC * computeB ch.x3 (List.ofFn ch.ipaRound)) from by ring]
+
+/-! ## The staged (round-adaptive) adversary: `hbridge` discharged beyond the constant strategy
+
+`deployedVerifierEq_iff_flatAccept` reads the *fixed* proof string as the constant strategy, so the accept
+event it identifies is one proof's accept set over the challenge space (the static dichotomy). Rewinding a
+real adversary produces more: the rewound runs share the pre-IPA prefix but answer each challenge path with
+their *own* round points and final opening — a prefix-respecting **staged** adversary, which is exactly a
+`Prover` tree together with the fixed pre-IPA data. This section discharges the bridge for *every* such
+strategy: `pathData` reads the strategy's outputs along one challenge path, `spliceIpa` forms its proof
+string at that path (pre-IPA fields fixed, IPA fields the path outputs), and
+`deployedVerifierEq_iff_flatAccept_adaptive` proves halo2's verifier equation on that proof *is*
+`flatAccept P` at the vector. So the corresponding capstones' `hprob` (`Soundness.Vesta`, the `_adaptive`
+pair) is the accept probability of an adaptive strategy — the object rewinding produces — rather than of one
+fixed proof. What remains is the execution-semantics identification (that a rewound random-oracle adversary
+*induces* such a staged strategy, with its RO-query loss) and the random-oracle uniformity axiom. The
+transcript-ordering and reprogramming content is internalized by `Forking.Ordering`,
+`roChallenges_reprogramRounds`, and the Vesta `_adaptive_rewind` capstones. -/
+
+/-- A strategy's outputs along one challenge path: the round points `(Lⱼ, Rⱼ)` it commits and the final
+opening `(c, f)` it sends when the round challenges are `χ` — `pathData P χ = (rounds, c, f)`. The round-`0`
+point is challenge-independent (the `Prover` node fixes it before its challenge); later points read only the
+challenge prefix, by the tree shape. -/
+def pathData : {d : ℕ} → Prover Fp G d → (Fin d → Fp) → (Fin d → G × G) × Fp × Fp
+  | 0, .leaf c f, _ => (Fin.elim0, c, f)
+  | _ + 1, .node L R cont, χ =>
+      (Fin.cons (L, R) (pathData (cont (χ 0)) (Fin.tail χ)).1, (pathData (cont (χ 0)) (Fin.tail χ)).2)
+
+/-- The staged adversary's proof string at one challenge path: every pre-IPA field is the fixed `ps`'s, and
+the IPA fields (`ipaRounds`, `ipaC`, `ipaF`) are replaced — with the strategy's path outputs, in the intended
+use. Rewinding shares the pre-IPA prefix and re-answers the rounds; this is that shape as data. -/
+def spliceIpa {shape : Shape} (ps : ProofString shape Fp G) (R : Fin shape.k → G × G) (c f : Fp) :
+    ProofString shape Fp G :=
+  { ps with ipaRounds := R, ipaC := c, ipaF := f }
+
+omit [AddCommGroup G] [Module Fp G] in
+/-- Splicing a strategy path's IPA fields leaves the pre-IPA Fiat–Shamir challenges unchanged. After replacing
+the IPA round vector by `χ`, the spliced proof and the original proof therefore have the same `Challenges`
+record: only the `ipaRound` field differs, and both sides overwrite it. This is the pre-IPA half of the
+staged rewinding capstone; `roChallenges_reprogramRounds` supplies the round-vector half. -/
+theorem roChallenges_spliceIpa_pre {shape : Shape} (O : List (TranscriptElt Fp G) → Fp)
+    (init : List (TranscriptElt Fp G)) (ps : ProofString shape Fp G) (R : Fin shape.k → G × G)
+    (c f : Fp) (χ : Fin shape.k → Fp) :
+    { roChallenges O init (spliceIpa ps R c f) with ipaRound := χ }
+      = { roChallenges O init ps with ipaRound := χ } := by
+  refine Challenges.ext' ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ <;> rfl
+
+/-- `flatAccept` reads the strategy only along the challenge path: the adaptive tree `P` at `χ` agrees with
+the constant prover built from `P`'s own path outputs `pathData P χ`. The per-path bridge from the adaptive
+tree to `flatAccept_proverOfRounds`'s constant form. -/
+theorem flatAccept_pathData {U W : G} {z : Fp} : {d : ℕ} → (P : Prover Fp G d) →
+    (g : Fin (2 ^ d) → G) → (b : Fin (2 ^ d) → Fp) → (Pwhole : G) → (χ : Fin d → Fp) →
+    (flatAccept P g b U W z Pwhole χ ↔
+      flatAccept (proverOfRounds (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2)
+        g b U W z Pwhole χ)
+  | 0, .leaf _ _, _, _, _, _ => Iff.rfl
+  | d + 1, .node L R cont, g, b, Pwhole, χ => by
+      rw [flatAccept, flatAccept_pathData (cont (χ 0)) (foldGens g (χ 0)⁻¹) (foldGens b (χ 0)⁻¹)
+        (Pwhole + (χ 0)⁻¹ • L + (χ 0) • R) (Fin.tail χ), pathData, proverOfRounds]
+      simp only [Fin.cons_zero, Fin.tail_cons]
+      rw [flatAccept]
+
+open Classical in
+/-- **`hbridge`, discharged for the staged (round-adaptive) adversary.** halo2's actual verifier equation on
+the strategy's spliced proof — pre-IPA fields the fixed `ps`'s, IPA fields the strategy's own outputs along
+`χ` — at IPA challenges `χ` is *exactly* `flatAccept P` at `χ`, with the eval vector
+`evalVector shape.k ch.x3` and the adjusted commitment built from the fixed `ps`. Chains
+`deployedVerifierEq_iff_flatAccept` on the spliced proof (whose pre-IPA projections are definitionally
+`ps`'s) with `flatAccept_pathData`. The constant-strategy identification is the special case
+`P := proverOfRounds ps.ipaRounds ps.ipaC ps.ipaF`; here `hbridge` is a theorem for every prefix-respecting
+strategy — the shape a rewound adversary's runs take. -/
+theorem deployedVerifierEq_iff_flatAccept_adaptive {shape : Shape} [DecidableEq G] [Inhabited G]
+    (g : Fin (2 ^ shape.k) → G) (w u : G) (vk : VerifyingKey shape Fp G) (ps : ProofString shape Fp G)
+    (ch : Challenges shape.k Fp) (P : Prover Fp G shape.k) (χ : Fin shape.k → Fp) :
+    DeployedIpaVerifierEq g w u vk
+        (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2) {ch with ipaRound := χ} ↔
+      flatAccept P g (evalVector shape.k ch.x3) u w ch.z
+        (multiopenCommitment g w u vk ps ch
+          + (∑ i, ([-(multiopenValue vk ps ch)].getD i.val 0) • g i) + ch.xi • ps.ipaS) χ := by
+  rw [deployedVerifierEq_iff_flatAccept]
+  have e1 : multiopenValue vk
+      (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2) {ch with ipaRound := χ}
+      = multiopenValue vk ps ch := rfl
+  have e2 : multiopenCommitment g w u vk
+      (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2) {ch with ipaRound := χ}
+      = multiopenCommitment g w u vk ps ch := rfl
+  rw [e1, e2]
+  exact (flatAccept_pathData P g (evalVector shape.k ch.x3)
+    (multiopenCommitment g w u vk ps ch
+      + (∑ i, ([-(multiopenValue vk ps ch)].getD i.val 0) • g i) + ch.xi • ps.ipaS) χ).symm
+
+/-! ## The deterministic content of the prover-as-oracle bridge `hbridge` is proven
+
+`hbridge` (the hypothesis of `deployed_forking_soundness_of_bridge` below) says: the deployed verifier's accept
+event, as a function of the challenge vector, is the flat predicate `flatAccept Q` of a prefix-respecting prover
+strategy `Q`. This is a **pointwise** (deterministic) identification — it carries no probability.
+
+Its deterministic content is now **proven**: `deployedVerifierEq_iff_flatAccept` (above) proves halo2's actual
+verifier equation `DeployedIpaVerifierEq` *is* `flatAccept (proverOfRounds ps.ipaRounds ps.ipaC ps.ipaF)` at the
+challenge vector. The earlier "needs a separate round-by-round transcript-semantics layer" is done inside the
+model: the tree is `proverOfRounds` (its round points fixed by the proof string, its leaf the final opening —
+the Fiat–Shamir prefix-determination), and each path's `flatAccept` matches the verifier equation by
+`flatAccept_proverOfRounds` (`flatAccept` ↔ `CF = 0`) composed with `deployedVerifierEq_cf` (`CF = 0` ↔ the
+verifier equation).
+
+**Status.** `hbridge` is *discharged* in the deployed opening capstone
+`orchard_verifier_vesta_forking_opening_deployed` (`Soundness.Vesta`): that theorem takes halo2's **actual**
+verifier accept `DeployedIpaVerifierEq` (no abstract `hbridge`) and proves the bridge internally via
+`deployedVerifierEq_iff_flatAccept`, at the cost of the `S`-opening witness `commit urs s = ps.ipaS` (and
+the `shape.k`↔`urs.k` transport, discharged by `subst`). **Scope of the discharge:** the `_deployed` pair
+instantiates the *constant* strategy `proverOfRounds` — the fixed proof string — so its `hprob` is that fixed
+proof's accept measure over the whole challenge space (the static dichotomy), *not* the Fiat–Shamir attack
+event. The staged discharge — `deployedVerifierEq_iff_flatAccept_adaptive` and the `_adaptive` capstones
+(`Soundness.Vesta`) — extends the bridge theorem to *every* prefix-respecting strategy (`spliceIpa` /
+`pathData`), so `hprob` there is the accept probability of a round-adaptive adversary, the object rewinding
+produces. What `hbridge` still names beyond that is the execution-semantics identification — that a rewound
+random-oracle adversary *induces* such a staged strategy, with its RO-query loss (the out-of-Lean
+execution-semantics floor). The abstract theorems —
+`deployed_forking_soundness_of_bridge` below, and `orchard_verifier_vesta_forking_opening`/`_constraint` —
+retain `hbridge` as that *modular* hypothesis (they are stated over an abstract `accepts`/`Q`): its
+deterministic content is a theorem for every staged strategy, and the round-by-round transcript ordering
+behind the prefix-respecting shape is likewise proven and sealed to the deployed derivation
+(`Soundness.Forking.Ordering`, `deriveChallenges_ipaRound_eq`; `proverRoundPoint_proverOfRounds` for the
+tree side). Its execution-semantics content is the residual prover-as-oracle floor — that a rewound
+random-oracle adversary *induces* such a staged strategy — alongside the random-oracle uniformity axiom on
+the accept *probability* (the uniform measure of `hprob`, `Forking.Oracle`) — that the challenges are
+uniform, independent, rewindable random-oracle draws. -/
+
+open scoped ENNReal in
+open Classical in
+/-- **The deployed forking soundness from an explicit prover-as-oracle bridge.** This is the honest top of the
+forking chain. It takes the deployed verifier's *actual* accept event `accepts χ` — the verifier on the proof
+at challenge vector `χ`, the proof being a function of `χ` is the Fiat–Shamir/random-oracle model — together
+with the **explicit** faithfulness bridge `hbridge` identifying that event with the strategy predicate
+`flatAccept Q`, and concludes the deployed opening from the accept *probability*.
+
+`flatAccept` folds generators by `foldGens g u⁻¹`, exactly halo2's `compute_s` direction, so the verifier
+equation `DeployedIpaVerifierEq` — which `deployedVerifierEq_cf` identifies with the closed form `CF = 0` —
+folds along each challenge path to `flatAccept Q`. The deterministic content of `hbridge` is **proven** by
+`deployedVerifierEq_iff_flatAccept` (the proof string read as the prefix-respecting `Prover`
+`proverOfRounds ps.ipaRounds ps.ipaC ps.ipaF`, whose per-path `flatAccept` *is* the verifier's accept), so
+`hbridge` is *dischargeable* — but this theorem still takes it as an explicit hypothesis (it has not been
+rewired to consume that identity; doing so also needs the `S`-opening fact `commit urs s = ps.ipaS`). With
+`hbridge` supplied, the residual is *only* the random-oracle uniformity axiom on the accept probability — every
+other link (extraction, root-consistency, value placement, the `u`-vs-`u⁻¹` convention) is a theorem, as is
+the round-by-round transcript ordering (`Soundness.Forking.Ordering`, sealed by
+`deriveChallenges_ipaRound_eq`). This is the granular replacement for the monolithic `FiatShamirTree`. -/
+noncomputable def deployed_forking_soundness_of_bridge [DecidableEq G] [Inhabited G] (urs : URS G)
+    (b : Fin (2 ^ urs.k) → Fp) (v ξ z blind : Fp) (aMulti aDep s : Fin (2 ^ urs.k) → Fp)
+    (Q : Prover Fp G urs.k) (accepts : (Fin urs.k → Fp) → Prop)
+    (hz : z ≠ 0) (hb0 : b 0 = 1)
+    (hP : commit urs aDep = commit urs aMulti - v • urs.g 0 + ξ • commit urs s)
+    (hbridge : ∀ χ, accepts χ ↔ flatAccept Q urs.g b urs.u urs.w z
+        (commit urs aDep + (z * 0) • urs.u + blind • urs.w) χ)
+    (hprob : (kerr (Fintype.card Fp) urs.k : ℝ≥0∞) / Fintype.card (Fin urs.k → Fp)
+        < (PMF.uniformOfFintype (Fin urs.k → Fp)).toOuterMeasure (Finset.univ.filter accepts)) :
+    (∃ a, IpaRelation urs (commit urs aMulti) b (v - ξ * innerProduct s b) a)
+      ⊕' NontrivialRelation (F := Fp) urs.g urs.u urs.w := by
+  refine deployed_forking_soundness_flat urs b v ξ z blind aMulti aDep s Q hz hb0 hP ?_
+  have hset : Finset.univ.filter accepts
+      = Finset.univ.filter (flatAccept Q urs.g b urs.u urs.w z
+          (commit urs aDep + (z * 0) • urs.u + blind • urs.w)) := by
+    ext χ
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+    exact hbridge χ
+  rwa [hset] at hprob
+
+end Zcash.Snark

--- a/Zcash/Snark/Soundness/Forking/Rewind.lean
+++ b/Zcash/Snark/Soundness/Forking/Rewind.lean
@@ -4,22 +4,15 @@ import Zcash.Snark.Soundness.Forking.Extractor
 import Zcash.Snark.Soundness.Forking.Ordering
 
 /-!
-# The deployed verifier under random-oracle rewinding
+# Random-oracle rewinding for the deployed verifier
 
-This module carries the live Fiat–Shamir forking path. First, `ofOracle`/`roChallenges` instantiate
-`deriveChallenges` with a random oracle, and `reprogramRounds` proves that re-running the deployed schedule
-under round-prefix reprogramming is exactly the same as replacing the IPA round-challenge vector. That
-identification is load-bearing in the `_rewind` Vesta capstones.
+`ofOracle` and `roChallenges` run the deployed schedule with a random oracle. `reprogramRounds` shows
+that changing the oracle at the IPA round prefixes is the same as replacing the round-challenge
+vector.
 
-Second, the probability chain replaces a posited forked transcript tree by an accept-probability hypothesis:
-`extractable_of_prob` yields an `Extractable` challenge tree, `proverAccept_forkValid` turns it into a
-`DeployedForkValid` certificate, `deployed_forking_relation` extracts the opened value, and
-`deployed_forking_soundness_of_bridge` isolates the remaining prover-as-oracle bridge. Its deterministic
-content is proven below (`deployedVerifierEq_iff_flatAccept`, `deployedVerifierEq_iff_flatAccept_adaptive`).
-The floor left is the execution-semantics identification for a rewound RO adversary — the
-querying-adversary/query-loss experiment that would *derive* `hprob`'s accept probability — plus
-Blake2b-as-random-oracle. The uniform *measure* of `hprob` is justified standalone by
-`roChallenges_ipaRound_uniform` (see its section for the scope).
+The probability chain turns acceptance above the knowledge error into a fork certificate and then an
+IPA opening. The remaining integration must derive that acceptance probability from a real
+random-oracle adversary, including query loss. Blake2b-as-random-oracle also remains an assumption.
 -/
 
 namespace Zcash.Snark
@@ -29,29 +22,20 @@ variable {G : Type*} [AddCommGroup G] [Module Fp G]
 /-- A random-oracle-backed Fiat–Shamir instance: the squeeze *is* the oracle `O`. -/
 def ofOracle (O : List (TranscriptElt Fp G) → Fp) : FiatShamir Fp G := ⟨O⟩
 
-/-- The challenges a proof induces under random oracle `O` — the deployed verifier's own Fiat–Shamir coins,
-`deriveChallenges` run through `ofOracle O`. -/
+/-- Run the deployed challenge schedule with oracle `O`. -/
 def roChallenges {shape : Shape} (O : List (TranscriptElt Fp G) → Fp)
     (init : List (TranscriptElt Fp G)) (ps : ProofString shape Fp G) : Challenges shape.k Fp :=
   deriveChallenges (ofOracle O) init ps
 
 /-! ## Redrawing the round vector *is* reprogramming the deployed oracle
 
-The forking layer redraws the IPA round-challenge vector `χ` and evaluates the verifier at
-`{ch with ipaRound := χ}`; the random-oracle model rewinds by *reprogramming* the oracle
-(`Soundness.Forking.Oracle.reprogram`) at the round prefixes and re-running the schedule. These are the same
-operation, and `roChallenges_reprogramRounds` proves it. The round prefixes are pairwise distinct and longer
-than every pre-IPA squeeze input (`roundTranscriptFin_length`/`_injective`), so reprogramming them changes
-exactly the round challenges (`deriveChallenges_ipaRound_eq`, the seal) and nothing upstream — which is why the
-proof consumes the round-by-round transcript ordering (`Soundness.Forking.Ordering`). This puts the ordering
-module on the Fiat–Shamir path: the `_rewind` capstones (`Soundness.Vesta`) state their accept probability over
-reprogrammed-oracle runs and reach the `_deployed` capstones through this identification. -/
+The forking proof replaces the IPA challenge vector. The random-oracle experiment instead changes the
+oracle at each round prefix and reruns the schedule. `roChallenges_reprogramRounds` proves these are
+the same operation. Distinct, longer round prefixes ensure that earlier challenges are unchanged.
+-/
 
 open Classical in
-/-- The `k`-point extension of `reprogram`: reprogram the oracle at *every* IPA round prefix of the fixed
-proof string at once, answering `χ j` at the round-`j` transcript (as `reprogram … (χ j)` would) and `O`
-elsewhere. Redrawing the whole round vector — what the forking probability ranges over — runs the deployed
-schedule under this oracle (`roChallenges_reprogramRounds`). -/
+/-- Change the oracle answer at every IPA round prefix to the corresponding value in `χ`. -/
 noncomputable def reprogramRounds {shape : Shape} (O : List (TranscriptElt Fp G) → Fp)
     (init : List (TranscriptElt Fp G)) (ps : ProofString shape Fp G) (χ : Fin shape.k → Fp) :
     List (TranscriptElt Fp G) → Fp :=
@@ -59,8 +43,7 @@ noncomputable def reprogramRounds {shape : Shape} (O : List (TranscriptElt Fp G)
       t = roundTranscriptFin (preIpaTranscript init ps) ps.ipaRounds j
     then χ h.choose else O t
 
-/-- At the round-`j` prefix, the reprogrammed oracle answers `χ j` (well-defined because distinct rounds
-have distinct prefixes, `roundTranscriptFin_injective`). -/
+/-- At the round-`j` prefix, the reprogrammed oracle answers `χ j`. -/
 theorem reprogramRounds_apply_round {shape : Shape} (O : List (TranscriptElt Fp G) → Fp)
     (init : List (TranscriptElt Fp G)) (ps : ProofString shape Fp G) (χ : Fin shape.k → Fp)
     (j : Fin shape.k) :
@@ -84,8 +67,7 @@ theorem reprogramRounds_apply_ne {shape : Shape} (O : List (TranscriptElt Fp G) 
   rintro ⟨j, hj⟩
   exact ht j hj
 
-/-- Every transcript no longer than the pre-IPA base is untouched by the round reprogramming: the round
-prefixes are strictly longer (`roundTranscriptFin_length`). In particular every pre-IPA squeeze input. -/
+/-- Reprogramming leaves every transcript no longer than the pre-IPA prefix unchanged. -/
 theorem reprogramRounds_apply_short {shape : Shape} (O : List (TranscriptElt Fp G) → Fp)
     (init : List (TranscriptElt Fp G)) (ps : ProofString shape Fp G) (χ : Fin shape.k → Fp)
     {t : List (TranscriptElt Fp G)} (ht : t.length ≤ (preIpaTranscript init ps).length) :
@@ -102,12 +84,7 @@ private theorem Challenges.ext' {k : ℕ} {F : Type*} {c₁ c₂ : Challenges k 
     (hu : c₁.ipaRound = c₂.ipaRound) : c₁ = c₂ := by
   cases c₁; cases c₂; simp_all
 
-/-- **Redrawing the round vector is reprogramming the deployed oracle.** Running the deployed schedule under
-the oracle reprogrammed at all `k` round prefixes yields exactly the honest run with its IPA round vector
-replaced by `χ`. The pre-IPA challenges are untouched (their squeeze inputs are no longer than the base,
-`reprogramRounds_apply_short`), and round `j`'s challenge is the reprogrammed answer `χ j` — the
-transcript-ordering seal `deriveChallenges_ipaRound_eq`. This is the identification the forking layer's
-`{ch with ipaRound := χ}` events rest on, and the load-bearing consumer of `Soundness.Forking.Ordering`. -/
+/-- Rerunning the deployed schedule with `reprogramRounds` replaces only its IPA round vector. -/
 theorem roChallenges_reprogramRounds {shape : Shape} (O : List (TranscriptElt Fp G) → Fp)
     (init : List (TranscriptElt Fp G)) (ps : ProofString shape Fp G) (χ : Fin shape.k → Fp) :
     roChallenges (reprogramRounds O init ps χ) init ps
@@ -124,44 +101,25 @@ theorem roChallenges_reprogramRounds {shape : Shape} (O : List (TranscriptElt Fp
 
 /-! ## Challenge-vector uniformity: a standalone justification for `hprob`'s measure
 
-`hprob` is stated over `PMF.uniformOfFintype (Fin k → Fp)`, the uniform measure on the IPA round-challenge
-vector. That a random oracle induces this distribution was an axiom; it is now a theorem:
+`hprob` uses the uniform distribution on IPA challenge vectors. The following theorems derive that
+distribution from a uniform random oracle for a fixed proof:
 
-* `roChallenges_ipaRound_apply` — each round challenge is the oracle's answer at that round's transcript prefix,
-  `(roChallenges O init ps).ipaRound j = O (φ j)`, `φ = roundTranscriptFin (preIpaTranscript init ps) ps.ipaRounds`.
-* `roChallenges_ipaRound_uniform` — the `k` prefixes are pairwise distinct (`roundTranscriptFin_injective`), so
-  reading a uniform random oracle at them (`uniformOfFintype_map_eval_injective`) is the uniform challenge vector.
+* `roChallenges_ipaRound_apply` identifies each round challenge with one oracle answer.
+* `roChallenges_ipaRound_uniform` uses distinct prefixes to prove the answers are uniformly distributed.
 
-**Scope.** This is a *standalone* justification, not a link in any capstone: nothing consumes
-`roChallenges_ipaRound_uniform`, and every `hprob` below is stated directly over `PMF.uniformOfFintype`. The
-theorem shows that measure is what a uniform random oracle induces; it is not substituted into the reduction.
-It has two limits:
+This theorem is not yet composed into the capstones. It has two limits:
 
-* it samples the oracle only at the `k` round prefixes — the marginal on the round vector, not a full query
-  domain;
-* it is for the fixed proof string `ps`. In the `_adaptive`/`_rewind` events the reprogrammed prefixes depend
-  on `χ`, so tying `hprob`'s measure to a rewound-oracle experiment there belongs to the execution-semantics
-  floor (a forger querying `O`, with query-loss — `Forking.Oracle`), above `hprob`, not this theorem. -/
+* it samples only the `k` round-prefix queries;
+* it fixes `ps`. Adaptive proofs require the full querying-adversary experiment and its query loss. -/
 
-/-- Each round challenge is the oracle's answer at that round's transcript prefix:
-`(roChallenges O init ps).ipaRound j = O (roundTranscriptFin (preIpaTranscript init ps) ps.ipaRounds j)`.
-`roChallenges` is `deriveChallenges` through `ofOracle O`, whose squeeze is `O`, so this is
-`deriveChallenges_ipaRound_eq` at the oracle — the challenge vector depends on the oracle's values at the `k`
-prefixes alone. -/
+/-- Each deployed IPA round challenge is the oracle answer at its round prefix. -/
 theorem roChallenges_ipaRound_apply {shape : Shape} (O : List (TranscriptElt Fp G) → Fp)
     (init : List (TranscriptElt Fp G)) (ps : ProofString shape Fp G) (j : Fin shape.k) :
     (roChallenges O init ps).ipaRound j
       = O (roundTranscriptFin (preIpaTranscript init ps) ps.ipaRounds j) :=
   deriveChallenges_ipaRound_eq (ofOracle O) init ps j
 
-/-- **Challenge-vector uniformity from a uniform random oracle.** Sampling the oracle uniformly over its query
-domain — the finite set `↥(Set.range φ)` of the `k` round prefixes
-`φ = roundTranscriptFin (preIpaTranscript init ps) ps.ipaRounds` — and reading its answers (`fun O j => O ⟨φ j, _⟩`,
-the round-challenge vector by `roChallenges_ipaRound_apply`) is distributed as
-`PMF.uniformOfFintype (Fin shape.k → Fp)`. This is `uniformOfFintype_map_eval_injective` at `φ`, whose injectivity
-(`roundTranscriptFin_injective`, the prefixes are distinct) makes the `k` answers independent-uniform. For its
-scope — a standalone justification of `hprob`'s measure, over the fixed-`ps` marginal, consumed by no capstone —
-see the section above. -/
+/-- A uniform random oracle gives a uniform IPA challenge vector at the distinct round prefixes. -/
 theorem roChallenges_ipaRound_uniform [DecidableEq G] {shape : Shape}
     (init : List (TranscriptElt Fp G)) (ps : ProofString shape Fp G) :
     (PMF.uniformOfFintype
@@ -174,12 +132,7 @@ theorem roChallenges_ipaRound_uniform [DecidableEq G] {shape : Shape}
 
 open scoped ENNReal in
 open Classical in
-/-- **Accept-measure monotonicity into the capstones' `hprob`.** The deployed accept (`DeployedAccepts`,
-the `assemble?` guards plus the MSM identity) implies the explicit verifier equation pointwise
-(`deployedAccepts_verifierEq`), so any threshold beaten by the *deployed-accept* event is beaten by the
-`DeployedIpaVerifierEq` event the capstones consume. Stated over arbitrary proof-string/challenge-record
-families, it covers the constant, `_rewind`, and `_adaptive_rewind` event shapes alike — use it to feed a
-capstone `hprob` from a genuine deployed-accept probability. -/
+/-- A lower bound on deployed acceptance also bounds the explicit verifier-equation event. -/
 theorem kerr_lt_verifierEq_of_deployedAccepts [DecidableEq G] [Inhabited G] {shape : Shape}
     (urs : URS G) (hk : shape.k = urs.k) (vk : VerifyingKey shape Fp G)
     (psf : (Fin shape.k → Fp) → ProofString shape Fp G)
@@ -196,30 +149,14 @@ theorem kerr_lt_verifierEq_of_deployedAccepts [DecidableEq G] [Inhabited G] {sha
 
 /-! ## The deployed forking opening: the value-placement composed end to end
 
-This closes the deterministic chain. From the flat forking output threading halo2's *adjusted* commitment
-`P' = ⟨aDep,G⟩ = multiopen − [v]g₀ + [ξ]⟨s,G⟩` (the verifier's `add_constant_term(-v)` plus the synthetic
-blinding `[ξ]S`), `deployed_forking_tree` extracts an opening of `P'` to inner product `0`; the
-adjusted-commitment theorems then lift it to an opening of the *multiopen* commitment `⟨aMulti,G⟩` to its
-**true** value `v − ξ·⟨s,b⟩` — `ipaRelation_unshift` (keyed on `b₀ = 1`) restores the value and
-`ipaRelation_unblind_value` strips the blinding *unconditionally*. So every link from the rewinding output to
-the deployed inner-product relation is a theorem; the residual is `DeployedForkValid` (the rewinding itself),
-the `g`-span/adjusted form, `b₀ = 1`, and Blake2b-as-random-oracle. -/
+`deployed_forking_tree` opens halo2's adjusted commitment. The unshift and unblinding lemmas convert
+that result to an opening of the multiopen commitment at value `v − ξ·⟨s,b⟩`.
+-/
 
-/-- **The deployed forking opening.** A flat forking output (`DeployedForkValid`, no posited decomposition)
-threading halo2's adjusted commitment `⟨aDep,G⟩ = ⟨aMulti,G⟩ − [v]g₀ + [ξ]⟨s,G⟩` yields an inner-product
-opening of the multiopen commitment `⟨aMulti,G⟩` to the value `v − ξ·⟨s,b⟩` for the supplied `S`-opening
-`s` — unique under binding: two distinct openings of `ps.ipaS` shift it by `ξ·⟨Δ,b⟩` while exhibiting a
-`g`-relation, the computed `NontrivialRelation` branch — or the multiopen opening. The extraction
-(`deployed_forking_tree`) opens `⟨aDep,G⟩` to inner product `0`; `ipaRelation_unshift`
-(keyed on `b₀ = 1`) restores the value, and `ipaRelation_unblind_value` strips the synthetic blinding
-*unconditionally* — reporting that opened value whatever the prover's blinder `s` is (no `⟨s,b⟩ = 0`
-assumed; the honest case `⟨s,b⟩ = 0` recovers the claimed `v`). As a *computable* `def`, the opening is
-returned as **computed data**
-(`ipaRelation_extract`), not the prime-order-vacuous `∃ a, …`: neither the opening witness nor the relation
-coefficients can be produced without the `cert` (the discrete-log preimage the reviewer's vacuity witness
-needs is not computable), so this reduction is genuinely non-vacuous. The `deployed_forking_soundness*`
-capstones that wrap it are the honest floor — they forget the data to `∃` because the `cert` is only
-classically obtained (the random-oracle experiment, `Forking.Oracle`, is unmodeled). -/
+/-- Compute a multiopen IPA opening or nontrivial relation from an explicit valid fork certificate.
+
+The opening value is `v − ξ·⟨s,b⟩`. The result is computed data; no certificate or witness is chosen
+from an existential proposition. -/
 def deployed_forking_relation [DecidableEq G] [Inhabited G] (urs : URS G)
     (b : Fin (2 ^ urs.k) → Fp) (v ξ z blind : Fp) (aMulti aDep s : Fin (2 ^ urs.k) → Fp)
     (cert : DForkCert Fp G urs.k) (hz : z ≠ 0) (hb0 : b 0 = 1)
@@ -246,24 +183,14 @@ def deployed_forking_relation [DecidableEq G] [Inhabited G] (urs : URS G)
 
 /-! ## Closing the rewinding gap: the forked transcripts are *produced* by the probability
 
-`deployed_forking_relation` still took `DeployedForkValid` (the forked transcripts) as a hypothesis; this
-discharges it. In the random-oracle model the challenge vector is uniform, so the prover's accept event is a
-finite set whose measure is its accept *probability*. When that probability exceeds the knowledge error
-`kerr/Nᵏ = 3k/N`, `extractable_of_prob` — the averaging argument that *is* the multi-round forking lemma —
-forces a full `(3,…,3)` forking tree to exist, and `proverAccept_forkValid` reads off the `DeployedForkValid`
-certificate. So the rewinding output is no longer assumed: the accept probability beating the knowledge error
-produces it, in the ideal RO model. The residual is Blake2b-as-random-oracle (what makes the challenge
-uniform), the prover-as-strategy `P`, and the standard structural/honest-prover facts. -/
+If a prover strategy accepts above `kerr`, `extractable_of_prob` gives a challenge tree and
+`proverAccept_forkValid` packages it as a valid fork certificate. The real adversary-to-strategy step
+and Blake2b random-oracle model remain outside this result.
+-/
 
 open scoped ENNReal in
 open Classical in
-/-- **Challenge inversion is measure-preserving.** Componentwise inversion `χ ↦ (·⁻¹) ∘ χ` is an involution
-on `Fin d → Fp` — a field satisfies `a⁻¹⁻¹ = a` for *every* `a` (including `0`, since `0⁻¹ = 0`) — hence a
-bijection of the uniform random-oracle sample space onto itself, so inverting the challenge vector leaves any
-accept event's probability unchanged. This is the probabilistic half of the consistency bridge: the deployed
-verifier folds generators by `foldGens g u⁻¹` (`foldAll`) while the extraction tree folds by `foldGens g u`,
-so the two accept events differ by exactly this inversion — equal probability, and the soundness hypothesis on
-the tree predicate is the deployed verifier's accept probability. -/
+/-- Componentwise inversion preserves the uniform measure on challenge vectors. -/
 theorem uniformOfFintype_measure_inv {d : ℕ} (acc : (Fin d → Fp) → Prop) :
     (PMF.uniformOfFintype (Fin d → Fp)).toOuterMeasure
         (Finset.univ.filter (fun χ : Fin d → Fp => acc (fun i => (χ i)⁻¹)))
@@ -287,13 +214,8 @@ theorem uniformOfFintype_measure_inv {d : ℕ} (acc : (Fin d → Fp) → Prop) :
   case ri => intro χ _; funext i; simp only [inv_inv]
 
 open scoped ENNReal in
-/-- **The synthetic blinder's soundness budget (ξ-randomization).** A malicious IPA blinder `S = ⟨s,G⟩` with
-`⟨s,b⟩ = δ ≠ 0` shifts the opened value of the multiopen commitment by `−ξδ` (`ipaRelation_unblind_value`):
-the plain commitment opens to `v − ξδ` rather than the claimed `v`. Because the verifier squeezes `ξ` *after*
-the prover has committed `S` (`deriveChallenges`), `δ` is fixed before `ξ`, so the shifted value `v − ξδ`
-hits any fixed target `c` for at most one challenge `ξ = (v−c)/δ` — a set of uniform random-oracle measure
-`≤ 1/p`. This is the `1/p` soundness role of `[ξ]S`: it replaces the honest-prover assumption `⟨s,b⟩ = 0`
-(the `hs` of `ipaRelation_unblind`) by a Schwartz–Zippel exclusion over `ξ`. -/
+/-- If a nonzero blinding shift is fixed before uniform `ξ`, it hits any target with probability at
+most `1 / |Fp|`. -/
 theorem blinder_shift_badSet_measure (δ c : Fp) (hδ : δ ≠ 0) :
     uniformChallenge.toOuterMeasure (Finset.univ.filter (fun ξ : Fp => ξ * δ = c))
       ≤ 1 / (Fintype.card Fp : ℝ≥0∞) := by
@@ -306,12 +228,7 @@ theorem blinder_shift_badSet_measure (δ c : Fp) (hδ : δ ≠ 0) :
   gcongr
   exact_mod_cast hcard
 
-/-- The deployed accept condition along one challenge path, in the **flat verifier's** IPA fold convention:
-generators (and eval vector) fold by `foldGens · u⁻¹` — exactly halo2's `foldAll`/`computeS` direction — rather
-than the extraction tree's `foldGens · u` (`proverAccept`). Everything else — the commitment fold
-`[u⁻¹]L + [u]R`, the leaf check — is identical. Its `CF`-fold matches `DeployedIpaVerifierEq`
-(`deployedVerifierEq_cf` identifies the verifier equation with `CF = 0`); the per-path identification is the
-explicit `hbridge` of `deployed_forking_soundness_of_bridge`, not proved here. -/
+/-- The accept condition along one path using halo2's inverse-challenge generator fold. -/
 def flatAccept : {d : ℕ} → Prover Fp G d → (Fin (2 ^ d) → G) → (Fin (2 ^ d) → Fp) → (U W : G) → (z : Fp) →
     G → (Fin d → Fp) → Prop
   | 0, .leaf c f, g, b, U, W, z, Pwhole, _ =>
@@ -320,9 +237,7 @@ def flatAccept : {d : ℕ} → Prover Fp G d → (Fin (2 ^ d) → G) → (Fin (2
       flatAccept (cont (χ 0)) (foldGens g (χ 0)⁻¹) (foldGens b (χ 0)⁻¹) U W z
         (Pwhole + (χ 0)⁻¹ • L + (χ 0) • R) (Fin.tail χ)
 
-/-- The prover strategy re-indexed for the flat convention: swap each round's `(L, R)` and feed every
-continuation the inverted challenge. The involution that, together with challenge inversion, turns the
-extraction tree's fold convention into the flat verifier's. -/
+/-- Swap each round point and invert each challenge to change fold conventions. -/
 def invProver : {d : ℕ} → Prover Fp G d → Prover Fp G d
   | 0, .leaf c f => .leaf c f
   | _ + 1, .node L R cont => .node R L (fun u => invProver (cont u⁻¹))
@@ -336,12 +251,7 @@ theorem invProver_invProver : {d : ℕ} → (P : Prover Fp G d) → invProver (i
       funext u
       rw [inv_inv, invProver_invProver (cont u)]
 
-/-- **The convention bridge (pointwise).** The extraction tree's accept predicate `proverAccept` (folding
-generators by `foldGens g u`) at challenge vector `χ` is *exactly* the flat verifier predicate `flatAccept`
-(folding by `foldGens g u⁻¹`) for the re-indexed prover `invProver P` at the inverted challenges `χ⁻¹`. The two
-IPA fold conventions differ only by this challenge inversion and an `L`/`R` swap — both discharged here by
-structural induction (`inv_inv`, `Fin.tail` of an inverted vector, and commutativity of the commitment fold).
-No correctness gap: the tree predicate *is* the flat verifier predicate, relabelled. -/
+/-- `proverAccept` equals `flatAccept` after swapping round points and inverting challenges. -/
 theorem proverAccept_iff_flatAccept {U W : G} {z : Fp} : {d : ℕ} → (P : Prover Fp G d) →
     (g : Fin (2 ^ d) → G) → (b : Fin (2 ^ d) → Fp) → (Pwhole : G) → (χ : Fin d → Fp) →
     (proverAccept P g b U W z Pwhole χ ↔
@@ -357,14 +267,7 @@ theorem proverAccept_iff_flatAccept {U W : G} {z : Fp} : {d : ℕ} → (P : Prov
 
 open scoped ENNReal in
 open Classical in
-/-- **The convention bridge (probabilistic) — the consistency gap, closed.** The extraction tree's accept
-predicate (`proverAccept`, fold `foldGens g u`) and the flat verifier predicate (`flatAccept`, fold
-`foldGens g u⁻¹` — halo2's actual `foldAll`/`computeS` direction) have *equal* accept probability under the
-uniform random oracle. Pointwise they are the same event up to challenge inversion
-(`proverAccept_iff_flatAccept`), and inversion is measure-preserving (`uniformOfFintype_measure_inv`). So the
-`u`-vs-`u⁻¹` IPA fold convention is not a correctness gap: the tree predicate and the flat-convention
-predicate share an accept probability. (Identifying `flatAccept` itself with the deployed verifier's *actual*
-accept event is the separate prover-as-oracle bridge, `deployed_forking_soundness_of_bridge`.) -/
+/-- `proverAccept` and `flatAccept` have equal probability under uniform challenges. -/
 theorem proverAccept_measure_eq_flatAccept {d : ℕ} {U W : G} {z : Fp} (P : Prover Fp G d)
     (g : Fin (2 ^ d) → G) (b : Fin (2 ^ d) → Fp) (Pwhole : G) :
     (PMF.uniformOfFintype (Fin d → Fp)).toOuterMeasure
@@ -380,17 +283,8 @@ theorem proverAccept_measure_eq_flatAccept {d : ℕ} {U W : G} {z : Fp} (P : Pro
   rw [hset, uniformOfFintype_measure_inv]
 
 open scoped ENNReal in
-/-- **The forking soundness for an abstract prover strategy.** For a strategy tree `P`, if its accept event
-`proverAccept P …` has probability exceeding the knowledge error `kerr (card Fp) k / (card Fp)ᵏ` (`= 3k/N`)
-over the uniform challenge vector, then the multiopen commitment `⟨aMulti,G⟩` opens to its **true** value
-`v − ξ·⟨s,b⟩` — or a nontrivial relation. The chain: `extractable_of_prob` (the averaging argument) turns the
-probability into a forking tree, `proverAccept_forkValid` into a `DeployedForkValid` certificate, and
-`deployed_forking_relation` into the opening. This is the **abstract** layer — `P` is an arbitrary strategy,
-the challenge vector uniform. Tying it to the deployed verifier (that the actual proof realizes such a `P`
-whose accept event is `DeployedIpaVerifierEq`, over the RO-derived challenge) is the explicit bridge
-`deployed_forking_soundness_of_bridge`. The residual is that bridge (the prover-as-oracle / Blake2b floor) and
-the structural facts (`b₀ = 1`, the adjusted/`g`-span form `hP`); the synthetic blinder is stripped
-unconditionally (no `s(x) = 0` assumed). -/
+/-- If an abstract prover strategy accepts above the knowledge error, derive an IPA opening or
+nontrivial relation. -/
 noncomputable def deployed_forking_soundness [DecidableEq G] [Inhabited G] (urs : URS G)
     (b : Fin (2 ^ urs.k) → Fp) (v ξ z blind : Fp) (aMulti aDep s : Fin (2 ^ urs.k) → Fp)
     (P : Prover Fp G urs.k) (hz : z ≠ 0) (hb0 : b 0 = 1)
@@ -416,13 +310,7 @@ noncomputable def deployed_forking_soundness [DecidableEq G] [Inhabited G] (urs 
 
 open scoped ENNReal in
 open Classical in
-/-- **The deployed forking soundness, in the verifier's own fold convention.** `deployed_forking_soundness`
-with the accept-probability hypothesis stated over `flatAccept` — folding generators by `foldGens g u⁻¹`,
-halo2's `foldAll`/`computeS` direction — instead of the extraction tree's `proverAccept` (`foldGens g u`). The
-two have equal accept probability (`proverAccept_measure_eq_flatAccept`, via the measure-preserving challenge
-inversion), so the `u`-vs-`u⁻¹` consistency gap is discharged by theorem. The hypothesis is still the
-*strategy* predicate `flatAccept Q`; identifying `Q` with the deployed proof is the explicit bridge
-`deployed_forking_soundness_of_bridge`. -/
+/-- State abstract forking soundness using the deployed verifier's inverse-challenge fold convention. -/
 noncomputable def deployed_forking_soundness_flat [DecidableEq G] [Inhabited G] (urs : URS G)
     (b : Fin (2 ^ urs.k) → Fp) (v ξ z blind : Fp) (aMulti aDep s : Fin (2 ^ urs.k) → Fp)
     (Q : Prover Fp G urs.k) (hz : z ≠ 0) (hb0 : b 0 = 1)
@@ -438,33 +326,19 @@ noncomputable def deployed_forking_soundness_flat [DecidableEq G] [Inhabited G] 
         (commit urs aDep + (z * 0) • urs.u + blind • urs.w), invProver_invProver Q]
   exact hprob
 
-/-! ## Discharging the deterministic half of the prover-as-oracle bridge `hbridge`
+/-! ## The deterministic prover-to-verifier bridge
 
-`hbridge` bundles a deterministic algebra half — the deployed verifier equation folds, along each challenge
-path, to the flat tree predicate `flatAccept` of the proof read as a `Prover` — with the irreducible
-random-oracle half (the accept *probability* is over uniform rewindable challenges). This section discharges
-the **algebra half**: `deployedVerifierEq_iff_flatAccept` proves halo2's actual `DeployedIpaVerifierEq` is
-`flatAccept (proverOfRounds …)` at the challenge vector, so `hbridge` is a *theorem* for the deployed verifier,
-not an assumption. The round-by-round ordering behind the prefix-respecting `Prover` shape is likewise a
-theorem (`Soundness.Forking.Ordering`, sealed to the deployed schedule by `deriveChallenges_ipaRound_eq`;
-`proverRoundPoint_proverOfRounds` below reads the fixed round points off `proverOfRounds` on every challenge
-path). The residual is then only the random-oracle adversary experiment above `hprob` (the querying forger and
-its query-loss) and Blake2b-as-random-oracle — challenge-vector uniformity is justified standalone
-(`roChallenges_ipaRound_uniform`; see its section, consumed by no capstone). -/
+This section builds the constant prover strategy represented by a fixed proof and proves that its
+`flatAccept` predicate is the deployed verifier equation. The random-oracle adversary experiment and
+query loss remain separate.
+-/
 
-/-- The prover-strategy tree the deployed non-interactive proof realises: at each IPA round it commits the
-proof's **fixed** round points `(Lⱼ, Rⱼ)` (they are written in the proof string, so the continuation ignores
-the challenge), and the leaf carries the final folded opening scalar `c` and blinding `f`. This is the concrete
-`Prover` object that `hbridge` posits abstractly — here built explicitly from the proof string. -/
+/-- Build the constant prover strategy encoded by a fixed proof's IPA fields. -/
 def proverOfRounds : {d : ℕ} → (Fin d → G × G) → Fp → Fp → Prover Fp G d
   | 0, _, c, f => .leaf c f
   | _ + 1, R, c, f => .node (R 0).1 (R 0).2 (fun _ => proverOfRounds (Fin.tail R) c f)
 
-/-- The deployed fixed-proof prover commits constant round points: on *every* challenge path,
-`proverRoundPoint` of `proverOfRounds R c f` at depth `j` is `R j` — the degenerate
-(challenge-independent) case of `proverRoundPoint_prefix`, and the prover-tree side of the deployed
-schedule's ordering (`deriveChallenges_ipaRound_eq`). So the tree `hbridge` instantiates satisfies the
-round-by-round prefix-determination by construction. -/
+/-- A fixed proof's strategy returns round point `R j` at depth `j` on every challenge path. -/
 theorem proverRoundPoint_proverOfRounds : {d : ℕ} → (R : Fin d → G × G) → (c f : Fp) →
     (χ : Fin d → Fp) → (j : ℕ) → (hj : j < d) →
     proverRoundPoint (proverOfRounds R c f) χ j = some (R ⟨j, hj⟩)
@@ -477,31 +351,23 @@ theorem proverRoundPoint_proverOfRounds : {d : ℕ} → (R : Fin d → G × G) �
       rw [proverRoundPoint_proverOfRounds (Fin.tail R) c f (Fin.tail χ) j (Nat.lt_of_succ_lt_succ hj)]
       rfl
 
-/-- `foldGens` commutes with reindexing the generators along a `Fin.cast` (`loHalf`/`hiHalf` read only the
-index value, which `Fin.cast` preserves). The bookkeeping lemma letting the `flatAccept` fold — indexed by the
-round count `d` — meet the closed-form `CF` fold, indexed by the challenge-*list* length `(List.ofFn χ).length`
-(propositionally, not definitionally, `d`). -/
+/-- `foldGens` commutes with reindexing by `Fin.cast`. -/
 theorem foldGens_comp_cast {m n : ℕ} (h : n = m) (g : Fin (2 ^ (m + 1)) → G) (u : Fp) :
     foldGens (fun j : Fin (2 ^ (n + 1)) => g (Fin.cast (by rw [h]) j)) u
       = fun i : Fin (2 ^ n) => foldGens g u (Fin.cast (by rw [h]) i) := by
   subst h; rfl
 
-/-- Fin-indexed generator fold: fold `g` by `foldGens · (χ j)⁻¹` down all `d` rounds to a single generator.
-The cast-free counterpart of the deployed list fold `foldAll (List.ofFn χ) …`, matching `flatAccept`'s
-per-round generator fold exactly, so the identity's induction stays cast-free. -/
+/-- Fold `g` through a `Fin`-indexed challenge vector without dependent casts. -/
 def foldAllFin : {d : ℕ} → (Fin d → Fp) → (Fin (2 ^ d) → G) → G
   | 0, _, g => g 0
   | _ + 1, χ, g => foldAllFin (Fin.tail χ) (foldGens g (χ 0)⁻¹)
 
-/-- `foldAll` reindexed along a list equality: rewrites the list and the generators' `Fin.cast` together (via
-`subst`), the tool that peels `foldAll (List.ofFn χ)` past the dependent cast that blocks a bare `rw`. -/
+/-- Reindex `foldAll` along an equality of challenge lists. -/
 theorem foldAll_congr_cast {u u' : List Fp} (h : u = u') (g : Fin (2 ^ u.length) → G) :
     foldAll u g = foldAll u' (fun j => g (Fin.cast (by rw [h]) j)) := by
   subst h; rfl
 
-/-- **The Fin↔list generator-fold bridge.** The cast-free `foldAllFin χ g` equals the deployed list fold
-`foldAll (List.ofFn χ) (g ∘ cast) 0`. Peels one round on each side (`foldAllFin` by definition, `foldAll` via
-`foldAll_congr_cast` past the dependent cast) and reconciles the folded generators by `foldGens_comp_cast`. -/
+/-- `foldAllFin` equals the deployed list-based `foldAll`. -/
 theorem foldAllFin_eq : {d : ℕ} → (χ : Fin d → Fp) → (g : Fin (2 ^ d) → G) →
     foldAllFin χ g = foldAll (List.ofFn χ) (fun j => g (Fin.cast (congrArg (2 ^ ·) List.length_ofFn) j)) 0
   | 0, _, g => by simp only [foldAllFin]; rfl
@@ -512,20 +378,14 @@ theorem foldAllFin_eq : {d : ℕ} → (χ : Fin d → Fp) → (g : Fin (2 ^ d) �
       exact congrArg (fun gen => foldAll (List.ofFn (Fin.tail χ)) gen 0)
         (foldGens_comp_cast (List.length_ofFn (f := Fin.tail χ)) g (χ 0)⁻¹).symm
 
-/-- `CF` reindexed along a challenge-list equality: rewrites the challenge list and the generators' `Fin.cast`
-together (via `subst`). -/
+/-- Reindex `CF` along an equality of challenge lists. -/
 theorem CF_congr_chal {u u' : List Fp} (h : u = u') (rounds : List (G × G))
     (g : Fin (2 ^ u.length) → G) (P : G) (c Uc Wc : Fp) (U W : G) :
     CF rounds u g P c Uc U Wc W
       = CF rounds u' (fun j => g (Fin.cast (by rw [h]) j)) P c Uc U Wc W := by
   subst h; rfl
 
-/-- **The verifier-fold ↔ tree-fold identity — the deterministic core of `hbridge`.** For the concrete prover
-tree `proverOfRounds R c f` built from a proof's fixed round points, the flat verifier predicate `flatAccept`
-along challenge path `χ` is *exactly* the closed-form verifier equation `CF … = 0` over the round list
-`List.ofFn R` and challenge list `List.ofFn χ`. Proven by induction on the round count: the leaf reconciles the
-final opening (base), and each round folds one `(Lⱼ, Rⱼ)` into the commitment (`CF_cons`, the round point
-undecomposed) while the value coefficient tracks the eval-vector fold `foldAllFin χ b`. No `sorry`/`axiom`. -/
+/-- For a fixed proof tree, `flatAccept` is exactly the closed-form verifier equation `CF = 0`. -/
 theorem flatAccept_proverOfRounds :
     {d : ℕ} → (R : Fin d → G × G) → (c f : Fp) → (g : Fin (2 ^ d) → G) → (b : Fin (2 ^ d) → Fp) →
     (U W : G) → (z : Fp) → (P : G) → (χ : Fin d → Fp) →
@@ -560,9 +420,7 @@ theorem flatAccept_proverOfRounds :
       congr 1
       exact (foldGens_comp_cast (List.length_ofFn (f := Fin.tail χ)) g (χ 0)⁻¹).symm
 
-/-- The Fin-indexed eval-vector fold is the flat `computeB` (the `b`-value bridge, Fin form): folds the powers
-vector `evalVector d x` down `χ` to `computeB x (List.ofFn χ)`. `foldAllFin_eq` moves to the list fold and
-`foldAll_evalVector` telescopes it. -/
+/-- Folding a `Fin`-indexed eval vector gives the flat verifier's `computeB`. -/
 theorem foldAllFin_evalVector {d : ℕ} (χ : Fin d → Fp) (x : Fp) :
     foldAllFin χ (evalVector d x) = computeB x (List.ofFn χ) := by
   rw [foldAllFin_eq]
@@ -572,16 +430,7 @@ theorem foldAllFin_evalVector {d : ℕ} (χ : Fin d → Fp) (x : Fp) :
   rw [hev]
   exact foldAll_evalVector x (List.ofFn χ)
 
-/-- **`hbridge`, discharged for the deployed verifier (the algebra half).** halo2's actual verifier equation
-`DeployedIpaVerifierEq` at any IPA challenge vector `ch.ipaRound` is *exactly* the flat verifier predicate
-`flatAccept` of the concrete prover tree `proverOfRounds ps.ipaRounds ps.ipaC ps.ipaF` read off the proof —
-with the eval vector `evalVector shape.k ch.x3` and the adjusted commitment `multiopen + [-v]g₀ + [ξ]S`. This is
-the deterministic content of the prover-as-oracle bridge, now a **theorem**, not an assumption: chaining
-`deployedVerifierEq_cf` (the verifier equation is `CF = 0`), `flatAccept_proverOfRounds` (`flatAccept` of the
-tree is that same `CF = 0`), and `foldAllFin_evalVector` (the `U`-coefficient is `computeB`). The only residual
-is the random-oracle adversary experiment above `hprob` (the querying forger and its query-loss) and
-Blake2b-as-random-oracle — the uniform *measure* of `hprob` is justified standalone
-(`roChallenges_ipaRound_uniform`; see its section). -/
+/-- Halo2's deployed IPA verifier equation equals `flatAccept` for the proof's fixed IPA tree. -/
 theorem deployedVerifierEq_iff_flatAccept {shape : Shape} [DecidableEq Fp] [DecidableEq G] [Inhabited G]
     (g : Fin (2 ^ shape.k) → G) (w u : G) (vk : VerifyingKey shape Fp G) (ps : ProofString shape Fp G)
     (ch : Challenges shape.k Fp) :
@@ -596,44 +445,25 @@ theorem deployedVerifierEq_iff_flatAccept {shape : Shape} [DecidableEq Fp] [Deci
 
 /-! ## The staged (round-adaptive) adversary: `hbridge` discharged beyond the constant strategy
 
-`deployedVerifierEq_iff_flatAccept` reads the *fixed* proof string as the constant strategy, so the accept
-event it identifies is one proof's accept set over the challenge space (the static dichotomy). Rewinding a
-real adversary produces more: the rewound runs share the pre-IPA prefix but answer each challenge path with
-their *own* round points and final opening — a prefix-respecting **staged** adversary, which is exactly a
-`Prover` tree together with the fixed pre-IPA data. This section discharges the bridge for *every* such
-strategy: `pathData` reads the strategy's outputs along one challenge path, `spliceIpa` forms its proof
-string at that path (pre-IPA fields fixed, IPA fields the path outputs), and
-`deployedVerifierEq_iff_flatAccept_adaptive` proves halo2's verifier equation on that proof *is*
-`flatAccept P` at the vector. So the corresponding capstones' `hprob` (`Soundness.Vesta`, the `_adaptive`
-pair) is the accept probability of an adaptive strategy — the object rewinding produces — rather than of one
-fixed proof. What remains is the execution-semantics identification (that a rewound random-oracle adversary
-*induces* such a staged strategy, with its RO-query loss) and Blake2b-as-random-oracle; the uniform measure of
-`hprob` is justified standalone (`roChallenges_ipaRound_uniform`; see its section), for the fixed proof string —
-the adaptive splices' χ-dependent prefixes are part of this same floor. The
-transcript-ordering and reprogramming content is internalized by `Forking.Ordering`,
-`roChallenges_reprogramRounds`, and the Vesta `_adaptive_rewind` capstones. -/
+The fixed-tree theorem measures one proof over all challenges. A rewound adversary instead supplies
+different IPA fields along different challenge paths. `pathData` reads one path, `spliceIpa` inserts
+it into the fixed pre-IPA proof, and `deployedVerifierEq_iff_flatAccept_adaptive` proves the same bridge
+for any prefix-respecting strategy.
+-/
 
-/-- A strategy's outputs along one challenge path: the round points `(Lⱼ, Rⱼ)` it commits and the final
-opening `(c, f)` it sends when the round challenges are `χ` — `pathData P χ = (rounds, c, f)`. The round-`0`
-point is challenge-independent (the `Prover` node fixes it before its challenge); later points read only the
-challenge prefix, by the tree shape. -/
+/-- The round points and final opening produced along one strategy path. -/
 def pathData : {d : ℕ} → Prover Fp G d → (Fin d → Fp) → (Fin d → G × G) × Fp × Fp
   | 0, .leaf c f, _ => (Fin.elim0, c, f)
   | _ + 1, .node L R cont, χ =>
       (Fin.cons (L, R) (pathData (cont (χ 0)) (Fin.tail χ)).1, (pathData (cont (χ 0)) (Fin.tail χ)).2)
 
-/-- The staged adversary's proof string at one challenge path: every pre-IPA field is the fixed `ps`'s, and
-the IPA fields (`ipaRounds`, `ipaC`, `ipaF`) are replaced — with the strategy's path outputs, in the intended
-use. Rewinding shares the pre-IPA prefix and re-answers the rounds; this is that shape as data. -/
+/-- Replace a proof's IPA fields while keeping its pre-IPA fields fixed. -/
 def spliceIpa {shape : Shape} (ps : ProofString shape Fp G) (R : Fin shape.k → G × G) (c f : Fp) :
     ProofString shape Fp G :=
   { ps with ipaRounds := R, ipaC := c, ipaF := f }
 
 omit [AddCommGroup G] [Module Fp G] in
-/-- Splicing a strategy path's IPA fields leaves the pre-IPA Fiat–Shamir challenges unchanged. After replacing
-the IPA round vector by `χ`, the spliced proof and the original proof therefore have the same `Challenges`
-record: only the `ipaRound` field differs, and both sides overwrite it. This is the pre-IPA half of the
-staged rewinding capstone; `roChallenges_reprogramRounds` supplies the round-vector half. -/
+/-- Splicing IPA fields leaves all pre-IPA Fiat–Shamir challenges unchanged. -/
 theorem roChallenges_spliceIpa_pre {shape : Shape} (O : List (TranscriptElt Fp G) → Fp)
     (init : List (TranscriptElt Fp G)) (ps : ProofString shape Fp G) (R : Fin shape.k → G × G)
     (c f : Fp) (χ : Fin shape.k → Fp) :
@@ -641,9 +471,7 @@ theorem roChallenges_spliceIpa_pre {shape : Shape} (O : List (TranscriptElt Fp G
       = { roChallenges O init ps with ipaRound := χ } := by
   refine Challenges.ext' ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ <;> rfl
 
-/-- `flatAccept` reads the strategy only along the challenge path: the adaptive tree `P` at `χ` agrees with
-the constant prover built from `P`'s own path outputs `pathData P χ`. The per-path bridge from the adaptive
-tree to `flatAccept_proverOfRounds`'s constant form. -/
+/-- Along `χ`, an adaptive strategy agrees with the fixed prover built from `pathData P χ`. -/
 theorem flatAccept_pathData {U W : G} {z : Fp} : {d : ℕ} → (P : Prover Fp G d) →
     (g : Fin (2 ^ d) → G) → (b : Fin (2 ^ d) → Fp) → (Pwhole : G) → (χ : Fin d → Fp) →
     (flatAccept P g b U W z Pwhole χ ↔
@@ -657,14 +485,7 @@ theorem flatAccept_pathData {U W : G} {z : Fp} : {d : ℕ} → (P : Prover Fp G 
       rw [flatAccept]
 
 open Classical in
-/-- **`hbridge`, discharged for the staged (round-adaptive) adversary.** halo2's actual verifier equation on
-the strategy's spliced proof — pre-IPA fields the fixed `ps`'s, IPA fields the strategy's own outputs along
-`χ` — at IPA challenges `χ` is *exactly* `flatAccept P` at `χ`, with the eval vector
-`evalVector shape.k ch.x3` and the adjusted commitment built from the fixed `ps`. Chains
-`deployedVerifierEq_iff_flatAccept` on the spliced proof (whose pre-IPA projections are definitionally
-`ps`'s) with `flatAccept_pathData`. The constant-strategy identification is the special case
-`P := proverOfRounds ps.ipaRounds ps.ipaC ps.ipaF`; here `hbridge` is a theorem for every prefix-respecting
-strategy — the shape a rewound adversary's runs take. -/
+/-- Halo2's verifier equation on a path-spliced proof equals `flatAccept P` on that path. -/
 theorem deployedVerifierEq_iff_flatAccept_adaptive {shape : Shape} [DecidableEq G] [Inhabited G]
     (g : Fin (2 ^ shape.k) → G) (w u : G) (vk : VerifyingKey shape Fp G) (ps : ProofString shape Fp G)
     (ch : Challenges shape.k Fp) (P : Prover Fp G shape.k) (χ : Fin shape.k → Fp) :
@@ -687,47 +508,16 @@ theorem deployedVerifierEq_iff_flatAccept_adaptive {shape : Shape} [DecidableEq 
 
 /-! ## The deterministic content of the prover-as-oracle bridge `hbridge` is proven
 
-`hbridge` (the hypothesis of `deployed_forking_soundness_of_bridge` below) is the **pointwise**
-identification — it carries no probability — of the deployed verifier's accept event, as a function of the
-challenge vector, with the flat predicate `flatAccept Q` of a prefix-respecting prover strategy `Q`.
-
-Its deterministic content is a **theorem**: `deployedVerifierEq_iff_flatAccept` (the constant strategy
-`proverOfRounds ps.ipaRounds ps.ipaC ps.ipaF`, round points fixed by the proof string) and
-`deployedVerifierEq_iff_flatAccept_adaptive` (every staged strategy) prove halo2's actual verifier equation
-`DeployedIpaVerifierEq` *is* `flatAccept` at the challenge vector — `flatAccept_proverOfRounds`
-(`flatAccept` ↔ `CF = 0`) composed with `deployedVerifierEq_cf` (`CF = 0` ↔ the equation). The round-by-round
-transcript ordering behind the prefix-respecting shape is likewise proven and sealed to the deployed schedule
-(`Soundness.Forking.Ordering`, `deriveChallenges_ipaRound_eq`; `proverRoundPoint_proverOfRounds` for the tree
-side).
-
-**Where it is discharged.** The Vesta capstones (`Soundness.Vesta`) take halo2's **actual** accept
-`DeployedIpaVerifierEq` — no abstract `hbridge` — and prove the bridge internally, at the cost of the
-`S`-opening witness `commit urs s = ps.ipaS` (and the `shape.k`↔`urs.k` transport, by `subst`). The `_deployed`
-pair uses the *constant* strategy, so its `hprob` is that fixed proof's accept measure over the whole challenge
-space — the static dichotomy, *not* the Fiat–Shamir attack event; the `_adaptive` pair uses `spliceIpa`/
-`pathData`, so its `hprob` is a round-adaptive adversary's accept probability, the object rewinding produces.
-The abstract theorems (`deployed_forking_soundness_of_bridge` below,
-`orchard_verifier_vesta_forking_opening`/`_constraint`) keep `hbridge` as a *modular* hypothesis over an
-abstract `accepts`/`Q`.
-
-What `hbridge` still names is the execution-semantics floor: a rewound random-oracle adversary *induces* such a
-staged strategy, with its RO-query loss, deriving `hprob`'s accept probability — alongside
-Blake2b-as-random-oracle. The uniform *measure* of `hprob` is justified standalone
-(`roChallenges_ipaRound_uniform`; see its section). -/
+`hbridge` identifies an accept event pointwise with `flatAccept Q`; it contains no probability.
+The constant and adaptive bridge theorems above prove its deterministic content for the deployed
+verifier. The remaining integration must show that a real rewound adversary induces such a strategy
+and transfer its acceptance probability with the correct query loss.
+-/
 
 open scoped ENNReal in
 open Classical in
-/-- **The deployed forking soundness from an explicit prover-as-oracle bridge.** The honest top of the forking
-chain: from the deployed verifier's *actual* accept event `accepts χ` (the proof a function of `χ` — the
-Fiat–Shamir/random-oracle model), the **explicit** faithfulness bridge `hbridge` identifying it with the
-strategy predicate `flatAccept Q`, and the accept *probability* beating the knowledge error, it concludes the
-deployed opening. `hbridge`'s deterministic content is a theorem (`deployedVerifierEq_iff_flatAccept`; see the
-section above), so it is *dischargeable* — this theorem keeps it as an explicit hypothesis (discharging it in
-place also needs the `S`-opening fact `commit urs s = ps.ipaS`). With `hbridge` supplied, the residual is
-*only* the random-oracle adversary experiment above `hprob` (a querying forger and the rewinding query-loss)
-plus Blake2b-as-random-oracle; every other link — challenge-vector uniformity (`roChallenges_ipaRound_uniform`),
-extraction, root-consistency, value placement, the `u`-vs-`u⁻¹` convention, the transcript ordering — is a
-theorem. The granular replacement for the monolithic `FiatShamirTree`. -/
+/-- Derive the deployed opening from a prover strategy, a pointwise accept-event bridge, and acceptance
+above the knowledge error. -/
 noncomputable def deployed_forking_soundness_of_bridge [DecidableEq G] [Inhabited G] (urs : URS G)
     (b : Fin (2 ^ urs.k) → Fp) (v ξ z blind : Fp) (aMulti aDep s : Fin (2 ^ urs.k) → Fp)
     (Q : Prover Fp G urs.k) (accepts : (Fin urs.k → Fp) → Prop)

--- a/Zcash/Snark/Soundness/Forking/Rewind.lean
+++ b/Zcash/Snark/Soundness/Forking/Rewind.lean
@@ -17,7 +17,11 @@ Second, the probability chain replaces a posited forked transcript tree by an ac
 `deployed_forking_soundness_of_bridge` exposes the remaining prover-as-oracle bridge explicitly. The bridge's
 deterministic content is discharged below (`deployedVerifierEq_iff_flatAccept` and
 `deployedVerifierEq_iff_flatAccept_adaptive`); the remaining floor is the execution-semantics identification
-for a rewound RO adversary plus the random-oracle uniformity axiom carried by `hprob`.
+for a rewound RO adversary — the querying-adversary/query-loss experiment that would *derive* the accept
+probability of `hprob` — plus Blake2b-as-random-oracle. Challenge-vector uniformity is justified separately:
+`roChallenges_ipaRound_uniform` shows `hprob`'s uniform measure is the one a uniform random oracle induces. It
+is a standalone theorem, consumed by no capstone, and covers the fixed proof string only — see its section
+below for the precise scope.
 -/
 
 namespace Zcash.Snark
@@ -120,6 +124,54 @@ theorem roChallenges_reprogramRounds {shape : Shape} (O : List (TranscriptElt Fp
       | exact reprogramRounds_apply_short O init ps χ (by
           simp only [preIpaTranscript, List.length_append, List.length_cons, List.length_nil]
           omega)
+
+/-! ## Challenge-vector uniformity: a standalone justification for `hprob`'s measure
+
+`hprob` is stated over `PMF.uniformOfFintype (Fin k → Fp)`, the uniform measure on the IPA round-challenge
+vector. That a random oracle induces this distribution was an axiom; it is now a theorem:
+
+* `roChallenges_ipaRound_apply` — each round challenge is the oracle's answer at that round's transcript prefix,
+  `(roChallenges O init ps).ipaRound j = O (φ j)`, `φ = roundTranscriptFin (preIpaTranscript init ps) ps.ipaRounds`.
+* `roChallenges_ipaRound_uniform` — the `k` prefixes are pairwise distinct (`roundTranscriptFin_injective`), so
+  reading a uniform random oracle at them (`uniformOfFintype_map_eval_injective`) is the uniform challenge vector.
+
+**Scope.** This is a *standalone* justification, not a step in any capstone: nothing consumes
+`roChallenges_ipaRound_uniform`, and every `hprob` below is stated directly over `PMF.uniformOfFintype`. The
+theorem shows that measure is what a uniform random oracle induces; it is not substituted into the reduction.
+It has two limits. It samples the oracle only at the `k` round prefixes — the marginal on the round vector, not
+a full query domain. And it is for the fixed proof string `ps`: in the `_adaptive`/`_rewind` events the
+reprogrammed prefixes depend on `χ`, so tying `hprob`'s measure to a rewound-oracle experiment there belongs to
+the execution-semantics floor (a forger querying `O`, with query-loss — `Forking.Oracle`), above `hprob`, not
+this theorem. -/
+
+/-- Each round challenge is the oracle's answer at that round's transcript prefix:
+`(roChallenges O init ps).ipaRound j = O (roundTranscriptFin (preIpaTranscript init ps) ps.ipaRounds j)`.
+`roChallenges` is `deriveChallenges` through `ofOracle O`, whose squeeze is `O`, so this is
+`deriveChallenges_ipaRound_eq` at the oracle — the challenge vector depends on the oracle's values at the `k`
+prefixes alone. -/
+theorem roChallenges_ipaRound_apply {shape : Shape} (O : List (TranscriptElt Fp G) → Fp)
+    (init : List (TranscriptElt Fp G)) (ps : ProofString shape Fp G) (j : Fin shape.k) :
+    (roChallenges O init ps).ipaRound j
+      = O (roundTranscriptFin (preIpaTranscript init ps) ps.ipaRounds j) :=
+  deriveChallenges_ipaRound_eq (ofOracle O) init ps j
+
+/-- **Challenge-vector uniformity from a uniform random oracle.** Sampling the oracle uniformly over its query
+domain — the finite set `↥(Set.range φ)` of the `k` round prefixes
+`φ = roundTranscriptFin (preIpaTranscript init ps) ps.ipaRounds` — and reading its answers (`fun O j => O ⟨φ j, _⟩`,
+the round-challenge vector by `roChallenges_ipaRound_apply`) is distributed as
+`PMF.uniformOfFintype (Fin shape.k → Fp)`. This is `uniformOfFintype_map_eval_injective` at `φ`, whose injectivity
+(`roundTranscriptFin_injective`, the prefixes are distinct) makes the `k` answers independent-uniform. For its
+scope — a standalone justification of `hprob`'s measure, over the fixed-`ps` marginal, consumed by no capstone —
+see the section above. -/
+theorem roChallenges_ipaRound_uniform [DecidableEq G] {shape : Shape}
+    (init : List (TranscriptElt Fp G)) (ps : ProofString shape Fp G) :
+    (PMF.uniformOfFintype
+        (↥(Set.range (roundTranscriptFin (preIpaTranscript init ps) ps.ipaRounds)) → Fp)).map
+        (fun O j => O (Equiv.ofInjective _
+          (roundTranscriptFin_injective (preIpaTranscript init ps) ps.ipaRounds) j))
+      = PMF.uniformOfFintype (Fin shape.k → Fp) :=
+  uniformOfFintype_map_eval_injective _
+    (roundTranscriptFin_injective (preIpaTranscript init ps) ps.ipaRounds)
 
 open scoped ENNReal in
 open Classical in
@@ -399,7 +451,9 @@ the **algebra half**: `deployedVerifierEq_iff_flatAccept` proves halo2's actual 
 not an assumption. The round-by-round ordering behind the prefix-respecting `Prover` shape is likewise a
 theorem (`Soundness.Forking.Ordering`, sealed to the deployed schedule by `deriveChallenges_ipaRound_eq`;
 `proverRoundPoint_proverOfRounds` below reads the fixed round points off `proverOfRounds` on every challenge
-path). The residual is then only the random-oracle uniformity axiom (`Forking.Oracle`). -/
+path). The residual is then only the random-oracle adversary experiment above `hprob` (the querying forger and
+its query-loss) and Blake2b-as-random-oracle — challenge-vector uniformity is justified standalone
+(`roChallenges_ipaRound_uniform`; see its section, consumed by no capstone). -/
 
 /-- The prover-strategy tree the deployed non-interactive proof realises: at each IPA round it commits the
 proof's **fixed** round points `(Lⱼ, Rⱼ)` (they are written in the proof string, so the continuation ignores
@@ -528,7 +582,9 @@ with the eval vector `evalVector shape.k ch.x3` and the adjusted commitment `mul
 the deterministic content of the prover-as-oracle bridge, now a **theorem**, not an assumption: chaining
 `deployedVerifierEq_cf` (the verifier equation is `CF = 0`), `flatAccept_proverOfRounds` (`flatAccept` of the
 tree is that same `CF = 0`), and `foldAllFin_evalVector` (the `U`-coefficient is `computeB`). The only residual
-is the random-oracle uniformity axiom on the accept *measure* (`Forking.Oracle`). -/
+is the random-oracle adversary experiment above `hprob` (the querying forger and its query-loss) and
+Blake2b-as-random-oracle — the uniform *measure* of `hprob` is justified standalone
+(`roChallenges_ipaRound_uniform`; see its section). -/
 theorem deployedVerifierEq_iff_flatAccept {shape : Shape} [DecidableEq Fp] [DecidableEq G] [Inhabited G]
     (g : Fin (2 ^ shape.k) → G) (w u : G) (vk : VerifyingKey shape Fp G) (ps : ProofString shape Fp G)
     (ch : Challenges shape.k Fp) :
@@ -554,7 +610,9 @@ string at that path (pre-IPA fields fixed, IPA fields the path outputs), and
 `flatAccept P` at the vector. So the corresponding capstones' `hprob` (`Soundness.Vesta`, the `_adaptive`
 pair) is the accept probability of an adaptive strategy — the object rewinding produces — rather than of one
 fixed proof. What remains is the execution-semantics identification (that a rewound random-oracle adversary
-*induces* such a staged strategy, with its RO-query loss) and the random-oracle uniformity axiom. The
+*induces* such a staged strategy, with its RO-query loss) and Blake2b-as-random-oracle; the uniform measure of
+`hprob` is justified standalone (`roChallenges_ipaRound_uniform`; see its section), for the fixed proof string —
+the adaptive splices' χ-dependent prefixes are part of this same floor. The
 transcript-ordering and reprogramming content is internalized by `Forking.Ordering`,
 `roChallenges_reprogramRounds`, and the Vesta `_adaptive_rewind` capstones. -/
 
@@ -663,9 +721,11 @@ deterministic content is a theorem for every staged strategy, and the round-by-r
 behind the prefix-respecting shape is likewise proven and sealed to the deployed derivation
 (`Soundness.Forking.Ordering`, `deriveChallenges_ipaRound_eq`; `proverRoundPoint_proverOfRounds` for the
 tree side). Its execution-semantics content is the residual prover-as-oracle floor — that a rewound
-random-oracle adversary *induces* such a staged strategy — alongside the random-oracle uniformity axiom on
-the accept *probability* (the uniform measure of `hprob`, `Forking.Oracle`) — that the challenges are
-uniform, independent, rewindable random-oracle draws. -/
+random-oracle adversary *induces* such a staged strategy, with its query-loss, deriving the accept probability
+of `hprob` — alongside Blake2b-as-random-oracle. The uniform *measure* of `hprob` has its own justification:
+`roChallenges_ipaRound_uniform` shows it is what a uniform random oracle induces for the fixed proof string. That
+theorem is standalone (consumed by no capstone; see its section), so it justifies the measure choice without
+itself discharging the floor above. -/
 
 open scoped ENNReal in
 open Classical in
@@ -682,10 +742,12 @@ folds along each challenge path to `flatAccept Q`. The deterministic content of 
 `proverOfRounds ps.ipaRounds ps.ipaC ps.ipaF`, whose per-path `flatAccept` *is* the verifier's accept), so
 `hbridge` is *dischargeable* — but this theorem still takes it as an explicit hypothesis (it has not been
 rewired to consume that identity; doing so also needs the `S`-opening fact `commit urs s = ps.ipaS`). With
-`hbridge` supplied, the residual is *only* the random-oracle uniformity axiom on the accept probability — every
-other link (extraction, root-consistency, value placement, the `u`-vs-`u⁻¹` convention) is a theorem, as is
-the round-by-round transcript ordering (`Soundness.Forking.Ordering`, sealed by
-`deriveChallenges_ipaRound_eq`). This is the granular replacement for the monolithic `FiatShamirTree`. -/
+`hbridge` supplied, the residual is *only* the random-oracle adversary experiment above `hprob` — a querying
+forger and the rewinding query-loss that would derive its accept probability — plus Blake2b-as-random-oracle.
+Every other link (challenge-vector uniformity, now derived by `roChallenges_ipaRound_uniform`; extraction;
+root-consistency; value placement; the `u`-vs-`u⁻¹` convention) is a theorem, as is the round-by-round transcript
+ordering (`Soundness.Forking.Ordering`, sealed by `deriveChallenges_ipaRound_eq`). This is the granular
+replacement for the monolithic `FiatShamirTree`. -/
 noncomputable def deployed_forking_soundness_of_bridge [DecidableEq G] [Inhabited G] (urs : URS G)
     (b : Fin (2 ^ urs.k) → Fp) (v ξ z blind : Fp) (aMulti aDep s : Fin (2 ^ urs.k) → Fp)
     (Q : Prover Fp G urs.k) (accepts : (Fin urs.k → Fp) → Prop)

--- a/Zcash/Snark/Soundness/Forking/Tree.lean
+++ b/Zcash/Snark/Soundness/Forking/Tree.lean
@@ -1,0 +1,135 @@
+import Mathlib
+
+/-!
+# Multi-round tree extraction (the Fiat–Shamir forking compounding)
+
+This module establishes, by a counting/averaging induction over the `d` rounds, that if the prover's
+accepting set of challenge vectors is large enough — more than the threshold count `kerr` — then a full
+`(3,…,3)`-tree of accepting challenge vectors exists (`Extractable`). It is self-contained: the multi-round
+existence *is* the `kerr` count below, not an iteration of the per-round cubic bound in
+`Soundness.Forking.Probability`.
+
+`kerr (card α) d` is a tree-existence threshold as a count out of `(card α)^d`; as a fraction it is `3d/N`
+(`N = card α`), a **conservative upper bound** on that threshold (the tight value is `1 − (1 − 3/N)^d`). The
+`3` is the price of requiring **nonzero** challenges — the IPA's `u⁻¹` fold needs each `uⱼ ≠ 0` — not vanilla
+3-special-soundness (error `≈ 2d/N`). This is the *tree-existence* threshold, not the end-to-end Fiat–Shamir
+knowledge error (which additionally carries the random-oracle query-count factor). `Extractable` holds
+whenever the accept probability exceeds `3d/N`.
+
+This is the abstract combinatorial core; the deployed verifier instantiates `acc` with its own accept
+predicate, and the per-node `(g,U,W)` decomposition is recovered separately (special-soundness / Vandermonde).
+-/
+
+namespace Zcash.Snark
+
+variable {α : Type*}
+
+/-- A conservative tree-existence-threshold count for the nonzero-challenge `(3,…,3)`-tree over a size-`N`
+challenge set and `d` rounds: `kerr N (d+1) = 3·N^d + N·kerr N d`, `kerr N 0 = 0`. As a fraction of `N^d` it
+is `3d/N` — an upper bound; the tight threshold is `1 − (1 − 3/N)^d`. -/
+def kerr (N : ℕ) : ℕ → ℕ
+  | 0 => 0
+  | d + 1 => 3 * N ^ d + N * kerr N d
+
+/-- A `(3,…,3)`-tree of accepting challenge vectors exists for `acc`: at each of the `d` rounds, three
+pairwise-distinct nonzero challenges, each extending to an accepting subtree. The forking output's challenge
+skeleton — what rewinding must produce, here shown to exist from a large enough accepting set. -/
+def Extractable [Zero α] : {d : ℕ} → ((Fin d → α) → Prop) → Prop
+  | 0, acc => acc Fin.elim0
+  | _ + 1, acc => ∃ u₁ u₂ u₃ : α, u₁ ≠ u₂ ∧ u₁ ≠ u₃ ∧ u₂ ≠ u₃ ∧ u₁ ≠ 0 ∧ u₂ ≠ 0 ∧ u₃ ≠ 0 ∧
+      Extractable (fun rest => acc (Fin.cons u₁ rest)) ∧
+      Extractable (fun rest => acc (Fin.cons u₂ rest)) ∧
+      Extractable (fun rest => acc (Fin.cons u₃ rest))
+
+/-- The accepting count splits over the first challenge: the number of accepting `(d+1)`-vectors is the sum,
+over each first challenge `u`, of the accepting `d`-vectors extending `u`. -/
+theorem card_filter_eq_sum_slice [Fintype α] [DecidableEq α] {d : ℕ}
+    (acc : (Fin (d + 1) → α) → Prop) [DecidablePred acc] :
+    (Finset.univ.filter acc).card
+      = ∑ u : α, (Finset.univ.filter (fun rest => acc (Fin.cons u rest))).card := by
+  simp only [Finset.card_filter]
+  rw [← (Fin.consEquiv (fun _ : Fin (d + 1) => α)).sum_comp (fun i => if acc i then 1 else 0),
+    Fintype.sum_prod_type]
+  rfl
+
+/-- **Multi-round tree extraction.** If the prover's accepting set of `d`-round challenge vectors exceeds the
+knowledge-error count `kerr N d` (`N = card α`), a full `(3,…,3)`-tree of accepting challenge vectors exists.
+By induction on rounds: at each round the accepting count splits over the first challenge (`card_filter_eq_sum_slice`),
+and an averaging argument forces at least four first challenges whose continuations are themselves above the
+`d`-round threshold — three of them nonzero, recursed by the induction hypothesis. This is the deterministic
+core of the Fiat–Shamir forking: the rewinding produces this tree whenever the accept probability beats the
+knowledge error `3d/N`. -/
+theorem extractable_of_kerr_lt [Fintype α] [DecidableEq α] [Zero α] :
+    ∀ {d : ℕ} (acc : (Fin d → α) → Prop) [DecidablePred acc],
+      kerr (Fintype.card α) d < (Finset.univ.filter acc).card → Extractable acc
+  | 0, acc, _, h => by
+      simp only [kerr] at h
+      rw [Finset.card_pos] at h
+      obtain ⟨x, hx⟩ := h
+      rw [Finset.mem_filter] at hx
+      show acc Fin.elim0
+      rw [Subsingleton.elim Fin.elim0 x]
+      exact hx.2
+  | d + 1, acc, _, h => by
+      classical
+      have hslice : (Finset.univ.filter acc).card
+          = ∑ u : α, (Finset.univ.filter (fun rest : Fin d → α => acc (Fin.cons u rest))).card :=
+        card_filter_eq_sum_slice acc
+      have hNd : ∀ u : α, (Finset.univ.filter (fun rest : Fin d → α => acc (Fin.cons u rest))).card
+          ≤ Fintype.card α ^ d := fun u =>
+        le_trans (Finset.card_filter_le _ _)
+          (by rw [Finset.card_univ, Fintype.card_fun, Fintype.card_fin])
+      have hgood4 : 4 ≤ (Finset.univ.filter (fun u : α =>
+          kerr (Fintype.card α) d
+            < (Finset.univ.filter (fun rest : Fin d → α => acc (Fin.cons u rest))).card)).card := by
+        by_contra hcon
+        push_neg at hcon
+        have hgc : (Finset.univ.filter (fun u : α => kerr (Fintype.card α) d
+            < (Finset.univ.filter (fun rest : Fin d → α => acc (Fin.cons u rest))).card)).card ≤ 3 := by
+          omega
+        have hbc : (Finset.univ.filter (fun u : α => ¬ kerr (Fintype.card α) d
+            < (Finset.univ.filter (fun rest : Fin d → α => acc (Fin.cons u rest))).card)).card
+            ≤ Fintype.card α :=
+          le_trans (Finset.card_filter_le _ _) (le_of_eq Finset.card_univ)
+        have h1 := Finset.sum_le_sum (s := Finset.univ.filter (fun u : α => kerr (Fintype.card α) d
+            < (Finset.univ.filter (fun rest : Fin d → α => acc (Fin.cons u rest))).card))
+            (f := fun u => (Finset.univ.filter (fun rest : Fin d → α => acc (Fin.cons u rest))).card)
+            (g := fun _ => Fintype.card α ^ d) (fun u _ => hNd u)
+        have h2 := Finset.sum_le_sum (s := Finset.univ.filter (fun u : α => ¬ kerr (Fintype.card α) d
+            < (Finset.univ.filter (fun rest : Fin d → α => acc (Fin.cons u rest))).card))
+            (f := fun u => (Finset.univ.filter (fun rest : Fin d → α => acc (Fin.cons u rest))).card)
+            (g := fun _ => kerr (Fintype.card α) d)
+            (fun u hu => not_lt.mp (Finset.mem_filter.mp hu).2)
+        rw [Finset.sum_const, smul_eq_mul] at h1 h2
+        have hb : (Finset.univ.filter acc).card
+            ≤ 3 * Fintype.card α ^ d + Fintype.card α * kerr (Fintype.card α) d := by
+          rw [hslice, ← Finset.sum_filter_add_sum_filter_not Finset.univ
+            (fun u => kerr (Fintype.card α) d
+              < (Finset.univ.filter (fun rest : Fin d → α => acc (Fin.cons u rest))).card)]
+          calc _ ≤ _ + _ := add_le_add h1 h2
+            _ ≤ 3 * Fintype.card α ^ d + Fintype.card α * kerr (Fintype.card α) d := by
+                gcongr
+        simp only [kerr] at h
+        omega
+      set g := Finset.univ.filter (fun u : α => kerr (Fintype.card α) d
+          < (Finset.univ.filter (fun rest : Fin d → α => acc (Fin.cons u rest))).card) with hg
+      have hg4 : 4 ≤ g.card := hgood4
+      have hg0 : 2 < (g.erase 0).card := by
+        by_cases h0 : (0 : α) ∈ g
+        · have he := Finset.card_erase_add_one h0
+          omega
+        · rw [Finset.erase_eq_of_notMem h0]; omega
+      obtain ⟨u₁, u₂, u₃, hu₁, hu₂, hu₃, h12, h13, h23⟩ := Finset.two_lt_card_iff.mp hg0
+      have key : ∀ u, u ∈ g.erase 0 → u ≠ 0 ∧ kerr (Fintype.card α) d
+          < (Finset.univ.filter (fun rest : Fin d → α => acc (Fin.cons u rest))).card := by
+        intro u hu
+        refine ⟨Finset.ne_of_mem_erase hu, ?_⟩
+        have hm := Finset.mem_of_mem_erase hu
+        rw [hg, Finset.mem_filter] at hm
+        exact hm.2
+      exact ⟨u₁, u₂, u₃, h12, h13, h23, (key u₁ hu₁).1, (key u₂ hu₂).1, (key u₃ hu₃).1,
+        extractable_of_kerr_lt _ (key u₁ hu₁).2,
+        extractable_of_kerr_lt _ (key u₂ hu₂).2,
+        extractable_of_kerr_lt _ (key u₃ hu₃).2⟩
+
+end Zcash.Snark

--- a/Zcash/Snark/Soundness/Forking/Tree.lean
+++ b/Zcash/Snark/Soundness/Forking/Tree.lean
@@ -1,38 +1,28 @@
 import Mathlib
 
 /-!
-# Multi-round tree extraction (the Fiat–Shamir forking compounding)
+# Multi-round fork-tree extraction
 
-If the prover's accepting set of challenge vectors is large enough — more than the threshold count `kerr` —
-a full `(3,…,3)`-tree of accepting challenge vectors exists (`Extractable`). Proved by a counting/averaging
-induction over the `d` rounds, and self-contained: the multi-round existence *is* the `kerr` count below, not
-an iteration of the per-round cubic bound in `Soundness.Forking.Probability`.
+If enough challenge vectors accept, a full `(3,…,3)` tree of accepting vectors exists. The proof is a
+counting induction over all rounds, not an iteration of a per-round cubic bound.
 
-`kerr (card α) d` is a count out of `(card α)^d`; as a fraction it is `3d/N` (`N = card α`), a conservative
-upper bound on the true threshold (whose tight value is `1 − (1 − 3/N)^d`). The `3` is the price of requiring
-nonzero challenges — the IPA's `u⁻¹` fold needs each `uⱼ ≠ 0` — rather than vanilla 3-special-soundness
-(error `≈ 2d/N`). This is the tree-existence threshold, not the end-to-end Fiat–Shamir knowledge error, which
-additionally carries the random-oracle query-count factor. `Extractable` holds whenever the accept
-probability exceeds `3d/N`.
+`kerr N d` is the threshold count out of `N^d` vectors. As a fraction it is the conservative bound
+`3d/N`; requiring nonzero IPA challenges causes the factor `3`. This is a tree-existence threshold,
+not the final Fiat–Shamir knowledge error, which must also include random-oracle query loss.
 
-The abstract combinatorial core: the deployed verifier instantiates `acc` with its own accept predicate, and
-the per-node `(g,U,W)` decomposition is recovered separately (special-soundness / Vandermonde).
+The deployed verifier supplies `acc`. Group-element recovery is handled separately.
 -/
 
 namespace Zcash.Snark
 
 variable {α : Type*}
 
-/-- The tree-existence-threshold count for the nonzero-challenge `(3,…,3)`-tree over a size-`N` challenge set
-and `d` rounds. As a fraction of `N^d` it is `3d/N` — a conservative upper bound; the tight threshold is
-`1 − (1 − 3/N)^d`. -/
+/-- The accepting-vector threshold for a nonzero-challenge `(3,…,3)` tree of depth `d`. -/
 def kerr (N : ℕ) : ℕ → ℕ
   | 0 => 0
   | d + 1 => 3 * N ^ d + N * kerr N d
 
-/-- A `(3,…,3)`-tree of accepting challenge vectors for `acc`: at each of the `d` rounds, three
-pairwise-distinct nonzero challenges, each extending to an accepting subtree. The forking output's challenge
-skeleton — what rewinding must produce, shown to exist above the `kerr` threshold by `extractable_of_kerr_lt`. -/
+/-- A depth-`d` tree with three distinct nonzero challenges at each node and acceptance at every leaf. -/
 def Extractable [Zero α] : {d : ℕ} → ((Fin d → α) → Prop) → Prop
   | 0, acc => acc Fin.elim0
   | _ + 1, acc => ∃ u₁ u₂ u₃ : α, u₁ ≠ u₂ ∧ u₁ ≠ u₃ ∧ u₂ ≠ u₃ ∧ u₁ ≠ 0 ∧ u₂ ≠ 0 ∧ u₃ ≠ 0 ∧
@@ -40,8 +30,7 @@ def Extractable [Zero α] : {d : ℕ} → ((Fin d → α) → Prop) → Prop
       Extractable (fun rest => acc (Fin.cons u₂ rest)) ∧
       Extractable (fun rest => acc (Fin.cons u₃ rest))
 
-/-- The accepting count splits over the first challenge: the number of accepting `(d+1)`-vectors is the sum,
-over each first challenge `u`, of the accepting `d`-vectors extending `u`. -/
+/-- Split the accepting-vector count by the first challenge. -/
 theorem card_filter_eq_sum_slice [Fintype α] [DecidableEq α] {d : ℕ}
     (acc : (Fin (d + 1) → α) → Prop) [DecidablePred acc] :
     (Finset.univ.filter acc).card
@@ -51,12 +40,9 @@ theorem card_filter_eq_sum_slice [Fintype α] [DecidableEq α] {d : ℕ}
     Fintype.sum_prod_type]
   rfl
 
-/-- **Multi-round tree extraction.** If the prover's accepting set of `d`-round challenge vectors exceeds the
-knowledge-error count `kerr N d` (`N = card α`), a full `(3,…,3)`-tree of accepting challenge vectors exists.
-Induction on rounds: the accepting count splits over the first challenge (`card_filter_eq_sum_slice`), and
-averaging forces at least four first challenges whose continuations again beat the `d`-round threshold — three
-of them nonzero, recursed by the induction hypothesis. The deterministic core of the Fiat–Shamir forking:
-rewinding produces this tree whenever the accept probability beats the knowledge error `3d/N`. -/
+/-- If the accepting-vector count exceeds `kerr`, a full `(3,…,3)` accepting tree exists.
+
+The induction finds at least four good first challenges, so three can be chosen nonzero. -/
 theorem extractable_of_kerr_lt [Fintype α] [DecidableEq α] [Zero α] :
     ∀ {d : ℕ} (acc : (Fin d → α) → Prop) [DecidablePred acc],
       kerr (Fintype.card α) d < (Finset.univ.filter acc).card → Extractable acc

--- a/Zcash/Snark/Soundness/Forking/Tree.lean
+++ b/Zcash/Snark/Soundness/Forking/Tree.lean
@@ -3,37 +3,36 @@ import Mathlib
 /-!
 # Multi-round tree extraction (the Fiat–Shamir forking compounding)
 
-This module establishes, by a counting/averaging induction over the `d` rounds, that if the prover's
-accepting set of challenge vectors is large enough — more than the threshold count `kerr` — then a full
-`(3,…,3)`-tree of accepting challenge vectors exists (`Extractable`). It is self-contained: the multi-round
-existence *is* the `kerr` count below, not an iteration of the per-round cubic bound in
-`Soundness.Forking.Probability`.
+If the prover's accepting set of challenge vectors is large enough — more than the threshold count `kerr` —
+a full `(3,…,3)`-tree of accepting challenge vectors exists (`Extractable`). Proved by a counting/averaging
+induction over the `d` rounds, and self-contained: the multi-round existence *is* the `kerr` count below, not
+an iteration of the per-round cubic bound in `Soundness.Forking.Probability`.
 
-`kerr (card α) d` is a tree-existence threshold as a count out of `(card α)^d`; as a fraction it is `3d/N`
-(`N = card α`), a **conservative upper bound** on that threshold (the tight value is `1 − (1 − 3/N)^d`). The
-`3` is the price of requiring **nonzero** challenges — the IPA's `u⁻¹` fold needs each `uⱼ ≠ 0` — not vanilla
-3-special-soundness (error `≈ 2d/N`). This is the *tree-existence* threshold, not the end-to-end Fiat–Shamir
-knowledge error (which additionally carries the random-oracle query-count factor). `Extractable` holds
-whenever the accept probability exceeds `3d/N`.
+`kerr (card α) d` is a count out of `(card α)^d`; as a fraction it is `3d/N` (`N = card α`), a conservative
+upper bound on the true threshold (whose tight value is `1 − (1 − 3/N)^d`). The `3` is the price of requiring
+nonzero challenges — the IPA's `u⁻¹` fold needs each `uⱼ ≠ 0` — rather than vanilla 3-special-soundness
+(error `≈ 2d/N`). This is the tree-existence threshold, not the end-to-end Fiat–Shamir knowledge error, which
+additionally carries the random-oracle query-count factor. `Extractable` holds whenever the accept
+probability exceeds `3d/N`.
 
-This is the abstract combinatorial core; the deployed verifier instantiates `acc` with its own accept
-predicate, and the per-node `(g,U,W)` decomposition is recovered separately (special-soundness / Vandermonde).
+The abstract combinatorial core: the deployed verifier instantiates `acc` with its own accept predicate, and
+the per-node `(g,U,W)` decomposition is recovered separately (special-soundness / Vandermonde).
 -/
 
 namespace Zcash.Snark
 
 variable {α : Type*}
 
-/-- A conservative tree-existence-threshold count for the nonzero-challenge `(3,…,3)`-tree over a size-`N`
-challenge set and `d` rounds: `kerr N (d+1) = 3·N^d + N·kerr N d`, `kerr N 0 = 0`. As a fraction of `N^d` it
-is `3d/N` — an upper bound; the tight threshold is `1 − (1 − 3/N)^d`. -/
+/-- The tree-existence-threshold count for the nonzero-challenge `(3,…,3)`-tree over a size-`N` challenge set
+and `d` rounds. As a fraction of `N^d` it is `3d/N` — a conservative upper bound; the tight threshold is
+`1 − (1 − 3/N)^d`. -/
 def kerr (N : ℕ) : ℕ → ℕ
   | 0 => 0
   | d + 1 => 3 * N ^ d + N * kerr N d
 
-/-- A `(3,…,3)`-tree of accepting challenge vectors exists for `acc`: at each of the `d` rounds, three
+/-- A `(3,…,3)`-tree of accepting challenge vectors for `acc`: at each of the `d` rounds, three
 pairwise-distinct nonzero challenges, each extending to an accepting subtree. The forking output's challenge
-skeleton — what rewinding must produce, here shown to exist from a large enough accepting set. -/
+skeleton — what rewinding must produce, shown to exist above the `kerr` threshold by `extractable_of_kerr_lt`. -/
 def Extractable [Zero α] : {d : ℕ} → ((Fin d → α) → Prop) → Prop
   | 0, acc => acc Fin.elim0
   | _ + 1, acc => ∃ u₁ u₂ u₃ : α, u₁ ≠ u₂ ∧ u₁ ≠ u₃ ∧ u₂ ≠ u₃ ∧ u₁ ≠ 0 ∧ u₂ ≠ 0 ∧ u₃ ≠ 0 ∧
@@ -54,11 +53,10 @@ theorem card_filter_eq_sum_slice [Fintype α] [DecidableEq α] {d : ℕ}
 
 /-- **Multi-round tree extraction.** If the prover's accepting set of `d`-round challenge vectors exceeds the
 knowledge-error count `kerr N d` (`N = card α`), a full `(3,…,3)`-tree of accepting challenge vectors exists.
-By induction on rounds: at each round the accepting count splits over the first challenge (`card_filter_eq_sum_slice`),
-and an averaging argument forces at least four first challenges whose continuations are themselves above the
-`d`-round threshold — three of them nonzero, recursed by the induction hypothesis. This is the deterministic
-core of the Fiat–Shamir forking: the rewinding produces this tree whenever the accept probability beats the
-knowledge error `3d/N`. -/
+Induction on rounds: the accepting count splits over the first challenge (`card_filter_eq_sum_slice`), and
+averaging forces at least four first challenges whose continuations again beat the `d`-round threshold — three
+of them nonzero, recursed by the induction hypothesis. The deterministic core of the Fiat–Shamir forking:
+rewinding produces this tree whenever the accept probability beats the knowledge error `3d/N`. -/
 theorem extractable_of_kerr_lt [Fintype α] [DecidableEq α] [Zero α] :
     ∀ {d : ℕ} (acc : (Fin d → α) → Prop) [DecidablePred acc],
       kerr (Fintype.card α) d < (Finset.univ.filter acc).card → Extractable acc

--- a/Zcash/Snark/Soundness/InnerProduct.lean
+++ b/Zcash/Snark/Soundness/InnerProduct.lean
@@ -4,11 +4,11 @@ import Zcash.Snark.Core.Group
 /-!
 # Knowledge soundness: the polynomial-commitment / inner-product-argument layer
 
-The transcription layer established faithfulness: the deployed verifier collapses to the
-fingerprint MSM, and the Lean assembly reproduces it (the captured match,
-`Zcash.Snark.Fingerprint`). This module begins soundness — that an accepting proof implies the
-prover knows a valid witness — via the special soundness of the inner-product argument (IPA), the
-cryptographic core of the halo2 opening.
+This module begins knowledge soundness: an accepting proof implies the prover knows a valid
+witness, via the special soundness of the inner-product argument (IPA) — the cryptographic core of
+the halo2 opening. It follows the transcription layer, which established faithfulness (the deployed
+verifier collapses to the fingerprint MSM, reproduced by the Lean assembly; the captured match,
+`Zcash.Snark.Fingerprint`).
 
 The IPA proves knowledge of a coefficient vector `a` (a polynomial) behind a commitment `P = ⟨a, G⟩`
 that opens to a value `v` at a point — i.e. `⟨a, b⟩ = v` for the evaluation vector `b = (1, x, x², …)`.

--- a/Zcash/Snark/Soundness/InnerProduct.lean
+++ b/Zcash/Snark/Soundness/InnerProduct.lean
@@ -55,6 +55,85 @@ def IpaRelation (urs : URS G) (P : G) (b : Fin (2 ^ urs.k) → F) (v : F)
     (a : Fin (2 ^ urs.k) → F) : Prop :=
   commit urs a = P ∧ innerProduct a b = v
 
+/-- `commit` is additive in the coefficient vector: `⟨a + a', G⟩ = ⟨a, G⟩ + ⟨a', G⟩`. -/
+theorem commit_add (urs : URS G) (a a' : Fin (2 ^ urs.k) → F) :
+    commit urs (a + a') = commit urs a + commit urs a' := by
+  simp only [commit, Pi.add_apply, add_smul, Finset.sum_add_distrib]
+
+/-- A single-index coefficient vector commits to that generator scaled: `⟨[i ↦ x], G⟩ = x • gᵢ`. -/
+theorem commit_single (urs : URS G) (i : Fin (2 ^ urs.k)) (x : F) :
+    commit urs (Pi.single i x) = x • urs.g i := by
+  simp only [commit]
+  rw [Finset.sum_eq_single i (fun j _ hj => by rw [Pi.single_eq_of_ne hj, zero_smul])
+    (fun h => absurd (Finset.mem_univ i) h), Pi.single_eq_same]
+
+/-- `innerProduct` is additive in its left argument. -/
+theorem innerProduct_add {n : ℕ} (a a' b : Fin n → F) :
+    innerProduct (a + a') b = innerProduct a b + innerProduct a' b := by
+  simp only [innerProduct, Pi.add_apply, add_mul, Finset.sum_add_distrib]
+
+/-- A single-index left argument: `⟨[i ↦ x], b⟩ = x · bᵢ`. -/
+theorem innerProduct_single {n : ℕ} (i : Fin n) (x : F) (b : Fin n → F) :
+    innerProduct (Pi.single i x) b = x * b i := by
+  simp only [innerProduct]
+  rw [Finset.sum_eq_single i (fun j _ hj => by rw [Pi.single_eq_of_ne hj, zero_mul])
+    (fun h => absurd (Finset.mem_univ i) h), Pi.single_eq_same]
+
+/-- **The adjusted-commitment un-shift (halo2's value placement).** halo2's IPA verifier folds the claimed
+value into the commitment at `g₀` (`msm.add_constant_term(-v)`, so the opened commitment is `P − [v]g₀`) while
+checking the inner product on `U`; the two are reconciled by the evaluation vector's leading entry `b₀ = 1`
+(`evalVector` gives `b 0 = x^0 = 1`). So opening `P − [v]g₀` to inner product `0` *is* opening `P` to inner
+product `v`: shift the witness's `g₀`-coefficient by `v`. This is the exact halo2 invariant resolving the
+value living on `g₀` (the verifier equation) versus on `U` (the transcript tree). -/
+theorem ipaRelation_unshift (urs : URS G) (P : G) (b : Fin (2 ^ urs.k) → F) (v : F)
+    (a : Fin (2 ^ urs.k) → F) (hb0 : b 0 = 1)
+    (h : IpaRelation urs (P - v • urs.g 0) b 0 a) :
+    IpaRelation urs P b v (a + Pi.single 0 v) := by
+  obtain ⟨hc, hi⟩ := h
+  refine ⟨?_, ?_⟩
+  · rw [commit_add, commit_single, hc]; abel
+  · rw [innerProduct_add, innerProduct_single, hi, hb0, mul_one, zero_add]
+
+/-- `commit` is homogeneous: `⟨c • a, G⟩ = c • ⟨a, G⟩`. -/
+theorem commit_smul (urs : URS G) (c : F) (a : Fin (2 ^ urs.k) → F) :
+    commit urs (c • a) = c • commit urs a := by
+  simp only [commit, Pi.smul_apply, smul_assoc, ← Finset.smul_sum]
+
+/-- `innerProduct` is homogeneous in its left argument: `⟨c • s, b⟩ = c · ⟨s, b⟩`. -/
+theorem innerProduct_smul {n : ℕ} (c : F) (s b : Fin n → F) :
+    innerProduct (c • s) b = c * innerProduct s b := by
+  simp only [innerProduct, Pi.smul_apply, smul_eq_mul, mul_assoc, ← Finset.mul_sum]
+
+/-- **The synthetic-blinding strip (the opened value, unique under binding).** halo2's IPA folds a synthetic
+blinding commitment `[ξ]S` into the opened commitment, with `S = ⟨s, G⟩`. Stripping it — subtract `ξ·s` from
+the witness — opens the plain `P` to `v − ξ·⟨s, b⟩`. This is *unconditional*: it reports the opened value
+of `P` for the supplied `S`-opening `s` (distinct `S`-openings shift it while exhibiting a `g`-relation —
+binding pins it), whatever the blinder is. The verifier never checks `s`; `S` is prover-supplied. So the
+soundness content lives in how `v − ξ·⟨s, b⟩` relates to the claimed value, which the caller must pin (see
+`ipaRelation_unblind` for the honest-prover case, and `Soundness.Forking.Rewind` for the `ξ`-randomization that
+bounds a malicious blinder). -/
+theorem ipaRelation_unblind_value (urs : URS G) (P : G) (b : Fin (2 ^ urs.k) → F) (v ξ : F)
+    (s a : Fin (2 ^ urs.k) → F)
+    (h : IpaRelation urs (P + ξ • commit urs s) b v a) :
+    IpaRelation urs P b (v - ξ * innerProduct s b) (a - ξ • s) := by
+  obtain ⟨hc, hi⟩ := h
+  refine ⟨?_, ?_⟩
+  · rw [sub_eq_add_neg, ← neg_smul, commit_add, commit_smul, hc, neg_smul]; abel
+  · rw [sub_eq_add_neg, ← neg_smul, innerProduct_add, innerProduct_smul, hi]; ring
+
+/-- **The synthetic-blinding strip, honest-prover case.** When the blinder vanishes at the evaluation point
+(`⟨s, b⟩ = 0` — halo2's prover sets `s_poly[0] -= s(x₃)` so `s(x₃) = 0`), stripping `[ξ]S` leaves the opened
+value at the claimed `v`. This is the `⟨s, b⟩ = 0` specialization of `ipaRelation_unblind_value`; a malicious
+prover need not satisfy it, which is exactly why `[ξ]S`'s soundness rests on `ξ` being drawn after `S`
+(`Soundness.Forking.Rewind`), not on this hypothesis. With `ipaRelation_unshift` it reconciles the adjusted
+commitment `P' = P − [v]g₀ + [ξ]S` with the plain `P`. -/
+theorem ipaRelation_unblind (urs : URS G) (P : G) (b : Fin (2 ^ urs.k) → F) (v ξ : F)
+    (s a : Fin (2 ^ urs.k) → F) (hs : innerProduct s b = 0)
+    (h : IpaRelation urs (P + ξ • commit urs s) b v a) :
+    IpaRelation urs P b v (a - ξ • s) := by
+  have h' := ipaRelation_unblind_value urs P b v ξ s a h
+  rwa [hs, mul_zero, sub_zero] at h'
+
 /-! ## The IPA round fold and its 2-special-soundness extractor
 
 One round of the inner-product argument halves the witness. The prover sends the cross-commitments

--- a/Zcash/Snark/Soundness/InnerProduct.lean
+++ b/Zcash/Snark/Soundness/InnerProduct.lean
@@ -2,32 +2,21 @@ import Mathlib
 import Zcash.Snark.Core.Group
 
 /-!
-# Knowledge soundness: the polynomial-commitment / inner-product-argument layer
+# Inner-product opening relation
 
-This module begins knowledge soundness: an accepting proof implies the prover knows a valid
-witness, via the special soundness of the inner-product argument (IPA) — the cryptographic core of
-the halo2 opening. It follows the transcription layer, which established faithfulness (the deployed
-verifier collapses to the fingerprint MSM, reproduced by the Lean assembly; the captured match,
-`Zcash.Snark.Fingerprint`).
+This module defines the polynomial commitment and opening relation used by the IPA soundness proof.
 
-The IPA proves knowledge of a coefficient vector `a` (a polynomial) behind a commitment `P = ⟨a, G⟩`
-that opens to a value `v` at a point — i.e. `⟨a, b⟩ = v` for the evaluation vector `b = (1, x, x², …)`.
-The fingerprint MSM's `g`-part is this commitment, so the layer is expressed directly over the URS:
+The witness is a coefficient vector `a` with `P = ⟨a, G⟩` and `v = ⟨a, b⟩`, where
+`b = (1, x, x², …)`.
 
 * `commit` — `⟨a, G⟩ = Σᵢ aᵢ • gᵢ`, the polynomial commitment (the MSM's `g`-part).
 * `evalVector` / `innerProduct` — `b = (1, x, …, x^{n−1})` and `⟨a, b⟩` (the polynomial at `x`).
 * `IpaRelation` — the opening relation `⟨a, G⟩ = P ∧ ⟨a, b⟩ = v` the IPA is an argument of knowledge for.
-* `innerProduct_add_left` — `⟨·, b⟩` is additive in its left argument; together with `commit`'s linearity
-  (`commitGen_add_left` / `commitGen_smul_left` in `Zcash.Snark.Soundness.CommitFold`, via
-  `commit_eq_commitGen`) this is the algebra the round extractor folds with.
+* `innerProduct_add_left` gives the linearity used by the extractor.
 
-The IPA's witness fold is 2-special-sound per round: from two accepting transcripts that share the
-round commitments `(Lⱼ, Rⱼ)` but answer distinct challenges `uⱼ`, the round's witness is uniquely
-recoverable, and recursing over the `k` rounds extracts an `a` satisfying `IpaRelation`. The
-extractor is built in `Zcash.Snark.Soundness.Extraction`; the per-round folding rests on the
-linearity proved here. Opening uniqueness holds up to a computed discrete-log relation
-(`NontrivialDLRelation.ofIpaOpenings` in `Zcash.Snark.Soundness.CommitFold`); DLR hardness is
-consumed only at the computational layer.
+Two distinct challenges recover one round's witness halves. The recursive extractor is defined in
+`Soundness.IpaSoundness`. Opening non-uniqueness produces an explicit discrete-log relation; hardness
+is used only at the computational boundary.
 -/
 
 namespace Zcash.Snark
@@ -48,9 +37,7 @@ def evalVector (k : ℕ) (x : F) : Fin (2 ^ k) → F :=
 def innerProduct {n : ℕ} (a b : Fin n → F) : F :=
   ∑ i, a i * b i
 
-/-- The IPA opening relation: the witness `a` is the polynomial committed by `P` (`⟨a, G⟩ = P`) that
-opens to `v` at the point encoded by `b` (`⟨a, b⟩ = v`). The inner-product argument is an argument of
-knowledge for this relation; special soundness produces such an `a` from accepting transcripts. -/
+/-- The coefficient vector `a` commits to `P` and has inner product `v` with `b`. -/
 def IpaRelation (urs : URS G) (P : G) (b : Fin (2 ^ urs.k) → F) (v : F)
     (a : Fin (2 ^ urs.k) → F) : Prop :=
   commit urs a = P ∧ innerProduct a b = v
@@ -79,12 +66,8 @@ theorem innerProduct_single {n : ℕ} (i : Fin n) (x : F) (b : Fin n → F) :
   rw [Finset.sum_eq_single i (fun j _ hj => by rw [Pi.single_eq_of_ne hj, zero_mul])
     (fun h => absurd (Finset.mem_univ i) h), Pi.single_eq_same]
 
-/-- **The adjusted-commitment un-shift (halo2's value placement).** halo2's IPA verifier folds the claimed
-value into the commitment at `g₀` (`msm.add_constant_term(-v)`, so the opened commitment is `P − [v]g₀`) while
-checking the inner product on `U`; the two are reconciled by the evaluation vector's leading entry `b₀ = 1`
-(`evalVector` gives `b 0 = x^0 = 1`). So opening `P − [v]g₀` to inner product `0` *is* opening `P` to inner
-product `v`: shift the witness's `g₀`-coefficient by `v`. This is the exact halo2 invariant resolving the
-value living on `g₀` (the verifier equation) versus on `U` (the transcript tree). -/
+/-- Convert an opening of `P − [v]g₀` at value zero to an opening of `P` at value `v`, using
+`b 0 = 1`. -/
 theorem ipaRelation_unshift (urs : URS G) (P : G) (b : Fin (2 ^ urs.k) → F) (v : F)
     (a : Fin (2 ^ urs.k) → F) (hb0 : b 0 = 1)
     (h : IpaRelation urs (P - v • urs.g 0) b 0 a) :
@@ -104,14 +87,9 @@ theorem innerProduct_smul {n : ℕ} (c : F) (s b : Fin n → F) :
     innerProduct (c • s) b = c * innerProduct s b := by
   simp only [innerProduct, Pi.smul_apply, smul_eq_mul, mul_assoc, ← Finset.mul_sum]
 
-/-- **The synthetic-blinding strip (the opened value, unique under binding).** halo2's IPA folds a synthetic
-blinding commitment `[ξ]S` into the opened commitment, with `S = ⟨s, G⟩`. Stripping it — subtract `ξ·s` from
-the witness — opens the plain `P` to `v − ξ·⟨s, b⟩`. This is *unconditional*: it reports the opened value
-of `P` for the supplied `S`-opening `s` (distinct `S`-openings shift it while exhibiting a `g`-relation —
-binding pins it), whatever the blinder is. The verifier never checks `s`; `S` is prover-supplied. So the
-soundness content lives in how `v − ξ·⟨s, b⟩` relates to the claimed value, which the caller must pin (see
-`ipaRelation_unblind` for the honest-prover case, and `Soundness.Forking.Rewind` for the `ξ`-randomization that
-bounds a malicious blinder). -/
+/-- Remove `[ξ]S` from the commitment and `ξ·s` from the witness.
+
+The resulting opening value is `v − ξ·⟨s,b⟩`. -/
 theorem ipaRelation_unblind_value (urs : URS G) (P : G) (b : Fin (2 ^ urs.k) → F) (v ξ : F)
     (s a : Fin (2 ^ urs.k) → F)
     (h : IpaRelation urs (P + ξ • commit urs s) b v a) :
@@ -121,12 +99,7 @@ theorem ipaRelation_unblind_value (urs : URS G) (P : G) (b : Fin (2 ^ urs.k) →
   · rw [sub_eq_add_neg, ← neg_smul, commit_add, commit_smul, hc, neg_smul]; abel
   · rw [sub_eq_add_neg, ← neg_smul, innerProduct_add, innerProduct_smul, hi]; ring
 
-/-- **The synthetic-blinding strip, honest-prover case.** When the blinder vanishes at the evaluation point
-(`⟨s, b⟩ = 0` — halo2's prover sets `s_poly[0] -= s(x₃)` so `s(x₃) = 0`), stripping `[ξ]S` leaves the opened
-value at the claimed `v`. This is the `⟨s, b⟩ = 0` specialization of `ipaRelation_unblind_value`; a malicious
-prover need not satisfy it, which is exactly why `[ξ]S`'s soundness rests on `ξ` being drawn after `S`
-(`Soundness.Forking.Rewind`), not on this hypothesis. With `ipaRelation_unshift` it reconciles the adjusted
-commitment `P' = P − [v]g₀ + [ξ]S` with the plain `P`. -/
+/-- If `⟨s,b⟩ = 0`, removing `[ξ]S` preserves the claimed opening value. -/
 theorem ipaRelation_unblind (urs : URS G) (P : G) (b : Fin (2 ^ urs.k) → F) (v ξ : F)
     (s a : Fin (2 ^ urs.k) → F) (hs : innerProduct s b = 0)
     (h : IpaRelation urs (P + ξ • commit urs s) b v a) :
@@ -150,10 +123,7 @@ def foldVec {m : ℕ} (lo hi : Fin m → F) (u : F) : Fin m → F := lo + u • 
 def roundExtract {m : ℕ} (f₁ f₂ : Fin m → F) (u₁ u₂ : F) : (Fin m → F) × (Fin m → F) :=
   (f₁ - u₁ • ((u₁ - u₂)⁻¹ • (f₁ - f₂)), (u₁ - u₂)⁻¹ • (f₁ - f₂))
 
-/-- **2-special soundness of one IPA round.** The folded vectors at two distinct challenges `u₁ ≠ u₂`
-(produced from the same halves `lo, hi`) determine the halves — `roundExtract` recovers exactly
-`(lo, hi)`. A prover answering two challenges consistently is thus committed to a unique pair that folds
-back to the round witness, the algebraic heart of the IPA's special soundness. -/
+/-- Two distinct challenge folds uniquely recover the original vector halves. -/
 theorem roundExtract_correct {m : ℕ} (lo hi : Fin m → F) (u₁ u₂ : F) (h : u₁ ≠ u₂) :
     roundExtract (foldVec lo hi u₁) (foldVec lo hi u₂) u₁ u₂ = (lo, hi) := by
   have hsub : u₁ - u₂ ≠ 0 := sub_ne_zero.mpr h

--- a/Zcash/Snark/Soundness/IpaSoundness.lean
+++ b/Zcash/Snark/Soundness/IpaSoundness.lean
@@ -31,8 +31,8 @@ variable {F G : Type*} [Field F] [AddCommGroup G] [Module F G]
 /-- Three-point linear-coefficient functional. For distinct `u₁,u₂,u₃` there are coefficients
 `l₁,l₂,l₃` with `Σ lᵢ = 0`, `Σ lᵢuᵢ = 1`, `Σ lᵢuᵢ² = 0` — i.e. `p ↦ Σ lᵢ·p(uᵢ)` reads off the
 coefficient of `u` from any degree-≤2 `p`. (The `lᵢ` are the `u`-coefficients of the Lagrange basis.) -/
-theorem vandermonde3 (u₁ u₂ u₃ : F) (h12 : u₁ ≠ u₂) (h13 : u₁ ≠ u₃) (h23 : u₂ ≠ u₃) :
-    ∃ l₁ l₂ l₃ : F, (l₁ + l₂ + l₃ = 0) ∧ (l₁ * u₁ + l₂ * u₂ + l₃ * u₃ = 1)
+def vandermonde3 (u₁ u₂ u₃ : F) (h12 : u₁ ≠ u₂) (h13 : u₁ ≠ u₃) (h23 : u₂ ≠ u₃) :
+    Σ' (l₁ l₂ l₃ : F), (l₁ + l₂ + l₃ = 0) ∧ (l₁ * u₁ + l₂ * u₂ + l₃ * u₃ = 1)
       ∧ (l₁ * u₁ ^ 2 + l₂ * u₂ ^ 2 + l₃ * u₃ ^ 2 = 0) := by
   have d12 : u₁ - u₂ ≠ 0 := sub_ne_zero.mpr h12
   have d13 : u₁ - u₃ ≠ 0 := sub_ne_zero.mpr h13
@@ -193,22 +193,22 @@ def IpaAcceptV : {d : ℕ} → (Fin (2 ^ d) → G) → (Fin (2 ^ d) → F) → G
         IpaAcceptV (foldGens g u₂) (foldGens b u₂) (P + u₂⁻¹ • L + u₂ • R) (v + u₂⁻¹ • Lv + u₂ • Rv) t₂ ∧
         IpaAcceptV (foldGens g u₃) (foldGens b u₃) (P + u₃⁻¹ • L + u₃ • R) (v + u₃⁻¹ • Lv + u₃ • Rv) t₃
 
-/-- **Full IPA knowledge soundness — the opening relation, derived from acceptance.** An accepting
-transcript tree yields a single witness `a` that both opens the commitment and gives the claimed inner
-product:
-`∃ a, commit g a = P ∧ commit b a = v` (and `commit b a = ⟨a, b⟩`). The two conjuncts share the same `a`
-— the explicit Vandermonde combination — by applying `ipa_round_commit_with_coeffs` to the commitment
-(`G`) and the inner product (`G := F`, generators `b`) with one set of coefficients. Binding-free. This is
-`IpaRelation` (`commit a = P ∧ ⟨a,b⟩ = v`) discharged from the verifier's accept. -/
-theorem ipa_soundV : {d : ℕ} → (g : Fin (2 ^ d) → G) → (b : Fin (2 ^ d) → F) → (P : G) → (v : F) →
+/-- **The IPA special-soundness extractor, as computed data.** The witness `a` is *constructed*
+(not merely shown to exist): the explicit `append` of Vandermonde combinations of the three
+sub-witnesses. Returning it as `Σ'` data (rather than behind an `∃`) is what makes the deployed
+opening a genuine reduction — the caller *has* the witness — instead of the prime-order-vacuous
+"an opening exists" (any group point has a `g`-preimage by prime order, so `∃ a, …` alone carries
+no content). Computable: `vandermonde3` and the fold are field arithmetic, and `ipa_round_commit_with_coeffs`
+only *proves* the two openings, it does not choose data. -/
+def ipa_extractV : {d : ℕ} → (g : Fin (2 ^ d) → G) → (b : Fin (2 ^ d) → F) → (P : G) → (v : F) →
     (t : IpaTreeV F G d) → IpaAcceptV g b P v t →
-    ∃ a : Fin (2 ^ d) → F, commitGen g a = P ∧ commitGen b a = v
+    Σ' a : Fin (2 ^ d) → F, commitGen g a = P ∧ commitGen b a = v
   | 0, g, b, P, v, .leaf c, h => ⟨fun _ => c, h.1.symm, h.2.symm⟩
   | _ + 1, g, b, P, v, .node L R Lv Rv u₁ u₂ u₃ t₁ t₂ t₃, h => by
       obtain ⟨h12, h13, h23, hu₁, hu₂, hu₃, ha₁, ha₂, ha₃⟩ := h
-      obtain ⟨c₁, hP₁, hv₁⟩ := ipa_soundV (foldGens g u₁) (foldGens b u₁) _ _ t₁ ha₁
-      obtain ⟨c₂, hP₂, hv₂⟩ := ipa_soundV (foldGens g u₂) (foldGens b u₂) _ _ t₂ ha₂
-      obtain ⟨c₃, hP₃, hv₃⟩ := ipa_soundV (foldGens g u₃) (foldGens b u₃) _ _ t₃ ha₃
+      obtain ⟨c₁, hP₁, hv₁⟩ := ipa_extractV (foldGens g u₁) (foldGens b u₁) _ _ t₁ ha₁
+      obtain ⟨c₂, hP₂, hv₂⟩ := ipa_extractV (foldGens g u₂) (foldGens b u₂) _ _ t₂ ha₂
+      obtain ⟨c₃, hP₃, hv₃⟩ := ipa_extractV (foldGens g u₃) (foldGens b u₃) _ _ t₃ ha₃
       obtain ⟨l₁, l₂, l₃, hl0, hl1, hl2⟩ := vandermonde3 u₁ u₂ u₃ h12 h13 h23
       refine ⟨append (l₁ • (u₁ • c₁) + l₂ • (u₂ • c₂) + l₃ • (u₃ • c₃)) (l₁ • c₁ + l₂ • c₂ + l₃ • c₃),
         ?_, ?_⟩
@@ -218,6 +218,14 @@ theorem ipa_soundV : {d : ℕ} → (g : Fin (2 ^ d) → G) → (b : Fin (2 ^ d) 
       · rw [commitGen_append]
         exact ipa_round_commit_with_coeffs (loHalf b) (hiHalf b) v Lv Rv c₁ c₂ c₃ u₁ u₂ u₃ l₁ l₂ l₃
           hl0 hl1 hl2 hu₁ hu₂ hu₃ hv₁ hv₂ hv₃
+
+/-- **Full IPA knowledge soundness — the opening relation, derived from acceptance.** The
+`∃`-shaped projection of `ipa_extractV` for callers that only need existence (`ipaRelation_of_acceptV`).
+The soundness content is in `ipa_extractV`'s *computed* witness; this forgets it to a `Prop`. -/
+theorem ipa_soundV {d : ℕ} (g : Fin (2 ^ d) → G) (b : Fin (2 ^ d) → F) (P : G) (v : F)
+    (t : IpaTreeV F G d) (h : IpaAcceptV g b P v t) :
+    ∃ a : Fin (2 ^ d) → F, commitGen g a = P ∧ commitGen b a = v :=
+  ⟨(ipa_extractV g b P v t h).1, (ipa_extractV g b P v t h).2⟩
 
 /-! ## The multiopen batch decode
 

--- a/Zcash/Snark/Soundness/IpaSoundness.lean
+++ b/Zcash/Snark/Soundness/IpaSoundness.lean
@@ -3,20 +3,15 @@ import Zcash.Snark.Soundness.CommitFold
 import Zcash.Snark.Soundness.Consistency
 
 /-!
-# IPA knowledge soundness: the commitment-soundness of one round (3-special)
+# IPA special-soundness extraction
 
-This begins the inner-product-argument knowledge-soundness proof — deriving the opening relation
-`commit g a = P` from the verifier's accept, not assuming it.
+This module derives an IPA opening witness from a ternary accepting transcript tree.
 
-The key fact: one IPA round is 3-special-sound for the commitment. At a round the verifier folds
-`g' = g_lo + u⁻¹·g_hi` and `P' = P + u⁻¹·L + u·R` (the prover's cross-terms `L`,`R` fixed before the
-challenge). Given three sub-openings at three distinct challenges, `commit g' cᵢ = P + uᵢ⁻¹·L + uᵢ·R`, the
-parent commitment is pinned: `commit g a = P` for an `a` assembled from the `cᵢ` by the Vandermonde
-combination that extracts the linear-in-`u` coefficient. Two challenges suffice to extract the witness but
-leave `commit g a − P = (u₁+u₂)·X` undetermined; three kill it.
+One IPA round is 3-special-sound for the commitment. Three sub-openings at distinct nonzero challenges
+determine a parent witness through a Vandermonde combination. Two challenges do not fully pin the
+parent commitment.
 
-This round fold needs no binding — it is pure module linear algebra. (Binding enters only for uniqueness
-of the opening.)
+The extraction uses only module algebra. Binding is needed later for uniqueness.
 
 * `vandermonde3` — the three-point functional reading off a degree-≤2 polynomial's linear
   coefficient from its samples.
@@ -28,9 +23,7 @@ namespace Zcash.Snark
 
 variable {F G : Type*} [Field F] [AddCommGroup G] [Module F G]
 
-/-- Three-point linear-coefficient functional, returned as computed data: for distinct `u₁,u₂,u₃` it
-constructs coefficients `l₁,l₂,l₃` with `Σ lᵢ = 0`, `Σ lᵢuᵢ = 1`, `Σ lᵢuᵢ² = 0` — so `p ↦ Σ lᵢ·p(uᵢ)`
-reads off the `u`-coefficient of any degree-≤2 `p`. (The `lᵢ` are the `u`-coefficients of the Lagrange basis.) -/
+/-- Compute coefficients that extract the linear term of a quadratic from three distinct samples. -/
 def vandermonde3 (u₁ u₂ u₃ : F) (h12 : u₁ ≠ u₂) (h13 : u₁ ≠ u₃) (h23 : u₂ ≠ u₃) :
     Σ' (l₁ l₂ l₃ : F), (l₁ + l₂ + l₃ = 0) ∧ (l₁ * u₁ + l₂ * u₂ + l₃ * u₃ = 1)
       ∧ (l₁ * u₁ ^ 2 + l₂ * u₂ ^ 2 + l₃ * u₃ ^ 2 = 0) := by
@@ -43,11 +36,7 @@ def vandermonde3 (u₁ u₂ u₃ : F) (h12 : u₁ ≠ u₂) (h13 : u₁ ≠ u₃
   refine ⟨-(u₂ + u₃) / ((u₁ - u₂) * (u₁ - u₃)), -(u₁ + u₃) / ((u₂ - u₁) * (u₂ - u₃)),
     -(u₁ + u₂) / ((u₃ - u₁) * (u₃ - u₂)), ?_, ?_, ?_⟩ <;> field_simp <;> ring
 
-/-- The IPA round is 3-special-sound for the commitment — with the witness explicit: given
-Vandermonde coefficients `lᵢ` (`vandermonde3`), the parent witness `a = (Σ lᵢuᵢ·cᵢ ‖ Σ lᵢ·cᵢ)`
-opens `P`. Combining the three openings by `lᵢ` keeps `P` (`Σ lᵢuᵢ = 1`) and cancels `L` and `R`
-(`Σ lᵢ = 0`, `Σ lᵢuᵢ² = 0`); the witness is explicit so the inner-product side can reuse it at
-`G := F`. No binding. -/
+/-- Combine three sub-opening witnesses into an explicit parent witness. -/
 theorem ipa_round_commit_with_coeffs {m : ℕ} (g_lo g_hi : Fin m → G) (P L R : G)
     (c₁ c₂ c₃ : Fin m → F) (u₁ u₂ u₃ l₁ l₂ l₃ : F)
     (hl0 : l₁ + l₂ + l₃ = 0) (hl1 : l₁ * u₁ + l₂ * u₂ + l₃ * u₃ = 1)
@@ -82,9 +71,7 @@ theorem ipa_round_commit_with_coeffs {m : ℕ} (g_lo g_hi : Fin m → G) (P L R 
       | linear_combination hl2
       | ring
 
-/-- **The IPA round is 3-special-sound for the commitment.** Three sub-openings at distinct nonzero
-challenges pin the parent opening: `∃ a_lo a_hi, commit g_lo a_lo + commit g_hi a_hi = P`. The existential
-form; the witness is the `vandermonde3` combination (`ipa_round_commit_with_coeffs`). No binding. -/
+/-- Three distinct nonzero challenge openings determine a parent commitment opening. -/
 theorem ipa_round_commit_sound {m : ℕ} (g_lo g_hi : Fin m → G) (P L R : G)
     (c₁ c₂ c₃ : Fin m → F) (u₁ u₂ u₃ : F)
     (h12 : u₁ ≠ u₂) (h13 : u₁ ≠ u₃) (h23 : u₂ ≠ u₃)
@@ -97,9 +84,7 @@ theorem ipa_round_commit_sound {m : ℕ} (g_lo g_hi : Fin m → G) (P L R : G)
   exact ⟨_, _, ipa_round_commit_with_coeffs g_lo g_hi P L R c₁ c₂ c₃ u₁ u₂ u₃ l₁ l₂ l₃
     hl0 hl1 hl2 hu₁ hu₂ hu₃ e₁ e₂ e₃⟩
 
-/-- A length-`2^{k+1}` commitment splits over the two halves:
-`commit g a = commit (loHalf g) (loHalf a) + commit (hiHalf g) (hiHalf a)`. The IPA recursion's bridge from
-a round's folded-generator openings back to the parent generators. -/
+/-- Split a commitment over the lower and upper halves of its vectors. -/
 theorem commitGen_split {k : ℕ} (g : Fin (2 ^ (k + 1)) → G) (a : Fin (2 ^ (k + 1)) → F) :
     commitGen g a = commitGen (loHalf g) (loHalf a) + commitGen (hiHalf g) (hiHalf a) := by
   have e : 2 ^ k + 2 ^ k = 2 ^ (k + 1) := by rw [pow_succ]; ring
@@ -119,28 +104,20 @@ theorem hiHalf_append {α : Type*} {k : ℕ} (lo hi : Fin (2 ^ k) → α) : hiHa
   simp only [hiHalf, append, dif_neg h]
   congr 1; apply Fin.ext; simp
 
-/-- A commitment of an `append` splits over the parent halves:
-`commit g (append a_lo a_hi) = commit (loHalf g) a_lo + commit (hiHalf g) a_hi`. -/
+/-- A commitment to `append a_lo a_hi` splits into commitments to both halves. -/
 theorem commitGen_append {k : ℕ} (g : Fin (2 ^ (k + 1)) → G) (a_lo a_hi : Fin (2 ^ k) → F) :
     commitGen g (append a_lo a_hi) = commitGen (loHalf g) a_lo + commitGen (hiHalf g) a_hi := by
   rw [commitGen_split, loHalf_append, hiHalf_append]
 
 /-! ## The IPA soundness recursion -/
 
-/-- A 3-ary IPA transcript tree for `d` rounds. At each round the prover's two cross-commitments
-`L`, `R` (fixed before the challenge) and three sub-transcripts answering three challenges; at a leaf the
-final scalar. The 3-arity is what `ipa_round_commit_sound` consumes (two challenges extract the witness,
-the third pins the commitment). -/
+/-- A ternary IPA transcript tree with three challenge continuations at each round. -/
 inductive IpaTree (F G : Type*) : ℕ → Type _ where
   | leaf : F → IpaTree F G 0
   | node {d : ℕ} : G → G → F → F → F →
       IpaTree F G d → IpaTree F G d → IpaTree F G d → IpaTree F G (d + 1)
 
-/-- The IPA verifier accepts a transcript tree against generators `g` and commitment `P`: at a leaf,
-the final check `P = [c]·g₀` (`= commit g (const c)`); at a node, the three challenges are distinct and
-nonzero and each sub-transcript opens the verifier's folded commitment `P + uᵢ⁻¹·L + uᵢ·R` against the
-folded generators `foldGens g uᵢ`. This is the verifier's recursion (external `P`, prover `L`/`R`) —
-the object `ipa_sound` walks back down to extract the witness. -/
+/-- Recursive acceptance for a ternary IPA transcript tree. -/
 def IpaAccept : {d : ℕ} → (Fin (2 ^ d) → G) → G → IpaTree F G d → Prop
   | 0, g, P, .leaf c => P = commitGen g (fun _ => c)
   | _ + 1, g, P, .node L R u₁ u₂ u₃ t₁ t₂ t₃ =>
@@ -149,12 +126,7 @@ def IpaAccept : {d : ℕ} → (Fin (2 ^ d) → G) → G → IpaTree F G d → Pr
         IpaAccept (foldGens g u₂) (P + u₂⁻¹ • L + u₂ • R) t₂ ∧
         IpaAccept (foldGens g u₃) (P + u₃⁻¹ • L + u₃ • R) t₃
 
-/-- **IPA knowledge soundness — the opening, derived (not assumed).** An accepting transcript tree yields
-a witness opening the commitment: `∃ a, commit g a = P`. By induction on the tree: the leaf gives
-`a = const c` directly; a node takes the three sub-witnesses from the IH, pins the parent commitment with
-`ipa_round_commit_sound`, and reassembles via `commitGen_append`. The whole argument uses no binding —
-3-special soundness alone pins the opening. (Uniqueness holds up to a computed discrete-log
-relation, `NontrivialDLRelation.ofIpaOpenings`.) -/
+/-- An accepting transcript tree yields a coefficient vector opening `P`. -/
 theorem ipa_sound : {d : ℕ} → (g : Fin (2 ^ d) → G) → (P : G) → (t : IpaTree F G d) →
     IpaAccept g P t → ∃ a : Fin (2 ^ d) → F, commitGen g a = P
   | 0, g, P, .leaf c, h => ⟨fun _ => c, h.symm⟩
@@ -169,22 +141,17 @@ theorem ipa_sound : {d : ℕ} → (g : Fin (2 ^ d) → G) → (P : G) → (t : I
 
 /-! ## The full opening relation (commitment + inner product)
 
-The inner product `⟨a, b⟩ = v` is the same theorem at `G := F`: `commitGen b a = ∑ aⱼ • bⱼ = ⟨a, b⟩`, so
-the eval vector `b` plays the role of the generators and the value `v` the role of the commitment, with the
-verifier folding `b` by `foldGens` exactly as it folds `g` (`innerProduct_round`). Carrying both in one
-tree and reusing `ipa_round_commit_with_coeffs` for each (with the same explicit witness) derives the full
-`IpaRelation`. -/
+The same extraction applied to `b` proves the inner-product equation. `IpaTreeV` carries both sets of
+round terms so one witness satisfies both equations.
+-/
 
-/-- A 3-ary IPA transcript tree carrying both the commitment cross-terms `L`,`R` (in `G`) and the
-inner-product cross-terms `Lv`,`Rv` (in `F`) per round. -/
+/-- A ternary IPA tree carrying commitment and inner-product round terms. -/
 inductive IpaTreeV (F G : Type*) : ℕ → Type _ where
   | leaf : F → IpaTreeV F G 0
   | node {d : ℕ} : G → G → F → F → F → F → F →
       IpaTreeV F G d → IpaTreeV F G d → IpaTreeV F G d → IpaTreeV F G (d + 1)
 
-/-- Acceptance for the full relation: the verifier folds the generators `g` and the eval vector `b` (both
-by `foldGens`), the commitment `P` (by `L`,`R`) and the value `v` (by `Lv`,`Rv`); the leaf checks
-`P = [c]·g₀` and `v = c·b₀`. -/
+/-- Recursive acceptance for both the commitment and inner-product equations. -/
 def IpaAcceptV : {d : ℕ} → (Fin (2 ^ d) → G) → (Fin (2 ^ d) → F) → G → F → IpaTreeV F G d → Prop
   | 0, g, b, P, v, .leaf c => P = commitGen g (fun _ => c) ∧ v = commitGen b (fun _ => c)
   | _ + 1, g, b, P, v, .node L R Lv Rv u₁ u₂ u₃ t₁ t₂ t₃ =>
@@ -193,13 +160,7 @@ def IpaAcceptV : {d : ℕ} → (Fin (2 ^ d) → G) → (Fin (2 ^ d) → F) → G
         IpaAcceptV (foldGens g u₂) (foldGens b u₂) (P + u₂⁻¹ • L + u₂ • R) (v + u₂⁻¹ • Lv + u₂ • Rv) t₂ ∧
         IpaAcceptV (foldGens g u₃) (foldGens b u₃) (P + u₃⁻¹ • L + u₃ • R) (v + u₃⁻¹ • Lv + u₃ • Rv) t₃
 
-/-- **The IPA special-soundness extractor, as computed data.** The witness `a` is *constructed*
-(not merely shown to exist): the explicit `append` of Vandermonde combinations of the three
-sub-witnesses. Returning it as `Σ'` data (rather than behind an `∃`) is what makes the deployed
-opening a genuine reduction — the caller *has* the witness — instead of the prime-order-vacuous
-"an opening exists" (any group point has a `g`-preimage by prime order, so `∃ a, …` alone carries
-no content). Computable: `vandermonde3` and the fold are field arithmetic, and `ipa_round_commit_with_coeffs`
-only *proves* the two openings, it does not choose data. -/
+/-- Compute an explicit opening witness and both of its equations from an accepting full IPA tree. -/
 def ipa_extractV : {d : ℕ} → (g : Fin (2 ^ d) → G) → (b : Fin (2 ^ d) → F) → (P : G) → (v : F) →
     (t : IpaTreeV F G d) → IpaAcceptV g b P v t →
     Σ' a : Fin (2 ^ d) → F, commitGen g a = P ∧ commitGen b a = v
@@ -219,9 +180,7 @@ def ipa_extractV : {d : ℕ} → (g : Fin (2 ^ d) → G) → (b : Fin (2 ^ d) �
         exact ipa_round_commit_with_coeffs (loHalf b) (hiHalf b) v Lv Rv c₁ c₂ c₃ u₁ u₂ u₃ l₁ l₂ l₃
           hl0 hl1 hl2 hu₁ hu₂ hu₃ hv₁ hv₂ hv₃
 
-/-- The `∃`-shaped projection of `ipa_extractV`, for callers that only need existence
-(`ipaRelation_of_acceptV`): it forgets the *computed* witness to a `Prop`. The soundness content lives in
-`ipa_extractV` (the milestone); this is the existential wrapper. -/
+/-- Existential projection of `ipa_extractV` for proof-only callers. -/
 theorem ipa_soundV {d : ℕ} (g : Fin (2 ^ d) → G) (b : Fin (2 ^ d) → F) (P : G) (v : F)
     (t : IpaTreeV F G d) (h : IpaAcceptV g b P v t) :
     ∃ a : Fin (2 ^ d) → F, commitGen g a = P ∧ commitGen b a = v :=
@@ -229,17 +188,11 @@ theorem ipa_soundV {d : ℕ} (g : Fin (2 ^ d) → G) (b : Fin (2 ^ d) → F) (P 
 
 /-! ## The multiopen batch decode
 
-The deployed verifier batches the per-column commitments by powers of a challenge `z` (the `x₁`/`x₄`
-folds), opens the single batched commitment, and the inner-product argument extracts the combined witness.
-To recover the individual column openings — what the gate check needs — one rewinds the batching challenge
-and solves a Vandermonde system over `n` distinct `z`'s: the `ipa_soundV` technique one layer up, but with
-no cross terms (the batch is a plain linear combination), so a single `n`-point Vandermonde inverse
-suffices. -/
+The verifier opens one linear combination of column commitments. Openings at enough distinct batching
+challenges form a Vandermonde system that recovers each column opening.
+-/
 
-/-- General Vandermonde inverse. For `n` distinct points `z`, there are coefficients `μ` with
-`Σ_k μ i k · (z k)ʲ = δ_{i,j}` — the functional reading off the `i`-th coefficient of a degree-`<n`
-polynomial from its `n` samples. (The `n = 3` special case is `vandermonde3`.) From invertibility of the
-Vandermonde matrix (`det = ∏_{i<j}(z j − z i) ≠ 0` for distinct points). -/
+/-- Compute coefficients that recover polynomial coefficients from values at distinct points. -/
 theorem vandermonde_inv {n : ℕ} (z : Fin n → F) (hz : Function.Injective z) :
     ∃ μ : Fin n → Fin n → F, ∀ (i j : Fin n), (∑ k, μ i k * z k ^ (j : ℕ)) = if i = j then 1 else 0 := by
   have hdet : (Matrix.vandermonde z).det ≠ 0 := by
@@ -264,9 +217,7 @@ theorem commitGen_sum {m : ℕ} (g : Fin m → G) {ι : Type*} (s : Finset ι) (
   | empty => simp [commitGen]
   | insert a s ha ih => rw [Finset.sum_insert ha, Finset.sum_insert ha, commitGen_add_left, ih]
 
-/-- Batch-opening soundness — explicit witness. Given the batched openings
-`commit g (a k) = Σⱼ (z k)ʲ · C j` at the `n` challenges and the Vandermonde coefficients `μ`, the explicit
-combination `Σ_k μ i k · a k` opens the `i`-th individual commitment: `commit g (Σ_k μ i k · a k) = C i`. -/
+/-- Use Vandermonde coefficients to recover one individual opening from batched openings. -/
 theorem batch_open_with_coeffs {m n : ℕ} (g : Fin m → G) (C : Fin n → G) (z : Fin n → F)
     (a : Fin n → (Fin m → F)) (μ : Fin n → Fin n → F)
     (hμ : ∀ (i j : Fin n), (∑ k, μ i k * z k ^ (j : ℕ)) = if i = j then 1 else 0)
@@ -278,12 +229,7 @@ theorem batch_open_with_coeffs {m n : ℕ} (g : Fin m → G) (C : Fin n → G) (
   simp only [← Finset.sum_smul, hμ, ite_smul, one_smul, zero_smul, Finset.sum_ite_eq,
     Finset.mem_univ, if_true]
 
-/-- **The multiopen batch decode is sound.** From the batched commitment/value openings at `n` distinct
-challenges, each individual column has a single witness opening it to its commitment `C i` and giving its
-claimed evaluation `e i`: `∃ col, ∀ i, commit g (col i) = C i ∧ ⟨col i, b⟩ = e i`. The same explicit
-Vandermonde combination serves both (the value side is `batch_open_with_coeffs` at `G := F`,
-`commit b = ⟨·,b⟩`). This recovers the per-column openings the gate check (`circuitSatViaGates`) consumes —
-the multiopen decode, derived. -/
+/-- Recover each commitment and value opening from valid batches at distinct challenges. -/
 theorem batch_open_soundV {m n : ℕ} (g : Fin m → G) (b : Fin m → F) (C : Fin n → G) (e : Fin n → F)
     (z : Fin n → F) (hz : Function.Injective z) (a : Fin n → (Fin m → F))
     (haC : ∀ k, commitGen g (a k) = ∑ j : Fin n, z k ^ (j : ℕ) • C j)

--- a/Zcash/Snark/Soundness/IpaSoundness.lean
+++ b/Zcash/Snark/Soundness/IpaSoundness.lean
@@ -5,8 +5,8 @@ import Zcash.Snark.Soundness.Consistency
 /-!
 # IPA knowledge soundness: the commitment-soundness of one round (3-special)
 
-This begins the genuine inner-product-argument knowledge-soundness proof — deriving the opening relation
-`commit g a = P` from the verifier's accept, rather than assuming it.
+This begins the inner-product-argument knowledge-soundness proof — deriving the opening relation
+`commit g a = P` from the verifier's accept, not assuming it.
 
 The key fact: one IPA round is 3-special-sound for the commitment. At a round the verifier folds
 `g' = g_lo + u⁻¹·g_hi` and `P' = P + u⁻¹·L + u·R` (the prover's cross-terms `L`,`R` fixed before the
@@ -15,12 +15,12 @@ parent commitment is pinned: `commit g a = P` for an `a` assembled from the `c�
 combination that extracts the linear-in-`u` coefficient. Two challenges suffice to extract the witness but
 leave `commit g a − P = (u₁+u₂)·X` undetermined; three kill it.
 
-This round step needs no binding — it is pure module linear algebra. (Binding enters only for uniqueness
+This round fold needs no binding — it is pure module linear algebra. (Binding enters only for uniqueness
 of the opening.)
 
 * `vandermonde3` — the three-point functional reading off a degree-≤2 polynomial's linear
   coefficient from its samples.
-* `ipa_round_commit_sound` — the round step as a lemma: three sub-openings at distinct nonzero
+* `ipa_round_commit_sound` — the round fold as a lemma: three sub-openings at distinct nonzero
   challenges pin the parent commitment. Pure module linear algebra, no binding.
 -/
 
@@ -28,9 +28,9 @@ namespace Zcash.Snark
 
 variable {F G : Type*} [Field F] [AddCommGroup G] [Module F G]
 
-/-- Three-point linear-coefficient functional. For distinct `u₁,u₂,u₃` there are coefficients
-`l₁,l₂,l₃` with `Σ lᵢ = 0`, `Σ lᵢuᵢ = 1`, `Σ lᵢuᵢ² = 0` — i.e. `p ↦ Σ lᵢ·p(uᵢ)` reads off the
-coefficient of `u` from any degree-≤2 `p`. (The `lᵢ` are the `u`-coefficients of the Lagrange basis.) -/
+/-- Three-point linear-coefficient functional, returned as computed data: for distinct `u₁,u₂,u₃` it
+constructs coefficients `l₁,l₂,l₃` with `Σ lᵢ = 0`, `Σ lᵢuᵢ = 1`, `Σ lᵢuᵢ² = 0` — so `p ↦ Σ lᵢ·p(uᵢ)`
+reads off the `u`-coefficient of any degree-≤2 `p`. (The `lᵢ` are the `u`-coefficients of the Lagrange basis.) -/
 def vandermonde3 (u₁ u₂ u₃ : F) (h12 : u₁ ≠ u₂) (h13 : u₁ ≠ u₃) (h23 : u₂ ≠ u₃) :
     Σ' (l₁ l₂ l₃ : F), (l₁ + l₂ + l₃ = 0) ∧ (l₁ * u₁ + l₂ * u₂ + l₃ * u₃ = 1)
       ∧ (l₁ * u₁ ^ 2 + l₂ * u₂ ^ 2 + l₃ * u₃ ^ 2 = 0) := by
@@ -219,9 +219,9 @@ def ipa_extractV : {d : ℕ} → (g : Fin (2 ^ d) → G) → (b : Fin (2 ^ d) �
         exact ipa_round_commit_with_coeffs (loHalf b) (hiHalf b) v Lv Rv c₁ c₂ c₃ u₁ u₂ u₃ l₁ l₂ l₃
           hl0 hl1 hl2 hu₁ hu₂ hu₃ hv₁ hv₂ hv₃
 
-/-- **Full IPA knowledge soundness — the opening relation, derived from acceptance.** The
-`∃`-shaped projection of `ipa_extractV` for callers that only need existence (`ipaRelation_of_acceptV`).
-The soundness content is in `ipa_extractV`'s *computed* witness; this forgets it to a `Prop`. -/
+/-- The `∃`-shaped projection of `ipa_extractV`, for callers that only need existence
+(`ipaRelation_of_acceptV`): it forgets the *computed* witness to a `Prop`. The soundness content lives in
+`ipa_extractV` (the milestone); this is the existential wrapper. -/
 theorem ipa_soundV {d : ℕ} (g : Fin (2 ^ d) → G) (b : Fin (2 ^ d) → F) (P : G) (v : F)
     (t : IpaTreeV F G d) (h : IpaAcceptV g b P v t) :
     ∃ a : Fin (2 ^ d) → F, commitGen g a = P ∧ commitGen b a = v :=

--- a/Zcash/Snark/Soundness/Main.lean
+++ b/Zcash/Snark/Soundness/Main.lean
@@ -33,7 +33,7 @@ commitment is opened up to its declared blinding — see
 2. `FiatShamirTree` (*legacy residual*) — the equation yields a forked transcript
    (`ForkedTranscript`, as data): the deployed tree opening the pinned `P`/`v`; bundles the
    Fiat–Shamir forking with the extraction content it supplies (inventory in its docstring).
-   `ForkedTranscript.ofAccepts` composes steps 1–2. Its (a)–(c) content is discharged on the live
+   `ForkedTranscript.ofAccepts` composes 1–2 above. Its (a)–(c) content is discharged on the live
    forking path (`Soundness.Forking.Rewind`, `deployed_forking_relation` — a computable reduction —
    and the Vesta `_forking_*` capstones), leaving the random-oracle rewinding as the floor.
 3. The fork *either* peels cleanly onto `IpaAcceptV` — then `ipa_soundV` extracts the opening
@@ -173,10 +173,10 @@ theorem ipaRelation_of_acceptV (urs : URS G) (b : Fin (2 ^ urs.k) → Fp) (P : G
   have hib : innerProduct a b = commitGen b a := by simp only [innerProduct, commitGen, smul_eq_mul]
   rw [hib]; exact hv
 
-/-- The `Σ'`-**data** companion of `ipaRelation_of_acceptV`: the *computed* opening witness (from
+/-- The `Σ'`-data companion of `ipaRelation_of_acceptV`: the *computed* opening witness (from
 `ipa_extractV`). The deployed reduction opens through this rather than the `∃`-shaped version, so the
 opening is carried as data — at prime order `∃ a, IpaRelation …` is vacuously satisfiable (any point has
-a `g`-preimage), while the *computed* witness cannot be produced without the accepting transcript. -/
+a `g`-preimage), while the computed witness cannot be produced without the accepting transcript. -/
 def ipaRelation_extract (urs : URS G) (b : Fin (2 ^ urs.k) → Fp) (P : G) (v : Fp)
     (t : IpaTreeV Fp G urs.k) (h : IpaAcceptV urs.g b P v t) :
     Σ' a, IpaRelation urs P b v a :=
@@ -255,7 +255,7 @@ theorem ForkedTranscript.nonempty_of_opening [DecidableEq G] [Inhabited G] {shap
   rw [hcancel, hv]
   exact ht
 
-/-- The forking bridge — the *residual* assumption. Its premise is halo2's explicit verifier
+/-- **The forking bridge — the residual assumption.** Its premise is halo2's explicit verifier
 equation `DeployedIpaVerifierEq` (which `deployedAccepts_verifierEq` proves the deployed accept
 entails); it produces a `ForkedTranscript`. It bundles the Fiat–Shamir *forking* with the
 special-soundness *extraction* content the forked transcripts would pin by Vandermonde over the
@@ -267,7 +267,7 @@ augmented `(g, U, W)` basis, here arriving as bridge-supplied tree data:
 (c) the leaf `g`-representation `aP` of the folded commitment (`DeployedIpaTreeV`'s leaf data);
     and
 (d) the commitment's declared `U`/`W` components `pU`/`pW` (the section note above) and the
-    adjusted-commitment step `P' = P − [v]g₀ + [ξ]S`: re-expressing the value term and the
+    adjusted-commitment identity `P' = P − [v]g₀ + [ξ]S`: re-expressing the value term and the
     `S`/`ξ` blinding poly against the declared opening needs a representation of the adversary
     point `S` (ξ-side rewinding or AGM), so it is not a deterministic rewrite.
 
@@ -295,7 +295,7 @@ def ForkedTranscript.ofAccepts [DecidableEq G] [Inhabited G] {shape : Shape} (ur
     ForkedTranscript urs hk vk ps ch b z blind :=
   hFS (deployedAccepts_verifierEq urs hk vk ps ch haccepts)
 
-/-- The Fiat–Shamir **forking** hypothesis — the genuine residual (the random-oracle floor). On halo2's
+/-- **The Fiat–Shamir forking hypothesis — the genuine residual (random-oracle floor).** On halo2's
 explicit verifier equation, rewinding the random oracle yields the 3-special-soundness forking *output*, as
 data: the declared `U`/`W` components `pU`/`pW` of the pinned commitment (the section note above) and a
 `DeployedIpaTreeV` whose every node records three accepting continuations at distinct nonzero per-round

--- a/Zcash/Snark/Soundness/Main.lean
+++ b/Zcash/Snark/Soundness/Main.lean
@@ -8,52 +8,29 @@ import Zcash.Snark.Soundness.Deployed.Verification
 import Zcash.Snark.Soundness.Forking.Assembly
 
 /-!
-# Soundness composition: conditional, and the deployed accept condition
+# Conditional soundness and deployed acceptance
 
-This module composes IPA knowledge soundness into SNARK-relation soundness for the Orchard
-verifier, in two layers:
+This module has two soundness layers:
 
-* the `_conditional` family, over an opaque `accepts : Prop`. The suffix avoids overclaiming:
-  these are scaffolds, not finished soundness.
-* the deployed family, over the concrete accept `DeployedAccepts`: the rejecting `assemble?`
-  succeeds and its MSM — the *fingerprint*, the transcribed form of halo2's final verifier
-  check — evaluates to the group identity.
+* `_conditional` theorems assume an opaque acceptance and extraction interface.
+* deployed theorems start from `DeployedAccepts`, where `assemble?` succeeds and the resulting MSM
+  evaluates to zero.
 
 ## The deployed route
 
-The route derives the IPA opening and the gate constraint with `P`/`v` *pinned* to the proof's
-`multiopenCommitment`/`multiopenValue` (read off `(vk, ps, ch)`, not free parameters; the
-commitment is opened up to its declared blinding — see
-`The tree opens the commitment up to declared U/W components` below):
+The deployed route pins the IPA commitment and value to the proof's `multiopenCommitment` and
+`multiopenValue`:
 
-1. `deployedAccepts_verifierEq` (*proven*) — the accept entails halo2's explicit IPA verifier
-   equation `DeployedIpaVerifierEq`. Fidelity of that closed form to the Rust is the
-   transcription layer (`assembleFinalMsm`/`ipaFold`, checked by the fingerprint), not re-proved
-   here.
-2. `FiatShamirTree` (*legacy residual*) — the equation yields a forked transcript
-   (`ForkedTranscript`, as data): the deployed tree opening the pinned `P`/`v`; bundles the
-   Fiat–Shamir forking with the extraction content it supplies (inventory in its docstring).
-   `ForkedTranscript.ofAccepts` composes 1–2 above. Its (a)–(c) content is discharged on the live
-   forking path (`Soundness.Forking.Rewind`, `deployed_forking_relation` — a computable reduction —
-   and the Vesta `_forking_*` capstones), leaving the random-oracle rewinding as the floor.
-3. The fork *either* peels cleanly onto `IpaAcceptV` — then `ipa_soundV` extracts the opening
-   witness and `orchard_verifier_deployed_opening_of_forked`/`_constraint_of_forked` conclude
-   `S` — *or* `NontrivialRelation.ofUnopenedFork` (*proven*, via
-   `NontrivialRelation.ofDeployedTree`) computes a discrete-log relation among `(g, U, W)`,
-   which DLR hardness forbids.
+1. `deployedAccepts_verifierEq` derives halo2's explicit IPA verifier equation.
+2. The legacy `FiatShamirTree` interface supplies forked transcript data. The live path in
+   `Soundness.Forking.Rewind` replaces most of that interface with explicit reductions.
+3. A fork either yields a clean IPA opening or computes a nontrivial `(g, U, W)` relation.
 
 ## The reduction form
 
-Commitment binding is load-bearing in the peel, but the statements assume no independence of
-`(g, U, W)`: in a prime-order group a nontrivial relation always *exists*, so that assumption
-would be false — and a `… ∨ ∃-relation` conclusion would be propositionally `True`. Per the
-breaks-as-computed-data convention (`Zcash.Security.RandomOracle`, and the Ironwood Book's
-formal-verification conventions), the relation is instead *computed*: `NontrivialRelation`
-carries the coefficients as data, the reductions are plain `def`s, and the positive soundness
-statement is the contrapositive under DLR hardness — no efficient adversary can produce what
-`NontrivialRelation.ofUnopenedFork` computes, so the clean opening holds. The binding-signature
-argument makes the same move (`NontrivialRelation.ofImbalance` in
-`Zcash.Security.BindingSignature.Balance`).
+In a prime-order group, a nontrivial relation exists mathematically. The security break is computing
+its coefficients. `NontrivialRelation` therefore carries those coefficients as data, and the
+reductions return it explicitly instead of asserting that one exists.
 
 ## Assumptions (the conditional family)
 
@@ -76,11 +53,8 @@ namespace Zcash.Snark
 
 variable {G : Type*} [AddCommGroup G] [Module Fp G]
 
-/-- Assumption: if the proof is accepted, there exist a consistent transcript tree and a witness
-`a` opening the commitment (`IpaRelation urs P b v a`) and satisfying the circuit
-(`circuitSat a`). This assumes more than Fiat–Shamir: it bundles the extraction conclusion that
-`accepting_fold_eq`/`extract_correct` already prove, so those lemmas are off this path; splitting
-the two apart is open. -/
+/-- Conditional interface: acceptance supplies a consistent transcript, IPA opening, and circuit
+witness. -/
 def ExtractableFromAcceptance (urs : URS G) (P : G) (b : Fin (2 ^ urs.k) → Fp) (v : Fp)
     (circuitSat : (Fin (2 ^ urs.k) → Fp) → Prop) (accepts : Prop) : Prop :=
   accepts → ∃ (t : Tree Fp urs.k) (a : Fin (2 ^ urs.k) → Fp),
@@ -92,11 +66,7 @@ def ExtractableFromAcceptance (urs : URS G) (P : G) (b : Fin (2 ^ urs.k) → Fp)
 -- correctly derived, spend authorized). Closing it means instantiating `S` to the concrete
 -- Orchard statement and proving `hencodes` — the output-side dual of the input-side
 -- VK-correctness gap (see `Verifier/Assemble.lean`). Large; not started.
-/-- **Conditional soundness (the scaffold).** *If* acceptance yields the extraction data
-(`hextract`), then the statement `S` follows via `hencodes`. `accepts` is opaque and the
-extraction is assumed (see the module docstring's assumption list); the deployed
-`_opening`/`_constraint` theorems below take the concrete accept and derive what is assumed
-here. -/
+/-- If opaque acceptance supplies the extraction data, derive `S` through `hencodes`. -/
 theorem orchard_verifier_sound_conditional (urs : URS G)
     {P : G} {b : Fin (2 ^ urs.k) → Fp} {v : Fp} {circuitSat : (Fin (2 ^ urs.k) → Fp) → Prop}
     {accepts : Prop} (haccepts : accepts)
@@ -106,10 +76,7 @@ theorem orchard_verifier_sound_conditional (urs : URS G)
   obtain ⟨t, a, hcons, hopen, hsat⟩ := hextract haccepts
   exact hencodes a (knowledge_sound urs hcons hopen hsat).2
 
-/-- The deployed verifier's accept condition: `assemble? vk ps ch` succeeds and the assembled MSM
-evaluates to the group identity against the URS. Proof data that `assemble?` rejects (duplicate
-queries, a mismatched `multiopenU` count, malformed permutation last-evals, zero inverse
-denominators) is `False`. `hk` aligns the circuit shape's `k` with the URS's. -/
+/-- The rejecting assembler succeeds and its final MSM evaluates to zero against the URS. -/
 def DeployedAccepts [DecidableEq G] [Inhabited G] {shape : Shape} (urs : URS G)
     (hk : shape.k = urs.k) (vk : VerifyingKey shape Fp G) (ps : ProofString shape Fp G)
     (ch : Challenges shape.k Fp) : Prop :=
@@ -117,9 +84,7 @@ def DeployedAccepts [DecidableEq G] [Inhabited G] {shape : Shape} (urs : URS G)
   | some m => (hk ▸ m : Msm urs.k Fp G).eval urs = 0
   | none => False
 
-/-- The `urs.k`↔`shape.k` transport: evaluating the `hk`-transported MSM against `urs` is the
-same as evaluating `m` against the URS rebuilt at `shape.k` with `urs`'s (transported)
-generators. -/
+/-- Transport MSM evaluation across the equality `shape.k = urs.k`. -/
 theorem eval_cast {shape : Shape} {urs : URS G} (hk : shape.k = urs.k) (m : Msm shape.k Fp G) :
     (hk ▸ m : Msm urs.k Fp G).eval urs = m.eval ⟨shape.k, hk ▸ urs.g, urs.w, urs.u⟩ := by
   -- With `urs` free, destructuring + `subst hk` collapses the cast to `rfl`. Isolating the
@@ -130,13 +95,7 @@ theorem eval_cast {shape : Shape} {urs : URS G} (hk : shape.k = urs.k) (m : Msm 
   subst hk
   rfl
 
-/-- **The deployed accept entails the verifier equation.** From `DeployedAccepts`,
-`assemble?_eq_some` identifies the accepted MSM with the non-rejecting `assembleFinalMsm`, and
-`deployed_verification_eq` rewrites its evaluation to the explicit closed form — so
-`DeployedIpaVerifierEq` holds for the proof's actual `(vk, ps, ch)`. An implication, not an
-`Iff`: the converse is a completeness claim, not made here. This discharges the MSM↔equation
-correspondence the Fiat–Shamir bridge used to absorb; what the bridge still supplies is
-inventoried at `FiatShamirTree`. -/
+/-- Deployed acceptance implies halo2's explicit IPA verifier equation. -/
 theorem deployedAccepts_verifierEq [DecidableEq G] [Inhabited G] {shape : Shape}
     (urs : URS G) (hk : shape.k = urs.k) (vk : VerifyingKey shape Fp G) (ps : ProofString shape Fp G)
     (ch : Challenges shape.k Fp) (h : DeployedAccepts urs hk vk ps ch) :
@@ -156,15 +115,11 @@ theorem deployedAccepts_verifierEq [DecidableEq G] [Inhabited G] {shape : Shape}
 
 /-! ## `IpaRelation` is derived from the transcript tree, not assumed
 
-`Zcash.Snark.ipa_soundV` derives the full opening relation — `commit g a = P` and `⟨a,b⟩ = v` —
-from an accepting IPA transcript tree (`IpaAcceptV`), binding-free, by 3-special soundness. So the
-bridge no longer assumes `IpaRelation`; the MSM↔equation correspondence and the `P`/`v` pinning it
-used to also absorb are discharged (`deployedAccepts_verifierEq`), and the `g`/`U`/`W` separation
-is derived — its failure computes a relation (`NontrivialRelation.ofDeployedTree`). What the
-bridge still absorbs beyond the rewinding is inventoried at `FiatShamirTree` below. -/
+`ipa_soundV` derives both opening equations from an accepting IPA tree. The bridge therefore does
+not assume `IpaRelation`.
+-/
 
-/-- `IpaAcceptV` over the URS generators derives `IpaRelation`: the witness `ipa_soundV` extracts
-opens `P` and gives the inner product. Derived, not assumed. -/
+/-- An accepting IPA tree has a witness satisfying `IpaRelation`. -/
 theorem ipaRelation_of_acceptV (urs : URS G) (b : Fin (2 ^ urs.k) → Fp) (P : G) (v : Fp)
     (t : IpaTreeV Fp G urs.k) (h : IpaAcceptV urs.g b P v t) :
     ∃ a, IpaRelation urs P b v a := by
@@ -173,10 +128,7 @@ theorem ipaRelation_of_acceptV (urs : URS G) (b : Fin (2 ^ urs.k) → Fp) (P : G
   have hib : innerProduct a b = commitGen b a := by simp only [innerProduct, commitGen, smul_eq_mul]
   rw [hib]; exact hv
 
-/-- The `Σ'`-data companion of `ipaRelation_of_acceptV`: the *computed* opening witness (from
-`ipa_extractV`). The deployed reduction opens through this rather than the `∃`-shaped version, so the
-opening is carried as data — at prime order `∃ a, IpaRelation …` is vacuously satisfiable (any point has
-a `g`-preimage), while the computed witness cannot be produced without the accepting transcript. -/
+/-- Compute the `IpaRelation` witness instead of hiding it behind an existential proposition. -/
 def ipaRelation_extract (urs : URS G) (b : Fin (2 ^ urs.k) → Fp) (P : G) (v : Fp)
     (t : IpaTreeV Fp G urs.k) (h : IpaAcceptV urs.g b P v t) :
     Σ' a, IpaRelation urs P b v a :=
@@ -185,9 +137,7 @@ def ipaRelation_extract (urs : URS G) (b : Fin (2 ^ urs.k) → Fp) (P : G) (v : 
     have hib : innerProduct s.1 b = commitGen b s.1 := by simp only [innerProduct, commitGen, smul_eq_mul]
     rw [hib]; exact s.2.2⟩
 
-/-- The deployed commitment the IPA verifier opens (`multiopenCommitment` with `urs`'s generators
-transported to the proof's `shape.k`): the pinned `P`, read off `(vk, ps, ch)`. Reducible, so it
-is defeq to its body for matching against `DeployedIpaVerifierEq`'s leading term. -/
+/-- The proof's deployed multiopen commitment over the supplied URS. -/
 abbrev deployedCommitment [DecidableEq G] [Inhabited G] {shape : Shape} (urs : URS G)
     (hk : shape.k = urs.k) (vk : VerifyingKey shape Fp G) (ps : ProofString shape Fp G)
     (ch : Challenges shape.k Fp) : G :=
@@ -195,23 +145,12 @@ abbrev deployedCommitment [DecidableEq G] [Inhabited G] {shape : Shape} (urs : U
 
 /-! ## The tree opens the commitment up to declared `U`/`W` components
 
-Every deployed commitment is blinded: `deployedCommitment` is an MSM over the proof's commitment
-points, each carrying a `W`-blind, so as a group element it has a nonzero `W`-component. The
-tree's commitment track, by contrast, ends in the pure `g`-span (the leaf's `P = ⟨aP, g⟩`), and
-the accept forces the opened commitment's `U`/`W`-components to `0` — at each node the three
-child equations at distinct challenges Vandermonde-pin them. Opening the raw `deployedCommitment`
-would therefore be unsatisfiable for every real proof. So the bridge *declares* those components
-(`ForkedTranscript.pU`/`pW`; honest values `0` and the aggregate blind), and the tree opens
-`deployedCommitment − [pU]u − [pW]w`. The declaration is itself pinned up to a break: two
-declarations for one commitment collide into a computed relation
-(`NontrivialRelation.ofCombinationCollision`). Satisfiability is checked, not asserted:
-`ForkedTranscript.nonempty_of_opening` builds a transcript from any blinded opening. -/
+Real commitments include a `W` blinding component, while an IPA leaf opens a point in the `g` span.
+The forked transcript therefore declares `U` and `W` components and opens the adjusted commitment
+`deployedCommitment − [pU]u − [pW]w`.
+-/
 
-/-- A forked deployed transcript, as data: the tree the Fiat–Shamir forking would produce, with
-its accept certificate. It opens the declared commitment `deployedCommitment − [pU]u − [pW]w`
-(the section note above) to the pinned `multiopenValue`. Carried as data, not behind an `∃`, so
-the peel can *compute* a discrete-log relation from it (see `The reduction form` in the module
-docstring). -/
+/-- A forked accepting IPA tree opening the deployed commitment after removing declared components. -/
 structure ForkedTranscript [DecidableEq G] [Inhabited G] {shape : Shape} (urs : URS G)
     (hk : shape.k = urs.k) (vk : VerifyingKey shape Fp G) (ps : ProofString shape Fp G)
     (ch : Challenges shape.k Fp) (b : Fin (2 ^ urs.k) → Fp) (z blind : Fp) where
@@ -224,19 +163,14 @@ structure ForkedTranscript [DecidableEq G] [Inhabited G] {shape : Shape} (urs : 
     (deployedCommitment urs hk vk ps ch - pU • urs.u - pW • urs.w)
     (multiopenValue vk ps ch) blind tree
 
-/-- The commitment the transcript's tree opens: the pinned `deployedCommitment` with the declared
-`U`/`W` components peeled off. Reducible, so it is defeq to `accepts`'s commitment argument. -/
+/-- The deployed commitment after removing the transcript's declared `U` and `W` components. -/
 abbrev ForkedTranscript.openedCommitment [DecidableEq G] [Inhabited G] {shape : Shape}
     {urs : URS G} {hk : shape.k = urs.k} {vk : VerifyingKey shape Fp G}
     {ps : ProofString shape Fp G} {ch : Challenges shape.k Fp} {b : Fin (2 ^ urs.k) → Fp}
     {z blind : Fp} (fs : ForkedTranscript urs hk vk ps ch b z blind) : G :=
   deployedCommitment urs hk vk ps ch - fs.pU • urs.u - fs.pW • urs.w
 
-/-- **The interface admits real proofs (completeness gate).** A blinded opening of the pinned
-commitment — `deployedCommitment = ⟨a, g⟩ + [pU]u + [pW]w` with `⟨a, b⟩` the pinned
-`multiopenValue` — yields a forked transcript: declare `(pU, pW)` and build the tree from the
-witness (`deployedIpaAcceptV_of_witness`). Honest proofs have exactly this shape (`pU = 0`,
-`pW` the aggregate blind), so assuming `FiatShamirTree` does not exclude them. -/
+/-- Build a forked transcript from a blinded opening of the deployed commitment. -/
 theorem ForkedTranscript.nonempty_of_opening [DecidableEq G] [Inhabited G] {shape : Shape}
     (urs : URS G) (hk : shape.k = urs.k) (vk : VerifyingKey shape Fp G)
     (ps : ProofString shape Fp G) (ch : Challenges shape.k Fp)
@@ -255,38 +189,17 @@ theorem ForkedTranscript.nonempty_of_opening [DecidableEq G] [Inhabited G] {shap
   rw [hcancel, hv]
   exact ht
 
-/-- **The forking bridge — the residual assumption.** Its premise is halo2's explicit verifier
-equation `DeployedIpaVerifierEq` (which `deployedAccepts_verifierEq` proves the deployed accept
-entails); it produces a `ForkedTranscript`. It bundles the Fiat–Shamir *forking* with the
-special-soundness *extraction* content the forked transcripts would pin by Vandermonde over the
-augmented `(g, U, W)` basis, here arriving as bridge-supplied tree data:
+/-- Legacy interface from the deployed verifier equation to a forked transcript.
 
-(a) the rewinding producing three accepting continuations per node at distinct nonzero challenges;
-(b) the node-level `L`/`R` ↦ value/blinding decomposition (`Lv`/`Rv`/`Lw`/`Rw` — each round
-    point's `(g, U, W)`-representation, which must not depend on `z`);
-(c) the leaf `g`-representation `aP` of the folded commitment (`DeployedIpaTreeV`'s leaf data);
-    and
-(d) the commitment's declared `U`/`W` components `pU`/`pW` (the section note above) and the
-    adjusted-commitment identity `P' = P − [v]g₀ + [ξ]S`: re-expressing the value term and the
-    `S`/`ξ` blinding poly against the declared opening needs a representation of the adversary
-    point `S` (ξ-side rewinding or AGM), so it is not a deterministic rewrite.
-
-This `FiatShamirTree` is the *legacy* bundled bridge; (a)–(c)'s content is now discharged on the live
-forking path (`Soundness.Forking.Rewind`'s `deployed_forking_relation` — a *computable* reduction returning
-the opening as data — assembled from `Forking.Extractor`/`Forking.Assembly`, and the Vesta
-`_forking_*`/`_rewind` capstones), leaving only (d)'s `S`/`ξ` representation and the random-oracle rewinding
-itself as the floor. The per-leaf `g`/`U`/`W` separation is *derived* — its failure computes a relation
-(`NontrivialRelation.ofDeployedTree`) — but `S`/`ξ` is not peeled, it lives in (d). `b`/`z`/`blind` are
-bridge-mediated (the protocol fixes `b = evalVector urs.k ch.x3`, telescoping at the leaf to
-`b₀ = computeB ch.x3 ·`, and `z = ch.z`); `v` is pinned, and `P` is pinned up to the declared `pU`/`pW`. -/
+It bundles random-oracle rewinding, round-point representations, leaf data, and declared commitment
+components. The live forking path proves the deterministic extraction pieces separately. -/
 def FiatShamirTree [DecidableEq G] [Inhabited G] {shape : Shape} (urs : URS G) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp G) (ps : ProofString shape Fp G) (ch : Challenges shape.k Fp)
     (b : Fin (2 ^ urs.k) → Fp) (z blind : Fp) : Type _ :=
   DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk ps ch →
     ForkedTranscript urs hk vk ps ch b z blind
 
-/-- The forked transcript of an accepting proof: the bridge applied to the *proven* verifier
-equation (`deployedAccepts_verifierEq`). -/
+/-- Apply the legacy fork bridge to a deployed accepting proof. -/
 def ForkedTranscript.ofAccepts [DecidableEq G] [Inhabited G] {shape : Shape} (urs : URS G)
     (hk : shape.k = urs.k) (vk : VerifyingKey shape Fp G) (ps : ProofString shape Fp G)
     (ch : Challenges shape.k Fp) {b : Fin (2 ^ urs.k) → Fp} {z blind : Fp}
@@ -295,13 +208,7 @@ def ForkedTranscript.ofAccepts [DecidableEq G] [Inhabited G] {shape : Shape} (ur
     ForkedTranscript urs hk vk ps ch b z blind :=
   hFS (deployedAccepts_verifierEq urs hk vk ps ch haccepts)
 
-/-- **The Fiat–Shamir forking hypothesis — the genuine residual (random-oracle floor).** On halo2's
-explicit verifier equation, rewinding the random oracle yields the 3-special-soundness forking *output*, as
-data: the declared `U`/`W` components `pU`/`pW` of the pinned commitment (the section note above) and a
-`DeployedIpaTreeV` whose every node records three accepting continuations at distinct nonzero per-round
-challenges and whose every leaf carries the flat closed-form verifier equation (`ForkAccept`), opening the
-declared commitment `deployedCommitment − [pU]u − [pW]w`. This is exactly the rewinding content that cannot be
-discharged in Lean; everything downstream of having it is a theorem (`fiatShamirTree_of_forking`). -/
+/-- Random-oracle forking output: declared commitment components and a ternary accepting tree. -/
 def FiatShamirForking [DecidableEq G] [Inhabited G] {shape : Shape} (urs : URS G) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp G) (ps : ProofString shape Fp G) (ch : Challenges shape.k Fp)
     (b : Fin (2 ^ urs.k) → Fp) (z blind : Fp) : Type _ :=
@@ -310,14 +217,7 @@ def FiatShamirForking [DecidableEq G] [Inhabited G] {shape : Shape} (urs : URS G
       ForkAccept urs.g b urs.u urs.w z
         (deployedCommitment urs hk vk ps ch - pU • urs.u - pW • urs.w) (multiopenValue vk ps ch) blind t
 
-/-- **The tree-assembly discharge.** The forking output (`FiatShamirForking`) *builds* the `FiatShamirTree`
-bridge: the forking supplies the declared components `pU`/`pW` and the distinct-challenge accepting
-transcripts, and the deterministic assembly `forkAccept_to_acceptV` (threading the per-round fold to the
-leaves, reconciling each flat closed-form equation to the reformulated leaf check) turns them into the
-`ForkedTranscript`'s `DeployedIpaAcceptV`. So the residual narrows from the handwave "an accepting verifier
-equation yields the whole 3-ary tree" to the genuine random-oracle floor "the rewinding yields the forked
-transcripts": the tree assembly itself — the node `L`/`R`↦value/blinding fold and the adjusted-commitment
-and leaf reconciliation — is a theorem, `sorry`/`axiom`-free. -/
+/-- Convert explicit forking output into the legacy `FiatShamirTree` interface. -/
 def fiatShamirTree_of_forking [DecidableEq G] [Inhabited G] {shape : Shape} (urs : URS G)
     (hk : shape.k = urs.k) (vk : VerifyingKey shape Fp G) (ps : ProofString shape Fp G)
     (ch : Challenges shape.k Fp) (b : Fin (2 ^ urs.k) → Fp) (z blind : Fp)
@@ -329,26 +229,13 @@ def fiatShamirTree_of_forking [DecidableEq G] [Inhabited G] {shape : Shape} (urs
 
 /-! ## The constraint-side hypotheses are unsatisfiable at a prime-order curve
 
-`hcirc` below (and `hquot`/`hgood` in the constraint variant) quantify over *every* mathematical
-opening `a` of the pinned `(P, b, v)`. At a prime-order curve those openings form an affine
-subspace of dimension `≥ 2^k − 2` (two linear conditions on `2^k` coordinates), so any
-`circuitSat` that genuinely reads the witness fails on almost all of it: the hypotheses are
-unsatisfiable for the intended instantiation, not merely undischarged.
-`circuitSatViaGates_of_check` does not help — it derives `circuitSat` for *one* `a` from that
-`a`'s own point-check, never the quantified premise.
+The constraint variants quantify over every mathematical opening, not only the extracted witness.
+At a prime-order curve that premise is too strong for a circuit predicate that reads the witness.
+These theorems therefore do not yet establish deployed gate soundness; they must be restated over the
+extracted witness and multiopen decode.
+-/
 
-The implication: the `_of_forked` theorems below currently carry no gate-level content — they
-conclude `S` only for `circuitSat` instantiations that ignore the witness, so no soundness for
-the deployed circuit's constraints follows from them yet. Their opening side stands on its own;
-the constraint side is a scaffold until it is restated over the *extracted* witness via the
-multiopen decode (`batch_open_soundV`), which is still open. -/
-
-/-- **The deployed binding reduction, as a computed relation.** A forked transcript whose
-projection is *not* cleanly accepted computes a nontrivial discrete-log relation among the
-augmented generators — `NontrivialRelation.ofDeployedTree` at the declared opening
-`fs.openedCommitment` and the pinned `multiopenValue`. Why this forces the clean accept — the
-hypothesis of the `_of_forked` theorems below — is `The reduction form` in the module
-docstring. -/
+/-- Compute a nontrivial relation when a forked transcript does not project to a clean IPA tree. -/
 def NontrivialRelation.ofUnopenedFork [DecidableEq G] [Inhabited G] {shape : Shape}
     (urs : URS G) (hk : shape.k = urs.k) (vk : VerifyingKey shape Fp G) (ps : ProofString shape Fp G)
     (ch : Challenges shape.k Fp) {b : Fin (2 ^ urs.k) → Fp} {z blind : Fp} (hz : z ≠ 0)
@@ -380,13 +267,9 @@ theorem orchard_verifier_deployed_opening_of_forked [DecidableEq G] [Inhabited G
 
 /-! ## `circuitSat` is derived from the verifier's gate check + Schwartz–Zippel
 
-The constraint side mirrors the opening side. The verifier checks the gate identity only at the
-challenge `x` — a point check (`quotientCheck`: `numerator.eval x = h.eval x · (xⁿ−1)`).
-`circuitSatViaGates_of_check` lifts that point check to the polynomial identity
-`circuitSatViaGates` (the witness's decoded columns satisfy the gates) provided `x` avoids the
-Schwartz–Zippel *bad set* — the roots of the difference polynomial when it is nonzero, which is
-what `hgood` excludes. So `circuitSat`, instantiated to the concrete `circuitSatViaGates`, is
-derived from the verifier's actual gate check rather than taken as an opaque hypothesis. -/
+`circuitSatViaGates_of_check` lifts the verifier's point check to a polynomial identity when the
+challenge avoids the Schwartz–Zippel bad set.
+-/
 
 open Polynomial in
 /-- **Deployed opening and constraint, given a clean fork.** As

--- a/Zcash/Snark/Soundness/Main.lean
+++ b/Zcash/Snark/Soundness/Main.lean
@@ -5,6 +5,7 @@ import Zcash.Snark.Soundness.Consistency
 import Zcash.Snark.Soundness.IpaSoundness
 import Zcash.Snark.Soundness.Deployed.IpaPeel
 import Zcash.Snark.Soundness.Deployed.Verification
+import Zcash.Snark.Soundness.Forking.Assembly
 
 /-!
 # Soundness composition: conditional, and the deployed accept condition
@@ -29,10 +30,12 @@ commitment is opened up to its declared blinding — see
    equation `DeployedIpaVerifierEq`. Fidelity of that closed form to the Rust is the
    transcription layer (`assembleFinalMsm`/`ipaFold`, checked by the fingerprint), not re-proved
    here.
-2. `FiatShamirTree` (*residual*) — the equation yields a forked transcript
+2. `FiatShamirTree` (*legacy residual*) — the equation yields a forked transcript
    (`ForkedTranscript`, as data): the deployed tree opening the pinned `P`/`v`; bundles the
    Fiat–Shamir forking with the extraction content it supplies (inventory in its docstring).
-   `ForkedTranscript.ofAccepts` composes steps 1–2.
+   `ForkedTranscript.ofAccepts` composes steps 1–2. Its (a)–(c) content is discharged on the live
+   forking path (`Soundness.Forking.Rewind`, `deployed_forking_relation` — a computable reduction —
+   and the Vesta `_forking_*` capstones), leaving the random-oracle rewinding as the floor.
 3. The fork *either* peels cleanly onto `IpaAcceptV` — then `ipa_soundV` extracts the opening
    witness and `orchard_verifier_deployed_opening_of_forked`/`_constraint_of_forked` conclude
    `S` — *or* `NontrivialRelation.ofUnopenedFork` (*proven*, via
@@ -170,6 +173,18 @@ theorem ipaRelation_of_acceptV (urs : URS G) (b : Fin (2 ^ urs.k) → Fp) (P : G
   have hib : innerProduct a b = commitGen b a := by simp only [innerProduct, commitGen, smul_eq_mul]
   rw [hib]; exact hv
 
+/-- The `Σ'`-**data** companion of `ipaRelation_of_acceptV`: the *computed* opening witness (from
+`ipa_extractV`). The deployed reduction opens through this rather than the `∃`-shaped version, so the
+opening is carried as data — at prime order `∃ a, IpaRelation …` is vacuously satisfiable (any point has
+a `g`-preimage), while the *computed* witness cannot be produced without the accepting transcript. -/
+def ipaRelation_extract (urs : URS G) (b : Fin (2 ^ urs.k) → Fp) (P : G) (v : Fp)
+    (t : IpaTreeV Fp G urs.k) (h : IpaAcceptV urs.g b P v t) :
+    Σ' a, IpaRelation urs P b v a :=
+  let s := ipa_extractV urs.g b P v t h
+  ⟨s.1, s.2.1, by
+    have hib : innerProduct s.1 b = commitGen b s.1 := by simp only [innerProduct, commitGen, smul_eq_mul]
+    rw [hib]; exact s.2.2⟩
+
 /-- The deployed commitment the IPA verifier opens (`multiopenCommitment` with `urs`'s generators
 transported to the proof's `shape.k`): the pinned `P`, read off `(vk, ps, ch)`. Reducible, so it
 is defeq to its body for matching against `DeployedIpaVerifierEq`'s leading term. -/
@@ -256,11 +271,14 @@ augmented `(g, U, W)` basis, here arriving as bridge-supplied tree data:
     `S`/`ξ` blinding poly against the declared opening needs a representation of the adversary
     point `S` (ξ-side rewinding or AGM), so it is not a deterministic rewrite.
 
-Deriving (a)–(d) under random-oracle Fiat–Shamir is open. The per-leaf `g`/`U`/`W` separation is
-*derived* — its failure computes a relation (`NontrivialRelation.ofDeployedTree`) — but `S`/`ξ`
-is not peeled, it lives in (d). `b`/`z`/`blind` are bridge-mediated (the protocol fixes
-`b = evalVector urs.k ch.x3`, telescoping at the leaf to `b₀ = computeB ch.x3 ·`, and
-`z = ch.z`); `v` is pinned, and `P` is pinned up to the declared `pU`/`pW`. -/
+This `FiatShamirTree` is the *legacy* bundled bridge; (a)–(c)'s content is now discharged on the live
+forking path (`Soundness.Forking.Rewind`'s `deployed_forking_relation` — a *computable* reduction returning
+the opening as data — assembled from `Forking.Extractor`/`Forking.Assembly`, and the Vesta
+`_forking_*`/`_rewind` capstones), leaving only (d)'s `S`/`ξ` representation and the random-oracle rewinding
+itself as the floor. The per-leaf `g`/`U`/`W` separation is *derived* — its failure computes a relation
+(`NontrivialRelation.ofDeployedTree`) — but `S`/`ξ` is not peeled, it lives in (d). `b`/`z`/`blind` are
+bridge-mediated (the protocol fixes `b = evalVector urs.k ch.x3`, telescoping at the leaf to
+`b₀ = computeB ch.x3 ·`, and `z = ch.z`); `v` is pinned, and `P` is pinned up to the declared `pU`/`pW`. -/
 def FiatShamirTree [DecidableEq G] [Inhabited G] {shape : Shape} (urs : URS G) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp G) (ps : ProofString shape Fp G) (ch : Challenges shape.k Fp)
     (b : Fin (2 ^ urs.k) → Fp) (z blind : Fp) : Type _ :=
@@ -276,6 +294,38 @@ def ForkedTranscript.ofAccepts [DecidableEq G] [Inhabited G] {shape : Shape} (ur
     (hFS : FiatShamirTree urs hk vk ps ch b z blind) :
     ForkedTranscript urs hk vk ps ch b z blind :=
   hFS (deployedAccepts_verifierEq urs hk vk ps ch haccepts)
+
+/-- The Fiat–Shamir **forking** hypothesis — the genuine residual (the random-oracle floor). On halo2's
+explicit verifier equation, rewinding the random oracle yields the 3-special-soundness forking *output*, as
+data: the declared `U`/`W` components `pU`/`pW` of the pinned commitment (the section note above) and a
+`DeployedIpaTreeV` whose every node records three accepting continuations at distinct nonzero per-round
+challenges and whose every leaf carries the flat closed-form verifier equation (`ForkAccept`), opening the
+declared commitment `deployedCommitment − [pU]u − [pW]w`. This is exactly the rewinding content that cannot be
+discharged in Lean; everything downstream of having it is a theorem (`fiatShamirTree_of_forking`). -/
+def FiatShamirForking [DecidableEq G] [Inhabited G] {shape : Shape} (urs : URS G) (hk : shape.k = urs.k)
+    (vk : VerifyingKey shape Fp G) (ps : ProofString shape Fp G) (ch : Challenges shape.k Fp)
+    (b : Fin (2 ^ urs.k) → Fp) (z blind : Fp) : Type _ :=
+  DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk ps ch →
+    Σ' (pU pW : Fp) (t : DeployedIpaTreeV Fp G urs.k),
+      ForkAccept urs.g b urs.u urs.w z
+        (deployedCommitment urs hk vk ps ch - pU • urs.u - pW • urs.w) (multiopenValue vk ps ch) blind t
+
+/-- **The tree-assembly discharge.** The forking output (`FiatShamirForking`) *builds* the `FiatShamirTree`
+bridge: the forking supplies the declared components `pU`/`pW` and the distinct-challenge accepting
+transcripts, and the deterministic assembly `forkAccept_to_acceptV` (threading the per-round fold to the
+leaves, reconciling each flat closed-form equation to the reformulated leaf check) turns them into the
+`ForkedTranscript`'s `DeployedIpaAcceptV`. So the residual narrows from the handwave "an accepting verifier
+equation yields the whole 3-ary tree" to the genuine random-oracle floor "the rewinding yields the forked
+transcripts": the tree assembly itself — the node `L`/`R`↦value/blinding fold and the adjusted-commitment
+and leaf reconciliation — is a theorem, `sorry`/`axiom`-free. -/
+def fiatShamirTree_of_forking [DecidableEq G] [Inhabited G] {shape : Shape} (urs : URS G)
+    (hk : shape.k = urs.k) (vk : VerifyingKey shape Fp G) (ps : ProofString shape Fp G)
+    (ch : Challenges shape.k Fp) (b : Fin (2 ^ urs.k) → Fp) (z blind : Fp)
+    (hForking : FiatShamirForking urs hk vk ps ch b z blind) :
+    FiatShamirTree urs hk vk ps ch b z blind := by
+  intro hEq
+  obtain ⟨pU, pW, t, hFork⟩ := hForking hEq
+  exact ⟨t, pU, pW, forkAccept_to_acceptV _ _ _ _ _ t hFork⟩
 
 /-! ## The constraint-side hypotheses are unsatisfiable at a prime-order curve
 

--- a/Zcash/Snark/Soundness/Vesta.lean
+++ b/Zcash/Snark/Soundness/Vesta.lean
@@ -155,12 +155,10 @@ theorem commit_adjustedWitness {G : Type*} [AddCommGroup G] [Module Fp G] (urs :
     intro a a'; simp only [commit, Pi.sub_apply, sub_smul, Finset.sum_sub_distrib]
   rw [adjustedWitness, commit_add, csub, commit_single, commit_smul]
 
-/-- **The deployed commitment lies in the `g`-span (discharging `hcommit`).** At Vesta's prime order a nonzero
-generator `urs.g 0` generates the whole group: `c ↦ c • g 0` is injective over `Fp` (nonzero scalars are
-invertible), and `Fp` and `VestaG` are equinumerous (`scalarFieldOrder`), so it is surjective — every group
-element, `deployedCommitment` included, is the `g`-commitment of some witness. So `hcommit` is always
-satisfiable: the witness is the discrete log of `P` base `g 0`, existing but not feasibly constructible —
-the same DLR-side status as the `⊕' NontrivialRelation` disjunct. -/
+/-- **Every Vesta point propositionally lies in the `g`-span.** At Vesta's prime order a nonzero generator
+`urs.g 0` generates the whole group. This theorem is proof-level only: selecting its existential witness
+would compute a discrete logarithm, so computational reductions must receive the representation as input and
+must not use `Classical.choose` on this result. -/
 theorem commit_surjective (urs : URS VestaG) (hg0 : urs.g 0 ≠ 0)
     (P : VestaG) : ∃ aMulti : Fin (2 ^ urs.k) → Fp, commit urs aMulti = P := by
   have hinj : Function.Injective (fun c : Fp => c • urs.g 0) := by
@@ -195,23 +193,27 @@ theorem blinder_value_recovery_badSet {k : ℕ} (s : Fin (2 ^ k) → Fp) (xEval 
 open scoped ENNReal in
 open Classical in
 /-- **The deployed Orchard opening over Vesta, via the forking refinements (no `FiatShamirTree`), with the
-structural facts discharged.** The multiopen
-evaluation vector is the concrete powers vector `b = evalVector urs.k xEval` (so `b 0 = 1` is *proved* by
-`evalVector_zero`, not assumed); the multiopen witness `aMulti` is *recovered* from the `g`-span
-(`commit_surjective`, from the nonzero generator `hg0`), so the `g`-span tie `hcommit` is **discharged** rather
-than assumed; and the adjusted witness is *constructed*, so halo2's adjusted-commitment relation `hP` holds by
-linearity (`commit_adjustedWitness`). The synthetic blinder is stripped *unconditionally*: the conclusion is
+structural facts discharged.** The multiopen evaluation vector is the concrete powers vector
+`b = evalVector urs.k xEval` (so `b 0 = 1` is *proved* by `evalVector_zero`, not assumed). The multiopen
+witness `aMulti` and its commitment equation `hcommit` are supplied as **data** by the algebraic-prover layer;
+they are deliberately not selected from prime-order surjectivity. The adjusted witness is constructed, so
+halo2's adjusted-commitment relation `hP` holds by linearity (`commit_adjustedWitness`). The synthetic blinder
+is stripped *unconditionally*: the conclusion is
 the **true** opened value `multiopenValue − ξ·⟨s,b⟩`, with no `⟨s,b⟩ = 0` assumed — covering a malicious blinder
 (the honest case `⟨s,b⟩ = 0` recovers the claimed value). What remains is the explicit prover-as-oracle bridge
-`hbridge` (the irreducible random-oracle floor), plus the antecedents `z ≠ 0`, the nonzero generator `hg0`, and
-the accept probability `hprob` beating the knowledge error `kerr/Nᵏ`. The `⊕' NontrivialRelation` caveat is
+`hbridge` (the irreducible random-oracle floor), plus the antecedents `z ≠ 0`, the explicit representation
+`aMulti`/`hcommit`, and the accept probability `hprob` beating the knowledge error `kerr/Nᵏ`. This wrapper is
+still proof-level and noncomputable because `deployed_forking_soundness_of_bridge` selects the existential
+fork certificate; the executable kernel is `deployed_forking_relation`, which takes that certificate as data.
+The `⊕' NontrivialRelation` caveat is
 unchanged — vacuous at Vesta's prime order, the force in the out-of-Lean DLR/AGM layer. -/
 noncomputable def orchard_verifier_vesta_forking_opening [DecidableEq VestaG]
     [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
-    (xEval ξ z blind : Fp) (s : Fin (2 ^ urs.k) → Fp)
+    (xEval ξ z blind : Fp) (s aMulti : Fin (2 ^ urs.k) → Fp)
     (Q : Prover Fp VestaG urs.k) (accepts : (Fin urs.k → Fp) → Prop)
-    (hz : z ≠ 0) (hg0 : urs.g 0 ≠ 0)
+    (hz : z ≠ 0)
+    (hcommit : commit urs aMulti = deployedCommitment urs hk vk ps ch)
     (hbridge : ∀ χ, accepts χ ↔ flatAccept Q urs.g (evalVector urs.k xEval) urs.u urs.w z
         (deployedCommitment urs hk vk ps ch - multiopenValue vk ps ch • urs.g 0 + ξ • commit urs s
           + (z * 0) • urs.u + blind • urs.w) χ)
@@ -220,11 +222,6 @@ noncomputable def orchard_verifier_vesta_forking_opening [DecidableEq VestaG]
     (∃ a, IpaRelation urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k xEval)
         (multiopenValue vk ps ch - ξ * innerProduct s (evalVector urs.k xEval)) a)
       ⊕' NontrivialRelation (F := Fp) urs.g urs.u urs.w := by
-  -- `aMulti` is the (prime-order) `g`-preimage of the deployed commitment, named as data by
-  -- `Classical.choose` — the source of this `def`'s `noncomputable`.
-  have hcs := commit_surjective urs hg0 (deployedCommitment urs hk vk ps ch)
-  set aMulti := hcs.choose with haMulti
-  have hcommit : commit urs aMulti = deployedCommitment urs hk vk ps ch := hcs.choose_spec
   have hbr : ∀ χ, accepts χ ↔ flatAccept Q urs.g (evalVector urs.k xEval) urs.u urs.w z
       (commit urs (adjustedWitness aMulti s (multiopenValue vk ps ch) ξ)
         + (z * 0) • urs.u + blind • urs.w) χ := by
@@ -242,17 +239,17 @@ open scoped ENNReal in
 open Classical in
 /-- **The deployed Orchard opening *and constraint* over Vesta, via the forking refinements (no
 `FiatShamirTree`), with the structural facts discharged.** The constraint-side companion of
-`orchard_verifier_vesta_forking_opening`: the same discharged structural facts (`b 0 = 1`, `hcommit`, `hP` —
-see there) and the same gate seam as `orchard_verifier_vesta_constraint_of_forked`
+`orchard_verifier_vesta_forking_opening`: the same derived structural facts (`b 0 = 1`, `hP`), the explicit
+representation input `aMulti`/`hcommit`, and the same gate seam as `orchard_verifier_vesta_constraint_of_forked`
 (`hquot`/`hgood` → `circuitSatViaGates`, `hencodes`). Unlike the opening, the circuit is checked at the
 *claimed* value `multiopenValue`, so the minimal value-recovery hypothesis `hξ : ξ·⟨s,b⟩ = 0` is retained — it
 pins the opened value `multiopenValue − ξ·⟨s,b⟩` (unique under binding) from the forking opening back to
 `multiopenValue`. `hξ`
 generalises honest blinding (`⟨s,b⟩ = 0`); for a *malicious* blinder (`⟨s,b⟩ ≠ 0`) it holds only on a
 `1/p`-measure set of post-`S` challenges `ξ` (`blinder_value_recovery_badSet`, the `ξ`-randomization budget).
-The deployed-curve residual is the explicit prover-as-oracle bridge `hbridge` (and the nonzero generator
-`hg0`); both the opening and the constraint side now route through it with `b 0 = 1`, `hcommit`, and `hP`
-discharged. The original `FiatShamirTree` reductions
+The deployed-curve residual is the explicit prover-as-oracle bridge `hbridge`; both the opening and the
+constraint side route through it with `b 0 = 1` and `hP` derived and `aMulti`/`hcommit` supplied as data. The
+original `FiatShamirTree` reductions
 (`orchard_verifier_vesta_opening_of_forked`/`_constraint`) remain as the coarser legacy endpoints. The
 `⊕' NontrivialRelation` caveat is unchanged — vacuous at Vesta's prime order, the force in the out-of-Lean
 DLR/AGM layer. `hquot`/`hgood` retain the ∀-openings shape — unsatisfiable at Vesta for any decode that
@@ -260,12 +257,13 @@ genuinely reads the witness (see `orchard_verifier_deployed_constraint_of_forked
 noncomputable def orchard_verifier_vesta_forking_constraint [DecidableEq VestaG]
     [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
-    (xEval ξ z blind : Fp) (s : Fin (2 ^ urs.k) → Fp)
+    (xEval ξ z blind : Fp) (s aMulti : Fin (2 ^ urs.k) → Fp)
     (Q : Prover Fp VestaG urs.k) (accepts : (Fin urs.k → Fp) → Prop)
     (fixedCols : ℕ → Polynomial Fp)
     (decodeAdvice decodeInstance : (Fin (2 ^ urs.k) → Fp) → (ℕ → Polynomial Fp))
     (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
-    (hz : z ≠ 0) (hg0 : urs.g 0 ≠ 0)
+    (hz : z ≠ 0)
+    (hcommit : commit urs aMulti = deployedCommitment urs hk vk ps ch)
     (hξ : ξ * innerProduct s (evalVector urs.k xEval) = 0)
     (hbridge : ∀ χ, accepts χ ↔ flatAccept Q urs.g (evalVector urs.k xEval) urs.u urs.w z
         (deployedCommitment urs hk vk ps ch - multiopenValue vk ps ch • urs.g 0 + ξ • commit urs s
@@ -285,8 +283,8 @@ noncomputable def orchard_verifier_vesta_forking_constraint [DecidableEq VestaG]
     (hprob : (kerr (Fintype.card Fp) urs.k : ℝ≥0∞) / Fintype.card (Fin urs.k → Fp)
         < (PMF.uniformOfFintype (Fin urs.k → Fp)).toOuterMeasure (Finset.univ.filter accepts)) :
     S ⊕' NontrivialRelation (F := Fp) urs.g urs.u urs.w := by
-  rcases orchard_verifier_vesta_forking_opening urs hk vk ps ch xEval ξ z blind s Q accepts
-      hz hg0 hbridge hprob with hopen | hrel
+  rcases orchard_verifier_vesta_forking_opening urs hk vk ps ch xEval ξ z blind s aMulti Q accepts
+      hz hcommit hbridge hprob with hopen | hrel
   · refine PSum.inl ?_
     obtain ⟨a, hrel'⟩ := hopen
     rw [hξ, sub_zero] at hrel'
@@ -320,10 +318,8 @@ halo2's **actual** verifier equation `DeployedIpaVerifierEq` at the rewound IPA 
 `flatAccept` of the concrete proof tree `proverOfRounds ps.ipaRounds ps.ipaC ps.ipaF` is **proven** internally
 by `deployedVerifierEq_iff_flatAccept` — not assumed. The `shape.k`↔`urs.k` transport is discharged by
 `subst`, and the commitment slot is reconciled (`sum_getD_single`, `deployedCommitment = multiopenCommitment`,
-the `S`-opening `hs : commit urs s = ps.ipaS`, `module`). The remaining hypotheses are `z ≠ 0`, the nonzero
-generator `hg0` (prime-order `g`-span), and the `S`-opening witness `hs` (such an opening always *exists* at
-prime order but is not feasibly constructible for a malicious prover — the same exists-but-not-findable tier
-as `commit_surjective` and the `⊕' NontrivialRelation` disjunct), plus the accept *probability* `hprob`
+the `S`-opening `hs : commit urs s = ps.ipaS`, `module`). The remaining hypotheses are `z ≠ 0`, the explicit
+multiopen representation `aMulti`/`hcommit`, and the `S`-opening witness `hs`, plus the accept *probability* `hprob`
 over the uniform IPA-challenge measure.
 
 **Quantifier-shape caveat (`hprob`).** Discharging the bridge with the *constant* strategy `proverOfRounds`
@@ -343,7 +339,9 @@ RO-query loss. The `⊕' NontrivialRelation` caveat is unchanged — vacuous at 
 noncomputable def orchard_verifier_vesta_forking_opening_deployed [DecidableEq VestaG]
     [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
-    (s : Fin (2 ^ urs.k) → Fp) (hz : ch.z ≠ 0) (hg0 : urs.g 0 ≠ 0) (hs : commit urs s = ps.ipaS)
+    (s aMulti : Fin (2 ^ urs.k) → Fp) (hz : ch.z ≠ 0)
+    (hcommit : commit urs aMulti = deployedCommitment urs hk vk ps ch)
+    (hs : commit urs s = ps.ipaS)
     (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
         < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
             (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk ps
@@ -355,8 +353,9 @@ noncomputable def orchard_verifier_vesta_forking_opening_deployed [DecidableEq V
   change shape.k = k at hk
   subst hk
   refine orchard_verifier_vesta_forking_opening ⟨shape.k, gg, ww, uu⟩ rfl vk ps ch ch.x3 ch.xi ch.z 0 s
+    aMulti
     (proverOfRounds ps.ipaRounds ps.ipaC ps.ipaF)
-    (fun χ => DeployedIpaVerifierEq gg ww uu vk ps {ch with ipaRound := χ}) hz hg0 ?_ hprob
+    (fun χ => DeployedIpaVerifierEq gg ww uu vk ps {ch with ipaRound := χ}) hz hcommit ?_ hprob
   intro χ
   dsimp only
   rw [deployedVerifierEq_iff_flatAccept]
@@ -386,8 +385,8 @@ accept, no abstract `hbridge`), routed through the opening to the gate-satisfact
 (`hquot`/`hgood` → `circuitSatViaGates`, `hencodes`) at the *claimed* value `multiopenValue` — pinned from the
 forking opening's `multiopenValue − ξ·⟨s,b⟩` by the minimal value-recovery hypothesis
 `hξ : ch.xi·⟨s,b⟩ = 0` (honest blinding, or a `1/p`-measure set of post-`S` challenges for a malicious blinder,
-`blinder_value_recovery_badSet`). Residual assumptions: `z ≠ 0`, the nonzero generator `hg0`, the `S`-opening
-witness `hs`, and `hξ` — plus the accept probability `hprob`, which carries the same quantifier-shape caveat
+`blinder_value_recovery_badSet`). Residual assumptions: `z ≠ 0`, the explicit multiopen representation,
+the `S`-opening witness `hs`, and `hξ` — plus the accept probability `hprob`, which carries the same quantifier-shape caveat
 as `orchard_verifier_vesta_forking_opening_deployed`: with the constant `proverOfRounds` strategy it measures
 the *fixed* proof's accept set over all round-challenge vectors, not the Fiat–Shamir attack event. For the
 adaptive form, use `orchard_verifier_vesta_forking_constraint_adaptive`; for the same statement over
@@ -397,11 +396,13 @@ reads the witness (see `orchard_verifier_deployed_constraint_of_forked`'s caveat
 noncomputable def orchard_verifier_vesta_forking_constraint_deployed [DecidableEq VestaG]
     [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
-    (s : Fin (2 ^ urs.k) → Fp)
+    (s aMulti : Fin (2 ^ urs.k) → Fp)
     (fixedCols : ℕ → Polynomial Fp)
     (decodeAdvice decodeInstance : (Fin (2 ^ urs.k) → Fp) → (ℕ → Polynomial Fp))
     (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
-    (hz : ch.z ≠ 0) (hg0 : urs.g 0 ≠ 0) (hs : commit urs s = ps.ipaS)
+    (hz : ch.z ≠ 0)
+    (hcommit : commit urs aMulti = deployedCommitment urs hk vk ps ch)
+    (hs : commit urs s = ps.ipaS)
     (hξ : ch.xi * innerProduct s (evalVector urs.k ch.x3) = 0)
     (hquot : ∀ a, IpaRelation urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k ch.x3)
         (multiopenValue vk ps ch) a →
@@ -420,7 +421,8 @@ noncomputable def orchard_verifier_vesta_forking_constraint_deployed [DecidableE
             (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk ps
               {ch with ipaRound := χ}))) :
     S ⊕' NontrivialRelation (F := Fp) urs.g urs.u urs.w := by
-  rcases orchard_verifier_vesta_forking_opening_deployed urs hk vk ps ch s hz hg0 hs hprob with hopen | hrel
+  rcases orchard_verifier_vesta_forking_opening_deployed urs hk vk ps ch s aMulti hz hcommit hs hprob
+    with hopen | hrel
   · refine PSum.inl ?_
     obtain ⟨a, hrel'⟩ := hopen
     rw [hξ, sub_zero] at hrel'
@@ -442,8 +444,8 @@ accept probability of an adaptive round-strategy — the object rewinding produc
 accept measure: the static-dichotomy caveat of the `_deployed` capstone does not apply at this rung. What
 remains is the execution-semantics identification (that a rewound random-oracle adversary *induces* such a
 staged strategy, with its RO-query loss — deriving the accept probability of `hprob`), Blake2b-as-random-oracle,
-and the structural witnesses (`z ≠ 0`, `hg0`, the `S`-opening `hs` — with `ps.ipaS` splice-invariant, so one `s`
-serves every path). The uniform measure of `hprob` is justified standalone
+and the structural witnesses (`z ≠ 0`, the explicit `aMulti`/`hcommit`, and the `S`-opening `hs` — with
+`ps.ipaS` splice-invariant, so one `s` serves every path). The uniform measure of `hprob` is justified standalone
 (`Forking.Rewind.roChallenges_ipaRound_uniform`, for the fixed proof string; consumed by no capstone). The
 transcript-ordering and reprogramming content is already on this path through the
 `_adaptive_rewind` capstone. The `⊕' NontrivialRelation` caveat is unchanged — vacuous at Vesta's prime
@@ -451,8 +453,10 @@ order. -/
 noncomputable def orchard_verifier_vesta_forking_opening_adaptive [DecidableEq VestaG]
     [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
-    (s : Fin (2 ^ urs.k) → Fp) (P : Prover Fp VestaG shape.k)
-    (hz : ch.z ≠ 0) (hg0 : urs.g 0 ≠ 0) (hs : commit urs s = ps.ipaS)
+    (s aMulti : Fin (2 ^ urs.k) → Fp) (P : Prover Fp VestaG shape.k)
+    (hz : ch.z ≠ 0)
+    (hcommit : commit urs aMulti = deployedCommitment urs hk vk ps ch)
+    (hs : commit urs s = ps.ipaS)
     (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
         < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
             (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk
@@ -465,9 +469,9 @@ noncomputable def orchard_verifier_vesta_forking_opening_adaptive [DecidableEq V
   change shape.k = k at hk
   subst hk
   refine orchard_verifier_vesta_forking_opening ⟨shape.k, gg, ww, uu⟩ rfl vk ps ch ch.x3 ch.xi ch.z 0 s
-    P (fun χ => DeployedIpaVerifierEq gg ww uu vk
+    aMulti P (fun χ => DeployedIpaVerifierEq gg ww uu vk
       (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2) {ch with ipaRound := χ})
-    hz hg0 ?_ hprob
+    hz hcommit ?_ hprob
   intro χ
   dsimp only
   rw [deployedVerifierEq_iff_flatAccept_adaptive]
@@ -500,11 +504,13 @@ unsatisfiable at Vesta for any decode that genuinely reads the witness. -/
 noncomputable def orchard_verifier_vesta_forking_constraint_adaptive
     [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
-    (s : Fin (2 ^ urs.k) → Fp) (P : Prover Fp VestaG shape.k)
+    (s aMulti : Fin (2 ^ urs.k) → Fp) (P : Prover Fp VestaG shape.k)
     (fixedCols : ℕ → Polynomial Fp)
     (decodeAdvice decodeInstance : (Fin (2 ^ urs.k) → Fp) → (ℕ → Polynomial Fp))
     (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
-    (hz : ch.z ≠ 0) (hg0 : urs.g 0 ≠ 0) (hs : commit urs s = ps.ipaS)
+    (hz : ch.z ≠ 0)
+    (hcommit : commit urs aMulti = deployedCommitment urs hk vk ps ch)
+    (hs : commit urs s = ps.ipaS)
     (hξ : ch.xi * innerProduct s (evalVector urs.k ch.x3) = 0)
     (hquot : ∀ a, IpaRelation urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k ch.x3)
         (multiopenValue vk ps ch) a →
@@ -524,7 +530,7 @@ noncomputable def orchard_verifier_vesta_forking_constraint_adaptive
               (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2)
               {ch with ipaRound := χ}))) :
     S ⊕' NontrivialRelation (F := Fp) urs.g urs.u urs.w := by
-  rcases orchard_verifier_vesta_forking_opening_adaptive urs hk vk ps ch s P hz hg0 hs hprob
+  rcases orchard_verifier_vesta_forking_opening_adaptive urs hk vk ps ch s aMulti P hz hcommit hs hprob
     with hopen | hrel
   · refine PSum.inl ?_
     obtain ⟨a, hrel'⟩ := hopen
@@ -563,7 +569,11 @@ The terminal readings, ordered by how much of the prover-as-oracle and rewinding
   execution-semantics content stays the floor.
 
 The legacy `orchard_verifier_vesta_opening_of_forked`/`_constraint` remain compiled and checked but are no
-longer the top statement a reader takes. -/
+longer the top statement a reader takes.
+
+These probability wrappers are proof-level existence statements. They remain `noncomputable` because the
+fork certificate is obtained behind `∃`; executable reductions must instead call `deployed_forking_relation`
+with an explicit `DForkCert`, `aMulti`, and `hcommit`. -/
 
 open scoped ENNReal in
 open Classical in
@@ -581,7 +591,8 @@ noncomputable def orchard_verifier_vesta_forking_opening_rewind [DecidableEq Ves
     [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG)
     (O : List (TranscriptElt Fp VestaG) → Fp) (init : List (TranscriptElt Fp VestaG))
-    (s : Fin (2 ^ urs.k) → Fp) (hz : (roChallenges O init ps).z ≠ 0) (hg0 : urs.g 0 ≠ 0)
+    (s aMulti : Fin (2 ^ urs.k) → Fp) (hz : (roChallenges O init ps).z ≠ 0)
+    (hcommit : commit urs aMulti = deployedCommitment urs hk vk ps (roChallenges O init ps))
     (hs : commit urs s = ps.ipaS)
     (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
         < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
@@ -593,7 +604,7 @@ noncomputable def orchard_verifier_vesta_forking_opening_rewind [DecidableEq Ves
           - (roChallenges O init ps).xi * innerProduct s (evalVector urs.k (roChallenges O init ps).x3)) a)
       ⊕' NontrivialRelation (F := Fp) urs.g urs.u urs.w := by
   refine orchard_verifier_vesta_forking_opening_deployed urs hk vk ps (roChallenges O init ps)
-    s hz hg0 hs ?_
+    s aMulti hz hcommit hs ?_
   simpa only [roChallenges_reprogramRounds] using hprob
 
 open Polynomial in
@@ -609,11 +620,13 @@ noncomputable def orchard_verifier_vesta_forking_constraint_rewind
     [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG)
     (O : List (TranscriptElt Fp VestaG) → Fp) (init : List (TranscriptElt Fp VestaG))
-    (s : Fin (2 ^ urs.k) → Fp)
+    (s aMulti : Fin (2 ^ urs.k) → Fp)
     (fixedCols : ℕ → Polynomial Fp)
     (decodeAdvice decodeInstance : (Fin (2 ^ urs.k) → Fp) → (ℕ → Polynomial Fp))
     (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
-    (hz : (roChallenges O init ps).z ≠ 0) (hg0 : urs.g 0 ≠ 0) (hs : commit urs s = ps.ipaS)
+    (hz : (roChallenges O init ps).z ≠ 0)
+    (hcommit : commit urs aMulti = deployedCommitment urs hk vk ps (roChallenges O init ps))
+    (hs : commit urs s = ps.ipaS)
     (hξ : (roChallenges O init ps).xi
         * innerProduct s (evalVector urs.k (roChallenges O init ps).x3) = 0)
     (hquot : ∀ a, IpaRelation urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
@@ -636,7 +649,8 @@ noncomputable def orchard_verifier_vesta_forking_constraint_rewind
               (roChallenges (reprogramRounds O init ps χ) init ps)))) :
     S ⊕' NontrivialRelation (F := Fp) urs.g urs.u urs.w := by
   refine orchard_verifier_vesta_forking_constraint_deployed urs hk vk ps (roChallenges O init ps)
-    s fixedCols decodeAdvice decodeInstance y gates hpoly deg x hz hg0 hs hξ hquot hgood hencodes ?_
+    s aMulti fixedCols decodeAdvice decodeInstance y gates hpoly deg x hz hcommit hs hξ hquot hgood
+    hencodes ?_
   simpa only [roChallenges_reprogramRounds] using hprob
 
 open scoped ENNReal in
@@ -653,8 +667,10 @@ noncomputable def orchard_verifier_vesta_forking_opening_adaptive_rewind
     [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG)
     (O : List (TranscriptElt Fp VestaG) → Fp) (init : List (TranscriptElt Fp VestaG))
-    (s : Fin (2 ^ urs.k) → Fp) (P : Prover Fp VestaG shape.k)
-    (hz : (roChallenges O init ps).z ≠ 0) (hg0 : urs.g 0 ≠ 0) (hs : commit urs s = ps.ipaS)
+    (s aMulti : Fin (2 ^ urs.k) → Fp) (P : Prover Fp VestaG shape.k)
+    (hz : (roChallenges O init ps).z ≠ 0)
+    (hcommit : commit urs aMulti = deployedCommitment urs hk vk ps (roChallenges O init ps))
+    (hs : commit urs s = ps.ipaS)
     (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
         < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
             (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk
@@ -670,7 +686,7 @@ noncomputable def orchard_verifier_vesta_forking_opening_adaptive_rewind
           - (roChallenges O init ps).xi * innerProduct s (evalVector urs.k (roChallenges O init ps).x3)) a)
       ⊕' NontrivialRelation (F := Fp) urs.g urs.u urs.w := by
   refine orchard_verifier_vesta_forking_opening_adaptive urs hk vk ps (roChallenges O init ps)
-    s P hz hg0 hs ?_
+    s aMulti P hz hcommit hs ?_
   simpa only [roChallenges_reprogramRounds, roChallenges_spliceIpa_pre] using hprob
 
 open Polynomial in
@@ -683,11 +699,13 @@ noncomputable def orchard_verifier_vesta_forking_constraint_adaptive_rewind
     [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG)
     (O : List (TranscriptElt Fp VestaG) → Fp) (init : List (TranscriptElt Fp VestaG))
-    (s : Fin (2 ^ urs.k) → Fp) (P : Prover Fp VestaG shape.k)
+    (s aMulti : Fin (2 ^ urs.k) → Fp) (P : Prover Fp VestaG shape.k)
     (fixedCols : ℕ → Polynomial Fp)
     (decodeAdvice decodeInstance : (Fin (2 ^ urs.k) → Fp) → (ℕ → Polynomial Fp))
     (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
-    (hz : (roChallenges O init ps).z ≠ 0) (hg0 : urs.g 0 ≠ 0) (hs : commit urs s = ps.ipaS)
+    (hz : (roChallenges O init ps).z ≠ 0)
+    (hcommit : commit urs aMulti = deployedCommitment urs hk vk ps (roChallenges O init ps))
+    (hs : commit urs s = ps.ipaS)
     (hξ : (roChallenges O init ps).xi
         * innerProduct s (evalVector urs.k (roChallenges O init ps).x3) = 0)
     (hquot : ∀ a, IpaRelation urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
@@ -714,8 +732,8 @@ noncomputable def orchard_verifier_vesta_forking_constraint_adaptive_rewind
                 init
                 (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2))))) :
     S ⊕' NontrivialRelation (F := Fp) urs.g urs.u urs.w := by
-  rcases orchard_verifier_vesta_forking_opening_adaptive_rewind urs hk vk ps O init s P hz hg0 hs hprob
-    with hopen | hrel
+  rcases orchard_verifier_vesta_forking_opening_adaptive_rewind urs hk vk ps O init s aMulti P hz
+    hcommit hs hprob with hopen | hrel
   · refine PSum.inl ?_
     obtain ⟨a, hrel'⟩ := hopen
     rw [hξ, sub_zero] at hrel'

--- a/Zcash/Snark/Soundness/Vesta.lean
+++ b/Zcash/Snark/Soundness/Vesta.lean
@@ -161,7 +161,7 @@ invertible), and `Fp` and `VestaG` are equinumerous (`scalarFieldOrder`), so it 
 element, `deployedCommitment` included, is the `g`-commitment of some witness. So `hcommit` is always
 satisfiable: the witness is the discrete log of `P` base `g 0`, existing but not feasibly constructible —
 the same DLR-side status as the `⊕' NontrivialRelation` disjunct. -/
-theorem commit_surjective [Fact (HasseBound Vesta.curve)] (urs : URS VestaG) (hg0 : urs.g 0 ≠ 0)
+theorem commit_surjective (urs : URS VestaG) (hg0 : urs.g 0 ≠ 0)
     (P : VestaG) : ∃ aMulti : Fin (2 ^ urs.k) → Fp, commit urs aMulti = P := by
   have hinj : Function.Injective (fun c : Fp => c • urs.g 0) := by
     intro c c' h
@@ -174,7 +174,7 @@ theorem commit_surjective [Fact (HasseBound Vesta.curve)] (urs : URS VestaG) (hg
       rw [← one_smul Fp (urs.g 0), ← inv_mul_cancel₀ hd, mul_smul, h0, smul_zero]
   haveI : Fintype VestaG := Fintype.ofFinite VestaG
   have hcardeq : Fintype.card Fp = Fintype.card VestaG := by
-    rw [card_Fp, ← Nat.card_eq_fintype_card, Vesta.card_eq Fact.out]
+    rw [card_Fp, ← Nat.card_eq_fintype_card, Vesta.card_eq]
   obtain ⟨c, hc⟩ := ((Fintype.bijective_iff_injective_and_card _).mpr ⟨hinj, hcardeq⟩).surjective P
   exact ⟨Pi.single 0 c, by rw [commit_single]; exact hc⟩
 
@@ -206,7 +206,7 @@ the **true** opened value `multiopenValue − ξ·⟨s,b⟩`, with no `⟨s,b⟩
 `hbridge` (the irreducible random-oracle floor), plus the antecedents `z ≠ 0`, the nonzero generator `hg0`, and
 the accept probability `hprob` beating the knowledge error `kerr/Nᵏ`. The `⊕' NontrivialRelation` caveat is
 unchanged — vacuous at Vesta's prime order, the force in the out-of-Lean DLR/AGM layer. -/
-noncomputable def orchard_verifier_vesta_forking_opening [Fact (HasseBound Vesta.curve)] [DecidableEq VestaG]
+noncomputable def orchard_verifier_vesta_forking_opening [DecidableEq VestaG]
     [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
     (xEval ξ z blind : Fp) (s : Fin (2 ^ urs.k) → Fp)
@@ -257,7 +257,7 @@ discharged. The original `FiatShamirTree` reductions
 `⊕' NontrivialRelation` caveat is unchanged — vacuous at Vesta's prime order, the force in the out-of-Lean
 DLR/AGM layer. `hquot`/`hgood` retain the ∀-openings shape — unsatisfiable at Vesta for any decode that
 genuinely reads the witness (see `orchard_verifier_deployed_constraint_of_forked`'s caveat). -/
-noncomputable def orchard_verifier_vesta_forking_constraint [Fact (HasseBound Vesta.curve)] [DecidableEq VestaG]
+noncomputable def orchard_verifier_vesta_forking_constraint [DecidableEq VestaG]
     [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
     (xEval ξ z blind : Fp) (s : Fin (2 ^ urs.k) → Fp)
@@ -340,7 +340,7 @@ prefix-respecting strategy and `orchard_verifier_vesta_forking_opening_adaptive_
 should be stated over reprogrammed-oracle runs. The remaining floor there is not the deterministic bridge but
 the execution-semantics identification — a rewound random-oracle adversary induces such a strategy, with its
 RO-query loss. The `⊕' NontrivialRelation` caveat is unchanged — vacuous at Vesta's prime order. -/
-noncomputable def orchard_verifier_vesta_forking_opening_deployed [Fact (HasseBound Vesta.curve)] [DecidableEq VestaG]
+noncomputable def orchard_verifier_vesta_forking_opening_deployed [DecidableEq VestaG]
     [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
     (s : Fin (2 ^ urs.k) → Fp) (hz : ch.z ≠ 0) (hg0 : urs.g 0 ≠ 0) (hs : commit urs s = ps.ipaS)
@@ -394,7 +394,7 @@ adaptive form, use `orchard_verifier_vesta_forking_constraint_adaptive`; for the
 reprogrammed-oracle runs, use `orchard_verifier_vesta_forking_constraint_adaptive_rewind`. `hquot`/`hgood`
 retain the ∀-openings shape — unsatisfiable at Vesta for any decode that genuinely
 reads the witness (see `orchard_verifier_deployed_constraint_of_forked`'s caveat). -/
-noncomputable def orchard_verifier_vesta_forking_constraint_deployed [Fact (HasseBound Vesta.curve)] [DecidableEq VestaG]
+noncomputable def orchard_verifier_vesta_forking_constraint_deployed [DecidableEq VestaG]
     [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
     (s : Fin (2 ^ urs.k) → Fp)
@@ -448,7 +448,7 @@ serves every path). The uniform measure of `hprob` is justified standalone
 transcript-ordering and reprogramming content is already on this path through the
 `_adaptive_rewind` capstone. The `⊕' NontrivialRelation` caveat is unchanged — vacuous at Vesta's prime
 order. -/
-noncomputable def orchard_verifier_vesta_forking_opening_adaptive [Fact (HasseBound Vesta.curve)] [DecidableEq VestaG]
+noncomputable def orchard_verifier_vesta_forking_opening_adaptive [DecidableEq VestaG]
     [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
     (s : Fin (2 ^ urs.k) → Fp) (P : Prover Fp VestaG shape.k)
@@ -497,7 +497,7 @@ witnesses; the uniform measure of `hprob` is justified standalone
 static-dichotomy caveat does not apply at this rung. The transcript-ordering and reprogramming content is
 discharged by the staged rewinding capstones below. `hquot`/`hgood` retain the ∀-openings shape —
 unsatisfiable at Vesta for any decode that genuinely reads the witness. -/
-noncomputable def orchard_verifier_vesta_forking_constraint_adaptive [Fact (HasseBound Vesta.curve)]
+noncomputable def orchard_verifier_vesta_forking_constraint_adaptive
     [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
     (s : Fin (2 ^ urs.k) → Fp) (P : Prover Fp VestaG shape.k)
@@ -577,7 +577,7 @@ measure is *derived* from the rewinding primitive, consuming the transcript orde
 (see `orchard_verifier_vesta_forking_opening_deployed`; the uniform measure of `hprob` is justified standalone,
 `Forking.Rewind.roChallenges_ipaRound_uniform`); the `_adaptive`/`_adaptive_rewind` rungs are the
 attack-event forms. -/
-noncomputable def orchard_verifier_vesta_forking_opening_rewind [Fact (HasseBound Vesta.curve)] [DecidableEq VestaG]
+noncomputable def orchard_verifier_vesta_forking_opening_rewind [DecidableEq VestaG]
     [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG)
     (O : List (TranscriptElt Fp VestaG) → Fp) (init : List (TranscriptElt Fp VestaG))
@@ -605,7 +605,7 @@ runs, the round-vector semantics derived via `roChallenges_reprogramRounds`. The
 caveat is unchanged — see `orchard_verifier_deployed_constraint_of_forked`'s caveat — and so
 is the constant rung's static-dichotomy scope (see `orchard_verifier_vesta_forking_opening_deployed`); the
 `_adaptive_rewind` pair is the attack-event form. -/
-noncomputable def orchard_verifier_vesta_forking_constraint_rewind [Fact (HasseBound Vesta.curve)]
+noncomputable def orchard_verifier_vesta_forking_constraint_rewind
     [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG)
     (O : List (TranscriptElt Fp VestaG) → Fp) (init : List (TranscriptElt Fp VestaG))
@@ -649,7 +649,7 @@ spliced proof's IPA round prefixes, and the deployed schedule is re-run. `roChal
 that run into round-vector replacement, and `roChallenges_spliceIpa_pre` drops the irrelevant spliced pre-IPA
 fields. The residual is unchanged from the staged rung (see
 `orchard_verifier_vesta_forking_opening_adaptive`). -/
-noncomputable def orchard_verifier_vesta_forking_opening_adaptive_rewind [Fact (HasseBound Vesta.curve)]
+noncomputable def orchard_verifier_vesta_forking_opening_adaptive_rewind
     [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG)
     (O : List (TranscriptElt Fp VestaG) → Fp) (init : List (TranscriptElt Fp VestaG))
@@ -679,7 +679,7 @@ open Classical in
 /-- The constraint companion of `orchard_verifier_vesta_forking_opening_adaptive_rewind`: the staged
 round-adaptive capstone with its accept event grounded in reprogrammed-oracle runs on each spliced proof. The
 `hquot`/`hgood` caveat is unchanged — see `orchard_verifier_deployed_constraint_of_forked`'s caveat. -/
-noncomputable def orchard_verifier_vesta_forking_constraint_adaptive_rewind [Fact (HasseBound Vesta.curve)]
+noncomputable def orchard_verifier_vesta_forking_constraint_adaptive_rewind
     [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG)
     (O : List (TranscriptElt Fp VestaG) → Fp) (init : List (TranscriptElt Fp VestaG))

--- a/Zcash/Snark/Soundness/Vesta.lean
+++ b/Zcash/Snark/Soundness/Vesta.lean
@@ -31,7 +31,7 @@ namespace Zcash.Snark
 
 open CompElliptic.Curves.Pasta CompElliptic.CurveForms.ShortWeierstrass CompElliptic.CurveOrder
 
-/-- The verifier group `E_q`, concretely: the points of the Vesta curve `y² = x³ + 5`. -/
+/-- The deployed verifier group `E_q`, concretely `SWPoint Vesta.curve`: the points of `y² = x³ + 5`. -/
 abbrev VestaG := SWPoint Vesta.curve
 
 /-- The Vesta group order as a proposition: every Vesta point is `p`-torsion, i.e. the group order
@@ -136,15 +136,14 @@ theorem orchard_verifier_vesta_constraint_of_forked [DecidableEq VestaG] [Inhabi
   orchard_verifier_deployed_constraint_of_forked urs hk vk ps ch fixedCols decodeAdvice
     decodeInstance y gates hpoly deg x a fs hrel hquot hgood hencodes
 
-/-- The powers evaluation vector's leading entry is `1` (`b 0 = x⁰ = 1`), discharging the IPA's `hb0`
-structural fact for the concrete deployed `b = evalVector`. -/
+/-- The powers evaluation vector has leading entry `1` (`evalVector k x 0 = x⁰ = 1`), discharging the IPA's
+`hb0` structural fact at the concrete deployed `b = evalVector`. -/
 theorem evalVector_zero {F : Type*} [Field F] (k : ℕ) (x : F) : evalVector k x 0 = 1 := by
   simp [evalVector]
 
-/-- halo2's adjusted IPA witness: `aMulti` with its `g₀`-coefficient shifted by the claimed value and the
-synthetic blinder `ξ·s` folded in, so its commitment is the adjusted commitment `⟨aMulti,G⟩ − [v]g₀ + [ξ]S`.
-Making it a *definition* (rather than positing an `aDep` with a relation `hP`) discharges `hP` by the linearity
-of `commit`. -/
+/-- halo2's adjusted IPA witness: `aMulti` with its `g₀`-coefficient shifted by the claimed value `v` and the
+synthetic blinder `ξ·s` folded in, so `commit` sends it to the adjusted commitment `⟨aMulti,G⟩ − [v]g₀ + [ξ]S`.
+A *definition* (not a posited `aDep` with a relation `hP`), so `hP` holds by `commit`'s linearity. -/
 def adjustedWitness {k : ℕ} (aMulti s : Fin (2 ^ k) → Fp) (v ξ : Fp) : Fin (2 ^ k) → Fp :=
   aMulti - Pi.single 0 v + ξ • s
 
@@ -157,12 +156,11 @@ theorem commit_adjustedWitness {G : Type*} [AddCommGroup G] [Module Fp G] (urs :
   rw [adjustedWitness, commit_add, csub, commit_single, commit_smul]
 
 /-- **The deployed commitment lies in the `g`-span (discharging `hcommit`).** At Vesta's prime order a nonzero
-generator `urs.g 0` generates the whole group: `c ↦ c • g 0` is injective over the field `Fp` (a nonzero
-scalar is invertible) and `Fp` and `VestaG` have equal cardinality (`scalarFieldOrder`), so it is surjective —
-every group element, in particular `deployedCommitment`, is the `g`-commitment of some witness. So the
-`hcommit` tie is always satisfiable: it is the prime-order/`g`-span fact, the witness being the discrete log of
-`P` base `g 0` (existing but not feasibly constructible — the same DLR-side status as the
-`⊕' NontrivialRelation` disjunct). -/
+generator `urs.g 0` generates the whole group: `c ↦ c • g 0` is injective over `Fp` (nonzero scalars are
+invertible), and `Fp` and `VestaG` are equinumerous (`scalarFieldOrder`), so it is surjective — every group
+element, `deployedCommitment` included, is the `g`-commitment of some witness. So `hcommit` is always
+satisfiable: the witness is the discrete log of `P` base `g 0`, existing but not feasibly constructible —
+the same DLR-side status as the `⊕' NontrivialRelation` disjunct. -/
 theorem commit_surjective [Fact (HasseBound Vesta.curve)] (urs : URS VestaG) (hg0 : urs.g 0 ≠ 0)
     (P : VestaG) : ∃ aMulti : Fin (2 ^ urs.k) → Fp, commit urs aMulti = P := by
   have hinj : Function.Injective (fun c : Fp => c • urs.g 0) := by
@@ -184,9 +182,9 @@ open scoped ENNReal in
 /-- **The ξ-randomization budget behind the constraint capstone's value recovery.** A malicious blinder with
 `⟨s,b⟩ = δ ≠ 0` satisfies the value-recovery premise `ξ·⟨s,b⟩ = 0` — which pins the opened value back to the
 claimed `multiopenValue` — only at `ξ = 0`, a set of uniform random-oracle measure `≤ 1/p`. So the `hξ`
-hypothesis of `orchard_verifier_vesta_forking_constraint` is, for a nonzero blinder, satisfiable only on a
-`1/p`-measure set of post-`S` challenges: the Schwartz–Zippel `ξ`-exclusion (`blinder_shift_badSet_measure`)
-made explicit for the constraint side. -/
+hypothesis of `orchard_verifier_vesta_forking_constraint`, for a nonzero blinder, holds only on that
+`1/p`-measure set of post-`S` challenges: `blinder_shift_badSet_measure` made explicit for the constraint
+side. -/
 theorem blinder_value_recovery_badSet {k : ℕ} (s : Fin (2 ^ k) → Fp) (xEval : Fp)
     (hδ : innerProduct s (evalVector k xEval) ≠ 0) :
     uniformChallenge.toOuterMeasure
@@ -197,7 +195,7 @@ theorem blinder_value_recovery_badSet {k : ℕ} (s : Fin (2 ^ k) → Fp) (xEval 
 open scoped ENNReal in
 open Classical in
 /-- **The deployed Orchard opening over Vesta, via the forking refinements (no `FiatShamirTree`), with the
-structural facts discharged.** Routes the forking development to the concrete deployed instance. The multiopen
+structural facts discharged.** The multiopen
 evaluation vector is the concrete powers vector `b = evalVector urs.k xEval` (so `b 0 = 1` is *proved* by
 `evalVector_zero`, not assumed); the multiopen witness `aMulti` is *recovered* from the `g`-span
 (`commit_surjective`, from the nonzero generator `hg0`), so the `g`-span tie `hcommit` is **discharged** rather
@@ -244,9 +242,8 @@ open scoped ENNReal in
 open Classical in
 /-- **The deployed Orchard opening *and constraint* over Vesta, via the forking refinements (no
 `FiatShamirTree`), with the structural facts discharged.** The constraint-side companion of
-`orchard_verifier_vesta_forking_opening`: same concrete instance (`b = evalVector urs.k xEval`, so `b 0 = 1` is
-*proved*; `aMulti` recovered from the `g`-span so `hcommit` is discharged; the adjusted witness *constructed*
-so `hP` holds by linearity) and the same gate seam as `orchard_verifier_vesta_constraint_of_forked`
+`orchard_verifier_vesta_forking_opening`: the same discharged structural facts (`b 0 = 1`, `hcommit`, `hP` —
+see there) and the same gate seam as `orchard_verifier_vesta_constraint_of_forked`
 (`hquot`/`hgood` → `circuitSatViaGates`, `hencodes`). Unlike the opening, the circuit is checked at the
 *claimed* value `multiopenValue`, so the minimal value-recovery hypothesis `hξ : ξ·⟨s,b⟩ = 0` is retained — it
 pins the opened value `multiopenValue − ξ·⟨s,b⟩` (unique under binding) from the forking opening back to
@@ -299,10 +296,10 @@ noncomputable def orchard_verifier_vesta_forking_constraint [Fact (HasseBound Ve
     exact hencodes a ⟨hrel', hsat⟩
   · exact PSum.inr hrel
 
-/-- The deployed adjusted-commitment's value term `Σᵢ [-v].getD i • gᵢ` is `-v` on the single generator `g 0`
-(the value list `[-v]` has one entry, placed at index `0`). Lets the deployed verifier's adjusted commitment
-`multiopen + Σ[-v].getD·g` meet the capstone's `-v • g 0` form. Pure module algebra, stated over any
-`Fp`-module (the Vesta instances supply `Module Fp VestaG` at the call sites). -/
+/-- The deployed adjusted-commitment's value term `Σᵢ [-v].getD i • gᵢ` collapses to `-v • g 0` (the value
+list `[-v]` has one entry, at index `0`) — letting the verifier's adjusted commitment `multiopen + Σ[-v].getD·g`
+meet the capstone's `-v • g 0` form. Pure module algebra over any `Fp`-module (the Vesta instances supply
+`Module Fp VestaG` at the call sites). -/
 theorem sum_getD_single {k : ℕ} {G : Type*} [AddCommGroup G] [Module Fp G] (gg : Fin (2 ^ k) → G)
     (v : Fp) :
     (∑ i, ([-v].getD i.val 0 : Fp) • gg i) = -v • gg 0 := by
@@ -576,13 +573,9 @@ with the accept probability stated over **reprogrammed-oracle runs**: the event 
 at `roChallenges (reprogramRounds O init ps χ) init ps` — the deployed schedule re-run under the oracle
 reprogrammed at the `k` round prefixes — rather than an unexplained `{ch with ipaRound := χ}` surgery.
 `roChallenges_reprogramRounds` proves the two events equal, so the round-vector semantics of the forking
-measure is *derived* from the rewinding primitive, consuming the transcript ordering. Residuals
-are unchanged: `z ≠ 0`, the nonzero generator `hg0`, the `S`-opening `hs`, and — above `hprob` — the querying
-adversary and its query-loss plus Blake2b-as-random-oracle (the uniform measure of `hprob` is justified
-standalone, `Forking.Rewind.roChallenges_ipaRound_uniform`, for the fixed proof string) — including the constant
-rung's static-dichotomy scope: `hprob` is still the *fixed* proof's accept measure over the whole challenge
-space (see
-`orchard_verifier_vesta_forking_opening_deployed`); the `_adaptive`/`_adaptive_rewind` rungs are the
+measure is *derived* from the rewinding primitive, consuming the transcript ordering. Residuals and the constant rung's static-dichotomy scope are unchanged
+(see `orchard_verifier_vesta_forking_opening_deployed`; the uniform measure of `hprob` is justified standalone,
+`Forking.Rewind.roChallenges_ipaRound_uniform`); the `_adaptive`/`_adaptive_rewind` rungs are the
 attack-event forms. -/
 noncomputable def orchard_verifier_vesta_forking_opening_rewind [Fact (HasseBound Vesta.curve)] [DecidableEq VestaG]
     [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
@@ -649,15 +642,13 @@ noncomputable def orchard_verifier_vesta_forking_constraint_rewind [Fact (HasseB
 open scoped ENNReal in
 open Classical in
 /-- **The staged Orchard opening over Vesta, from oracle rewinding.**
-This is `orchard_verifier_vesta_forking_opening_adaptive` with the adaptive accept probability stated over
-reprogrammed-oracle runs on each strategy-spliced proof. For each challenge path `χ`, the proof string is
-`spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2`; the oracle is reprogrammed at that
-spliced proof's IPA round prefixes and the deployed schedule is re-run. `roChallenges_reprogramRounds` turns
-that run into round-vector replacement, and `roChallenges_spliceIpa_pre` removes the irrelevant spliced
-pre-IPA fields. The residual is unchanged from the staged rung: the execution-semantics identification that a
-rewound random-oracle adversary induces such a strategy, with its RO-query loss (deriving the accept probability
-of `hprob`), plus Blake2b-as-random-oracle — the uniform measure of `hprob` is justified standalone
-(`Forking.Rewind.roChallenges_ipaRound_uniform`, for the fixed proof string; consumed by no capstone). -/
+`orchard_verifier_vesta_forking_opening_adaptive` with `hprob` stated over reprogrammed-oracle runs on each
+strategy-spliced proof: for each challenge path `χ` the proof string is
+`spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2`, the oracle is reprogrammed at that
+spliced proof's IPA round prefixes, and the deployed schedule is re-run. `roChallenges_reprogramRounds` turns
+that run into round-vector replacement, and `roChallenges_spliceIpa_pre` drops the irrelevant spliced pre-IPA
+fields. The residual is unchanged from the staged rung (see
+`orchard_verifier_vesta_forking_opening_adaptive`). -/
 noncomputable def orchard_verifier_vesta_forking_opening_adaptive_rewind [Fact (HasseBound Vesta.curve)]
     [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG)

--- a/Zcash/Snark/Soundness/Vesta.lean
+++ b/Zcash/Snark/Soundness/Vesta.lean
@@ -1,5 +1,6 @@
 import Mathlib
 import Zcash.Snark.Soundness.Main
+import Zcash.Snark.Soundness.Forking.Rewind
 import CompElliptic.Curves.Pasta
 import CompElliptic.Curves.PastaOrder
 
@@ -134,5 +135,594 @@ theorem orchard_verifier_vesta_constraint_of_forked [DecidableEq VestaG] [Inhabi
     S :=
   orchard_verifier_deployed_constraint_of_forked urs hk vk ps ch fixedCols decodeAdvice
     decodeInstance y gates hpoly deg x a fs hrel hquot hgood hencodes
+
+/-- The powers evaluation vector's leading entry is `1` (`b 0 = x⁰ = 1`), discharging the IPA's `hb0`
+structural fact for the concrete deployed `b = evalVector`. -/
+theorem evalVector_zero {F : Type*} [Field F] (k : ℕ) (x : F) : evalVector k x 0 = 1 := by
+  simp [evalVector]
+
+/-- halo2's adjusted IPA witness: `aMulti` with its `g₀`-coefficient shifted by the claimed value and the
+synthetic blinder `ξ·s` folded in, so its commitment is the adjusted commitment `⟨aMulti,G⟩ − [v]g₀ + [ξ]S`.
+Making it a *definition* (rather than positing an `aDep` with a relation `hP`) discharges `hP` by the linearity
+of `commit`. -/
+def adjustedWitness {k : ℕ} (aMulti s : Fin (2 ^ k) → Fp) (v ξ : Fp) : Fin (2 ^ k) → Fp :=
+  aMulti - Pi.single 0 v + ξ • s
+
+/-- The adjusted witness commits to halo2's adjusted commitment — `hP` holds by linearity, not by assumption. -/
+theorem commit_adjustedWitness {G : Type*} [AddCommGroup G] [Module Fp G] (urs : URS G)
+    (aMulti s : Fin (2 ^ urs.k) → Fp) (v ξ : Fp) :
+    commit urs (adjustedWitness aMulti s v ξ) = commit urs aMulti - v • urs.g 0 + ξ • commit urs s := by
+  have csub : ∀ a a' : Fin (2 ^ urs.k) → Fp, commit urs (a - a') = commit urs a - commit urs a' := by
+    intro a a'; simp only [commit, Pi.sub_apply, sub_smul, Finset.sum_sub_distrib]
+  rw [adjustedWitness, commit_add, csub, commit_single, commit_smul]
+
+/-- **The deployed commitment lies in the `g`-span (discharging `hcommit`).** At Vesta's prime order a nonzero
+generator `urs.g 0` generates the whole group: `c ↦ c • g 0` is injective over the field `Fp` (a nonzero
+scalar is invertible) and `Fp` and `VestaG` have equal cardinality (`scalarFieldOrder`), so it is surjective —
+every group element, in particular `deployedCommitment`, is the `g`-commitment of some witness. So the
+`hcommit` tie is always satisfiable: it is the prime-order/`g`-span fact, the witness being the discrete log of
+`P` base `g 0` (existing but not feasibly constructible — the same DLR-side status as the
+`⊕' NontrivialRelation` disjunct). -/
+theorem commit_surjective [Fact (HasseBound Vesta.curve)] (urs : URS VestaG) (hg0 : urs.g 0 ≠ 0)
+    (P : VestaG) : ∃ aMulti : Fin (2 ^ urs.k) → Fp, commit urs aMulti = P := by
+  have hinj : Function.Injective (fun c : Fp => c • urs.g 0) := by
+    intro c c' h
+    have h' : c • urs.g 0 = c' • urs.g 0 := h
+    rcases eq_or_ne c c' with hcc | hcc
+    · exact hcc
+    · refine absurd ?_ hg0
+      have hd : c - c' ≠ 0 := sub_ne_zero.mpr hcc
+      have h0 : (c - c') • urs.g 0 = 0 := by rw [sub_smul, h', sub_self]
+      rw [← one_smul Fp (urs.g 0), ← inv_mul_cancel₀ hd, mul_smul, h0, smul_zero]
+  haveI : Fintype VestaG := Fintype.ofFinite VestaG
+  have hcardeq : Fintype.card Fp = Fintype.card VestaG := by
+    rw [card_Fp, ← Nat.card_eq_fintype_card, Vesta.card_eq Fact.out]
+  obtain ⟨c, hc⟩ := ((Fintype.bijective_iff_injective_and_card _).mpr ⟨hinj, hcardeq⟩).surjective P
+  exact ⟨Pi.single 0 c, by rw [commit_single]; exact hc⟩
+
+open scoped ENNReal in
+/-- **The ξ-randomization budget behind the constraint capstone's value recovery.** A malicious blinder with
+`⟨s,b⟩ = δ ≠ 0` satisfies the value-recovery premise `ξ·⟨s,b⟩ = 0` — which pins the opened value back to the
+claimed `multiopenValue` — only at `ξ = 0`, a set of uniform random-oracle measure `≤ 1/p`. So the `hξ`
+hypothesis of `orchard_verifier_vesta_forking_constraint` is, for a nonzero blinder, satisfiable only on a
+`1/p`-measure set of post-`S` challenges: the Schwartz–Zippel `ξ`-exclusion (`blinder_shift_badSet_measure`)
+made explicit for the constraint side. -/
+theorem blinder_value_recovery_badSet {k : ℕ} (s : Fin (2 ^ k) → Fp) (xEval : Fp)
+    (hδ : innerProduct s (evalVector k xEval) ≠ 0) :
+    uniformChallenge.toOuterMeasure
+        (Finset.univ.filter (fun ξ : Fp => ξ * innerProduct s (evalVector k xEval) = 0))
+      ≤ 1 / (Fintype.card Fp : ℝ≥0∞) :=
+  blinder_shift_badSet_measure (innerProduct s (evalVector k xEval)) 0 hδ
+
+open scoped ENNReal in
+open Classical in
+/-- **The deployed Orchard opening over Vesta, via the forking refinements (no `FiatShamirTree`), with the
+structural facts discharged.** Routes the forking development to the concrete deployed instance. The multiopen
+evaluation vector is the concrete powers vector `b = evalVector urs.k xEval` (so `b 0 = 1` is *proved* by
+`evalVector_zero`, not assumed); the multiopen witness `aMulti` is *recovered* from the `g`-span
+(`commit_surjective`, from the nonzero generator `hg0`), so the `g`-span tie `hcommit` is **discharged** rather
+than assumed; and the adjusted witness is *constructed*, so halo2's adjusted-commitment relation `hP` holds by
+linearity (`commit_adjustedWitness`). The synthetic blinder is stripped *unconditionally*: the conclusion is
+the **true** opened value `multiopenValue − ξ·⟨s,b⟩`, with no `⟨s,b⟩ = 0` assumed — covering a malicious blinder
+(the honest case `⟨s,b⟩ = 0` recovers the claimed value). What remains is the explicit prover-as-oracle bridge
+`hbridge` (the irreducible random-oracle floor), plus the antecedents `z ≠ 0`, the nonzero generator `hg0`, and
+the accept probability `hprob` beating the knowledge error `kerr/Nᵏ`. The `⊕' NontrivialRelation` caveat is
+unchanged — vacuous at Vesta's prime order, the force in the out-of-Lean DLR/AGM layer. -/
+noncomputable def orchard_verifier_vesta_forking_opening [Fact (HasseBound Vesta.curve)] [DecidableEq VestaG]
+    [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
+    (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
+    (xEval ξ z blind : Fp) (s : Fin (2 ^ urs.k) → Fp)
+    (Q : Prover Fp VestaG urs.k) (accepts : (Fin urs.k → Fp) → Prop)
+    (hz : z ≠ 0) (hg0 : urs.g 0 ≠ 0)
+    (hbridge : ∀ χ, accepts χ ↔ flatAccept Q urs.g (evalVector urs.k xEval) urs.u urs.w z
+        (deployedCommitment urs hk vk ps ch - multiopenValue vk ps ch • urs.g 0 + ξ • commit urs s
+          + (z * 0) • urs.u + blind • urs.w) χ)
+    (hprob : (kerr (Fintype.card Fp) urs.k : ℝ≥0∞) / Fintype.card (Fin urs.k → Fp)
+        < (PMF.uniformOfFintype (Fin urs.k → Fp)).toOuterMeasure (Finset.univ.filter accepts)) :
+    (∃ a, IpaRelation urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k xEval)
+        (multiopenValue vk ps ch - ξ * innerProduct s (evalVector urs.k xEval)) a)
+      ⊕' NontrivialRelation (F := Fp) urs.g urs.u urs.w := by
+  -- `aMulti` is the (prime-order) `g`-preimage of the deployed commitment, named as data by
+  -- `Classical.choose` — the source of this `def`'s `noncomputable`.
+  have hcs := commit_surjective urs hg0 (deployedCommitment urs hk vk ps ch)
+  set aMulti := hcs.choose with haMulti
+  have hcommit : commit urs aMulti = deployedCommitment urs hk vk ps ch := hcs.choose_spec
+  have hbr : ∀ χ, accepts χ ↔ flatAccept Q urs.g (evalVector urs.k xEval) urs.u urs.w z
+      (commit urs (adjustedWitness aMulti s (multiopenValue vk ps ch) ξ)
+        + (z * 0) • urs.u + blind • urs.w) χ := by
+    intro χ
+    rw [commit_adjustedWitness, hcommit]
+    exact hbridge χ
+  have h := deployed_forking_soundness_of_bridge urs (evalVector urs.k xEval) (multiopenValue vk ps ch) ξ z
+    blind aMulti (adjustedWitness aMulti s (multiopenValue vk ps ch) ξ) s Q accepts hz
+    (evalVector_zero urs.k xEval) (commit_adjustedWitness urs aMulti s (multiopenValue vk ps ch) ξ)
+    hbr hprob
+  rwa [hcommit] at h
+
+open Polynomial in
+open scoped ENNReal in
+open Classical in
+/-- **The deployed Orchard opening *and constraint* over Vesta, via the forking refinements (no
+`FiatShamirTree`), with the structural facts discharged.** The constraint-side companion of
+`orchard_verifier_vesta_forking_opening`: same concrete instance (`b = evalVector urs.k xEval`, so `b 0 = 1` is
+*proved*; `aMulti` recovered from the `g`-span so `hcommit` is discharged; the adjusted witness *constructed*
+so `hP` holds by linearity) and the same gate seam as `orchard_verifier_vesta_constraint_of_forked`
+(`hquot`/`hgood` → `circuitSatViaGates`, `hencodes`). Unlike the opening, the circuit is checked at the
+*claimed* value `multiopenValue`, so the minimal value-recovery hypothesis `hξ : ξ·⟨s,b⟩ = 0` is retained — it
+pins the opened value `multiopenValue − ξ·⟨s,b⟩` (unique under binding) from the forking opening back to
+`multiopenValue`. `hξ`
+generalises honest blinding (`⟨s,b⟩ = 0`); for a *malicious* blinder (`⟨s,b⟩ ≠ 0`) it holds only on a
+`1/p`-measure set of post-`S` challenges `ξ` (`blinder_value_recovery_badSet`, the `ξ`-randomization budget).
+The deployed-curve residual is the explicit prover-as-oracle bridge `hbridge` (and the nonzero generator
+`hg0`); both the opening and the constraint side now route through it with `b 0 = 1`, `hcommit`, and `hP`
+discharged. The original `FiatShamirTree` reductions
+(`orchard_verifier_vesta_opening_of_forked`/`_constraint`) remain as the coarser legacy endpoints. The
+`⊕' NontrivialRelation` caveat is unchanged — vacuous at Vesta's prime order, the force in the out-of-Lean
+DLR/AGM layer. `hquot`/`hgood` retain the ∀-openings shape — unsatisfiable at Vesta for any decode that
+genuinely reads the witness (see `orchard_verifier_deployed_constraint_of_forked`'s caveat). -/
+noncomputable def orchard_verifier_vesta_forking_constraint [Fact (HasseBound Vesta.curve)] [DecidableEq VestaG]
+    [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
+    (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
+    (xEval ξ z blind : Fp) (s : Fin (2 ^ urs.k) → Fp)
+    (Q : Prover Fp VestaG urs.k) (accepts : (Fin urs.k → Fp) → Prop)
+    (fixedCols : ℕ → Polynomial Fp)
+    (decodeAdvice decodeInstance : (Fin (2 ^ urs.k) → Fp) → (ℕ → Polynomial Fp))
+    (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
+    (hz : z ≠ 0) (hg0 : urs.g 0 ≠ 0)
+    (hξ : ξ * innerProduct s (evalVector urs.k xEval) = 0)
+    (hbridge : ∀ χ, accepts χ ↔ flatAccept Q urs.g (evalVector urs.k xEval) urs.u urs.w z
+        (deployedCommitment urs hk vk ps ch - multiopenValue vk ps ch • urs.g 0 + ξ • commit urs s
+          + (z * 0) • urs.u + blind • urs.w) χ)
+    (hquot : ∀ a, IpaRelation urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k xEval)
+        (multiopenValue vk ps ch) a →
+      quotientCheck (combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates) hpoly deg x)
+    (hgood : ∀ a, IpaRelation urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k xEval)
+        (multiopenValue vk ps ch) a →
+      combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates ≠ hpoly * (X ^ deg - 1) →
+      (combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates
+        - hpoly * (X ^ deg - 1)).eval x ≠ 0)
+    {S : Prop}
+    (hencodes : ∀ a, SnarkRelation urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k xEval)
+        (multiopenValue vk ps ch)
+      (circuitSatViaGates fixedCols decodeAdvice decodeInstance y gates hpoly deg) a → S)
+    (hprob : (kerr (Fintype.card Fp) urs.k : ℝ≥0∞) / Fintype.card (Fin urs.k → Fp)
+        < (PMF.uniformOfFintype (Fin urs.k → Fp)).toOuterMeasure (Finset.univ.filter accepts)) :
+    S ⊕' NontrivialRelation (F := Fp) urs.g urs.u urs.w := by
+  rcases orchard_verifier_vesta_forking_opening urs hk vk ps ch xEval ξ z blind s Q accepts
+      hz hg0 hbridge hprob with hopen | hrel
+  · refine PSum.inl ?_
+    obtain ⟨a, hrel'⟩ := hopen
+    rw [hξ, sub_zero] at hrel'
+    have hsat : circuitSatViaGates fixedCols decodeAdvice decodeInstance y gates hpoly deg a :=
+      circuitSatViaGates_of_check fixedCols decodeAdvice decodeInstance y gates hpoly deg a x
+        (hquot a hrel') (hgood a hrel')
+    exact hencodes a ⟨hrel', hsat⟩
+  · exact PSum.inr hrel
+
+/-- The deployed adjusted-commitment's value term `Σᵢ [-v].getD i • gᵢ` is `-v` on the single generator `g 0`
+(the value list `[-v]` has one entry, placed at index `0`). Lets the deployed verifier's adjusted commitment
+`multiopen + Σ[-v].getD·g` meet the capstone's `-v • g 0` form. Pure module algebra, stated over any
+`Fp`-module (the Vesta instances supply `Module Fp VestaG` at the call sites). -/
+theorem sum_getD_single {k : ℕ} {G : Type*} [AddCommGroup G] [Module Fp G] (gg : Fin (2 ^ k) → G)
+    (v : Fp) :
+    (∑ i, ([-v].getD i.val 0 : Fp) • gg i) = -v • gg 0 := by
+  rw [Finset.sum_eq_single (0 : Fin (2 ^ k))]
+  · simp
+  · intro i _ hi
+    have hival : i.val ≠ 0 := Fin.val_ne_zero_iff.mpr hi
+    rw [List.getD_eq_default, zero_smul]
+    simp only [List.length_cons, List.length_nil, Nat.zero_add]
+    omega
+  · intro h; exact absurd (Finset.mem_univ _) h
+
+open scoped ENNReal in
+open Classical in
+/-- **The deployed Orchard opening over Vesta, with `hbridge` discharged.** This is
+`orchard_verifier_vesta_forking_opening` with the abstract prover-as-oracle bridge *removed*: `accepts` is
+halo2's **actual** verifier equation `DeployedIpaVerifierEq` at the rewound IPA challenges, and the bridge to
+`flatAccept` of the concrete proof tree `proverOfRounds ps.ipaRounds ps.ipaC ps.ipaF` is **proven** internally
+by `deployedVerifierEq_iff_flatAccept` — not assumed. The `shape.k`↔`urs.k` transport is discharged by
+`subst`, and the commitment slot is reconciled (`sum_getD_single`, `deployedCommitment = multiopenCommitment`,
+the `S`-opening `hs : commit urs s = ps.ipaS`, `module`). The remaining hypotheses are `z ≠ 0`, the nonzero
+generator `hg0` (prime-order `g`-span), and the `S`-opening witness `hs` (such an opening always *exists* at
+prime order but is not feasibly constructible for a malicious prover — the same exists-but-not-findable tier
+as `commit_surjective` and the `⊕' NontrivialRelation` disjunct), plus the accept *probability* `hprob`
+over the uniform IPA-challenge measure.
+
+**Quantifier-shape caveat (`hprob`).** Discharging the bridge with the *constant* strategy `proverOfRounds`
+changes what `hprob` measures: it is the accept set of this **fixed** proof string over *all* round-challenge
+vectors — not the Fiat–Shamir attack event. A real prover (honest ones included) produces a proof whose
+accept set is a low-degree variety of measure ≤ `3k/p` — clearing the verifier equation by `∏ χⱼ` leaves
+total degree ≤ `2k`, so Schwartz–Zippel gives ≤ `2k/p`, plus ≤ `k/p` for the zero-challenge hyperplanes
+where the total inverse departs from the cleared polynomial — generically ≈ `1/p`, and never *strictly
+above* the `3k/p` threshold: `hprob` here is satisfiable only by a proof that accepts *identically*, while
+a forger only needs its single RO-derived vector to land on that variety. So this theorem is the *static
+dichotomy* "a proof accepting on more than `3k/p` of challenge space yields an opening". For adaptive
+adversaries, use `orchard_verifier_vesta_forking_opening_adaptive` for the bridge-discharge over a
+prefix-respecting strategy and `orchard_verifier_vesta_forking_opening_adaptive_rewind` when the accept event
+should be stated over reprogrammed-oracle runs. The remaining floor there is not the deterministic bridge but
+the execution-semantics identification — a rewound random-oracle adversary induces such a strategy, with its
+RO-query loss. The `⊕' NontrivialRelation` caveat is unchanged — vacuous at Vesta's prime order. -/
+noncomputable def orchard_verifier_vesta_forking_opening_deployed [Fact (HasseBound Vesta.curve)] [DecidableEq VestaG]
+    [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
+    (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
+    (s : Fin (2 ^ urs.k) → Fp) (hz : ch.z ≠ 0) (hg0 : urs.g 0 ≠ 0) (hs : commit urs s = ps.ipaS)
+    (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
+        < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
+            (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk ps
+              {ch with ipaRound := χ}))) :
+    (∃ a, IpaRelation urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k ch.x3)
+        (multiopenValue vk ps ch - ch.xi * innerProduct s (evalVector urs.k ch.x3)) a)
+      ⊕' NontrivialRelation (F := Fp) urs.g urs.u urs.w := by
+  obtain ⟨k, gg, ww, uu⟩ := urs
+  change shape.k = k at hk
+  subst hk
+  refine orchard_verifier_vesta_forking_opening ⟨shape.k, gg, ww, uu⟩ rfl vk ps ch ch.x3 ch.xi ch.z 0 s
+    (proverOfRounds ps.ipaRounds ps.ipaC ps.ipaF)
+    (fun χ => DeployedIpaVerifierEq gg ww uu vk ps {ch with ipaRound := χ}) hz hg0 ?_ hprob
+  intro χ
+  dsimp only
+  rw [deployedVerifierEq_iff_flatAccept]
+  have hPwhole :
+      (multiopenCommitment gg ww uu vk ps {ch with ipaRound := χ}
+          + (∑ i, ([-(multiopenValue vk ps {ch with ipaRound := χ})].getD i.val 0) • gg i)
+          + ({ch with ipaRound := χ} : Challenges shape.k Fp).xi • ps.ipaS)
+        = (deployedCommitment ⟨shape.k, gg, ww, uu⟩ rfl vk ps ch
+            - multiopenValue vk ps ch • gg 0 + ch.xi • commit ⟨shape.k, gg, ww, uu⟩ s
+            + (ch.z * 0) • uu + 0 • ww) := by
+    have e1 : multiopenValue vk ps {ch with ipaRound := χ} = multiopenValue vk ps ch := rfl
+    have e2 : multiopenCommitment gg ww uu vk ps {ch with ipaRound := χ}
+        = multiopenCommitment gg ww uu vk ps ch := rfl
+    have e3 : ({ch with ipaRound := χ} : Challenges shape.k Fp).xi = ch.xi := rfl
+    rw [e1, e2, e3, sum_getD_single gg (multiopenValue vk ps ch), ← hs]
+    simp only [deployedCommitment]
+    module
+  rw [hPwhole]
+  exact Iff.rfl
+
+open Polynomial in
+open scoped ENNReal in
+open Classical in
+/-- **The deployed Orchard opening *and constraint* over Vesta, with `hbridge` discharged.** The constraint
+companion of `orchard_verifier_vesta_forking_opening_deployed`: same discharged bridge (halo2's actual verifier
+accept, no abstract `hbridge`), routed through the opening to the gate-satisfaction seam
+(`hquot`/`hgood` → `circuitSatViaGates`, `hencodes`) at the *claimed* value `multiopenValue` — pinned from the
+forking opening's `multiopenValue − ξ·⟨s,b⟩` by the minimal value-recovery hypothesis
+`hξ : ch.xi·⟨s,b⟩ = 0` (honest blinding, or a `1/p`-measure set of post-`S` challenges for a malicious blinder,
+`blinder_value_recovery_badSet`). Residual assumptions: `z ≠ 0`, the nonzero generator `hg0`, the `S`-opening
+witness `hs`, and `hξ` — plus the accept probability `hprob`, which carries the same quantifier-shape caveat
+as `orchard_verifier_vesta_forking_opening_deployed`: with the constant `proverOfRounds` strategy it measures
+the *fixed* proof's accept set over all round-challenge vectors, not the Fiat–Shamir attack event. For the
+adaptive form, use `orchard_verifier_vesta_forking_constraint_adaptive`; for the same statement over
+reprogrammed-oracle runs, use `orchard_verifier_vesta_forking_constraint_adaptive_rewind`. `hquot`/`hgood`
+retain the ∀-openings shape — unsatisfiable at Vesta for any decode that genuinely
+reads the witness (see `orchard_verifier_deployed_constraint_of_forked`'s caveat). -/
+noncomputable def orchard_verifier_vesta_forking_constraint_deployed [Fact (HasseBound Vesta.curve)] [DecidableEq VestaG]
+    [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
+    (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
+    (s : Fin (2 ^ urs.k) → Fp)
+    (fixedCols : ℕ → Polynomial Fp)
+    (decodeAdvice decodeInstance : (Fin (2 ^ urs.k) → Fp) → (ℕ → Polynomial Fp))
+    (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
+    (hz : ch.z ≠ 0) (hg0 : urs.g 0 ≠ 0) (hs : commit urs s = ps.ipaS)
+    (hξ : ch.xi * innerProduct s (evalVector urs.k ch.x3) = 0)
+    (hquot : ∀ a, IpaRelation urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k ch.x3)
+        (multiopenValue vk ps ch) a →
+      quotientCheck (combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates) hpoly deg x)
+    (hgood : ∀ a, IpaRelation urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k ch.x3)
+        (multiopenValue vk ps ch) a →
+      combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates ≠ hpoly * (X ^ deg - 1) →
+      (combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates
+        - hpoly * (X ^ deg - 1)).eval x ≠ 0)
+    {S : Prop}
+    (hencodes : ∀ a, SnarkRelation urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k ch.x3)
+        (multiopenValue vk ps ch)
+      (circuitSatViaGates fixedCols decodeAdvice decodeInstance y gates hpoly deg) a → S)
+    (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
+        < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
+            (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk ps
+              {ch with ipaRound := χ}))) :
+    S ⊕' NontrivialRelation (F := Fp) urs.g urs.u urs.w := by
+  rcases orchard_verifier_vesta_forking_opening_deployed urs hk vk ps ch s hz hg0 hs hprob with hopen | hrel
+  · refine PSum.inl ?_
+    obtain ⟨a, hrel'⟩ := hopen
+    rw [hξ, sub_zero] at hrel'
+    have hsat : circuitSatViaGates fixedCols decodeAdvice decodeInstance y gates hpoly deg a :=
+      circuitSatViaGates_of_check fixedCols decodeAdvice decodeInstance y gates hpoly deg a x
+        (hquot a hrel') (hgood a hrel')
+    exact hencodes a ⟨hrel', hsat⟩
+  · exact PSum.inr hrel
+
+open scoped ENNReal in
+open Classical in
+/-- **The deployed Orchard opening over Vesta for the staged (round-adaptive) adversary, bridge
+discharged.** `orchard_verifier_vesta_forking_opening_deployed` upgraded from the constant strategy to an
+arbitrary prefix-respecting strategy `P : Prover`: the accept event is halo2's **actual** verifier equation
+on the strategy's spliced proof (`spliceIpa` at `pathData P χ` — pre-IPA fields the fixed `ps`'s, since
+rewinding shares the pre-IPA prefix; IPA fields the strategy's own outputs along `χ`), and the bridge to
+`flatAccept P` is **proven** internally (`deployedVerifierEq_iff_flatAccept_adaptive`). So `hprob` is the
+accept probability of an adaptive round-strategy — the object rewinding produces — not one fixed proof's
+accept measure: the static-dichotomy caveat of the `_deployed` capstone does not apply at this rung. What
+remains is the execution-semantics identification (that a rewound random-oracle adversary *induces* such a
+staged strategy, with its RO-query loss), the random-oracle uniformity axiom in `hprob`, and the structural
+witnesses (`z ≠ 0`, `hg0`, the `S`-opening `hs` — with `ps.ipaS` splice-invariant, so one `s` serves every
+path). The transcript-ordering and reprogramming content is already on this path through the
+`_adaptive_rewind` capstone. The `⊕' NontrivialRelation` caveat is unchanged — vacuous at Vesta's prime
+order. -/
+noncomputable def orchard_verifier_vesta_forking_opening_adaptive [Fact (HasseBound Vesta.curve)] [DecidableEq VestaG]
+    [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
+    (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
+    (s : Fin (2 ^ urs.k) → Fp) (P : Prover Fp VestaG shape.k)
+    (hz : ch.z ≠ 0) (hg0 : urs.g 0 ≠ 0) (hs : commit urs s = ps.ipaS)
+    (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
+        < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
+            (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk
+              (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2)
+              {ch with ipaRound := χ}))) :
+    (∃ a, IpaRelation urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k ch.x3)
+        (multiopenValue vk ps ch - ch.xi * innerProduct s (evalVector urs.k ch.x3)) a)
+      ⊕' NontrivialRelation (F := Fp) urs.g urs.u urs.w := by
+  obtain ⟨k, gg, ww, uu⟩ := urs
+  change shape.k = k at hk
+  subst hk
+  refine orchard_verifier_vesta_forking_opening ⟨shape.k, gg, ww, uu⟩ rfl vk ps ch ch.x3 ch.xi ch.z 0 s
+    P (fun χ => DeployedIpaVerifierEq gg ww uu vk
+      (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2) {ch with ipaRound := χ})
+    hz hg0 ?_ hprob
+  intro χ
+  dsimp only
+  rw [deployedVerifierEq_iff_flatAccept_adaptive]
+  have hPwhole : (multiopenCommitment gg ww uu vk ps ch
+        + (∑ i, ([-(multiopenValue vk ps ch)].getD i.val 0) • gg i) + ch.xi • ps.ipaS)
+      = (deployedCommitment ⟨shape.k, gg, ww, uu⟩ rfl vk ps ch
+          - multiopenValue vk ps ch • gg 0 + ch.xi • commit ⟨shape.k, gg, ww, uu⟩ s
+          + (ch.z * 0) • uu + 0 • ww) := by
+    rw [sum_getD_single gg (multiopenValue vk ps ch), ← hs]
+    simp only [deployedCommitment]
+    module
+  rw [hPwhole]
+  exact Iff.rfl
+
+open Polynomial in
+open scoped ENNReal in
+open Classical in
+/-- **The deployed Orchard opening *and constraint* over Vesta for the staged (round-adaptive) adversary,
+bridge discharged.** The constraint companion of `orchard_verifier_vesta_forking_opening_adaptive`: same
+adaptive accept event and internally-proven bridge, routed to the gate-satisfaction seam
+(`hquot`/`hgood` → `circuitSatViaGates`, `hencodes`) at the *claimed* value `multiopenValue`, pinned by the
+value-recovery hypothesis `hξ` (honest blinding, or a `1/p`-measure set of post-`S` challenges for a
+malicious blinder, `blinder_value_recovery_badSet`). Residual: the execution-semantics identification, the
+random-oracle uniformity axiom in `hprob`, and the structural witnesses; the static-dichotomy caveat does not
+apply at this rung. The transcript-ordering and reprogramming content is discharged by the staged
+rewinding capstones below. `hquot`/`hgood` retain the ∀-openings shape — unsatisfiable at Vesta for any decode
+that genuinely reads the witness. -/
+noncomputable def orchard_verifier_vesta_forking_constraint_adaptive [Fact (HasseBound Vesta.curve)]
+    [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
+    (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
+    (s : Fin (2 ^ urs.k) → Fp) (P : Prover Fp VestaG shape.k)
+    (fixedCols : ℕ → Polynomial Fp)
+    (decodeAdvice decodeInstance : (Fin (2 ^ urs.k) → Fp) → (ℕ → Polynomial Fp))
+    (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
+    (hz : ch.z ≠ 0) (hg0 : urs.g 0 ≠ 0) (hs : commit urs s = ps.ipaS)
+    (hξ : ch.xi * innerProduct s (evalVector urs.k ch.x3) = 0)
+    (hquot : ∀ a, IpaRelation urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k ch.x3)
+        (multiopenValue vk ps ch) a →
+      quotientCheck (combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates) hpoly deg x)
+    (hgood : ∀ a, IpaRelation urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k ch.x3)
+        (multiopenValue vk ps ch) a →
+      combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates ≠ hpoly * (X ^ deg - 1) →
+      (combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates
+        - hpoly * (X ^ deg - 1)).eval x ≠ 0)
+    {S : Prop}
+    (hencodes : ∀ a, SnarkRelation urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k ch.x3)
+        (multiopenValue vk ps ch)
+      (circuitSatViaGates fixedCols decodeAdvice decodeInstance y gates hpoly deg) a → S)
+    (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
+        < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
+            (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk
+              (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2)
+              {ch with ipaRound := χ}))) :
+    S ⊕' NontrivialRelation (F := Fp) urs.g urs.u urs.w := by
+  rcases orchard_verifier_vesta_forking_opening_adaptive urs hk vk ps ch s P hz hg0 hs hprob
+    with hopen | hrel
+  · refine PSum.inl ?_
+    obtain ⟨a, hrel'⟩ := hopen
+    rw [hξ, sub_zero] at hrel'
+    have hsat : circuitSatViaGates fixedCols decodeAdvice decodeInstance y gates hpoly deg a :=
+      circuitSatViaGates_of_check fixedCols decodeAdvice decodeInstance y gates hpoly deg a x
+        (hquot a hrel') (hgood a hrel')
+    exact hencodes a ⟨hrel', hsat⟩
+  · exact PSum.inr hrel
+
+/-! ## The forking capstones: staged and rewound endpoints
+
+The terminal readings, ordered by how much of the prover-as-oracle and rewinding content is internalized:
+
+* **Constant** — `orchard_verifier_vesta_forking_opening_deployed`/`_constraint_deployed`: halo2's actual
+  accept on the *fixed* proof string, bridge proven for the constant strategy `proverOfRounds`. Their
+  `hprob` is one proof's accept measure over the whole challenge space (the static dichotomy), not the
+  Fiat–Shamir attack event: see the quantifier-shape caveat on each.
+* **Staged (round-adaptive)** — `orchard_verifier_vesta_forking_opening_adaptive`/`_constraint_adaptive`:
+  halo2's actual accept on the spliced proofs of an arbitrary prefix-respecting strategy `P : Prover`,
+  bridge proven for every such strategy (`deployedVerifierEq_iff_flatAccept_adaptive`). Their `hprob` is an
+  adaptive strategy's accept probability — the object rewinding produces — so the static-dichotomy caveat
+  falls away; what remains is the execution-semantics identification that a rewound random-oracle adversary
+  *induces* such a strategy, with its RO-query loss, plus the random-oracle uniformity axiom.
+* **Constant, rewound** — the `_rewind` forms below state the constant rung's accept events over
+  **reprogrammed-oracle runs** (`reprogramRounds`), deriving the `{ch with ipaRound := χ}` round-vector
+  surgery from the rewinding primitive via `roChallenges_reprogramRounds` — the transcript-ordering module
+  (`Soundness.Forking.Ordering`) on the Fiat–Shamir path.
+* **Staged, rewound** — the `_adaptive_rewind` forms below state the staged rung over reprogrammed-oracle
+  runs on each strategy-spliced proof. `roChallenges_spliceIpa_pre` proves those splices share the fixed
+  pre-IPA challenge prefix with `ps`; `roChallenges_reprogramRounds` then supplies the per-path round vector.
+* **Abstract** — `orchard_verifier_vesta_forking_opening`/`_constraint`, whose modular `hbridge` names the
+  full prover-as-oracle identification; the staged rungs prove its deterministic content, while the
+  execution-semantics content stays the floor.
+
+The legacy `orchard_verifier_vesta_opening_of_forked`/`_constraint` remain compiled and checked but are no
+longer the top statement a reader takes. -/
+
+open scoped ENNReal in
+open Classical in
+/-- **The deployed Orchard opening over Vesta, from oracle rewinding.**
+`orchard_verifier_vesta_forking_opening_deployed` at the honest run's challenges `roChallenges O init ps`,
+with the accept probability stated over **reprogrammed-oracle runs**: the event is halo2's verifier equation
+at `roChallenges (reprogramRounds O init ps χ) init ps` — the deployed schedule re-run under the oracle
+reprogrammed at the `k` round prefixes — rather than an unexplained `{ch with ipaRound := χ}` surgery.
+`roChallenges_reprogramRounds` proves the two events equal, so the round-vector semantics of the forking
+measure is *derived* from the rewinding primitive, consuming the transcript ordering. Residuals
+are unchanged: `z ≠ 0`, the nonzero generator `hg0`, the `S`-opening `hs`, and the random-oracle uniformity
+axiom in `hprob` — including the constant rung's static-dichotomy scope: `hprob` is still the *fixed*
+proof's accept measure over the whole challenge space (see
+`orchard_verifier_vesta_forking_opening_deployed`); the `_adaptive`/`_adaptive_rewind` rungs are the
+attack-event forms. -/
+noncomputable def orchard_verifier_vesta_forking_opening_rewind [Fact (HasseBound Vesta.curve)] [DecidableEq VestaG]
+    [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
+    (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG)
+    (O : List (TranscriptElt Fp VestaG) → Fp) (init : List (TranscriptElt Fp VestaG))
+    (s : Fin (2 ^ urs.k) → Fp) (hz : (roChallenges O init ps).z ≠ 0) (hg0 : urs.g 0 ≠ 0)
+    (hs : commit urs s = ps.ipaS)
+    (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
+        < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
+            (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk ps
+              (roChallenges (reprogramRounds O init ps χ) init ps)))) :
+    (∃ a, IpaRelation urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
+        (evalVector urs.k (roChallenges O init ps).x3)
+        (multiopenValue vk ps (roChallenges O init ps)
+          - (roChallenges O init ps).xi * innerProduct s (evalVector urs.k (roChallenges O init ps).x3)) a)
+      ⊕' NontrivialRelation (F := Fp) urs.g urs.u urs.w := by
+  refine orchard_verifier_vesta_forking_opening_deployed urs hk vk ps (roChallenges O init ps)
+    s hz hg0 hs ?_
+  simpa only [roChallenges_reprogramRounds] using hprob
+
+open Polynomial in
+open scoped ENNReal in
+open Classical in
+/-- The constraint companion of `orchard_verifier_vesta_forking_opening_rewind`:
+`orchard_verifier_vesta_forking_constraint_deployed` with the accept probability over reprogrammed-oracle
+runs, the round-vector semantics derived via `roChallenges_reprogramRounds`. The `hquot`/`hgood`
+caveat is unchanged — see `orchard_verifier_deployed_constraint_of_forked`'s caveat — and so
+is the constant rung's static-dichotomy scope (see `orchard_verifier_vesta_forking_opening_deployed`); the
+`_adaptive_rewind` pair is the attack-event form. -/
+noncomputable def orchard_verifier_vesta_forking_constraint_rewind [Fact (HasseBound Vesta.curve)]
+    [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
+    (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG)
+    (O : List (TranscriptElt Fp VestaG) → Fp) (init : List (TranscriptElt Fp VestaG))
+    (s : Fin (2 ^ urs.k) → Fp)
+    (fixedCols : ℕ → Polynomial Fp)
+    (decodeAdvice decodeInstance : (Fin (2 ^ urs.k) → Fp) → (ℕ → Polynomial Fp))
+    (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
+    (hz : (roChallenges O init ps).z ≠ 0) (hg0 : urs.g 0 ≠ 0) (hs : commit urs s = ps.ipaS)
+    (hξ : (roChallenges O init ps).xi
+        * innerProduct s (evalVector urs.k (roChallenges O init ps).x3) = 0)
+    (hquot : ∀ a, IpaRelation urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
+        (evalVector urs.k (roChallenges O init ps).x3)
+        (multiopenValue vk ps (roChallenges O init ps)) a →
+      quotientCheck (combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates) hpoly deg x)
+    (hgood : ∀ a, IpaRelation urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
+        (evalVector urs.k (roChallenges O init ps).x3)
+        (multiopenValue vk ps (roChallenges O init ps)) a →
+      combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates ≠ hpoly * (X ^ deg - 1) →
+      (combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates
+        - hpoly * (X ^ deg - 1)).eval x ≠ 0)
+    {S : Prop}
+    (hencodes : ∀ a, SnarkRelation urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
+        (evalVector urs.k (roChallenges O init ps).x3) (multiopenValue vk ps (roChallenges O init ps))
+      (circuitSatViaGates fixedCols decodeAdvice decodeInstance y gates hpoly deg) a → S)
+    (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
+        < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
+            (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk ps
+              (roChallenges (reprogramRounds O init ps χ) init ps)))) :
+    S ⊕' NontrivialRelation (F := Fp) urs.g urs.u urs.w := by
+  refine orchard_verifier_vesta_forking_constraint_deployed urs hk vk ps (roChallenges O init ps)
+    s fixedCols decodeAdvice decodeInstance y gates hpoly deg x hz hg0 hs hξ hquot hgood hencodes ?_
+  simpa only [roChallenges_reprogramRounds] using hprob
+
+open scoped ENNReal in
+open Classical in
+/-- **The staged Orchard opening over Vesta, from oracle rewinding.**
+This is `orchard_verifier_vesta_forking_opening_adaptive` with the adaptive accept probability stated over
+reprogrammed-oracle runs on each strategy-spliced proof. For each challenge path `χ`, the proof string is
+`spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2`; the oracle is reprogrammed at that
+spliced proof's IPA round prefixes and the deployed schedule is re-run. `roChallenges_reprogramRounds` turns
+that run into round-vector replacement, and `roChallenges_spliceIpa_pre` removes the irrelevant spliced
+pre-IPA fields. The residual is unchanged from the staged rung: the execution-semantics identification that a
+rewound random-oracle adversary induces such a strategy, with its RO-query loss, plus the uniformity axiom in
+`hprob`. -/
+noncomputable def orchard_verifier_vesta_forking_opening_adaptive_rewind [Fact (HasseBound Vesta.curve)]
+    [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
+    (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG)
+    (O : List (TranscriptElt Fp VestaG) → Fp) (init : List (TranscriptElt Fp VestaG))
+    (s : Fin (2 ^ urs.k) → Fp) (P : Prover Fp VestaG shape.k)
+    (hz : (roChallenges O init ps).z ≠ 0) (hg0 : urs.g 0 ≠ 0) (hs : commit urs s = ps.ipaS)
+    (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
+        < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
+            (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk
+              (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2)
+              (roChallenges
+                (reprogramRounds O init
+                  (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2) χ)
+                init
+                (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2))))) :
+    (∃ a, IpaRelation urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
+        (evalVector urs.k (roChallenges O init ps).x3)
+        (multiopenValue vk ps (roChallenges O init ps)
+          - (roChallenges O init ps).xi * innerProduct s (evalVector urs.k (roChallenges O init ps).x3)) a)
+      ⊕' NontrivialRelation (F := Fp) urs.g urs.u urs.w := by
+  refine orchard_verifier_vesta_forking_opening_adaptive urs hk vk ps (roChallenges O init ps)
+    s P hz hg0 hs ?_
+  simpa only [roChallenges_reprogramRounds, roChallenges_spliceIpa_pre] using hprob
+
+open Polynomial in
+open scoped ENNReal in
+open Classical in
+/-- The constraint companion of `orchard_verifier_vesta_forking_opening_adaptive_rewind`: the staged
+round-adaptive capstone with its accept event grounded in reprogrammed-oracle runs on each spliced proof. The
+`hquot`/`hgood` caveat is unchanged — see `orchard_verifier_deployed_constraint_of_forked`'s caveat. -/
+noncomputable def orchard_verifier_vesta_forking_constraint_adaptive_rewind [Fact (HasseBound Vesta.curve)]
+    [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
+    (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG)
+    (O : List (TranscriptElt Fp VestaG) → Fp) (init : List (TranscriptElt Fp VestaG))
+    (s : Fin (2 ^ urs.k) → Fp) (P : Prover Fp VestaG shape.k)
+    (fixedCols : ℕ → Polynomial Fp)
+    (decodeAdvice decodeInstance : (Fin (2 ^ urs.k) → Fp) → (ℕ → Polynomial Fp))
+    (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
+    (hz : (roChallenges O init ps).z ≠ 0) (hg0 : urs.g 0 ≠ 0) (hs : commit urs s = ps.ipaS)
+    (hξ : (roChallenges O init ps).xi
+        * innerProduct s (evalVector urs.k (roChallenges O init ps).x3) = 0)
+    (hquot : ∀ a, IpaRelation urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
+        (evalVector urs.k (roChallenges O init ps).x3)
+        (multiopenValue vk ps (roChallenges O init ps)) a →
+      quotientCheck (combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates) hpoly deg x)
+    (hgood : ∀ a, IpaRelation urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
+        (evalVector urs.k (roChallenges O init ps).x3)
+        (multiopenValue vk ps (roChallenges O init ps)) a →
+      combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates ≠ hpoly * (X ^ deg - 1) →
+      (combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates
+        - hpoly * (X ^ deg - 1)).eval x ≠ 0)
+    {S : Prop}
+    (hencodes : ∀ a, SnarkRelation urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
+        (evalVector urs.k (roChallenges O init ps).x3) (multiopenValue vk ps (roChallenges O init ps))
+      (circuitSatViaGates fixedCols decodeAdvice decodeInstance y gates hpoly deg) a → S)
+    (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
+        < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
+            (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk
+              (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2)
+              (roChallenges
+                (reprogramRounds O init
+                  (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2) χ)
+                init
+                (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2))))) :
+    S ⊕' NontrivialRelation (F := Fp) urs.g urs.u urs.w := by
+  rcases orchard_verifier_vesta_forking_opening_adaptive_rewind urs hk vk ps O init s P hz hg0 hs hprob
+    with hopen | hrel
+  · refine PSum.inl ?_
+    obtain ⟨a, hrel'⟩ := hopen
+    rw [hξ, sub_zero] at hrel'
+    have hsat : circuitSatViaGates fixedCols decodeAdvice decodeInstance y gates hpoly deg a :=
+      circuitSatViaGates_of_check fixedCols decodeAdvice decodeInstance y gates hpoly deg a x
+        (hquot a hrel') (hgood a hrel')
+    exact hencodes a ⟨hrel', hsat⟩
+  · exact PSum.inr hrel
 
 end Zcash.Snark

--- a/Zcash/Snark/Soundness/Vesta.lean
+++ b/Zcash/Snark/Soundness/Vesta.lean
@@ -155,27 +155,6 @@ theorem commit_adjustedWitness {G : Type*} [AddCommGroup G] [Module Fp G] (urs :
     intro a a'; simp only [commit, Pi.sub_apply, sub_smul, Finset.sum_sub_distrib]
   rw [adjustedWitness, commit_add, csub, commit_single, commit_smul]
 
-/-- **Every Vesta point propositionally lies in the `g`-span.** At Vesta's prime order a nonzero generator
-`urs.g 0` generates the whole group. This theorem is proof-level only: selecting its existential witness
-would compute a discrete logarithm, so computational reductions must receive the representation as input and
-must not use `Classical.choose` on this result. -/
-theorem commit_surjective (urs : URS VestaG) (hg0 : urs.g 0 ≠ 0)
-    (P : VestaG) : ∃ aMulti : Fin (2 ^ urs.k) → Fp, commit urs aMulti = P := by
-  have hinj : Function.Injective (fun c : Fp => c • urs.g 0) := by
-    intro c c' h
-    have h' : c • urs.g 0 = c' • urs.g 0 := h
-    rcases eq_or_ne c c' with hcc | hcc
-    · exact hcc
-    · refine absurd ?_ hg0
-      have hd : c - c' ≠ 0 := sub_ne_zero.mpr hcc
-      have h0 : (c - c') • urs.g 0 = 0 := by rw [sub_smul, h', sub_self]
-      rw [← one_smul Fp (urs.g 0), ← inv_mul_cancel₀ hd, mul_smul, h0, smul_zero]
-  haveI : Fintype VestaG := Fintype.ofFinite VestaG
-  have hcardeq : Fintype.card Fp = Fintype.card VestaG := by
-    rw [card_Fp, ← Nat.card_eq_fintype_card, Vesta.card_eq]
-  obtain ⟨c, hc⟩ := ((Fintype.bijective_iff_injective_and_card _).mpr ⟨hinj, hcardeq⟩).surjective P
-  exact ⟨Pi.single 0 c, by rw [commit_single]; exact hc⟩
-
 open scoped ENNReal in
 /-- A nonzero blinding shift vanishes for at most a `1 / |Fp|` fraction of uniform `ξ` challenges. -/
 theorem blinder_value_recovery_badSet {k : ℕ} (s : Fin (2 ^ k) → Fp) (xEval : Fp)

--- a/Zcash/Snark/Soundness/Vesta.lean
+++ b/Zcash/Snark/Soundness/Vesta.lean
@@ -444,9 +444,11 @@ rewinding shares the pre-IPA prefix; IPA fields the strategy's own outputs along
 accept probability of an adaptive round-strategy — the object rewinding produces — not one fixed proof's
 accept measure: the static-dichotomy caveat of the `_deployed` capstone does not apply at this rung. What
 remains is the execution-semantics identification (that a rewound random-oracle adversary *induces* such a
-staged strategy, with its RO-query loss), the random-oracle uniformity axiom in `hprob`, and the structural
-witnesses (`z ≠ 0`, `hg0`, the `S`-opening `hs` — with `ps.ipaS` splice-invariant, so one `s` serves every
-path). The transcript-ordering and reprogramming content is already on this path through the
+staged strategy, with its RO-query loss — deriving the accept probability of `hprob`), Blake2b-as-random-oracle,
+and the structural witnesses (`z ≠ 0`, `hg0`, the `S`-opening `hs` — with `ps.ipaS` splice-invariant, so one `s`
+serves every path). The uniform measure of `hprob` is justified standalone
+(`Forking.Rewind.roChallenges_ipaRound_uniform`, for the fixed proof string; consumed by no capstone). The
+transcript-ordering and reprogramming content is already on this path through the
 `_adaptive_rewind` capstone. The `⊕' NontrivialRelation` caveat is unchanged — vacuous at Vesta's prime
 order. -/
 noncomputable def orchard_verifier_vesta_forking_opening_adaptive [Fact (HasseBound Vesta.curve)] [DecidableEq VestaG]
@@ -491,11 +493,13 @@ bridge discharged.** The constraint companion of `orchard_verifier_vesta_forking
 adaptive accept event and internally-proven bridge, routed to the gate-satisfaction seam
 (`hquot`/`hgood` → `circuitSatViaGates`, `hencodes`) at the *claimed* value `multiopenValue`, pinned by the
 value-recovery hypothesis `hξ` (honest blinding, or a `1/p`-measure set of post-`S` challenges for a
-malicious blinder, `blinder_value_recovery_badSet`). Residual: the execution-semantics identification, the
-random-oracle uniformity axiom in `hprob`, and the structural witnesses; the static-dichotomy caveat does not
-apply at this rung. The transcript-ordering and reprogramming content is discharged by the staged
-rewinding capstones below. `hquot`/`hgood` retain the ∀-openings shape — unsatisfiable at Vesta for any decode
-that genuinely reads the witness. -/
+malicious blinder, `blinder_value_recovery_badSet`). Residual: the execution-semantics identification (the
+querying adversary and its query-loss, deriving `hprob`), Blake2b-as-random-oracle, and the structural
+witnesses; the uniform measure of `hprob` is justified standalone
+(`Forking.Rewind.roChallenges_ipaRound_uniform`, for the fixed proof string; consumed by no capstone); the
+static-dichotomy caveat does not apply at this rung. The transcript-ordering and reprogramming content is
+discharged by the staged rewinding capstones below. `hquot`/`hgood` retain the ∀-openings shape —
+unsatisfiable at Vesta for any decode that genuinely reads the witness. -/
 noncomputable def orchard_verifier_vesta_forking_constraint_adaptive [Fact (HasseBound Vesta.curve)]
     [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
@@ -547,7 +551,9 @@ The terminal readings, ordered by how much of the prover-as-oracle and rewinding
   bridge proven for every such strategy (`deployedVerifierEq_iff_flatAccept_adaptive`). Their `hprob` is an
   adaptive strategy's accept probability — the object rewinding produces — so the static-dichotomy caveat
   falls away; what remains is the execution-semantics identification that a rewound random-oracle adversary
-  *induces* such a strategy, with its RO-query loss, plus the random-oracle uniformity axiom.
+  *induces* such a strategy, with its RO-query loss (deriving the accept probability), plus
+  Blake2b-as-random-oracle. The uniform measure of `hprob` is justified standalone
+  (`Forking.Rewind.roChallenges_ipaRound_uniform`, for the fixed proof string; consumed by no capstone).
 * **Constant, rewound** — the `_rewind` forms below state the constant rung's accept events over
   **reprogrammed-oracle runs** (`reprogramRounds`), deriving the `{ch with ipaRound := χ}` round-vector
   surgery from the rewinding primitive via `roChallenges_reprogramRounds` — the transcript-ordering module
@@ -571,9 +577,11 @@ at `roChallenges (reprogramRounds O init ps χ) init ps` — the deployed schedu
 reprogrammed at the `k` round prefixes — rather than an unexplained `{ch with ipaRound := χ}` surgery.
 `roChallenges_reprogramRounds` proves the two events equal, so the round-vector semantics of the forking
 measure is *derived* from the rewinding primitive, consuming the transcript ordering. Residuals
-are unchanged: `z ≠ 0`, the nonzero generator `hg0`, the `S`-opening `hs`, and the random-oracle uniformity
-axiom in `hprob` — including the constant rung's static-dichotomy scope: `hprob` is still the *fixed*
-proof's accept measure over the whole challenge space (see
+are unchanged: `z ≠ 0`, the nonzero generator `hg0`, the `S`-opening `hs`, and — above `hprob` — the querying
+adversary and its query-loss plus Blake2b-as-random-oracle (the uniform measure of `hprob` is justified
+standalone, `Forking.Rewind.roChallenges_ipaRound_uniform`, for the fixed proof string) — including the constant
+rung's static-dichotomy scope: `hprob` is still the *fixed* proof's accept measure over the whole challenge
+space (see
 `orchard_verifier_vesta_forking_opening_deployed`); the `_adaptive`/`_adaptive_rewind` rungs are the
 attack-event forms. -/
 noncomputable def orchard_verifier_vesta_forking_opening_rewind [Fact (HasseBound Vesta.curve)] [DecidableEq VestaG]
@@ -647,8 +655,9 @@ reprogrammed-oracle runs on each strategy-spliced proof. For each challenge path
 spliced proof's IPA round prefixes and the deployed schedule is re-run. `roChallenges_reprogramRounds` turns
 that run into round-vector replacement, and `roChallenges_spliceIpa_pre` removes the irrelevant spliced
 pre-IPA fields. The residual is unchanged from the staged rung: the execution-semantics identification that a
-rewound random-oracle adversary induces such a strategy, with its RO-query loss, plus the uniformity axiom in
-`hprob`. -/
+rewound random-oracle adversary induces such a strategy, with its RO-query loss (deriving the accept probability
+of `hprob`), plus Blake2b-as-random-oracle — the uniform measure of `hprob` is justified standalone
+(`Forking.Rewind.roChallenges_ipaRound_uniform`, for the fixed proof string; consumed by no capstone). -/
 noncomputable def orchard_verifier_vesta_forking_opening_adaptive_rewind [Fact (HasseBound Vesta.curve)]
     [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG)

--- a/Zcash/Snark/Soundness/Vesta.lean
+++ b/Zcash/Snark/Soundness/Vesta.lean
@@ -177,12 +177,7 @@ theorem commit_surjective (urs : URS VestaG) (hg0 : urs.g 0 ≠ 0)
   exact ⟨Pi.single 0 c, by rw [commit_single]; exact hc⟩
 
 open scoped ENNReal in
-/-- **The ξ-randomization budget behind the constraint capstone's value recovery.** A malicious blinder with
-`⟨s,b⟩ = δ ≠ 0` satisfies the value-recovery premise `ξ·⟨s,b⟩ = 0` — which pins the opened value back to the
-claimed `multiopenValue` — only at `ξ = 0`, a set of uniform random-oracle measure `≤ 1/p`. So the `hξ`
-hypothesis of `orchard_verifier_vesta_forking_constraint`, for a nonzero blinder, holds only on that
-`1/p`-measure set of post-`S` challenges: `blinder_shift_badSet_measure` made explicit for the constraint
-side. -/
+/-- A nonzero blinding shift vanishes for at most a `1 / |Fp|` fraction of uniform `ξ` challenges. -/
 theorem blinder_value_recovery_badSet {k : ℕ} (s : Fin (2 ^ k) → Fp) (xEval : Fp)
     (hδ : innerProduct s (evalVector k xEval) ≠ 0) :
     uniformChallenge.toOuterMeasure
@@ -192,21 +187,12 @@ theorem blinder_value_recovery_badSet {k : ℕ} (s : Fin (2 ^ k) → Fp) (xEval 
 
 open scoped ENNReal in
 open Classical in
-/-- **The deployed Orchard opening over Vesta, via the forking refinements (no `FiatShamirTree`), with the
-structural facts discharged.** The multiopen evaluation vector is the concrete powers vector
-`b = evalVector urs.k xEval` (so `b 0 = 1` is *proved* by `evalVector_zero`, not assumed). The multiopen
-witness `aMulti` and its commitment equation `hcommit` are supplied as **data** by the algebraic-prover layer;
-they are deliberately not selected from prime-order surjectivity. The adjusted witness is constructed, so
-halo2's adjusted-commitment relation `hP` holds by linearity (`commit_adjustedWitness`). The synthetic blinder
-is stripped *unconditionally*: the conclusion is
-the **true** opened value `multiopenValue − ξ·⟨s,b⟩`, with no `⟨s,b⟩ = 0` assumed — covering a malicious blinder
-(the honest case `⟨s,b⟩ = 0` recovers the claimed value). What remains is the explicit prover-as-oracle bridge
-`hbridge` (the irreducible random-oracle floor), plus the antecedents `z ≠ 0`, the explicit representation
-`aMulti`/`hcommit`, and the accept probability `hprob` beating the knowledge error `kerr/Nᵏ`. This wrapper is
-still proof-level and noncomputable because `deployed_forking_soundness_of_bridge` selects the existential
-fork certificate; the executable kernel is `deployed_forking_relation`, which takes that certificate as data.
-The `⊕' NontrivialRelation` caveat is
-unchanged — vacuous at Vesta's prime order, the force in the out-of-Lean DLR/AGM layer. -/
+/-- Open the deployed Orchard commitment over Vesta using the forking result.
+
+The returned value is `multiopenValue − ξ·⟨s,b⟩`; honest blinding makes the second term zero.
+`hbridge` connects the accept event to a prover strategy, and `hprob` must beat the knowledge error.
+This wrapper remains noncomputable because it selects an existential fork certificate;
+`deployed_forking_relation` is the executable kernel for an explicit certificate. -/
 noncomputable def orchard_verifier_vesta_forking_opening [DecidableEq VestaG]
     [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
@@ -237,23 +223,10 @@ noncomputable def orchard_verifier_vesta_forking_opening [DecidableEq VestaG]
 open Polynomial in
 open scoped ENNReal in
 open Classical in
-/-- **The deployed Orchard opening *and constraint* over Vesta, via the forking refinements (no
-`FiatShamirTree`), with the structural facts discharged.** The constraint-side companion of
-`orchard_verifier_vesta_forking_opening`: the same derived structural facts (`b 0 = 1`, `hP`), the explicit
-representation input `aMulti`/`hcommit`, and the same gate seam as `orchard_verifier_vesta_constraint_of_forked`
-(`hquot`/`hgood` → `circuitSatViaGates`, `hencodes`). Unlike the opening, the circuit is checked at the
-*claimed* value `multiopenValue`, so the minimal value-recovery hypothesis `hξ : ξ·⟨s,b⟩ = 0` is retained — it
-pins the opened value `multiopenValue − ξ·⟨s,b⟩` (unique under binding) from the forking opening back to
-`multiopenValue`. `hξ`
-generalises honest blinding (`⟨s,b⟩ = 0`); for a *malicious* blinder (`⟨s,b⟩ ≠ 0`) it holds only on a
-`1/p`-measure set of post-`S` challenges `ξ` (`blinder_value_recovery_badSet`, the `ξ`-randomization budget).
-The deployed-curve residual is the explicit prover-as-oracle bridge `hbridge`; both the opening and the
-constraint side route through it with `b 0 = 1` and `hP` derived and `aMulti`/`hcommit` supplied as data. The
-original `FiatShamirTree` reductions
-(`orchard_verifier_vesta_opening_of_forked`/`_constraint`) remain as the coarser legacy endpoints. The
-`⊕' NontrivialRelation` caveat is unchanged — vacuous at Vesta's prime order, the force in the out-of-Lean
-DLR/AGM layer. `hquot`/`hgood` retain the ∀-openings shape — unsatisfiable at Vesta for any decode that
-genuinely reads the witness (see `orchard_verifier_deployed_constraint_of_forked`'s caveat). -/
+/-- Add the constraint conclusion to `orchard_verifier_vesta_forking_opening`.
+
+`hξ` restores the claimed value by proving the blinding shift is zero. The `hquot` and `hgood`
+hypotheses retain the all-openings caveat from the legacy constraint theorem. -/
 noncomputable def orchard_verifier_vesta_forking_constraint [DecidableEq VestaG]
     [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
@@ -294,10 +267,7 @@ noncomputable def orchard_verifier_vesta_forking_constraint [DecidableEq VestaG]
     exact hencodes a ⟨hrel', hsat⟩
   · exact PSum.inr hrel
 
-/-- The deployed adjusted-commitment's value term `Σᵢ [-v].getD i • gᵢ` collapses to `-v • g 0` (the value
-list `[-v]` has one entry, at index `0`) — letting the verifier's adjusted commitment `multiopen + Σ[-v].getD·g`
-meet the capstone's `-v • g 0` form. Pure module algebra over any `Fp`-module (the Vesta instances supply
-`Module Fp VestaG` at the call sites). -/
+/-- The single-entry value term in the adjusted commitment is `-v • g 0`. -/
 theorem sum_getD_single {k : ℕ} {G : Type*} [AddCommGroup G] [Module Fp G] (gg : Fin (2 ^ k) → G)
     (v : Fp) :
     (∑ i, ([-v].getD i.val 0 : Fp) • gg i) = -v • gg 0 := by
@@ -312,30 +282,12 @@ theorem sum_getD_single {k : ℕ} {G : Type*} [AddCommGroup G] [Module Fp G] (gg
 
 open scoped ENNReal in
 open Classical in
-/-- **The deployed Orchard opening over Vesta, with `hbridge` discharged.** This is
-`orchard_verifier_vesta_forking_opening` with the abstract prover-as-oracle bridge *removed*: `accepts` is
-halo2's **actual** verifier equation `DeployedIpaVerifierEq` at the rewound IPA challenges, and the bridge to
-`flatAccept` of the concrete proof tree `proverOfRounds ps.ipaRounds ps.ipaC ps.ipaF` is **proven** internally
-by `deployedVerifierEq_iff_flatAccept` — not assumed. The `shape.k`↔`urs.k` transport is discharged by
-`subst`, and the commitment slot is reconciled (`sum_getD_single`, `deployedCommitment = multiopenCommitment`,
-the `S`-opening `hs : commit urs s = ps.ipaS`, `module`). The remaining hypotheses are `z ≠ 0`, the explicit
-multiopen representation `aMulti`/`hcommit`, and the `S`-opening witness `hs`, plus the accept *probability* `hprob`
-over the uniform IPA-challenge measure.
+/-- Open the deployed Orchard commitment for a fixed proof string.
 
-**Quantifier-shape caveat (`hprob`).** Discharging the bridge with the *constant* strategy `proverOfRounds`
-changes what `hprob` measures: it is the accept set of this **fixed** proof string over *all* round-challenge
-vectors — not the Fiat–Shamir attack event. A real prover (honest ones included) produces a proof whose
-accept set is a low-degree variety of measure ≤ `3k/p` — clearing the verifier equation by `∏ χⱼ` leaves
-total degree ≤ `2k`, so Schwartz–Zippel gives ≤ `2k/p`, plus ≤ `k/p` for the zero-challenge hyperplanes
-where the total inverse departs from the cleared polynomial — generically ≈ `1/p`, and never *strictly
-above* the `3k/p` threshold: `hprob` here is satisfiable only by a proof that accepts *identically*, while
-a forger only needs its single RO-derived vector to land on that variety. So this theorem is the *static
-dichotomy* "a proof accepting on more than `3k/p` of challenge space yields an opening". For adaptive
-adversaries, use `orchard_verifier_vesta_forking_opening_adaptive` for the bridge-discharge over a
-prefix-respecting strategy and `orchard_verifier_vesta_forking_opening_adaptive_rewind` when the accept event
-should be stated over reprogrammed-oracle runs. The remaining floor there is not the deterministic bridge but
-the execution-semantics identification — a rewound random-oracle adversary induces such a strategy, with its
-RO-query loss. The `⊕' NontrivialRelation` caveat is unchanged — vacuous at Vesta's prime order. -/
+The accept event is halo2's verifier equation, and `deployedVerifierEq_iff_flatAccept` proves its
+bridge to the constant strategy. `hprob` measures this one proof over all round challenges, not the
+Fiat–Shamir attack event. Use the adaptive variants for a prefix-respecting strategy and
+reprogrammed-oracle runs. -/
 noncomputable def orchard_verifier_vesta_forking_opening_deployed [DecidableEq VestaG]
     [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
@@ -379,20 +331,10 @@ noncomputable def orchard_verifier_vesta_forking_opening_deployed [DecidableEq V
 open Polynomial in
 open scoped ENNReal in
 open Classical in
-/-- **The deployed Orchard opening *and constraint* over Vesta, with `hbridge` discharged.** The constraint
-companion of `orchard_verifier_vesta_forking_opening_deployed`: same discharged bridge (halo2's actual verifier
-accept, no abstract `hbridge`), routed through the opening to the gate-satisfaction seam
-(`hquot`/`hgood` → `circuitSatViaGates`, `hencodes`) at the *claimed* value `multiopenValue` — pinned from the
-forking opening's `multiopenValue − ξ·⟨s,b⟩` by the minimal value-recovery hypothesis
-`hξ : ch.xi·⟨s,b⟩ = 0` (honest blinding, or a `1/p`-measure set of post-`S` challenges for a malicious blinder,
-`blinder_value_recovery_badSet`). Residual assumptions: `z ≠ 0`, the explicit multiopen representation,
-the `S`-opening witness `hs`, and `hξ` — plus the accept probability `hprob`, which carries the same quantifier-shape caveat
-as `orchard_verifier_vesta_forking_opening_deployed`: with the constant `proverOfRounds` strategy it measures
-the *fixed* proof's accept set over all round-challenge vectors, not the Fiat–Shamir attack event. For the
-adaptive form, use `orchard_verifier_vesta_forking_constraint_adaptive`; for the same statement over
-reprogrammed-oracle runs, use `orchard_verifier_vesta_forking_constraint_adaptive_rewind`. `hquot`/`hgood`
-retain the ∀-openings shape — unsatisfiable at Vesta for any decode that genuinely
-reads the witness (see `orchard_verifier_deployed_constraint_of_forked`'s caveat). -/
+/-- Add the constraint conclusion to `orchard_verifier_vesta_forking_opening_deployed`.
+
+`hξ` restores the claimed value by proving the blinding shift is zero. `hprob` still measures one
+fixed proof. The `hquot` and `hgood` hypotheses retain the all-openings caveat. -/
 noncomputable def orchard_verifier_vesta_forking_constraint_deployed [DecidableEq VestaG]
     [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
@@ -434,22 +376,11 @@ noncomputable def orchard_verifier_vesta_forking_constraint_deployed [DecidableE
 
 open scoped ENNReal in
 open Classical in
-/-- **The deployed Orchard opening over Vesta for the staged (round-adaptive) adversary, bridge
-discharged.** `orchard_verifier_vesta_forking_opening_deployed` upgraded from the constant strategy to an
-arbitrary prefix-respecting strategy `P : Prover`: the accept event is halo2's **actual** verifier equation
-on the strategy's spliced proof (`spliceIpa` at `pathData P χ` — pre-IPA fields the fixed `ps`'s, since
-rewinding shares the pre-IPA prefix; IPA fields the strategy's own outputs along `χ`), and the bridge to
-`flatAccept P` is **proven** internally (`deployedVerifierEq_iff_flatAccept_adaptive`). So `hprob` is the
-accept probability of an adaptive round-strategy — the object rewinding produces — not one fixed proof's
-accept measure: the static-dichotomy caveat of the `_deployed` capstone does not apply at this rung. What
-remains is the execution-semantics identification (that a rewound random-oracle adversary *induces* such a
-staged strategy, with its RO-query loss — deriving the accept probability of `hprob`), Blake2b-as-random-oracle,
-and the structural witnesses (`z ≠ 0`, the explicit `aMulti`/`hcommit`, and the `S`-opening `hs` — with
-`ps.ipaS` splice-invariant, so one `s` serves every path). The uniform measure of `hprob` is justified standalone
-(`Forking.Rewind.roChallenges_ipaRound_uniform`, for the fixed proof string; consumed by no capstone). The
-transcript-ordering and reprogramming content is already on this path through the
-`_adaptive_rewind` capstone. The `⊕' NontrivialRelation` caveat is unchanged — vacuous at Vesta's prime
-order. -/
+/-- Open the deployed Orchard commitment for a prefix-respecting prover strategy.
+
+The verifier runs on the proof assembled for each challenge path, and
+`deployedVerifierEq_iff_flatAccept_adaptive` proves the bridge to `P`. Connecting a real
+random-oracle adversary to this strategy, including query loss, remains outside this theorem. -/
 noncomputable def orchard_verifier_vesta_forking_opening_adaptive [DecidableEq VestaG]
     [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
@@ -489,18 +420,10 @@ noncomputable def orchard_verifier_vesta_forking_opening_adaptive [DecidableEq V
 open Polynomial in
 open scoped ENNReal in
 open Classical in
-/-- **The deployed Orchard opening *and constraint* over Vesta for the staged (round-adaptive) adversary,
-bridge discharged.** The constraint companion of `orchard_verifier_vesta_forking_opening_adaptive`: same
-adaptive accept event and internally-proven bridge, routed to the gate-satisfaction seam
-(`hquot`/`hgood` → `circuitSatViaGates`, `hencodes`) at the *claimed* value `multiopenValue`, pinned by the
-value-recovery hypothesis `hξ` (honest blinding, or a `1/p`-measure set of post-`S` challenges for a
-malicious blinder, `blinder_value_recovery_badSet`). Residual: the execution-semantics identification (the
-querying adversary and its query-loss, deriving `hprob`), Blake2b-as-random-oracle, and the structural
-witnesses; the uniform measure of `hprob` is justified standalone
-(`Forking.Rewind.roChallenges_ipaRound_uniform`, for the fixed proof string; consumed by no capstone); the
-static-dichotomy caveat does not apply at this rung. The transcript-ordering and reprogramming content is
-discharged by the staged rewinding capstones below. `hquot`/`hgood` retain the ∀-openings shape —
-unsatisfiable at Vesta for any decode that genuinely reads the witness. -/
+/-- Add the constraint conclusion to `orchard_verifier_vesta_forking_opening_adaptive`.
+
+`hξ` restores the claimed value. Connecting the Fiat–Shamir adversary and its query loss remains
+outside this theorem. The `hquot` and `hgood` hypotheses retain the all-openings caveat. -/
 noncomputable def orchard_verifier_vesta_forking_constraint_adaptive
     [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
@@ -541,52 +464,33 @@ noncomputable def orchard_verifier_vesta_forking_constraint_adaptive
     exact hencodes a ⟨hrel', hsat⟩
   · exact PSum.inr hrel
 
-/-! ## The forking capstones: staged and rewound endpoints
+/-! ## Forking capstones
 
-The terminal readings, ordered by how much of the prover-as-oracle and rewinding content is internalized:
+The endpoints differ in how much of the adversary and rewinding model they include:
 
-* **Constant** — `orchard_verifier_vesta_forking_opening_deployed`/`_constraint_deployed`: halo2's actual
-  accept on the *fixed* proof string, bridge proven for the constant strategy `proverOfRounds`. Their
-  `hprob` is one proof's accept measure over the whole challenge space (the static dichotomy), not the
-  Fiat–Shamir attack event: see the quantifier-shape caveat on each.
-* **Staged (round-adaptive)** — `orchard_verifier_vesta_forking_opening_adaptive`/`_constraint_adaptive`:
-  halo2's actual accept on the spliced proofs of an arbitrary prefix-respecting strategy `P : Prover`,
-  bridge proven for every such strategy (`deployedVerifierEq_iff_flatAccept_adaptive`). Their `hprob` is an
-  adaptive strategy's accept probability — the object rewinding produces — so the static-dichotomy caveat
-  falls away; what remains is the execution-semantics identification that a rewound random-oracle adversary
-  *induces* such a strategy, with its RO-query loss (deriving the accept probability), plus
-  Blake2b-as-random-oracle. The uniform measure of `hprob` is justified standalone
-  (`Forking.Rewind.roChallenges_ipaRound_uniform`, for the fixed proof string; consumed by no capstone).
-* **Constant, rewound** — the `_rewind` forms below state the constant rung's accept events over
-  **reprogrammed-oracle runs** (`reprogramRounds`), deriving the `{ch with ipaRound := χ}` round-vector
-  surgery from the rewinding primitive via `roChallenges_reprogramRounds` — the transcript-ordering module
-  (`Soundness.Forking.Ordering`) on the Fiat–Shamir path.
-* **Staged, rewound** — the `_adaptive_rewind` forms below state the staged rung over reprogrammed-oracle
-  runs on each strategy-spliced proof. `roChallenges_spliceIpa_pre` proves those splices share the fixed
-  pre-IPA challenge prefix with `ps`; `roChallenges_reprogramRounds` then supplies the per-path round vector.
-* **Abstract** — `orchard_verifier_vesta_forking_opening`/`_constraint`, whose modular `hbridge` names the
-  full prover-as-oracle identification; the staged rungs prove its deterministic content, while the
-  execution-semantics content stays the floor.
+* **Fixed proof** — the `_deployed` pair runs halo2's verifier on one proof string. Its `hprob`
+  measures acceptance over all round challenges, not a Fiat–Shamir attack.
+* **Round-adaptive** — the `_adaptive` pair runs the verifier on proofs assembled from a
+  prefix-respecting `Prover`. A real random-oracle adversary still has to induce that strategy with
+  the required probability and query loss.
+* **Rewound** — the `_rewind` and `_adaptive_rewind` pairs state those events over reprogrammed-oracle
+  runs. `roChallenges_reprogramRounds` derives the replaced round challenges; the adaptive form also
+  uses `roChallenges_spliceIpa_pre` to preserve the pre-IPA challenges.
+* **Abstract** — `orchard_verifier_vesta_forking_opening` and `_constraint` expose the remaining
+  prover-as-oracle identification as `hbridge`.
 
-The legacy `orchard_verifier_vesta_opening_of_forked`/`_constraint` remain compiled and checked but are no
-longer the top statement a reader takes.
+The legacy `_of_forked` endpoints remain checked but are no longer the main statements.
 
-These probability wrappers are proof-level existence statements. They remain `noncomputable` because the
-fork certificate is obtained behind `∃`; executable reductions must instead call `deployed_forking_relation`
-with an explicit `DForkCert`, `aMulti`, and `hcommit`. -/
+These wrappers are `noncomputable` because they obtain the fork certificate through `∃`. Code that
+needs computed output must call `deployed_forking_relation` with an explicit `DForkCert`, `aMulti`, and
+`hcommit`. -/
 
 open scoped ENNReal in
 open Classical in
-/-- **The deployed Orchard opening over Vesta, from oracle rewinding.**
-`orchard_verifier_vesta_forking_opening_deployed` at the honest run's challenges `roChallenges O init ps`,
-with the accept probability stated over **reprogrammed-oracle runs**: the event is halo2's verifier equation
-at `roChallenges (reprogramRounds O init ps χ) init ps` — the deployed schedule re-run under the oracle
-reprogrammed at the `k` round prefixes — rather than an unexplained `{ch with ipaRound := χ}` surgery.
-`roChallenges_reprogramRounds` proves the two events equal, so the round-vector semantics of the forking
-measure is *derived* from the rewinding primitive, consuming the transcript ordering. Residuals and the constant rung's static-dichotomy scope are unchanged
-(see `orchard_verifier_vesta_forking_opening_deployed`; the uniform measure of `hprob` is justified standalone,
-`Forking.Rewind.roChallenges_ipaRound_uniform`); the `_adaptive`/`_adaptive_rewind` rungs are the
-attack-event forms. -/
+/-- Apply the fixed-proof opening theorem to reprogrammed-oracle runs.
+
+`roChallenges_reprogramRounds` identifies each run with replacement of the IPA round challenges.
+This remains a fixed-proof acceptance statement; the adaptive endpoints model the attack event. -/
 noncomputable def orchard_verifier_vesta_forking_opening_rewind [DecidableEq VestaG]
     [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG)
@@ -610,12 +514,10 @@ noncomputable def orchard_verifier_vesta_forking_opening_rewind [DecidableEq Ves
 open Polynomial in
 open scoped ENNReal in
 open Classical in
-/-- The constraint companion of `orchard_verifier_vesta_forking_opening_rewind`:
-`orchard_verifier_vesta_forking_constraint_deployed` with the accept probability over reprogrammed-oracle
-runs, the round-vector semantics derived via `roChallenges_reprogramRounds`. The `hquot`/`hgood`
-caveat is unchanged — see `orchard_verifier_deployed_constraint_of_forked`'s caveat — and so
-is the constant rung's static-dichotomy scope (see `orchard_verifier_vesta_forking_opening_deployed`); the
-`_adaptive_rewind` pair is the attack-event form. -/
+/-- Add the constraint conclusion to `orchard_verifier_vesta_forking_opening_rewind`.
+
+The accept event uses reprogrammed-oracle runs. The `hquot` and `hgood` all-openings caveat and the
+fixed-proof scope are unchanged. -/
 noncomputable def orchard_verifier_vesta_forking_constraint_rewind
     [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG)
@@ -655,14 +557,10 @@ noncomputable def orchard_verifier_vesta_forking_constraint_rewind
 
 open scoped ENNReal in
 open Classical in
-/-- **The staged Orchard opening over Vesta, from oracle rewinding.**
-`orchard_verifier_vesta_forking_opening_adaptive` with `hprob` stated over reprogrammed-oracle runs on each
-strategy-spliced proof: for each challenge path `χ` the proof string is
-`spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2`, the oracle is reprogrammed at that
-spliced proof's IPA round prefixes, and the deployed schedule is re-run. `roChallenges_reprogramRounds` turns
-that run into round-vector replacement, and `roChallenges_spliceIpa_pre` drops the irrelevant spliced pre-IPA
-fields. The residual is unchanged from the staged rung (see
-`orchard_verifier_vesta_forking_opening_adaptive`). -/
+/-- Apply the round-adaptive opening theorem to reprogrammed-oracle runs on each spliced proof.
+
+`roChallenges_reprogramRounds` supplies the path's round challenges, while
+`roChallenges_spliceIpa_pre` shows that splicing leaves the pre-IPA challenges unchanged. -/
 noncomputable def orchard_verifier_vesta_forking_opening_adaptive_rewind
     [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG)
@@ -692,9 +590,10 @@ noncomputable def orchard_verifier_vesta_forking_opening_adaptive_rewind
 open Polynomial in
 open scoped ENNReal in
 open Classical in
-/-- The constraint companion of `orchard_verifier_vesta_forking_opening_adaptive_rewind`: the staged
-round-adaptive capstone with its accept event grounded in reprogrammed-oracle runs on each spliced proof. The
-`hquot`/`hgood` caveat is unchanged — see `orchard_verifier_deployed_constraint_of_forked`'s caveat. -/
+/-- Add the constraint conclusion to `orchard_verifier_vesta_forking_opening_adaptive_rewind`.
+
+The accept event uses reprogrammed-oracle runs on each spliced proof. The `hquot` and `hgood`
+all-openings caveat is unchanged. -/
 noncomputable def orchard_verifier_vesta_forking_constraint_adaptive_rewind
     [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG)

--- a/Zcash/Snark/Verifier/FiatShamir.lean
+++ b/Zcash/Snark/Verifier/FiatShamir.lean
@@ -24,7 +24,7 @@ sense in which the deployed verifier is the Fiat–Shamir image of the interacti
 
 ## Assumptions
 
-* The Fiat–Shamir assumption (the random-oracle step) — that these hashed challenges carry the
+* The Fiat–Shamir assumption (the random-oracle idealization) — that these hashed challenges carry the
   interactive verifier's soundness to the non-interactive setting. This is the explicit hand-wave. In
   the fingerprint match the challenges are taken from the captured real transcript, so the match never
   re-derives them and does not depend on this assumption.
@@ -140,7 +140,7 @@ def deriveChallenges {shape : Shape} {F G : Type*} [Zero F] (fs : FiatShamir F G
 
 /-- The deployed (non-interactive) verifier's fingerprint MSM: `assemble` at the Fiat–Shamir
 challenges (the multiopen grouping is re-derived in Lean by `constructIntermediateSets`). The
-Fiat–Shamir assumption (the random-oracle step) is what carries the interactive verifier's soundness to
+Fiat–Shamir assumption (the random-oracle idealization) is what carries the interactive verifier's soundness to
 this non-interactive MSM. -/
 def nonInteractiveFingerprint {shape : Shape} {F G : Type*} [Field F] [DecidableEq F] [DecidableEq G]
     [Inhabited G] (fs : FiatShamir F G) (init : List (TranscriptElt F G))

--- a/Zcash/Snark/Verifier/FiatShamir.lean
+++ b/Zcash/Snark/Verifier/FiatShamir.lean
@@ -8,9 +8,10 @@ import Zcash.Snark.Verifier.Assemble
 
 The deployed verifier is non-interactive: each challenge is a hash of the transcript absorbed so far,
 rather than a fresh verifier coin. The hash is Blake2b (`transcript.rs`, personalization
-`"Halo2-Transcript"`). Per
-project scope the hash is hand-waved: we model it as an abstract `squeeze` function (`FiatShamir`) and
-formalize neither Blake2b nor the random-oracle reduction.
+`"Halo2-Transcript"`). Per project scope the hash is hand-waved *here*: this module models it as an abstract
+`squeeze` function (`FiatShamir`) and does not formalize Blake2b. The random-oracle idealization of the
+squeeze — reprogramming and the uniform-challenge bound the forking argument draws on — is separate, in
+`Zcash.Snark.Soundness.Forking.Oracle`.
 
 ## What is pinned down
 
@@ -31,12 +32,17 @@ sense in which the deployed verifier is the Fiat–Shamir image of the interacti
 
 namespace Zcash.Snark
 
-/-- An element absorbed into the Fiat–Shamir transcript: a commitment (group point, via `common_point`
-/ `read_point`) or a scalar (via `common_scalar` / `read_scalar`). -/
+/-- An element written to the Fiat–Shamir transcript, carrying halo2's three Blake2b domain prefixes: a
+commitment (group point, via `common_point` / `read_point`, `BLAKE2B_PREFIX_POINT`), a scalar (via
+`common_scalar` / `read_scalar`, `BLAKE2B_PREFIX_SCALAR`), or the domain marker written before each
+squeeze (`BLAKE2B_PREFIX_CHALLENGE`). The `challenge` marker — rather than re-absorbing the squeezed value —
+is what makes consecutive squeezes differ, matching the deployed transcript (the prefix-byte writes persist
+in the hash state; the challenge value is never fed back). -/
 inductive TranscriptElt (F G : Type*) where
   | point : G → TranscriptElt F G
   | scalar : F → TranscriptElt F G
-deriving DecidableEq
+  | challenge : TranscriptElt F G
+  deriving DecidableEq
 
 /-- The Fiat–Shamir hash, hand-waved: squeezes a field challenge from the transcript absorbed so far.
 In the deployed verifier this is Blake2b; neither it nor the random-oracle reduction is modeled. -/
@@ -76,26 +82,27 @@ def absorbLookup {F G : Type*} (e : LookupEval F) : List (TranscriptElt F G) :=
    .scalar e.permutedInputInvEval, .scalar e.permutedTableEval]
 
 /-- Derive the verifier's challenges by Fiat–Shamir, following the deployed schedule
-(`plonk/verifier.rs` → `multiopen/verifier.rs` → `commitment/verifier.rs`). Modeling choice: each
-squeezed challenge is re-absorbed so consecutive squeezes differ, where deployed Blake2b instead
-uses a domain-prefix byte (`BLAKE2B_PREFIX_CHALLENGE`). `init` is the pre-absorbed prefix (the
-verifying-key hash and instance commitments). -/
+(`plonk/verifier.rs` → `multiopen/verifier.rs` → `commitment/verifier.rs`). Before each squeeze a
+`TranscriptElt.challenge` domain marker (halo2's `BLAKE2B_PREFIX_CHALLENGE` byte) is appended, and the
+squeezed challenge is *not* re-absorbed — matching the deployed Blake2b transcript, where the prefix-byte
+writes persist in the hash state and the challenge value is never fed back. `init` is the pre-absorbed
+prefix (the verifying-key hash and instance commitments). -/
 def deriveChallenges {shape : Shape} {F G : Type*} [Zero F] (fs : FiatShamir F G)
     (init : List (TranscriptElt F G)) (ps : ProofString shape F G) : Challenges shape.k F :=
   -- advice commitments → θ
-  let t := init ++ absorbPoints2 ps.adviceCommitments
+  let t := init ++ absorbPoints2 ps.adviceCommitments ++ [.challenge]
   let theta := fs.squeeze t
   -- lookup permuted commitments → β, γ
-  let t := t ++ [.scalar theta] ++ absorbLookupPermuted ps.lookupPermutedInput ps.lookupPermutedTable
+  let t := t ++ absorbLookupPermuted ps.lookupPermutedInput ps.lookupPermutedTable ++ [.challenge]
   let beta := fs.squeeze t
-  let t := t ++ [.scalar beta]
+  let t := t ++ [.challenge]
   let gamma := fs.squeeze t
   -- permutation / lookup product commitments + vanishing random commitment → y
-  let t := t ++ [.scalar gamma] ++ absorbPoints2 ps.permutationProduct ++ absorbPoints2 ps.lookupProduct
-    ++ [TranscriptElt.point ps.vanishingRandom]
+  let t := t ++ absorbPoints2 ps.permutationProduct ++ absorbPoints2 ps.lookupProduct
+    ++ [TranscriptElt.point ps.vanishingRandom] ++ [.challenge]
   let y := fs.squeeze t
   -- quotient h pieces → x
-  let t := t ++ [.scalar y] ++ absorbPoints ps.hPieces
+  let t := t ++ absorbPoints ps.hPieces ++ [.challenge]
   let x := fs.squeeze t
   -- all evaluations → (multiopen) x₁, x₂
   let evalElts := absorbScalars2 ps.instanceEvals ++ absorbScalars2 ps.adviceEvals
@@ -103,34 +110,35 @@ def deriveChallenges {shape : Shape} {F G : Type*} [Zero F] (fs : FiatShamir F G
     ++ absorbScalars ps.permutationCommonEvals
     ++ (List.ofFn (fun p => (List.ofFn (fun s => absorbPermSet (ps.permutationSetEvals p s))).flatten)).flatten
     ++ (List.ofFn (fun p => (List.ofFn (fun l => absorbLookup (ps.lookupEvals p l))).flatten)).flatten
-  let t := t ++ [.scalar x] ++ evalElts
+  let t := t ++ evalElts ++ [.challenge]
   let x1 := fs.squeeze t
-  let t := t ++ [.scalar x1]
+  let t := t ++ [.challenge]
   let x2 := fs.squeeze t
   -- q' → x₃
-  let t := t ++ [.scalar x2] ++ [TranscriptElt.point ps.multiopenQPrime]
+  let t := t ++ [TranscriptElt.point ps.multiopenQPrime] ++ [.challenge]
   let x3 := fs.squeeze t
   -- multiopen evals u → x₄
-  let t := t ++ [.scalar x3] ++ absorbScalars ps.multiopenU
+  let t := t ++ absorbScalars ps.multiopenU ++ [.challenge]
   let x4 := fs.squeeze t
   -- (IPA) S → ξ, z
-  let t := t ++ [.scalar x4] ++ [TranscriptElt.point ps.ipaS]
+  let t := t ++ [TranscriptElt.point ps.ipaS] ++ [.challenge]
   let xi := fs.squeeze t
-  let t := t ++ [.scalar xi]
+  let t := t ++ [.challenge]
   let z := fs.squeeze t
-  let t := t ++ [.scalar z]
   -- per IPA round: (Lⱼ, Rⱼ) → uⱼ
   let ipaRes := (List.finRange shape.k).foldl (fun (st : List (TranscriptElt F G) × List F) j =>
-      let t := st.1 ++ [TranscriptElt.point (ps.ipaRounds j).1, TranscriptElt.point (ps.ipaRounds j).2]
+      let t := st.1 ++ [TranscriptElt.point (ps.ipaRounds j).1, TranscriptElt.point (ps.ipaRounds j).2,
+        TranscriptElt.challenge]
       let uj := fs.squeeze t
-      (t ++ [TranscriptElt.scalar uj], st.2 ++ [uj])) (t, [])
+      (t, st.2 ++ [uj])) (t, [])
   { theta := theta, beta := beta, gamma := gamma, y := y, x := x,
     x1 := x1, x2 := x2, x3 := x3, x4 := x4, xi := xi, z := z,
     ipaRound := fun j => ipaRes.2.getD j.val 0 }
 
 /-- The deployed (non-interactive) verifier's fingerprint MSM: `assemble` at the Fiat–Shamir
-challenges. The Fiat–Shamir assumption (the random-oracle step) is what carries the interactive
-verifier's soundness to this non-interactive MSM. -/
+challenges (the multiopen grouping is re-derived in Lean by `constructIntermediateSets`). The
+Fiat–Shamir assumption (the random-oracle step) is what carries the interactive verifier's soundness to
+this non-interactive MSM. -/
 def nonInteractiveFingerprint {shape : Shape} {F G : Type*} [Field F] [DecidableEq F] [DecidableEq G]
     [Inhabited G] (fs : FiatShamir F G) (init : List (TranscriptElt F G))
     (vk : VerifyingKey shape F G) (ps : ProofString shape F G) : Msm shape.k F G :=

--- a/Zcash/Snark/Verifier/FiatShamir.lean
+++ b/Zcash/Snark/Verifier/FiatShamir.lean
@@ -45,7 +45,10 @@ inductive TranscriptElt (F G : Type*) where
   deriving DecidableEq
 
 /-- The Fiat–Shamir hash, hand-waved: squeezes a field challenge from the transcript absorbed so far.
-In the deployed verifier this is Blake2b; neither it nor the random-oracle reduction is modeled. -/
+In the deployed verifier this is Blake2b, idealized as a random oracle (`Soundness.Forking.Oracle`). Given that
+idealization, challenge-vector uniformity has a standalone justification
+(`Soundness.Forking.Rewind.roChallenges_ipaRound_uniform`, for the fixed proof string); what stays unmodeled is
+the querying-adversary experiment and its query-loss, and Blake2b-as-random-oracle itself. -/
 structure FiatShamir (F G : Type*) where
   squeeze : List (TranscriptElt F G) → F
 

--- a/Zcash/Snark/Verifier/FiatShamir.lean
+++ b/Zcash/Snark/Verifier/FiatShamir.lean
@@ -4,51 +4,35 @@ import Zcash.Snark.Core.Challenges
 import Zcash.Snark.Verifier.Assemble
 
 /-!
-# Fiat–Shamir: the challenge schedule (hash hand-waved)
+# Fiat–Shamir challenge schedule
 
-The deployed verifier is non-interactive: each challenge is a hash of the transcript absorbed so far,
-rather than a fresh verifier coin. The hash is Blake2b (`transcript.rs`, personalization
-`"Halo2-Transcript"`). Per project scope the hash is hand-waved *here*: this module models it as an abstract
-`squeeze` function (`FiatShamir`) and does not formalize Blake2b. The random-oracle idealization of the
-squeeze — reprogramming and the uniform-challenge bound the forking argument draws on — is separate, in
-`Zcash.Snark.Soundness.Forking.Oracle`.
+The deployed verifier derives each challenge by hashing the transcript absorbed so far. This module
+models halo2's Blake2b hash as the abstract `FiatShamir.squeeze`; it does not formalize Blake2b.
+Reprogramming and uniform-challenge results live in `Soundness.Forking.Oracle`.
 
-## What is pinned down
+`deriveChallenges` records the absorb/squeeze order from halo2's PLONK, multiopen, and commitment
+verifiers. `nonInteractiveFingerprint` runs `assemble` at those derived challenges.
 
-The schedule — which proof elements are absorbed before each challenge is squeezed — transcribed from
-`plonk/verifier.rs`, `multiopen/verifier.rs`, and `commitment/verifier.rs`. This makes precise the
-sense in which the deployed verifier is the Fiat–Shamir image of the interactive one
-(`Zcash.Snark.Challenges` as genuine coins): the two differ only in the source of the challenges, and
-`deriveChallenges` is that source. `nonInteractiveFingerprint` is then the deployed verifier's MSM,
-`assemble` at the FS-derived challenges.
-
-## Assumptions
-
-* The Fiat–Shamir assumption (the random-oracle idealization) — that these hashed challenges carry the
-  interactive verifier's soundness to the non-interactive setting. This is the explicit hand-wave. In
-  the fingerprint match the challenges are taken from the captured real transcript, so the match never
-  re-derives them and does not depend on this assumption.
+The remaining Fiat–Shamir assumption is that the hash behaves as a random oracle. The captured
+fingerprint checks do not use that assumption: they replay captured transcript events and challenges.
 -/
 
 namespace Zcash.Snark
 
-/-- An element written to the Fiat–Shamir transcript, carrying halo2's three Blake2b domain prefixes: a
-commitment (group point, via `common_point` / `read_point`, `BLAKE2B_PREFIX_POINT`), a scalar (via
-`common_scalar` / `read_scalar`, `BLAKE2B_PREFIX_SCALAR`), or the domain marker written before each
-squeeze (`BLAKE2B_PREFIX_CHALLENGE`). The `challenge` marker — rather than re-absorbing the squeezed value —
-is what makes consecutive squeezes differ, matching the deployed transcript (the prefix-byte writes persist
-in the hash state; the challenge value is never fed back). -/
+/-- A point, scalar, or challenge-domain marker written to the Fiat–Shamir transcript.
+
+The constructors correspond to halo2's three Blake2b domain prefixes. A squeeze absorbs `challenge`;
+it does not feed the resulting field element back into the transcript. -/
 inductive TranscriptElt (F G : Type*) where
   | point : G → TranscriptElt F G
   | scalar : F → TranscriptElt F G
   | challenge : TranscriptElt F G
   deriving DecidableEq
 
-/-- The Fiat–Shamir hash, hand-waved: squeezes a field challenge from the transcript absorbed so far.
-In the deployed verifier this is Blake2b, idealized as a random oracle (`Soundness.Forking.Oracle`). Given that
-idealization, challenge-vector uniformity has a standalone justification
-(`Soundness.Forking.Rewind.roChallenges_ipaRound_uniform`, for the fixed proof string); what stays unmodeled is
-the querying-adversary experiment and its query-loss, and Blake2b-as-random-oracle itself. -/
+/-- The abstract Fiat–Shamir hash: squeeze a field challenge from the absorbed transcript.
+
+The deployed hash is Blake2b. The model treats it as a random oracle; the querying adversary,
+query loss, and Blake2b justification remain outside this structure. -/
 structure FiatShamir (F G : Type*) where
   squeeze : List (TranscriptElt F G) → F
 
@@ -84,12 +68,10 @@ def absorbLookup {F G : Type*} (e : LookupEval F) : List (TranscriptElt F G) :=
   [.scalar e.productEval, .scalar e.productNextEval, .scalar e.permutedInputEval,
    .scalar e.permutedInputInvEval, .scalar e.permutedTableEval]
 
-/-- Derive the verifier's challenges by Fiat–Shamir, following the deployed schedule
-(`plonk/verifier.rs` → `multiopen/verifier.rs` → `commitment/verifier.rs`). Before each squeeze a
-`TranscriptElt.challenge` domain marker (halo2's `BLAKE2B_PREFIX_CHALLENGE` byte) is appended, and the
-squeezed challenge is *not* re-absorbed — matching the deployed Blake2b transcript, where the prefix-byte
-writes persist in the hash state and the challenge value is never fed back. `init` is the pre-absorbed
-prefix (the verifying-key hash and instance commitments). -/
+/-- Derive the verifier's challenges in halo2's deployed absorb/squeeze order.
+
+Each squeeze first appends `TranscriptElt.challenge`; the result is not re-absorbed. `init` contains
+the verifying-key hash and instance commitments absorbed before the proof. -/
 def deriveChallenges {shape : Shape} {F G : Type*} [Zero F] (fs : FiatShamir F G)
     (init : List (TranscriptElt F G)) (ps : ProofString shape F G) : Challenges shape.k F :=
   -- advice commitments → θ
@@ -138,10 +120,9 @@ def deriveChallenges {shape : Shape} {F G : Type*} [Zero F] (fs : FiatShamir F G
     x1 := x1, x2 := x2, x3 := x3, x4 := x4, xi := xi, z := z,
     ipaRound := fun j => ipaRes.2.getD j.val 0 }
 
-/-- The deployed (non-interactive) verifier's fingerprint MSM: `assemble` at the Fiat–Shamir
-challenges (the multiopen grouping is re-derived in Lean by `constructIntermediateSets`). The
-Fiat–Shamir assumption (the random-oracle idealization) is what carries the interactive verifier's soundness to
-this non-interactive MSM. -/
+/-- The deployed verifier's fingerprint MSM: `assemble` at the Fiat–Shamir challenges.
+
+The random-oracle assumption is what transfers interactive soundness to this non-interactive MSM. -/
 def nonInteractiveFingerprint {shape : Shape} {F G : Type*} [Field F] [DecidableEq F] [DecidableEq G]
     [Inhabited G] (fs : FiatShamir F G) (init : List (TranscriptElt F G))
     (vk : VerifyingKey shape F G) (ps : ProofString shape F G) : Msm shape.k F G :=

--- a/Zcash/Snark/Verifier/Parametric.lean
+++ b/Zcash/Snark/Verifier/Parametric.lean
@@ -202,21 +202,21 @@ theorem deriveChallenges_parametric_numProofs {shape : Shape} {F G : Type*} [Zer
     (fs : FiatShamir F G) (init : List (TranscriptElt F G)) (ps : ProofString shape F G) :
     deriveChallenges fs init ps =
       let t := init ++ subProofBlocks (fun p : Fin shape.numProofs =>
-        absorbPoints (ps.adviceCommitments p))
+        absorbPoints (ps.adviceCommitments p)) ++ [.challenge]
       let theta := fs.squeeze t
-      let t := t ++ [.scalar theta] ++ subProofBlocks (fun p : Fin shape.numProofs =>
+      let t := t ++ subProofBlocks (fun p : Fin shape.numProofs =>
         subProofBlocks (fun l : Fin shape.numLookups =>
           [TranscriptElt.point (ps.lookupPermutedInput p l),
-           TranscriptElt.point (ps.lookupPermutedTable p l)]))
+           TranscriptElt.point (ps.lookupPermutedTable p l)])) ++ [.challenge]
       let beta := fs.squeeze t
-      let t := t ++ [.scalar beta]
+      let t := t ++ [.challenge]
       let gamma := fs.squeeze t
-      let t := t ++ [.scalar gamma]
+      let t := t
         ++ subProofBlocks (fun p : Fin shape.numProofs => absorbPoints (ps.permutationProduct p))
         ++ subProofBlocks (fun p : Fin shape.numProofs => absorbPoints (ps.lookupProduct p))
-        ++ [TranscriptElt.point ps.vanishingRandom]
+        ++ [TranscriptElt.point ps.vanishingRandom] ++ [.challenge]
       let y := fs.squeeze t
-      let t := t ++ [.scalar y] ++ absorbPoints ps.hPieces
+      let t := t ++ absorbPoints ps.hPieces ++ [.challenge]
       let x := fs.squeeze t
       let evalElts := subProofBlocks (fun p : Fin shape.numProofs =>
         absorbScalars (ps.instanceEvals p))
@@ -228,25 +228,24 @@ theorem deriveChallenges_parametric_numProofs {shape : Shape} {F G : Type*} [Zer
             absorbPermSet (ps.permutationSetEvals p s)))
         ++ subProofBlocks (fun p : Fin shape.numProofs =>
           subProofBlocks (fun l : Fin shape.numLookups => absorbLookup (ps.lookupEvals p l)))
-      let t := t ++ [.scalar x] ++ evalElts
+      let t := t ++ evalElts ++ [.challenge]
       let x1 := fs.squeeze t
-      let t := t ++ [.scalar x1]
+      let t := t ++ [.challenge]
       let x2 := fs.squeeze t
-      let t := t ++ [.scalar x2] ++ [TranscriptElt.point ps.multiopenQPrime]
+      let t := t ++ [TranscriptElt.point ps.multiopenQPrime] ++ [.challenge]
       let x3 := fs.squeeze t
-      let t := t ++ [.scalar x3] ++ absorbScalars ps.multiopenU
+      let t := t ++ absorbScalars ps.multiopenU ++ [.challenge]
       let x4 := fs.squeeze t
-      let t := t ++ [.scalar x4] ++ [TranscriptElt.point ps.ipaS]
+      let t := t ++ [TranscriptElt.point ps.ipaS] ++ [.challenge]
       let xi := fs.squeeze t
-      let t := t ++ [.scalar xi]
+      let t := t ++ [.challenge]
       let z := fs.squeeze t
-      let t := t ++ [.scalar z]
       let ipaRes := (List.finRange shape.k).foldl
         (fun (st : List (TranscriptElt F G) × List F) j =>
           let t := st.1 ++ [TranscriptElt.point (ps.ipaRounds j).1,
-            TranscriptElt.point (ps.ipaRounds j).2]
+            TranscriptElt.point (ps.ipaRounds j).2, TranscriptElt.challenge]
           let uj := fs.squeeze t
-          (t ++ [TranscriptElt.scalar uj], st.2 ++ [uj])) (t, [])
+          (t, st.2 ++ [uj])) (t, [])
       { theta := theta, beta := beta, gamma := gamma, y := y, x := x,
         x1 := x1, x2 := x2, x3 := x3, x4 := x4, xi := xi, z := z,
         ipaRound := fun j => ipaRes.2.getD j.val 0 } := by

--- a/Zcash/Snark/Verifier/Parametric.lean
+++ b/Zcash/Snark/Verifier/Parametric.lean
@@ -3,45 +3,28 @@ import Zcash.Snark.Verifier.FiatShamir
 /-!
 # Parametric verifier schedule obligations
 
-The generated fingerprint fixtures remain concrete empirical checks (`numProofs = 1` and `numProofs = 2`,
-plus any future selected captures). This module records the complementary generic obligation: the Lean verifier
-traverses every sub-proof by a `Fin shape.numProofs` fold, for arbitrary `shape.numProofs`.
-This is stronger than the Orchard consensus-scoped need: every consensus-valid action count
-`N ≤ 2^16 - 1` is one instantiation of the same `shape.numProofs` parameter.
+These theorems show that verifier assembly and the Fiat–Shamir schedule traverse every sub-proof for
+arbitrary `shape.numProofs`. Every consensus-valid Orchard action count is one instance.
 
-These theorems do not prove byte-for-byte Rust faithfulness; that boundary is still supplied by the
-capture/dumper plus selected fixtures. They make explicit that the Lean-side assembly and Fiat–Shamir
-schedule are not specialized to the current concrete fixtures.
-
-Most obligations here are definitional pins — `rfl`-provable restatements that fail loudly if a
-definition drifts. Two carry content beyond a pin: `subProofBlocks_length_const` (the flattened
-schedule carries exactly one block per sub-proof — none dropped, none duplicated) and
-`subProofOpeningQueries_commId_disjoint` (distinct sub-proofs' opening queries occupy disjoint
-commitment slots, so the multiopen grouping can never merge commitments across sub-proofs).
+They do not prove byte-level Rust faithfulness; the generated fixtures cover that boundary. Most are
+definitional pins. `subProofBlocks_length_const` proves that flattening neither drops nor duplicates a
+block, and `subProofOpeningQueries_commId_disjoint` prevents multiopen grouping across sub-proofs.
 -/
 
 namespace Zcash.Snark
 
-/-- Orchard's consensus maximum number of actions, hence the maximum `numProofs` for the Orchard
-bundle proof verified by this model.
+/-- Orchard's consensus maximum action count, and therefore the maximum `numProofs` in this model.
 
-The bound is a consensus rule, not an encoding artifact: `nActionsOrchard` is a `compactSize` (which
-admits values up to `2^64 - 1`), but the Zcash Protocol Specification §7.1.2 "Transaction Consensus
-Rules" requires `nActionsOrchard < 2^16` (NU5 onward), so `nActionsOrchard ≤ 2^16 - 1 = 65535`. The v5
-transaction format carrying it is defined by ZIP 225. -/
+The protocol requires `nActionsOrchard < 2^16`; this is a consensus bound, not an encoding limit. -/
 def orchardConsensusMaxProofs : ℕ := 2^16 - 1
 
-/-- The consensus-scoped subcase of the stronger parametric theorems below. Only the upper bound is
-load-bearing: a consensus-valid transaction verifies an Orchard proof only when it has at least one
-action (`proofsOrchard` is present iff `nActionsOrchard > 0`, ZIP 225), so `numProofs = 0` never
-reaches the deployed verifier and is not excluded here. -/
+/-- The consensus-scoped upper bound on `shape.numProofs`.
+
+Zero is not excluded because a transaction with no actions never invokes the Orchard verifier. -/
 def Shape.hasConsensusNumProofs (shape : Shape) : Prop :=
   shape.numProofs ≤ orchardConsensusMaxProofs
 
-/-- Flatten one list-producing block over all sub-proofs. This is the parametric shape shared by the
-assembly and Fiat–Shamir schedules: the number of blocks is exactly the ambient `numProofs`. (The
-restatements below also reuse it for the inner per-lookup / per-permutation-set folds, where the index
-runs over lookups or sets rather than sub-proofs.) -/
+/-- Flatten one list-valued block for each index. Assembly and the Fiat–Shamir schedule use this shape. -/
 def subProofBlocks {α : Type*} {numProofs : ℕ} (block : Fin numProofs → List α) : List α :=
   (List.ofFn block).flatten
 
@@ -150,10 +133,7 @@ theorem commId_subProofIdx_of_mem_subProofOpeningQueries {shape : Shape} {F G : 
     simp only [List.mem_cons, List.not_mem_nil, or_false] at hl
     rcases hl with rfl | rfl | rfl | rfl | rfl <;> rfl
 
-/-- Distinct sub-proofs' opening queries occupy disjoint commitment slots. `constructIntermediateSets`
-groups queries by `commId` (the Lean image of halo2 `construct_intermediate_sets`' pointer-identity
-keying), so the multiopen grouping can never merge commitments across sub-proofs — for any
-`numProofs`, not just the captured fixtures. -/
+/-- Distinct sub-proofs use disjoint commitment slots, so multiopen grouping cannot merge them. -/
 theorem subProofOpeningQueries_commId_disjoint {shape : Shape} {F G : Type*} [Field F]
     [Inhabited G] (vk : VerifyingKey shape F G) (ps : ProofString shape F G)
     (x xInv xNext xLast : F) {p p' : Fin shape.numProofs} (hpp : p ≠ p') :
@@ -192,12 +172,10 @@ theorem assembleQueries_parametric_numProofs {shape : Shape} {F G : Type*} [Fiel
       perProof ++ fixedQ ++ permCommonQ ++ vanishingQ :=
   rfl
 
-/-- The Fiat–Shamir challenge schedule is generic in `shape.numProofs`. The per-proof absorbs in this
-schedule are the generic folds exposed by `absorbPoints2_parametric_numProofs`,
-`absorbScalars2_parametric_numProofs`, and `absorbLookupPermuted_parametric_numProofs`.
-The hash output is intentionally outside these parametric lemmas: Blake2b is taken at the
-random-oracle boundary, while the concrete fixtures use a fixture oracle over the captured transcript
-events (`Zcash.Snark.Fixtures.SingleAction.FiatShamir`, `Zcash.Snark.Fixtures.MultiAction.FiatShamir`). -/
+/-- The Fiat–Shamir schedule is generic in `shape.numProofs`.
+
+This theorem pins the per-proof folds, not Blake2b. The concrete fixtures check captured transcript
+events with their fixture oracles. -/
 theorem deriveChallenges_parametric_numProofs {shape : Shape} {F G : Type*} [Zero F]
     (fs : FiatShamir F G) (init : List (TranscriptElt F G)) (ps : ProofString shape F G) :
     deriveChallenges fs init ps =

--- a/book/src/formal-verification/proof-journey-data.json
+++ b/book/src/formal-verification/proof-journey-data.json
@@ -398,8 +398,7 @@
         "structural",
         "hprob",
         "hquot",
-        "hgood",
-        "hasse"
+        "hgood"
       ],
       "theorems": [
         {
@@ -445,8 +444,7 @@
         "DLhard",
         "blake2b",
         "hlrel",
-        "vkfaith",
-        "hasse"
+        "vkfaith"
       ],
       "theorems": [
         {

--- a/book/src/formal-verification/proof-map-embed.html
+++ b/book/src/formal-verification/proof-map-embed.html
@@ -236,7 +236,7 @@ const territories = [
   { id:'dec',  label:'Multiopen Decode', cells:[[6,3],[7,3],[6,4],[7,4]],       h:'var(--c-proven)', labelSide:'right' },
   { id:'sz',   label:'Schwartz–Zippel', cells:[[6,6],[7,6]],                   h:'var(--c-incoming)' },
   { id:'agm',  label:'AGM → Discrete Log', cells:[[0,7],[1,7],[0,8],[1,8]],       h:'#a06fb0' },
-  { id:'floor',label:'Assumptions · outside Lean',    cells:[[2,8],[3,8],[4,8],[5,8],[6,8]], h:'var(--c-floor)' },
+  { id:'floor',label:'Assumptions · outside Lean',    cells:[[2,8],[3,8],[4,8],[5,8]], h:'var(--c-floor)' },
 ];
 
 const nodes = [
@@ -354,12 +354,9 @@ const nodes = [
   { id:'hlrel', c:4,r:8, label:'high-level relation', status:'floor',
     anchor:'hencodes',
     role:'Semantic adequacy (hencodes): SnarkRelation — the witness satisfies the gates — implies the intended high-level Ironwood statement (note well-formed, values balance, nullifier derived, spend authorized). An assumed hypothesis over a free Prop; the composition otherwise stops at SnarkRelation. The output-side gap. Not started.' },
-  { id:'vkfaith', c:6,r:8, label:'VK correctness', status:'floor',
+  { id:'vkfaith', c:5,r:8, label:'VK correctness', status:'floor',
     anchor:'Verifier.Assemble',
     role:'The input-side gap: the verifying key and circuit description fed to the verifier faithfully encode the real deployed Ironwood circuit. Dual to the high-level relation on the output side; VK derivation in Lean is not started.' },
-  { id:'hasse', c:5,r:8, label:'Vesta order ⇐ Hasse', status:'floor',
-    anchor:'HasseBound · Vesta.vestaOrder_of_hasse',
-    role:'The Vesta group order, proven from the assumed Hasse bound.' },
 ];
 
 // Each edge is [from, to, kind, via?] where `via` names the Lean lemma/def that
@@ -408,7 +405,6 @@ const edges = [
   ['capstones','hlrel','rests'],
   ['capstones','structural','rests'],
   ['capstones','vkfaith','rests'],
-  ['capstones','hasse','rests'],
 ];
 
 const statusColor = { proven:'--c-proven', hyp:'--c-hyp', floor:'--c-floor', object:'--c-object', goal:'--accent' };


### PR DESCRIPTION
**Human Summary:**

Builds on #20, and progresses [zcash/ironwood#11](https://github.com/zcash/ironwood/issues/11) and closes [zcash/ironwood#23](https://github.com/zcash/ironwood/issues/23) (which were tightly coupled after trying to implement them separately, so I combined the PRs).

The status quo hand-waved Fiat-Shamir in two places: (1) challenges came from an opaque squeeze function (opaque in the sense that it did not model the squeeze at a RO abstraction level), and (2) the bridge from an accepting deployed proof to the transcript tree was assumed. The objective here is to give FS real RO semantics and prove forking / rewinding as lemmas that produce the transcript tree that the extractor ultimately consumes. Simply, this formalizes Ironwood's Fiat–Shamir/IPA forking argument in Lean.

The random oracle is currently a plain deterministic function `O` (transcript → `Fp`) standing in for the black-box hash. Randomness comes from sampling `O` as a uniform random function, so outputs at distinct queries are uniform and independent; oracle reprogramming and the challenge schedule are built on top of that.

Strictly, the goal is to reduce the FS assumptions to the random-oracle idealization itself (where the Blake2b transcript is modeled as a RO). We no longer assume either of:

- forking/rewinding: that the forked transcript tree exists; it is now derived by rewinding in the abstract RO model.
- tree assembly: that the forked transcript tree yields an accepting IPA tree; that assembly is now proved.

The deployed verifier itself is still non-interactive in shape (it takes challenges as free inputs, a deliberate initial design choice), and the soundness layer analyzes it through an interactive lens by relating those challenges to verifier coins in the interactive protocol.

Additionally, this implements round-by-round special soundness lifted from #26.

**Out of scope:** a general oracle-querying adversary and query loss; that is part of #56.

The probability-level capstones here remain `noncomputable` because their probability premise proves that a fork certificate exists. Given a certificate and the commitment representation as explicit inputs, the deployed reduction itself is a plain computed definition; #56 is the operational adversary/extractor follow-up.

----------

**AI Summary:**

This PR replaces the assumed Fiat–Shamir fork with a random-oracle rewinding proof that constructs the accepting transcript tree consumed by the IPA extractor.

## What Is Proven

- **Random-oracle model:** models Fiat–Shamir with an abstract random oracle matching Halo2's challenge schedule.
- **Transcript ordering:** proves challenge ordering, oracle reprogramming, and challenge-vector uniformity.
- **Fork construction:** constructs and assembles the forked transcript tree above the knowledge-error threshold.
- **Computed reduction:** given a fork certificate and explicit commitment representation, computes either an IPA opening or a nontrivial relation.
- **Vesta endpoints:** adds fixed-proof and round-adaptive capstones over the deployed curve.

## Remaining Floor

`hprob` is still the accept-probability premise, so the probability wrappers obtain the fork certificate existentially and remain `noncomputable`. PR #56 adds the general querying-adversary/query-loss layer; an operational recursive extractor must ultimately return that certificate as data. The remaining assumptions are Blake2b-as-random-oracle and the AGM/DL discharge tracked by #28. Constraint-side binding and budget composition are tracked by #18.

## Issue Scope Check

- #23 is implemented.
- #11 is progressed; #56 supplies the querying-adversary/query-loss follow-up.

Builds are green on the current PR head.
