### PR TITLE
feat(fv): bind witness columns to verifier openings

### DIFF
--- a/Zcash/Snark.lean
+++ b/Zcash/Snark.lean
@@ -25,6 +25,7 @@ import Zcash.Snark.Soundness.AGM
 import Zcash.Snark.Soundness.Consistency
 import Zcash.Snark.Soundness.KnowledgeSoundness
 import Zcash.Snark.Soundness.IpaSoundness
+import Zcash.Snark.Soundness.MultiopenDecode
 import Zcash.Snark.Soundness.DeployedFold
 import Zcash.Snark.Soundness.DeployedIpa
 import Zcash.Snark.Soundness.DeployedIpaPeel

--- a/Zcash/Snark/Soundness/IpaSoundness.lean
+++ b/Zcash/Snark/Soundness/IpaSoundness.lean
@@ -237,13 +237,7 @@ polynomial from its `n` samples. (The `n = 3` special case is `vandermonde3`.) F
 Vandermonde matrix (`det = ∏_{i<j}(z j − z i) ≠ 0` for distinct points). -/
 theorem vandermonde_inv {n : ℕ} (z : Fin n → F) (hz : Function.Injective z) :
     ∃ μ : Fin n → Fin n → F, ∀ (i j : Fin n), (∑ k, μ i k * z k ^ (j : ℕ)) = if i = j then 1 else 0 := by
-  have hdet : (Matrix.vandermonde z).det ≠ 0 := by
-    rw [Matrix.det_vandermonde, Finset.prod_ne_zero_iff]
-    intro i _
-    rw [Finset.prod_ne_zero_iff]
-    intro j hj
-    rw [Finset.mem_Ioi] at hj
-    exact sub_ne_zero.mpr (fun h => absurd (hz h) (ne_of_lt hj).symm)
+  have hdet : (Matrix.vandermonde z).det ≠ 0 := Matrix.det_vandermonde_ne_zero_iff.mpr hz
   refine ⟨fun i k => (Matrix.vandermonde z)⁻¹ i k, fun i j => ?_⟩
   have hmul : (Matrix.vandermonde z)⁻¹ * Matrix.vandermonde z = 1 :=
     Matrix.nonsing_inv_mul _ (isUnit_iff_ne_zero.mpr hdet)

--- a/Zcash/Snark/Soundness/KnowledgeSoundness.lean
+++ b/Zcash/Snark/Soundness/KnowledgeSoundness.lean
@@ -60,14 +60,14 @@ variable {G : Type*} [AddCommGroup G] [Module Fp G]
 (`IpaRelation`) and satisfies the circuit (`circuitSat a`). Both conjuncts are about the same extracted
 witness `a` (fixing the earlier flaw where the constraint was on free, unrelated polynomials).
 `circuitSat` is the circuit-satisfaction predicate — its intended instantiation is `circuitSatViaGates`
-("the witness's decoded columns satisfy the `y`-combined gates"). The remaining gap is deriving
-`circuitSat a` for the extracted `a` from the deployed constraint check (`constraint_identity_of_accept`)
-through the multiopen decode.
+("the witness's decoded columns satisfy the `y`-combined gates"). This raw relation is intentionally
+generic; the deployed decoded-column capstone in `Soundness.MultiopenDecode` /
+`orchard_verifier_deployed_decoded_constraint_reduction` pins the decode to the extracted witness via
+`batch_open_soundV`.
 
-Sharper statement of that gap: the two conjuncts share only the symbol `a`. Until the decode is pinned,
-`circuitSat a` may be instantiated independently of `a` (the decode that feeds `circuitSatViaGates` is a
-free function), so it need not constrain the extracted witness at all. Binding the decode to `a` — via
-the already-proven but currently unused `batch_open_soundV` — is exactly what closes this (issue #18). -/
+Sharper statement of the legacy gap: the two conjuncts share only the symbol `a`. If the decode that feeds
+`circuitSatViaGates` is left as a free function, `circuitSat a` may be instantiated independently of `a`,
+so it need not constrain the extracted witness at all. -/
 structure SnarkRelation (urs : URS G) (P : G) (b : Fin (2 ^ urs.k) → Fp) (v : Fp)
     (circuitSat : (Fin (2 ^ urs.k) → Fp) → Prop) (a : Fin (2 ^ urs.k) → Fp) : Prop where
   opens : IpaRelation urs P b v a
@@ -78,7 +78,7 @@ satisfy the `y`-combined gates' quotient identity. `decodeAdvice`/`decodeInstanc
 the circuit's column polynomials (the multiopen decode — abstract until the assembly is modeled), and
 `combineGates` is the `y`-combination of the gate `Expr`s (`eval_combineGates`). So
 `circuitSat := circuitSatViaGates …` reads "the extracted witness satisfies the circuit's gate constraints",
-and `constraint_identity_of_accept` is what would discharge it from the deployed check. -/
+and `constraint_identity_of_accept` is what discharges it once the caller supplies a non-free decode. -/
 def circuitSatViaGates {k : ℕ} (fixedCols : ℕ → Polynomial Fp)
     (decodeAdvice decodeInstance : (Fin (2 ^ k) → Fp) → (ℕ → Polynomial Fp))
     (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ)
@@ -109,8 +109,9 @@ unique witness satisfying `SnarkRelation`. Composes `extract_correct` (extractio
 `ipaRelation_unique` (uniqueness under DLR hardness).
 
 The hypotheses `hcons` and `hsat` are assumed here, not derived from acceptance — deriving them
-(via `accepting_fold_eq` + `commitGen_round`, and `constraint_identity_of_accept` off the `d/p` bad set
-through the multiopen decode) is the open composition work. -/
+(via `accepting_fold_eq` + `commitGen_round`, and `constraint_identity_of_accept` off the `d/p` bad set)
+is the open composition work for this raw theorem. The deployed decoded-column reduction handles the
+multiopen witness-to-columns bridge separately. -/
 theorem knowledge_sound (urs : URS G) (hbind : CommitmentBinding (F := Fp) urs)
     {t : Tree Fp urs.k} {a : Fin (2 ^ urs.k) → Fp} (hcons : Consistent t a)
     {P : G} {b : Fin (2 ^ urs.k) → Fp} {v : Fp} (hopen : IpaRelation urs P b v a)

--- a/Zcash/Snark/Soundness/Main.lean
+++ b/Zcash/Snark/Soundness/Main.lean
@@ -3,6 +3,7 @@ import Zcash.Snark.Soundness.KnowledgeSoundness
 import Zcash.Snark.Verifier.Assemble
 import Zcash.Snark.Soundness.Consistency
 import Zcash.Snark.Soundness.IpaSoundness
+import Zcash.Snark.Soundness.MultiopenDecode
 import Zcash.Snark.Soundness.DeployedIpaPeel
 import Zcash.Snark.Soundness.DeployedVerification
 import Zcash.Snark.Soundness.ForkingAssembly
@@ -74,7 +75,7 @@ def ExtractableFromAcceptance (urs : URS G) (P : G) (b : Fin (2 ^ urs.k) → Fp)
   accepts → ∃ (t : Tree Fp urs.k) (a : Fin (2 ^ urs.k) → Fp),
     Consistent t a ∧ IpaRelation urs P b v a ∧ circuitSat a
 
--- Tracked semantic-adequacy gap (issue #18): `hencodes`/`S` below are the seam from circuit-satisfiability to the
+-- Tracked semantic-adequacy gap: `hencodes`/`S` below are the seam from circuit-satisfiability to the
 -- high-level Orchard relation. `S` is a free `Prop` and `hencodes` is an assumed hypothesis, so the
 -- chain stops at "the extracted witness satisfies the gates" (`SnarkRelation`) and never reaches
 -- "…therefore a valid Orchard action" (note well-formed, value balances, nullifier correctly derived,
@@ -270,8 +271,8 @@ conditions on `2^k` coordinates), so any `circuitSat` that genuinely reads the w
 all of it — the hypothesis is unsatisfiable for the intended instantiation, the `AugmentedBinding`
 failure mode in hypothesis position. `circuitSatViaGates_of_check` does not discharge it: that lemma
 derives `circuitSat` for *one* `a` from that `a`'s own point-check, never the quantified premise.
-The fix is restating the constraint side as a derived fact about the *extracted* witness via the
-multiopen decode — issue #18. -/
+The decoded-column capstone below restates the constraint side as a derived fact about columns recovered
+from the batched openings that contain the extracted witness. -/
 theorem orchard_verifier_deployed_opening_reduction [DecidableEq G] [Inhabited G] {shape : Shape}
     (urs : URS G) (hk : shape.k = urs.k) (vk : VerifyingKey shape Fp G) (ps : ProofString shape Fp G)
     (ch : Challenges shape.k Fp) {b : Fin (2 ^ urs.k) → Fp} {z blind : Fp}
@@ -320,8 +321,8 @@ Caveat on the `hquot`/`hgood` shape (as for `hcirc` above): both quantify over *
 opening `a` of the pinned `(P, b, v)` — an affine subspace of dimension `≥ 2^k − 2` at a prime-order
 curve — so for any decode that genuinely reads columns out of `a` they are unsatisfiable, not merely
 undischarged: the verifier's actual gate check constrains the *claimed* evaluations, not every
-opening's decode. Restating them as facts about the *extracted* witness — binding the decode to the
-real columns via `batch_open_soundV` — is issue #18. -/
+opening's decode. The decoded-column capstone below restates them over columns recovered from batched
+openings via `batch_open_soundV`. -/
 theorem orchard_verifier_deployed_constraint_reduction [DecidableEq G] [Inhabited G] {shape : Shape}
     (urs : URS G) (hk : shape.k = urs.k) (vk : VerifyingKey shape Fp G) (ps : ProofString shape Fp G)
     (ch : Challenges shape.k Fp) {b : Fin (2 ^ urs.k) → Fp} {z blind : Fp}
@@ -349,6 +350,74 @@ theorem orchard_verifier_deployed_constraint_reduction [DecidableEq G] [Inhabite
       circuitSatViaGates_of_check fixedCols decodeAdvice decodeInstance y gates hpoly deg a x
         (hquot a hrel') (hgood a hrel')
     exact Or.inl (hencodes a ⟨hrel', hsat⟩)
+  · exact Or.inr hrel
+
+open Polynomial in
+/-- The deployed Orchard verifier opening and constraint, with the multiopen witness decoded into real
+columns before the gate check is applied.
+
+Compared with `orchard_verifier_deployed_constraint_reduction`, `hquot`/`hgood` are no longer quantified
+over every mathematical opening of the pinned IPA relation. Instead, after the deployed accept extracts the
+current IPA witness `a`, `hbatch` supplies the rewound batched openings containing that witness, and
+`decodedColumnFamily_of_batch_openings` recovers the individual columns by `batch_open_soundV`. The gate
+check is then stated over those recovered columns, selected into the advice/instance slots the gate
+expressions read.
+
+This discharges the witness-to-real-columns half of the constraint-side bridge. The remaining hypothesis
+shape is deliberately explicit: `hquot` is still the separate quotient-check-from-deployed-assembly fact —
+stated for the canonical decode of the supplied batch (`decodedCols`), the family this proof constructs
+(the ∀-families form is jointly unsatisfiable; see the `MultiopenDecode` scope section). -/
+theorem orchard_verifier_deployed_decoded_constraint_reduction [DecidableEq G] [Inhabited G]
+    {shape : Shape} (urs : URS G) (hk : shape.k = urs.k) (vk : VerifyingKey shape Fp G)
+    (ps : ProofString shape Fp G) (ch : Challenges shape.k Fp)
+    {b : Fin (2 ^ urs.k) → Fp} {z blind : Fp}
+    {numColumns numAdvice numInstance : ℕ}
+    (columnCommitments : Fin numColumns → G) (columnEvals : Fin numColumns → Fp)
+    (adviceIndex : Fin numAdvice → Fin numColumns) (instanceIndex : Fin numInstance → Fin numColumns)
+    (fixedCols : ℕ → Polynomial Fp)
+    (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
+    (hz : z ≠ 0)
+    (haccepts : DeployedAccepts urs hk vk ps ch)
+    (hFS : FiatShamirTree urs hk vk ps ch b z blind)
+    (hbatch : ∀ a, IpaRelation urs (deployedCommitment urs hk vk ps ch) b (multiopenValue vk ps ch) a →
+      BatchOpeningsForWitness urs b columnCommitments columnEvals a)
+    (hquot : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps ch) b
+        (multiopenValue vk ps ch) a),
+      quotientCheck
+        (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates) hpoly deg x)
+    (hgood : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps ch) b
+        (multiopenValue vk ps ch) a),
+      combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
+        ≠ hpoly * (X ^ deg - 1) →
+      (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
+        - hpoly * (X ^ deg - 1)).eval x ≠ 0)
+    {S : Prop}
+    (hencodes : ∀ a cols,
+      SnarkRelationWithDecodedColumns urs (deployedCommitment urs hk vk ps ch) b
+        (multiopenValue vk ps ch) columnCommitments columnEvals adviceIndex instanceIndex fixedCols
+        y gates hpoly deg a cols → S) :
+    S ∨ HasNontrivialRelation (F := Fp) urs.g urs.u urs.w := by
+  obtain ⟨t, ht⟩ := hFS (deployedAccepts_verifierEq urs hk vk ps ch haccepts)
+  rcases deployed_to_acceptV hz urs.g b (deployedCommitment urs hk vk ps ch) (multiopenValue vk ps ch)
+    blind t ht with hclean | hrel
+  · obtain ⟨a, hrel'⟩ := ipaRelation_of_acceptV urs b (deployedCommitment urs hk vk ps ch)
+      (multiopenValue vk ps ch) (projTree t) hclean
+    have hsat : circuitSatViaGates fixedCols
+        (selectedPolysDecode (k := urs.k) (decodedCols (hbatch a hrel')) adviceIndex)
+        (selectedPolysDecode (k := urs.k) (decodedCols (hbatch a hrel')) instanceIndex)
+        y gates hpoly deg a :=
+      circuitSatViaGates_of_check fixedCols
+        (selectedPolysDecode (k := urs.k) (decodedCols (hbatch a hrel')) adviceIndex)
+        (selectedPolysDecode (k := urs.k) (decodedCols (hbatch a hrel')) instanceIndex)
+        y gates hpoly deg a x (hquot a hrel') (hgood a hrel')
+    exact Or.inl (hencodes a (decodedCols (hbatch a hrel'))
+      { opens := hrel'
+        batchOpenings := hbatch a hrel'
+        decodedColumns := decodedCols_spec (hbatch a hrel')
+        satisfiesCircuit := hsat })
   · exact Or.inr hrel
 
 end Zcash.Snark

--- a/Zcash/Snark/Soundness/Main.lean
+++ b/Zcash/Snark/Soundness/Main.lean
@@ -247,6 +247,34 @@ theorem fiatShamirTree_of_forking [DecidableEq G] [Inhabited G] {shape : Shape} 
   obtain ⟨t, hFork⟩ := hForking hEq
   exact ⟨t, forkAccept_to_acceptV _ _ _ _ _ t hFork⟩
 
+/-- One multiopen-forking output: the deployed IPA transcript tree, halo2's accept for it, and the
+`x₁`/`x₄` batch-rewinding data for that same tree. -/
+structure MultiopenForkingOutput [DecidableEq G] [Inhabited G] {shape : Shape} (urs : URS G)
+    (hk : shape.k = urs.k) (vk : VerifyingKey shape Fp G) (ps : ProofString shape Fp G)
+    (ch : Challenges shape.k Fp) (b : Fin (2 ^ urs.k) → Fp) (z blind : Fp)
+    {numColumns : ℕ} (columnCommitments : Fin numColumns → G)
+    (columnEvals : Fin numColumns → Fp) where
+  tree : DeployedIpaTreeV Fp G urs.k
+  rewind : MultiopenRewindBatch urs (deployedCommitment urs hk vk ps ch) b
+    (multiopenValue vk ps ch) columnCommitments columnEvals (projTree tree)
+  accepts : DeployedIpaAcceptV urs.g b urs.u urs.w z
+    (deployedCommitment urs hk vk ps ch) (multiopenValue vk ps ch) blind tree
+
+/-- The issue-18 residual as one explicit forking output, *data-producing*: from the deployed verifier
+equation it returns the deployed IPA tree together with the multiopen batch-rewinding data for that same
+tree. Compared with `FiatShamirTree`, this also carries the `x₁`/`x₄` multiopen rewinds needed to bind the
+extracted witness to real decoded columns. It returns data (a structure, not an `∃`) so the decoded
+capstone's `hquot`/`hgood` can be stated about the canonical decode of the returned batch — an existential
+output would force quantifying them over every batch, which is unsatisfiable (see the `MultiopenDecode`
+scope section). -/
+def FiatShamirMultiopenForking [DecidableEq G] [Inhabited G] {shape : Shape} (urs : URS G)
+    (hk : shape.k = urs.k) (vk : VerifyingKey shape Fp G) (ps : ProofString shape Fp G)
+    (ch : Challenges shape.k Fp) (b : Fin (2 ^ urs.k) → Fp) (z blind : Fp)
+    {numColumns : ℕ} (columnCommitments : Fin numColumns → G) (columnEvals : Fin numColumns → Fp) :
+    Type _ :=
+  DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk ps ch →
+    MultiopenForkingOutput urs hk vk ps ch b z blind columnCommitments columnEvals
+
 /-- The deployed Orchard verifier opening, as a binding **reduction**, with `P`/`v` **pinned** to the proof
 (`deployedCommitment`/`multiopenValue` from `(vk, ps, ch)`, not free parameters). From the deployed accept,
 `deployedAccepts_verifierEq` *proves* the explicit `DeployedIpaVerifierEq` form; the forking
@@ -450,6 +478,68 @@ theorem orchard_verifier_deployed_decoded_constraint_reduction [DecidableEq G] [
           satisfiesCircuit := hsat })
     · exact Or.inr (hasNontrivialRelation_of_two_openings urs hw
         ((hbatch (projTree t) hclean).opens.1.trans hrel'.1.symm))
+  · exact Or.inr hrel
+
+open Polynomial in
+/-- The decoded-column deployed capstone consuming one multiopen-forking output. This is the tighter
+closure surface for the witness-to-columns bridge: the caller supplies the deployed IPA tree, halo2's
+accept for it, and the batch openings for that same tree as one object — obtained from the forking
+bridge as `hForkBatch (deployedAccepts_verifierEq …)` with
+`hForkBatch : FiatShamirMultiopenForking …` — instead of a separate witness-indexed decode function.
+The output's batch `witness` is identified with the transcript's own extracted witness (a mismatch
+collides on `commit` and yields the relation branch), and `hquot`/`hgood` are stated for the canonical
+decode of the output's batch. -/
+theorem orchard_verifier_deployed_decoded_constraint_reduction_of_multiopen_forking
+    [DecidableEq G] [Inhabited G] {shape : Shape} (urs : URS G) (hk : shape.k = urs.k)
+    (vk : VerifyingKey shape Fp G) (ps : ProofString shape Fp G) (ch : Challenges shape.k Fp)
+    {b : Fin (2 ^ urs.k) → Fp} {z blind : Fp}
+    {numColumns numAdvice numInstance : ℕ}
+    (columnCommitments : Fin numColumns → G) (columnEvals : Fin numColumns → Fp)
+    (adviceIndex : Fin numAdvice → Fin numColumns) (instanceIndex : Fin numInstance → Fin numColumns)
+    (fixedCols : ℕ → Polynomial Fp)
+    (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
+    (hz : z ≠ 0)
+    (out : MultiopenForkingOutput urs hk vk ps ch b z blind columnCommitments columnEvals)
+    (hquot : quotientCheck
+      (combineGates fixedCols
+        (selectedPolys (decodedCols out.rewind.batchOpenings) adviceIndex)
+        (selectedPolys (decodedCols out.rewind.batchOpenings) instanceIndex) y gates)
+      hpoly deg x)
+    (hgood : combineGates fixedCols
+          (selectedPolys (decodedCols out.rewind.batchOpenings) adviceIndex)
+          (selectedPolys (decodedCols out.rewind.batchOpenings) instanceIndex) y gates
+        ≠ hpoly * (X ^ deg - 1) →
+      (combineGates fixedCols
+          (selectedPolys (decodedCols out.rewind.batchOpenings) adviceIndex)
+          (selectedPolys (decodedCols out.rewind.batchOpenings) instanceIndex) y gates
+        - hpoly * (X ^ deg - 1)).eval x ≠ 0)
+    {S : Prop}
+    (hencodes : ∀ a cols,
+      SnarkRelationWithDecodedColumns urs (deployedCommitment urs hk vk ps ch) b
+        (multiopenValue vk ps ch) columnCommitments columnEvals adviceIndex instanceIndex fixedCols
+        y gates hpoly deg a cols → S) :
+    S ∨ HasNontrivialRelation (F := Fp) urs.g urs.u urs.w := by
+  rcases deployed_to_acceptV hz urs.g b (deployedCommitment urs hk vk ps ch) (multiopenValue vk ps ch)
+    blind out.tree out.accepts with hclean | hrel
+  · obtain ⟨a, hrel'⟩ := ipaRelation_of_acceptV urs b (deployedCommitment urs hk vk ps ch)
+      (multiopenValue vk ps ch) (projTree out.tree) hclean
+    by_cases hw : out.rewind.witness = a
+    · subst hw
+      have hsat : circuitSatViaGates fixedCols
+          (selectedPolysDecode (k := urs.k) (decodedCols out.rewind.batchOpenings) adviceIndex)
+          (selectedPolysDecode (k := urs.k) (decodedCols out.rewind.batchOpenings) instanceIndex)
+          y gates hpoly deg out.rewind.witness :=
+        circuitSatViaGates_of_check fixedCols
+          (selectedPolysDecode (k := urs.k) (decodedCols out.rewind.batchOpenings) adviceIndex)
+          (selectedPolysDecode (k := urs.k) (decodedCols out.rewind.batchOpenings) instanceIndex)
+          y gates hpoly deg out.rewind.witness x hquot hgood
+      exact Or.inl (hencodes out.rewind.witness (decodedCols out.rewind.batchOpenings)
+        { opens := hrel'
+          batchOpenings := out.rewind.batchOpenings
+          decodedColumns := decodedCols_spec out.rewind.batchOpenings
+          satisfiesCircuit := hsat })
+    · exact Or.inr (hasNontrivialRelation_of_two_openings urs hw
+        (out.rewind.opens.1.trans hrel'.1.symm))
   · exact Or.inr hrel
 
 end Zcash.Snark

--- a/Zcash/Snark/Soundness/Main.lean
+++ b/Zcash/Snark/Soundness/Main.lean
@@ -481,6 +481,85 @@ theorem orchard_verifier_deployed_decoded_constraint_reduction [DecidableEq G] [
   · exact Or.inr hrel
 
 open Polynomial in
+/-- Turn a final multiopen relation plus same-witness batch rewinds into the decoded-column SNARK
+relation. This is the terminal constraint-side bridge used by the probability/AGM capstones: the circuit is
+checked on columns recovered from the verifier-opened multiopen relation, not through an arbitrary
+`decodeAdvice`/`decodeInstance` function. `hquot`/`hgood` are stated for the canonical decode
+`decodedCols hbatch` — the family this proof constructs — and are dischargeable only with `x` the opened
+point (see the `MultiopenDecode` scope section). -/
+theorem decoded_constraint_of_relation_and_batch {urs : URS G} {P : G}
+    {b : Fin (2 ^ urs.k) → Fp} {v : Fp}
+    {numColumns numAdvice numInstance : ℕ}
+    (columnCommitments : Fin numColumns → G) (columnEvals : Fin numColumns → Fp)
+    (adviceIndex : Fin numAdvice → Fin numColumns) (instanceIndex : Fin numInstance → Fin numColumns)
+    (fixedCols : ℕ → Polynomial Fp)
+    (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
+    {a : Fin (2 ^ urs.k) → Fp}
+    (hrel : IpaRelation urs P b v a)
+    (hbatch : BatchOpeningsForWitness urs b columnCommitments columnEvals a)
+    (hquot : quotientCheck
+      (combineGates fixedCols (selectedPolys (decodedCols hbatch) adviceIndex)
+        (selectedPolys (decodedCols hbatch) instanceIndex) y gates) hpoly deg x)
+    (hgood : combineGates fixedCols (selectedPolys (decodedCols hbatch) adviceIndex)
+        (selectedPolys (decodedCols hbatch) instanceIndex) y gates ≠ hpoly * (X ^ deg - 1) →
+      (combineGates fixedCols (selectedPolys (decodedCols hbatch) adviceIndex)
+        (selectedPolys (decodedCols hbatch) instanceIndex) y gates
+          - hpoly * (X ^ deg - 1)).eval x ≠ 0)
+    {S : Prop}
+    (hencodes : ∀ a cols,
+      SnarkRelationWithDecodedColumns urs P b v columnCommitments columnEvals adviceIndex instanceIndex
+        fixedCols y gates hpoly deg a cols → S) :
+    S := by
+  have hsat : circuitSatViaGates fixedCols
+      (selectedPolysDecode (k := urs.k) (decodedCols hbatch) adviceIndex)
+      (selectedPolysDecode (k := urs.k) (decodedCols hbatch) instanceIndex) y gates hpoly deg a :=
+    circuitSatViaGates_of_check fixedCols
+      (selectedPolysDecode (k := urs.k) (decodedCols hbatch) adviceIndex)
+      (selectedPolysDecode (k := urs.k) (decodedCols hbatch) instanceIndex) y gates hpoly deg a x
+      hquot hgood
+  exact hencodes a (decodedCols hbatch)
+    { opens := hrel
+      batchOpenings := hbatch
+      decodedColumns := decodedCols_spec hbatch
+      satisfiesCircuit := hsat }
+
+open Polynomial in
+/-- Lift an opening-or-DLR terminal capstone to the decoded-column constraint endpoint, provided the
+multiopen batch rewinding output is available for the final relation witness. Conditional interface: the
+batch family is assumed via `MultiopenRewindForRelation` (see its docstring), and `hquot`/`hgood` are
+stated for the canonical decode of the batch supplied at each relation witness. -/
+theorem decoded_constraint_of_opening_or_relation {urs : URS G} {P : G}
+    {b : Fin (2 ^ urs.k) → Fp} {v : Fp}
+    {numColumns numAdvice numInstance : ℕ}
+    (columnCommitments : Fin numColumns → G) (columnEvals : Fin numColumns → Fp)
+    (adviceIndex : Fin numAdvice → Fin numColumns) (instanceIndex : Fin numInstance → Fin numColumns)
+    (fixedCols : ℕ → Polynomial Fp)
+    (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
+    (hopening : (∃ a, IpaRelation urs P b v a) ∨ HasNontrivialRelation (F := Fp) urs.g urs.u urs.w)
+    (hbatch : MultiopenRewindForRelation urs P b v columnCommitments columnEvals)
+    (hquot : ∀ a (hrel : IpaRelation urs P b v a),
+      quotientCheck
+        (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates) hpoly deg x)
+    (hgood : ∀ a (hrel : IpaRelation urs P b v a),
+      combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
+        ≠ hpoly * (X ^ deg - 1) →
+      (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
+        - hpoly * (X ^ deg - 1)).eval x ≠ 0)
+    {S : Prop}
+    (hencodes : ∀ a cols,
+      SnarkRelationWithDecodedColumns urs P b v columnCommitments columnEvals adviceIndex instanceIndex
+        fixedCols y gates hpoly deg a cols → S) :
+    S ∨ HasNontrivialRelation (F := Fp) urs.g urs.u urs.w := by
+  rcases hopening with ⟨a, hrel⟩ | hrel
+  · exact Or.inl (decoded_constraint_of_relation_and_batch columnCommitments columnEvals adviceIndex
+      instanceIndex fixedCols y gates hpoly deg x hrel (hbatch a hrel) (hquot a hrel) (hgood a hrel)
+      hencodes)
+  · exact Or.inr hrel
+
+open Polynomial in
 /-- The decoded-column deployed capstone consuming one multiopen-forking output. This is the tighter
 closure surface for the witness-to-columns bridge: the caller supplies the deployed IPA tree, halo2's
 accept for it, and the batch openings for that same tree as one object — obtained from the forking

--- a/Zcash/Snark/Soundness/Main.lean
+++ b/Zcash/Snark/Soundness/Main.lean
@@ -352,21 +352,37 @@ theorem orchard_verifier_deployed_constraint_reduction [DecidableEq G] [Inhabite
     exact Or.inl (hencodes a ⟨hrel', hsat⟩)
   · exact Or.inr hrel
 
+/-- Two distinct openings of the same commitment exhibit a nontrivial `(g, U, W)` relation: their
+difference is a nonzero kernel vector of `commit`. Lets the decoded capstones identify a supplied batch
+witness with the transcript's own extracted witness, or fall into the relation branch. -/
+theorem hasNontrivialRelation_of_two_openings (urs : URS G) {a a' : Fin (2 ^ urs.k) → Fp}
+    (hne : a ≠ a') (hcollision : commit urs a = commit urs a') :
+    HasNontrivialRelation (F := Fp) urs.g urs.u urs.w := by
+  refine ⟨a - a', 0, 0, Or.inl (sub_ne_zero.mpr hne), ?_⟩
+  have hsub : commitGen (F := Fp) urs.g (a - a') = commit urs a - commit urs a' := by
+    simp only [commit, commitGen, Pi.sub_apply, sub_smul, Finset.sum_sub_distrib]
+  rw [hsub, hcollision]
+  simp
+
 open Polynomial in
 /-- The deployed Orchard verifier opening and constraint, with the multiopen witness decoded into real
 columns before the gate check is applied.
 
 Compared with `orchard_verifier_deployed_constraint_reduction`, `hquot`/`hgood` are no longer quantified
-over every mathematical opening of the pinned IPA relation. Instead, after the deployed accept extracts the
-current IPA witness `a`, `hbatch` supplies the rewound batched openings containing that witness, and
-`decodedColumnFamily_of_batch_openings` recovers the individual columns by `batch_open_soundV`. The gate
-check is then stated over those recovered columns, selected into the advice/instance slots the gate
-expressions read.
+over every mathematical opening of the pinned IPA relation. Instead, after the deployed accept peels to a
+clean accepting IPA transcript, `hbatch` supplies the multiopen-rewinding output for that transcript: a
+current IPA witness plus enough rewound batched openings containing it. `decodedColumnFamily_of_batch_openings`
+then recovers the individual columns by `batch_open_soundV`. The gate check is stated over those recovered
+columns, selected into the advice/instance slots the gate expressions read.
 
-This discharges the witness-to-real-columns half of the constraint-side bridge. The remaining hypothesis
-shape is deliberately explicit: `hquot` is still the separate quotient-check-from-deployed-assembly fact —
-stated for the canonical decode of the supplied batch (`decodedCols`), the family this proof constructs
-(the ∀-families form is jointly unsatisfiable; see the `MultiopenDecode` scope section). -/
+This discharges the witness-to-real-columns half of the constraint-side bridge once the multiopen rewinding
+output is supplied. The remaining hypothesis shape is deliberately explicit: `hbatch` is the `x₁`/`x₄`
+rewinding output for the accepted transcript, and `hquot` is still the separate
+quotient-check-from-deployed-assembly fact — stated for the canonical decode of the supplied batch
+(`decodedCols`), the family this proof constructs (the ∀-families form is jointly unsatisfiable; see the
+`MultiopenDecode` scope section). The batch's `witness` is identified with the transcript's own extracted
+witness: on mismatch the two openings of the pinned `(P, b, v)` collide on `commit` and the theorem
+returns the relation branch, so `hencodes` only ever receives the extracted witness. -/
 theorem orchard_verifier_deployed_decoded_constraint_reduction [DecidableEq G] [Inhabited G]
     {shape : Shape} (urs : URS G) (hk : shape.k = urs.k) (vk : VerifyingKey shape Fp G)
     (ps : ProofString shape Fp G) (ch : Challenges shape.k Fp)
@@ -379,20 +395,26 @@ theorem orchard_verifier_deployed_decoded_constraint_reduction [DecidableEq G] [
     (hz : z ≠ 0)
     (haccepts : DeployedAccepts urs hk vk ps ch)
     (hFS : FiatShamirTree urs hk vk ps ch b z blind)
-    (hbatch : ∀ a, IpaRelation urs (deployedCommitment urs hk vk ps ch) b (multiopenValue vk ps ch) a →
-      BatchOpeningsForWitness urs b columnCommitments columnEvals a)
-    (hquot : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps ch) b
-        (multiopenValue vk ps ch) a),
+    (hbatch : ∀ t, IpaAcceptV urs.g b (deployedCommitment urs hk vk ps ch)
+      (multiopenValue vk ps ch) t →
+      MultiopenRewindBatch urs (deployedCommitment urs hk vk ps ch) b (multiopenValue vk ps ch)
+        columnCommitments columnEvals t)
+    (hquot : ∀ t (hacc : IpaAcceptV urs.g b (deployedCommitment urs hk vk ps ch)
+        (multiopenValue vk ps ch) t),
       quotientCheck
-        (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
-          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates) hpoly deg x)
-    (hgood : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps ch) b
-        (multiopenValue vk ps ch) a),
-      combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
-          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
+        (combineGates fixedCols
+          (selectedPolys (decodedCols (hbatch t hacc).batchOpenings) adviceIndex)
+          (selectedPolys (decodedCols (hbatch t hacc).batchOpenings) instanceIndex) y gates)
+        hpoly deg x)
+    (hgood : ∀ t (hacc : IpaAcceptV urs.g b (deployedCommitment urs hk vk ps ch)
+        (multiopenValue vk ps ch) t),
+      combineGates fixedCols
+          (selectedPolys (decodedCols (hbatch t hacc).batchOpenings) adviceIndex)
+          (selectedPolys (decodedCols (hbatch t hacc).batchOpenings) instanceIndex) y gates
         ≠ hpoly * (X ^ deg - 1) →
-      (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
-          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
+      (combineGates fixedCols
+          (selectedPolys (decodedCols (hbatch t hacc).batchOpenings) adviceIndex)
+          (selectedPolys (decodedCols (hbatch t hacc).batchOpenings) instanceIndex) y gates
         - hpoly * (X ^ deg - 1)).eval x ≠ 0)
     {S : Prop}
     (hencodes : ∀ a cols,
@@ -405,19 +427,29 @@ theorem orchard_verifier_deployed_decoded_constraint_reduction [DecidableEq G] [
     blind t ht with hclean | hrel
   · obtain ⟨a, hrel'⟩ := ipaRelation_of_acceptV urs b (deployedCommitment urs hk vk ps ch)
       (multiopenValue vk ps ch) (projTree t) hclean
-    have hsat : circuitSatViaGates fixedCols
-        (selectedPolysDecode (k := urs.k) (decodedCols (hbatch a hrel')) adviceIndex)
-        (selectedPolysDecode (k := urs.k) (decodedCols (hbatch a hrel')) instanceIndex)
-        y gates hpoly deg a :=
-      circuitSatViaGates_of_check fixedCols
-        (selectedPolysDecode (k := urs.k) (decodedCols (hbatch a hrel')) adviceIndex)
-        (selectedPolysDecode (k := urs.k) (decodedCols (hbatch a hrel')) instanceIndex)
-        y gates hpoly deg a x (hquot a hrel') (hgood a hrel')
-    exact Or.inl (hencodes a (decodedCols (hbatch a hrel'))
-      { opens := hrel'
-        batchOpenings := hbatch a hrel'
-        decodedColumns := decodedCols_spec (hbatch a hrel')
-        satisfiesCircuit := hsat })
+    by_cases hw : (hbatch (projTree t) hclean).witness = a
+    · subst hw
+      have hsat : circuitSatViaGates fixedCols
+          (selectedPolysDecode (k := urs.k)
+            (decodedCols (hbatch (projTree t) hclean).batchOpenings) adviceIndex)
+          (selectedPolysDecode (k := urs.k)
+            (decodedCols (hbatch (projTree t) hclean).batchOpenings) instanceIndex)
+          y gates hpoly deg (hbatch (projTree t) hclean).witness :=
+        circuitSatViaGates_of_check fixedCols
+          (selectedPolysDecode (k := urs.k)
+            (decodedCols (hbatch (projTree t) hclean).batchOpenings) adviceIndex)
+          (selectedPolysDecode (k := urs.k)
+            (decodedCols (hbatch (projTree t) hclean).batchOpenings) instanceIndex)
+          y gates hpoly deg (hbatch (projTree t) hclean).witness x
+          (hquot (projTree t) hclean) (hgood (projTree t) hclean)
+      exact Or.inl (hencodes (hbatch (projTree t) hclean).witness
+        (decodedCols (hbatch (projTree t) hclean).batchOpenings)
+        { opens := hrel'
+          batchOpenings := (hbatch (projTree t) hclean).batchOpenings
+          decodedColumns := decodedCols_spec (hbatch (projTree t) hclean).batchOpenings
+          satisfiesCircuit := hsat })
+    · exact Or.inr (hasNontrivialRelation_of_two_openings urs hw
+        ((hbatch (projTree t) hclean).opens.1.trans hrel'.1.symm))
   · exact Or.inr hrel
 
 end Zcash.Snark

--- a/Zcash/Snark/Soundness/MultiopenDecode.lean
+++ b/Zcash/Snark/Soundness/MultiopenDecode.lean
@@ -90,6 +90,19 @@ structure MultiopenRewindBatch (urs : URS G) (P : G) (b : Fin (2 ^ urs.k) → Fp
   opens : IpaRelation urs P b v witness
   batchOpenings : BatchOpeningsForWitness urs b columnCommitments columnEvals witness
 
+/-- Terminal form of the multiopen-rewinding output, for capstones whose forking ladder exposes only the
+final opened multiopen relation (post unshift/unblind). This is a *conditional* interface: no `x₁`/`x₄`
+rewinding data is threaded through the forking path yet, so the terminal capstones assume this output
+rather than derive it — they bind the gate check to decoded columns *given* the batch family, no more.
+The `∀`-witness shape costs nothing beyond a transcript-tied one: all openings of the pinned `(P, b, v)`
+share the same commitment and value, so a batch family for one witness transfers to any other by swapping
+the `current` slot. -/
+abbrev MultiopenRewindForRelation (urs : URS G) (P : G) (b : Fin (2 ^ urs.k) → Fp) (v : Fp)
+    {numColumns : ℕ} (columnCommitments : Fin numColumns → G) (columnEvals : Fin numColumns → Fp) :
+    Type _ :=
+  ∀ a, IpaRelation urs P b v a →
+    BatchOpeningsForWitness urs b columnCommitments columnEvals a
+
 /-- The recovered per-column polynomials and their opening facts. -/
 structure DecodedColumnFamily (urs : URS G) (b : Fin (2 ^ urs.k) → Fp) {numColumns : ℕ}
     (columnCommitments : Fin numColumns → G) (columnEvals : Fin numColumns → Fp)

--- a/Zcash/Snark/Soundness/MultiopenDecode.lean
+++ b/Zcash/Snark/Soundness/MultiopenDecode.lean
@@ -1,0 +1,178 @@
+import Mathlib
+import Zcash.Snark.Soundness.IpaSoundness
+import Zcash.Snark.Soundness.KnowledgeSoundness
+import Zcash.Snark.Verifier.Assemble
+
+/-!
+# Binding the multiopen witness to decoded columns
+
+The IPA extractor returns one coefficient vector for the deployed batched multiopen commitment. The gate
+check, however, talks about the individual column polynomials. This module records the missing witness
+decode layer: if rewinding supplies openings of the same batched commitment at enough distinct batching
+challenges, `batch_open_soundV` recovers the individual columns and proves that they open the claimed
+commitments and evaluations.
+
+This closes the witness-to-real-columns half of the constraint-side bridge. The separate fact that the
+deployed quotient check supplies `hquot` for those decoded columns remains outside this module.
+
+## Scope of the model
+
+This decode layer models a *single-point, rotation-free* multiopen: every column is opened at the one
+evaluation vector `b`, batching is one flat challenge-power combination, and the recovered columns feed
+gate polynomials with no rotation structure (`Expr.toPoly` has no `X ↦ ωX` composition). The deployed
+assembly (`assembleQueries`/`constructIntermediateSets`) is richer on all three axes: queries hit rotated
+points `ωⁱ·x`, the collapse is two-level (`x₁` within point sets, then `x₄` across, with components the
+multiopen aggregates `qPrime`/`u_j`, not circuit columns), and the gate check lives at `ch.x` while the
+final opening is at `x₃`. Discharging `hbatch`/`hquot` against the deployed verifier therefore needs a
+generalization of this module — per-column opening points, a nested batch structure, and the `x`-to-`x₃`
+quotient transport — not only a rewinding lemma. Until then, the decoded capstones are exercised
+faithfully only by single-point, rotation-free instantiations.
+
+To keep the hypotheses satisfiable, the decoded capstones state `hquot`/`hgood` for the *canonical*
+decode of the supplied batch (`decodedCols`), not for every family opening the same commitments: the
+family set has `≥ 2^k − 2` free dimensions per column at a prime-order curve (only the commitment and one
+evaluation are pinned), so quantified over all of it the pair `hquot ∧ hgood` is jointly unsatisfiable —
+tweak one gate-read column by a kernel vector vanishing at the opened point and at `x`. For the same
+reason they are dischargeable only with `x` the opened point.
+-/
+
+namespace Zcash.Snark
+
+open Polynomial
+
+variable {G : Type*} [AddCommGroup G] [Module Fp G]
+
+/-- Interpret a coefficient vector as the corresponding polynomial. -/
+noncomputable def coeffsToPoly {n : ℕ} (a : Fin n → Fp) : Polynomial Fp :=
+  ∑ i, Polynomial.C (a i) * Polynomial.X ^ (i : ℕ)
+
+/-- Evaluating `coeffsToPoly` is the same linear form as committing to the powers evaluation vector. -/
+theorem coeffsToPoly_eval {k : ℕ} (a : Fin (2 ^ k) → Fp) (x : Fp) :
+    (coeffsToPoly a).eval x = commitGen (evalVector k x) a := by
+  rw [coeffsToPoly, Polynomial.eval_finset_sum]
+  simp [commitGen, evalVector, smul_eq_mul]
+
+/-- A family of rewound batched openings for one batch of column commitments.
+
+`batched r` is the IPA witness extracted when the batching challenge is `batchChallenge r`; `current_eq`
+marks which rewound opening is the current deployed witness. The commitment and value equations are the
+premises consumed by `batch_open_soundV`. -/
+structure BatchOpeningsForWitness (urs : URS G) (b : Fin (2 ^ urs.k) → Fp) {numColumns : ℕ}
+    (columnCommitments : Fin numColumns → G) (columnEvals : Fin numColumns → Fp)
+    (currentWitness : Fin (2 ^ urs.k) → Fp) where
+  batchChallenge : Fin numColumns → Fp
+  challengesDistinct : Function.Injective batchChallenge
+  batched : Fin numColumns → (Fin (2 ^ urs.k) → Fp)
+  current : Fin numColumns
+  current_eq : batched current = currentWitness
+  commitment :
+    ∀ r, commit urs (batched r)
+      = ∑ j : Fin numColumns, batchChallenge r ^ (j : ℕ) • columnCommitments j
+  value :
+    ∀ r, commitGen b (batched r)
+      = ∑ j : Fin numColumns, batchChallenge r ^ (j : ℕ) • columnEvals j
+
+/-- The recovered per-column polynomials and their opening facts. -/
+structure DecodedColumnFamily (urs : URS G) (b : Fin (2 ^ urs.k) → Fp) {numColumns : ℕ}
+    (columnCommitments : Fin numColumns → G) (columnEvals : Fin numColumns → Fp)
+    (cols : Fin numColumns → Polynomial Fp) where
+  coeffs : Fin numColumns → (Fin (2 ^ urs.k) → Fp)
+  commitment : ∀ i, commit urs (coeffs i) = columnCommitments i
+  value : ∀ i, commitGen b (coeffs i) = columnEvals i
+  polynomial : ∀ i, cols i = coeffsToPoly (coeffs i)
+
+/-- Recover the individual column polynomials from rewound batched openings. -/
+noncomputable def decodedColumnFamily_of_batch_openings {urs : URS G} {b : Fin (2 ^ urs.k) → Fp}
+    {numColumns : ℕ} {columnCommitments : Fin numColumns → G}
+    {columnEvals : Fin numColumns → Fp} {currentWitness : Fin (2 ^ urs.k) → Fp}
+    (hbatch : BatchOpeningsForWitness urs b columnCommitments columnEvals currentWitness) :
+    Σ cols : Fin numColumns → Polynomial Fp,
+      DecodedColumnFamily urs b columnCommitments columnEvals cols := by
+  classical
+  have haC :
+      ∀ r, commitGen urs.g (hbatch.batched r)
+        = ∑ j : Fin numColumns, hbatch.batchChallenge r ^ (j : ℕ) • columnCommitments j := by
+    intro r
+    rw [← commit_eq_commitGen urs (hbatch.batched r)]
+    exact hbatch.commitment r
+  let hdecoded :=
+    batch_open_soundV urs.g b columnCommitments columnEvals hbatch.batchChallenge
+      hbatch.challengesDistinct hbatch.batched haC hbatch.value
+  let cols := Classical.choose hdecoded
+  have hcols : ∀ i, commitGen urs.g (cols i) = columnCommitments i ∧ commitGen b (cols i) = columnEvals i :=
+    Classical.choose_spec hdecoded
+  exact
+    ⟨fun i => coeffsToPoly (cols i),
+      { coeffs := cols
+        commitment := by
+          intro i
+          rw [commit_eq_commitGen]
+          exact (hcols i).1
+        value := by
+          intro i
+          exact (hcols i).2
+        polynomial := by
+          intro i
+          rfl }⟩
+
+/-- The canonical decoded columns of a batch family: the decode of
+`decodedColumnFamily_of_batch_openings`, projected out. The decoded capstones state their
+`hquot`/`hgood` hypotheses about *this* family — the one their proofs construct — see the module doc's
+scope section for why quantifying over every decoded family instead is unsatisfiable. -/
+noncomputable def decodedCols {urs : URS G} {b : Fin (2 ^ urs.k) → Fp} {numColumns : ℕ}
+    {columnCommitments : Fin numColumns → G} {columnEvals : Fin numColumns → Fp}
+    {currentWitness : Fin (2 ^ urs.k) → Fp}
+    (hbatch : BatchOpeningsForWitness urs b columnCommitments columnEvals currentWitness) :
+    Fin numColumns → Polynomial Fp :=
+  (decodedColumnFamily_of_batch_openings hbatch).1
+
+/-- The canonical decode is a decoded-column family: it opens the claimed commitments and
+evaluations. -/
+noncomputable def decodedCols_spec {urs : URS G} {b : Fin (2 ^ urs.k) → Fp} {numColumns : ℕ}
+    {columnCommitments : Fin numColumns → G} {columnEvals : Fin numColumns → Fp}
+    {currentWitness : Fin (2 ^ urs.k) → Fp}
+    (hbatch : BatchOpeningsForWitness urs b columnCommitments columnEvals currentWitness) :
+    DecodedColumnFamily urs b columnCommitments columnEvals (decodedCols hbatch) :=
+  (decodedColumnFamily_of_batch_openings hbatch).2
+
+namespace DecodedColumnFamily
+
+/-- A decoded column's claimed evaluation is the value of the recovered polynomial at the opened point. -/
+theorem eval_eq {urs : URS G} {numColumns : ℕ} {columnCommitments : Fin numColumns → G}
+    {columnEvals : Fin numColumns → Fp} {cols : Fin numColumns → Polynomial Fp}
+    {x : Fp}
+    (hcols : DecodedColumnFamily urs (evalVector urs.k x) columnCommitments columnEvals cols)
+    (i : Fin numColumns) :
+    (cols i).eval x = columnEvals i := by
+  rw [hcols.polynomial i, coeffsToPoly_eval, hcols.value i]
+
+end DecodedColumnFamily
+
+/-- Select a finite family of recovered columns and totalize it for gate-expression evaluation. -/
+noncomputable def selectedPolys {numColumns numSelected : ℕ} (cols : Fin numColumns → Polynomial Fp)
+    (idx : Fin numSelected → Fin numColumns) : ℕ → Polynomial Fp :=
+  finFn fun i : Fin numSelected => cols (idx i)
+
+/-- A witness-indexed decode function that ignores the witness after the columns have been recovered. -/
+noncomputable def selectedPolysDecode {k numColumns numSelected : ℕ}
+    (cols : Fin numColumns → Polynomial Fp) (idx : Fin numSelected → Fin numColumns) :
+    (Fin (2 ^ k) → Fp) → ℕ → Polynomial Fp :=
+  fun _ => selectedPolys cols idx
+
+/-- The SNARK relation with the circuit side fed by columns recovered from the same batched opening family
+that contains the extracted IPA witness. -/
+structure SnarkRelationWithDecodedColumns (urs : URS G) (P : G) (b : Fin (2 ^ urs.k) → Fp) (v : Fp)
+    {numColumns numAdvice numInstance : ℕ}
+    (columnCommitments : Fin numColumns → G) (columnEvals : Fin numColumns → Fp)
+    (adviceIndex : Fin numAdvice → Fin numColumns) (instanceIndex : Fin numInstance → Fin numColumns)
+    (fixedCols : ℕ → Polynomial Fp)
+    (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ)
+    (a : Fin (2 ^ urs.k) → Fp) (cols : Fin numColumns → Polynomial Fp) where
+  opens : IpaRelation urs P b v a
+  batchOpenings : BatchOpeningsForWitness urs b columnCommitments columnEvals a
+  decodedColumns : DecodedColumnFamily urs b columnCommitments columnEvals cols
+  satisfiesCircuit :
+    circuitSatViaGates fixedCols (selectedPolysDecode (k := urs.k) cols adviceIndex)
+      (selectedPolysDecode (k := urs.k) cols instanceIndex) y gates hpoly deg a
+
+end Zcash.Snark

--- a/Zcash/Snark/Soundness/MultiopenDecode.lean
+++ b/Zcash/Snark/Soundness/MultiopenDecode.lean
@@ -12,8 +12,10 @@ decode layer: if rewinding supplies openings of the same batched commitment at e
 challenges, `batch_open_soundV` recovers the individual columns and proves that they open the claimed
 commitments and evaluations.
 
-This closes the witness-to-real-columns half of the constraint-side bridge. The separate fact that the
-deployed quotient check supplies `hquot` for those decoded columns remains outside this module.
+This closes the witness-to-real-columns half of the constraint-side bridge once the multiopen rewinding has
+produced the relevant batch openings. The separate facts that the deployed quotient check supplies `hquot`
+for those decoded columns, and that the `x₁`/`x₄` transcript rewinds produce the batch family, remain outside
+this module.
 
 ## Scope of the model
 
@@ -71,6 +73,22 @@ structure BatchOpeningsForWitness (urs : URS G) (b : Fin (2 ^ urs.k) → Fp) {nu
   value :
     ∀ r, commitGen b (batched r)
       = ∑ j : Fin numColumns, batchChallenge r ^ (j : ℕ) • columnEvals j
+
+/-- The exact multiopen-rewinding output the decoded-column capstone consumes, indexed by the accepting
+clean IPA transcript `t` it is rewound from.
+
+The index records the intended provenance but is not itself binding — no field constrains `witness` by
+`t`. The tie is enforced where the structure is consumed: the decoded capstones extract the transcript's
+own witness from `t`'s acceptance and either identify it with `witness` or return the
+`HasNontrivialRelation` branch (two distinct openings of the pinned `(P, b, v)` collide on `commit`,
+`hasNontrivialRelation_of_two_openings`). It is not a free function from arbitrary mathematical openings
+to columns. -/
+structure MultiopenRewindBatch (urs : URS G) (P : G) (b : Fin (2 ^ urs.k) → Fp) (v : Fp)
+    {numColumns : ℕ} (columnCommitments : Fin numColumns → G) (columnEvals : Fin numColumns → Fp)
+    (t : IpaTreeV Fp G urs.k) where
+  witness : Fin (2 ^ urs.k) → Fp
+  opens : IpaRelation urs P b v witness
+  batchOpenings : BatchOpeningsForWitness urs b columnCommitments columnEvals witness
 
 /-- The recovered per-column polynomials and their opening facts. -/
 structure DecodedColumnFamily (urs : URS G) (b : Fin (2 ^ urs.k) → Fp) {numColumns : ℕ}

--- a/Zcash/Snark/Soundness/MultiopenDecode.lean
+++ b/Zcash/Snark/Soundness/MultiopenDecode.lean
@@ -81,41 +81,117 @@ structure DecodedColumnFamily (urs : URS G) (b : Fin (2 ^ urs.k) → Fp) {numCol
   value : ∀ i, commitGen b (coeffs i) = columnEvals i
   polynomial : ∀ i, cols i = coeffsToPoly (coeffs i)
 
+/-- The same decoded columns, tied back to the full family of rewound batched witnesses. -/
+structure DecodedColumnFamilyOfBatch {urs : URS G} {b : Fin (2 ^ urs.k) → Fp} {numColumns : ℕ}
+    {columnCommitments : Fin numColumns → G} {columnEvals : Fin numColumns → Fp}
+    {currentWitness : Fin (2 ^ urs.k) → Fp}
+    (hbatch : BatchOpeningsForWitness urs b columnCommitments columnEvals currentWitness)
+    (cols : Fin numColumns → Polynomial Fp) where
+  decodedColumns : DecodedColumnFamily urs b columnCommitments columnEvals cols
+  reconstruct :
+    ∀ r, hbatch.batched r
+      = ∑ i : Fin numColumns, hbatch.batchChallenge r ^ (i : ℕ) • decodedColumns.coeffs i
+
+/-- The current extracted witness is the current batch-challenge combination of the decoded columns. -/
+theorem DecodedColumnFamilyOfBatch.currentWitness_eq {urs : URS G} {b : Fin (2 ^ urs.k) → Fp}
+    {numColumns : ℕ} {columnCommitments : Fin numColumns → G} {columnEvals : Fin numColumns → Fp}
+    {currentWitness : Fin (2 ^ urs.k) → Fp}
+    {hbatch : BatchOpeningsForWitness urs b columnCommitments columnEvals currentWitness}
+    {cols : Fin numColumns → Polynomial Fp} (hdecoded : DecodedColumnFamilyOfBatch hbatch cols) :
+    currentWitness
+      = ∑ i : Fin numColumns, hbatch.batchChallenge hbatch.current ^ (i : ℕ)
+          • hdecoded.decodedColumns.coeffs i := by
+  calc
+    currentWitness = hbatch.batched hbatch.current := hbatch.current_eq.symm
+    _ = ∑ i : Fin numColumns, hbatch.batchChallenge hbatch.current ^ (i : ℕ)
+          • hdecoded.decodedColumns.coeffs i := hdecoded.reconstruct hbatch.current
+
+/-- Right inverse of the Vandermonde inverse: the row functional reconstructing a sample. -/
+theorem vandermonde_inv_right {n : ℕ} (z : Fin n → Fp) (hz : Function.Injective z) :
+    ∀ (i j : Fin n), (∑ k : Fin n, z i ^ (k : ℕ) * (Matrix.vandermonde z)⁻¹ k j)
+      = if i = j then 1 else 0 := by
+  have hdet : (Matrix.vandermonde z).det ≠ 0 := Matrix.det_vandermonde_ne_zero_iff.mpr hz
+  intro i j
+  have hmul : Matrix.vandermonde z * (Matrix.vandermonde z)⁻¹ = 1 :=
+    Matrix.mul_nonsing_inv _ (isUnit_iff_ne_zero.mpr hdet)
+  have h2 := congrFun (congrFun hmul i) j
+  rw [Matrix.mul_apply] at h2
+  simpa only [Matrix.vandermonde_apply, Matrix.one_apply] using h2
+
+/-- Left inverse of the Vandermonde inverse, specialized to the explicit inverse coefficients. -/
+theorem vandermonde_inv_left {n : ℕ} (z : Fin n → Fp) (hz : Function.Injective z) :
+    ∀ (i j : Fin n), (∑ k : Fin n, (Matrix.vandermonde z)⁻¹ i k * z k ^ (j : ℕ))
+      = if i = j then 1 else 0 := by
+  have hdet : (Matrix.vandermonde z).det ≠ 0 := Matrix.det_vandermonde_ne_zero_iff.mpr hz
+  intro i j
+  have hmul : (Matrix.vandermonde z)⁻¹ * Matrix.vandermonde z = 1 :=
+    Matrix.nonsing_inv_mul _ (isUnit_iff_ne_zero.mpr hdet)
+  have h2 := congrFun (congrFun hmul i) j
+  rw [Matrix.mul_apply] at h2
+  simpa only [Matrix.vandermonde_apply, Matrix.one_apply] using h2
+
+/-- The explicit Vandermonde-decoded columns reconstruct each rewound batched witness. -/
+theorem batch_open_reconstruct_with_coeffs {m n : ℕ} (z : Fin n → Fp)
+    (a : Fin n → (Fin m → Fp)) (μ : Fin n → Fin n → Fp)
+    (hμ : ∀ (i j : Fin n), (∑ k : Fin n, z i ^ (k : ℕ) * μ k j)
+      = if i = j then 1 else 0)
+    (i : Fin n) :
+    (∑ j : Fin n, z i ^ (j : ℕ) • (∑ k : Fin n, μ j k • a k)) = a i := by
+  simp only [Finset.smul_sum, smul_smul]
+  rw [Finset.sum_comm]
+  simp only [← Finset.sum_smul, hμ, ite_smul, one_smul, zero_smul, Finset.sum_ite_eq,
+    Finset.mem_univ, if_true]
+
 /-- Recover the individual column polynomials from rewound batched openings. -/
 noncomputable def decodedColumnFamily_of_batch_openings {urs : URS G} {b : Fin (2 ^ urs.k) → Fp}
     {numColumns : ℕ} {columnCommitments : Fin numColumns → G}
     {columnEvals : Fin numColumns → Fp} {currentWitness : Fin (2 ^ urs.k) → Fp}
     (hbatch : BatchOpeningsForWitness urs b columnCommitments columnEvals currentWitness) :
     Σ cols : Fin numColumns → Polynomial Fp,
-      DecodedColumnFamily urs b columnCommitments columnEvals cols := by
-  classical
+      DecodedColumnFamilyOfBatch hbatch cols := by
   have haC :
       ∀ r, commitGen urs.g (hbatch.batched r)
         = ∑ j : Fin numColumns, hbatch.batchChallenge r ^ (j : ℕ) • columnCommitments j := by
     intro r
     rw [← commit_eq_commitGen urs (hbatch.batched r)]
     exact hbatch.commitment r
-  let hdecoded :=
-    batch_open_soundV urs.g b columnCommitments columnEvals hbatch.batchChallenge
-      hbatch.challengesDistinct hbatch.batched haC hbatch.value
-  let cols := Classical.choose hdecoded
-  have hcols : ∀ i, commitGen urs.g (cols i) = columnCommitments i ∧ commitGen b (cols i) = columnEvals i :=
-    Classical.choose_spec hdecoded
+  let μ : Matrix (Fin numColumns) (Fin numColumns) Fp :=
+    (Matrix.vandermonde hbatch.batchChallenge)⁻¹
+  let coeffs : Fin numColumns → (Fin (2 ^ urs.k) → Fp) :=
+    fun i => ∑ r, μ i r • hbatch.batched r
+  have hleft :
+      ∀ (i j : Fin numColumns), (∑ k : Fin numColumns,
+          μ i k * hbatch.batchChallenge k ^ (j : ℕ))
+        = if i = j then 1 else 0 := by
+    intro i j
+    simpa [μ] using vandermonde_inv_left hbatch.batchChallenge hbatch.challengesDistinct i j
+  have hright :
+      ∀ (i j : Fin numColumns), (∑ k : Fin numColumns,
+          hbatch.batchChallenge i ^ (k : ℕ) * μ k j)
+        = if i = j then 1 else 0 := by
+    intro i j
+    simpa [μ] using vandermonde_inv_right hbatch.batchChallenge hbatch.challengesDistinct i j
   exact
-    ⟨fun i => coeffsToPoly (cols i),
-      { coeffs := cols
-        commitment := by
-          intro i
-          rw [commit_eq_commitGen]
-          exact (hcols i).1
-        value := by
-          intro i
-          exact (hcols i).2
-        polynomial := by
-          intro i
-          rfl }⟩
+    ⟨fun i => coeffsToPoly (coeffs i),
+      { decodedColumns :=
+          { coeffs := coeffs
+            commitment := by
+              intro i
+              rw [commit_eq_commitGen]
+              exact batch_open_with_coeffs urs.g columnCommitments hbatch.batchChallenge
+                hbatch.batched μ hleft haC i
+            value := by
+              intro i
+              exact batch_open_with_coeffs b columnEvals hbatch.batchChallenge hbatch.batched μ
+                hleft hbatch.value i
+            polynomial := by
+              intro i
+              rfl }
+        reconstruct := by
+          intro r
+          exact (batch_open_reconstruct_with_coeffs hbatch.batchChallenge hbatch.batched μ hright r).symm }⟩
 
-/-- The canonical decoded columns of a batch family: the decode of
+/-- The canonical decoded columns of a batch family: the explicit Vandermonde decode of
 `decodedColumnFamily_of_batch_openings`, projected out. The decoded capstones state their
 `hquot`/`hgood` hypotheses about *this* family — the one their proofs construct — see the module doc's
 scope section for why quantifying over every decoded family instead is unsatisfiable. -/
@@ -126,13 +202,13 @@ noncomputable def decodedCols {urs : URS G} {b : Fin (2 ^ urs.k) → Fp} {numCol
     Fin numColumns → Polynomial Fp :=
   (decodedColumnFamily_of_batch_openings hbatch).1
 
-/-- The canonical decode is a decoded-column family: it opens the claimed commitments and
-evaluations. -/
+/-- The canonical decode is a decoded-column family for its batch: it opens the claimed
+commitments/evaluations and reconstructs every rewound batched witness (hence the current one). -/
 noncomputable def decodedCols_spec {urs : URS G} {b : Fin (2 ^ urs.k) → Fp} {numColumns : ℕ}
     {columnCommitments : Fin numColumns → G} {columnEvals : Fin numColumns → Fp}
     {currentWitness : Fin (2 ^ urs.k) → Fp}
     (hbatch : BatchOpeningsForWitness urs b columnCommitments columnEvals currentWitness) :
-    DecodedColumnFamily urs b columnCommitments columnEvals (decodedCols hbatch) :=
+    DecodedColumnFamilyOfBatch hbatch (decodedCols hbatch) :=
   (decodedColumnFamily_of_batch_openings hbatch).2
 
 namespace DecodedColumnFamily
@@ -170,7 +246,7 @@ structure SnarkRelationWithDecodedColumns (urs : URS G) (P : G) (b : Fin (2 ^ ur
     (a : Fin (2 ^ urs.k) → Fp) (cols : Fin numColumns → Polynomial Fp) where
   opens : IpaRelation urs P b v a
   batchOpenings : BatchOpeningsForWitness urs b columnCommitments columnEvals a
-  decodedColumns : DecodedColumnFamily urs b columnCommitments columnEvals cols
+  decodedColumns : DecodedColumnFamilyOfBatch batchOpenings cols
   satisfiesCircuit :
     circuitSatViaGates fixedCols (selectedPolysDecode (k := urs.k) cols adviceIndex)
       (selectedPolysDecode (k := urs.k) cols instanceIndex) y gates hpoly deg a

--- a/Zcash/Snark/Soundness/Vesta.lean
+++ b/Zcash/Snark/Soundness/Vesta.lean
@@ -378,76 +378,67 @@ theorem orchard_verifier_vesta_forking_opening_agm_dl [Fact (HasseBound Vesta.cu
 open Polynomial in
 open scoped ENNReal in
 open Classical in
-/-- **The deployed Orchard opening *and constraint* over Vesta, via the forking refinements (no
-`FiatShamirTree`), with the structural facts discharged.** The constraint-side companion of
-`orchard_verifier_vesta_forking_opening`: same concrete instance (`b = evalVector urs.k xEval`, so `b 0 = 1` is
-*proved*; `aMulti` recovered from the `g`-span so `hcommit` is discharged; the adjusted witness *constructed*
-so `hP` holds by linearity) and the same gate seam as `orchard_verifier_vesta_constraint_reduction`
-(`hquot`/`hgood` → `circuitSatViaGates`, `hencodes`). Unlike the opening, the circuit is checked at the
-*claimed* value `multiopenValue`, so the minimal value-recovery hypothesis `hξ : ξ·⟨s,b⟩ = 0` is retained — it
-pins the opened value `multiopenValue − ξ·⟨s,b⟩` (unique under binding) from the forking opening back to
-`multiopenValue`. `hξ`
-generalises honest blinding (`⟨s,b⟩ = 0`); for a *malicious* blinder (`⟨s,b⟩ ≠ 0`) it holds only on a
-`1/p`-measure set of post-`S` challenges `ξ` (`blinder_value_recovery_badSet`, the `ξ`-randomization budget).
-The deployed-curve residual is the explicit prover-as-oracle bridge `hbridge` (and the nonzero generator
-`hg0`); both the opening and the constraint side now route through it with `b 0 = 1`, `hcommit`, and `hP`
-discharged. The original `FiatShamirTree` reductions
-(`orchard_verifier_vesta_opening_reduction`/`_constraint`) remain as the coarser legacy endpoints. The
-`∨ HasNontrivialRelation` caveat is unchanged — vacuous at Vesta's prime order, with force in the
-computational DLR/AGM layer outside Lean (`Soundness.AGM` records only its deterministic fixed-slot
-core). `hquot`/`hgood` retain the ∀-openings shape —
-unsatisfiable at Vesta for any decode that genuinely reads the witness (see
-`orchard_verifier_deployed_constraint_reduction`'s caveat, and the decoded capstone above). -/
-theorem orchard_verifier_vesta_forking_constraint_legacy [Fact (HasseBound Vesta.curve)] [DecidableEq VestaG]
-    [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
+/-- Bridge-level decoded constraint capstone: the deployed verifier relation is bridged through `hbridge`,
+then the final multiopen opening is decoded into real columns before the circuit gate check. -/
+theorem orchard_verifier_vesta_forking_constraint [Fact (HasseBound Vesta.curve)]
+    [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
     (xEval ξ z blind : Fp) (s : Fin (2 ^ urs.k) → Fp)
     (Q : Prover Fp VestaG urs.k) (accepts : (Fin urs.k → Fp) → Prop)
+    {numColumns numAdvice numInstance : ℕ}
+    (columnCommitments : Fin numColumns → VestaG) (columnEvals : Fin numColumns → Fp)
+    (adviceIndex : Fin numAdvice → Fin numColumns) (instanceIndex : Fin numInstance → Fin numColumns)
     (fixedCols : ℕ → Polynomial Fp)
-    (decodeAdvice decodeInstance : (Fin (2 ^ urs.k) → Fp) → (ℕ → Polynomial Fp))
     (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
     (hz : z ≠ 0) (hg0 : urs.g 0 ≠ 0)
     (hξ : ξ * innerProduct s (evalVector urs.k xEval) = 0)
     (hbridge : ∀ χ, accepts χ ↔ flatAccept Q urs.g (evalVector urs.k xEval) urs.u urs.w z
         (deployedCommitment urs hk vk ps ch - multiopenValue vk ps ch • urs.g 0 + ξ • commit urs s
           + (z * 0) • urs.u + blind • urs.w) χ)
-    (hquot : ∀ a, IpaRelation urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k xEval)
-        (multiopenValue vk ps ch) a →
-      quotientCheck (combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates) hpoly deg x)
-    (hgood : ∀ a, IpaRelation urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k xEval)
-        (multiopenValue vk ps ch) a →
-      combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates ≠ hpoly * (X ^ deg - 1) →
-      (combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates
+    (hbatch : MultiopenRewindForRelation urs (deployedCommitment urs hk vk ps ch)
+      (evalVector urs.k xEval) (multiopenValue vk ps ch) columnCommitments columnEvals)
+    (hquot : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps ch)
+        (evalVector urs.k xEval) (multiopenValue vk ps ch) a),
+      quotientCheck
+        (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates) hpoly deg x)
+    (hgood : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps ch)
+        (evalVector urs.k xEval) (multiopenValue vk ps ch) a),
+      combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
+        ≠ hpoly * (X ^ deg - 1) →
+      (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
         - hpoly * (X ^ deg - 1)).eval x ≠ 0)
     {S : Prop}
-    (hencodes : ∀ a, SnarkRelation urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k xEval)
-        (multiopenValue vk ps ch)
-      (circuitSatViaGates fixedCols decodeAdvice decodeInstance y gates hpoly deg) a → S)
+    (hencodes : ∀ a cols,
+      SnarkRelationWithDecodedColumns urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k xEval)
+        (multiopenValue vk ps ch) columnCommitments columnEvals adviceIndex instanceIndex fixedCols
+        y gates hpoly deg a cols → S)
     (hprob : (kerr (Fintype.card Fp) urs.k : ℝ≥0∞) / Fintype.card (Fin urs.k → Fp)
         < (PMF.uniformOfFintype (Fin urs.k → Fp)).toOuterMeasure (Finset.univ.filter accepts)) :
     S ∨ HasNontrivialRelation (F := Fp) urs.g urs.u urs.w := by
-  rcases orchard_verifier_vesta_forking_opening urs hk vk ps ch xEval ξ z blind s Q accepts
-      hz hg0 hbridge hprob with ⟨a, hrel'⟩ | hrel
-  · rw [hξ, sub_zero] at hrel'
-    have hsat : circuitSatViaGates fixedCols decodeAdvice decodeInstance y gates hpoly deg a :=
-      circuitSatViaGates_of_check fixedCols decodeAdvice decodeInstance y gates hpoly deg a x
-        (hquot a hrel') (hgood a hrel')
-    exact Or.inl (hencodes a ⟨hrel', hsat⟩)
-  · exact Or.inr hrel
+  have hopen := orchard_verifier_vesta_forking_opening urs hk vk ps ch xEval ξ z blind s Q accepts
+    hz hg0 hbridge hprob
+  rw [hξ, sub_zero] at hopen
+  exact decoded_constraint_of_opening_or_relation (urs := urs)
+    (P := deployedCommitment urs hk vk ps ch) (b := evalVector urs.k xEval)
+    (v := multiopenValue vk ps ch) columnCommitments columnEvals adviceIndex instanceIndex fixedCols
+    y gates hpoly deg x hopen hbatch hquot hgood hencodes
 
 open Polynomial in
 open scoped ENNReal in
 open Classical in
-/-- The deployed Orchard constraint capstone over Vesta, with the augmented relation branch consumed
-by the fixed-slot AGM adapter (`soundnessOrDLAt_of_soundnessOrRelation`). Vacuity caveat as on
-`orchard_verifier_vesta_forking_opening_agm_dl`. -/
-theorem orchard_verifier_vesta_forking_constraint_legacy_agm_dl [Fact (HasseBound Vesta.curve)]
-    [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG)
-    (hk : shape.k = urs.k) (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG)
-    (ch : Challenges shape.k Fp) (xEval ξ z blind : Fp) (s : Fin (2 ^ urs.k) → Fp)
+/-- AGM/DL wrapper for `orchard_verifier_vesta_forking_constraint`. -/
+theorem orchard_verifier_vesta_forking_constraint_agm_dl [Fact (HasseBound Vesta.curve)]
+    [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
+    (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
+    (xEval ξ z blind : Fp) (s : Fin (2 ^ urs.k) → Fp)
     (Q : Prover Fp VestaG urs.k) (accepts : (Fin urs.k → Fp) → Prop)
+    {numColumns numAdvice numInstance : ℕ}
+    (columnCommitments : Fin numColumns → VestaG) (columnEvals : Fin numColumns → Fp)
+    (adviceIndex : Fin numAdvice → Fin numColumns) (instanceIndex : Fin numInstance → Fin numColumns)
     (fixedCols : ℕ → Polynomial Fp)
-    (decodeAdvice decodeInstance : (Fin (2 ^ urs.k) → Fp) → (ℕ → Polynomial Fp))
     (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
     (B : VestaG) (challenge : AugmentedIndex (2 ^ urs.k))
     (embedding : FixedSlotEmbedding (F := Fp) B (augmentedBasis urs.g urs.u urs.w) challenge)
@@ -456,25 +447,34 @@ theorem orchard_verifier_vesta_forking_constraint_legacy_agm_dl [Fact (HasseBoun
     (hbridge : ∀ χ, accepts χ ↔ flatAccept Q urs.g (evalVector urs.k xEval) urs.u urs.w z
         (deployedCommitment urs hk vk ps ch - multiopenValue vk ps ch • urs.g 0 + ξ • commit urs s
           + (z * 0) • urs.u + blind • urs.w) χ)
-    (hquot : ∀ a, IpaRelation urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k xEval)
-        (multiopenValue vk ps ch) a →
-      quotientCheck (combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates) hpoly deg x)
-    (hgood : ∀ a, IpaRelation urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k xEval)
-        (multiopenValue vk ps ch) a →
-      combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates ≠ hpoly * (X ^ deg - 1) →
-      (combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates
+    (hbatch : MultiopenRewindForRelation urs (deployedCommitment urs hk vk ps ch)
+      (evalVector urs.k xEval) (multiopenValue vk ps ch) columnCommitments columnEvals)
+    (hquot : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps ch)
+        (evalVector urs.k xEval) (multiopenValue vk ps ch) a),
+      quotientCheck
+        (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates) hpoly deg x)
+    (hgood : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps ch)
+        (evalVector urs.k xEval) (multiopenValue vk ps ch) a),
+      combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
+        ≠ hpoly * (X ^ deg - 1) →
+      (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
         - hpoly * (X ^ deg - 1)).eval x ≠ 0)
     {S : Prop}
-    (hencodes : ∀ a, SnarkRelation urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k xEval)
-        (multiopenValue vk ps ch)
-      (circuitSatViaGates fixedCols decodeAdvice decodeInstance y gates hpoly deg) a → S)
+    (hencodes : ∀ a cols,
+      SnarkRelationWithDecodedColumns urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k xEval)
+        (multiopenValue vk ps ch) columnCommitments columnEvals adviceIndex instanceIndex fixedCols
+        y gates hpoly deg a cols → S)
     (hprob : (kerr (Fintype.card Fp) urs.k : ℝ≥0∞) / Fintype.card (Fin urs.k → Fp)
         < (PMF.uniformOfFintype (Fin urs.k → Fp)).toOuterMeasure (Finset.univ.filter accepts)) :
     S ∨ Nonempty (DiscreteLogRepresentation (F := Fp) B (augmentedBasis urs.g urs.u urs.w challenge))
       ∨ RelationMissesSlot (F := Fp) urs.g urs.u urs.w challenge :=
   soundnessOrDLAt_of_soundnessOrRelation B urs.g urs.u urs.w challenge embedding
-    (orchard_verifier_vesta_forking_constraint_legacy urs hk vk ps ch xEval ξ z blind s Q accepts fixedCols
-      decodeAdvice decodeInstance y gates hpoly deg x hz hg0 hξ hbridge hquot hgood hencodes hprob)
+    (orchard_verifier_vesta_forking_constraint urs hk vk ps ch xEval ξ z blind s Q accepts
+      columnCommitments columnEvals adviceIndex instanceIndex fixedCols y gates hpoly deg x hz hg0 hξ
+      hbridge hbatch hquot hgood hencodes hprob)
 
 /-- The deployed adjusted-commitment's value term `Σᵢ [-v].getD i • gᵢ` is `-v` on the single generator `g 0`
 (the value list `[-v]` has one entry, placed at index `0`). Lets the deployed verifier's adjusted commitment
@@ -560,54 +560,50 @@ theorem orchard_verifier_vesta_forking_opening_deployed [Fact (HasseBound Vesta.
 open Polynomial in
 open scoped ENNReal in
 open Classical in
-/-- **The deployed Orchard opening *and constraint* over Vesta, with `hbridge` discharged.** The constraint
-companion of `orchard_verifier_vesta_forking_opening_deployed`: same discharged bridge (halo2's actual verifier
-accept, no abstract `hbridge`), routed through the opening to the gate-satisfaction seam
-(`hquot`/`hgood` → `circuitSatViaGates`, `hencodes`) at the *claimed* value `multiopenValue` — pinned from the
-forking opening's `multiopenValue − ξ·⟨s,b⟩` by the minimal value-recovery hypothesis
-`hξ : ch.xi·⟨s,b⟩ = 0` (honest blinding, or a `1/p`-measure set of post-`S` challenges for a malicious blinder,
-`blinder_value_recovery_badSet`). Residual assumptions: `z ≠ 0`, the nonzero generator `hg0`, the `S`-opening
-witness `hs`, and `hξ` — plus the accept probability `hprob`, which carries the same quantifier-shape caveat
-as `orchard_verifier_vesta_forking_opening_deployed`: with the constant `proverOfRounds` strategy it measures
-the *fixed* proof's accept set over all round-challenge vectors, not the Fiat–Shamir attack event. For the
-adaptive form, use `orchard_verifier_vesta_forking_constraint_adaptive`; for the same statement over
-reprogrammed-oracle runs, use `orchard_verifier_vesta_forking_constraint_adaptive_rewind`. `hquot`/`hgood`
-retain the ∀-openings shape — unsatisfiable at Vesta for any decode that genuinely
-reads the witness (see `orchard_verifier_deployed_constraint_reduction`'s caveat, and the decoded
-capstone above). -/
-theorem orchard_verifier_vesta_forking_constraint_deployed_legacy [Fact (HasseBound Vesta.curve)] [DecidableEq VestaG]
-    [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
+/-- Deployed decoded constraint capstone: the constant-proof deployed probability rung, with the circuit
+side fed by columns recovered from the final multiopen opening. -/
+theorem orchard_verifier_vesta_forking_constraint_deployed [Fact (HasseBound Vesta.curve)]
+    [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
     (s : Fin (2 ^ urs.k) → Fp)
+    {numColumns numAdvice numInstance : ℕ}
+    (columnCommitments : Fin numColumns → VestaG) (columnEvals : Fin numColumns → Fp)
+    (adviceIndex : Fin numAdvice → Fin numColumns) (instanceIndex : Fin numInstance → Fin numColumns)
     (fixedCols : ℕ → Polynomial Fp)
-    (decodeAdvice decodeInstance : (Fin (2 ^ urs.k) → Fp) → (ℕ → Polynomial Fp))
     (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
     (hz : ch.z ≠ 0) (hg0 : urs.g 0 ≠ 0) (hs : commit urs s = ps.ipaS)
     (hξ : ch.xi * innerProduct s (evalVector urs.k ch.x3) = 0)
-    (hquot : ∀ a, IpaRelation urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k ch.x3)
-        (multiopenValue vk ps ch) a →
-      quotientCheck (combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates) hpoly deg x)
-    (hgood : ∀ a, IpaRelation urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k ch.x3)
-        (multiopenValue vk ps ch) a →
-      combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates ≠ hpoly * (X ^ deg - 1) →
-      (combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates
+    (hbatch : MultiopenRewindForRelation urs (deployedCommitment urs hk vk ps ch)
+      (evalVector urs.k ch.x3) (multiopenValue vk ps ch) columnCommitments columnEvals)
+    (hquot : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps ch)
+        (evalVector urs.k ch.x3) (multiopenValue vk ps ch) a),
+      quotientCheck
+        (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates) hpoly deg x)
+    (hgood : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps ch)
+        (evalVector urs.k ch.x3) (multiopenValue vk ps ch) a),
+      combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
+        ≠ hpoly * (X ^ deg - 1) →
+      (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
         - hpoly * (X ^ deg - 1)).eval x ≠ 0)
     {S : Prop}
-    (hencodes : ∀ a, SnarkRelation urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k ch.x3)
-        (multiopenValue vk ps ch)
-      (circuitSatViaGates fixedCols decodeAdvice decodeInstance y gates hpoly deg) a → S)
+    (hencodes : ∀ a cols,
+      SnarkRelationWithDecodedColumns urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k ch.x3)
+        (multiopenValue vk ps ch) columnCommitments columnEvals adviceIndex instanceIndex fixedCols
+        y gates hpoly deg a cols → S)
     (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
         < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
             (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk ps
               {ch with ipaRound := χ}))) :
     S ∨ HasNontrivialRelation (F := Fp) urs.g urs.u urs.w := by
-  rcases orchard_verifier_vesta_forking_opening_deployed urs hk vk ps ch s hz hg0 hs hprob with ⟨a, hrel'⟩ | hrel
-  · rw [hξ, sub_zero] at hrel'
-    have hsat : circuitSatViaGates fixedCols decodeAdvice decodeInstance y gates hpoly deg a :=
-      circuitSatViaGates_of_check fixedCols decodeAdvice decodeInstance y gates hpoly deg a x
-        (hquot a hrel') (hgood a hrel')
-    exact Or.inl (hencodes a ⟨hrel', hsat⟩)
-  · exact Or.inr hrel
+  have hopen := orchard_verifier_vesta_forking_opening_deployed urs hk vk ps ch s hz hg0 hs hprob
+  rw [hξ, sub_zero] at hopen
+  exact decoded_constraint_of_opening_or_relation (urs := urs)
+    (P := deployedCommitment urs hk vk ps ch) (b := evalVector urs.k ch.x3)
+    (v := multiopenValue vk ps ch) columnCommitments columnEvals adviceIndex instanceIndex fixedCols
+    y gates hpoly deg x hopen hbatch hquot hgood hencodes
 
 open scoped ENNReal in
 open Classical in
@@ -662,51 +658,51 @@ theorem orchard_verifier_vesta_forking_opening_adaptive [Fact (HasseBound Vesta.
 open Polynomial in
 open scoped ENNReal in
 open Classical in
-/-- **The deployed Orchard opening *and constraint* over Vesta for the staged (round-adaptive) adversary,
-bridge discharged.** The constraint companion of `orchard_verifier_vesta_forking_opening_adaptive`: same
-adaptive accept event and internally-proven bridge, routed to the gate-satisfaction seam
-(`hquot`/`hgood` → `circuitSatViaGates`, `hencodes`) at the *claimed* value `multiopenValue`, pinned by the
-value-recovery hypothesis `hξ` (honest blinding, or a `1/p`-measure set of post-`S` challenges for a
-malicious blinder, `blinder_value_recovery_badSet`). Residual: the execution-semantics identification, the
-random-oracle uniformity axiom in `hprob`, and the structural witnesses; the static-dichotomy caveat does not
-apply at this rung. Issue #23's transcript-ordering and reprogramming content is discharged by the staged
-rewinding capstones below. `hquot`/`hgood` retain the ∀-openings shape — unsatisfiable at Vesta for any decode
-that genuinely reads the witness; the decoded capstone above is the witness-to-columns endpoint. -/
-theorem orchard_verifier_vesta_forking_constraint_adaptive_legacy [Fact (HasseBound Vesta.curve)]
+/-- Adaptive-strategy decoded constraint capstone, with the staged prover accept event and decoded columns
+for the final multiopen relation. -/
+theorem orchard_verifier_vesta_forking_constraint_adaptive [Fact (HasseBound Vesta.curve)]
     [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
     (s : Fin (2 ^ urs.k) → Fp) (P : Prover Fp VestaG shape.k)
+    {numColumns numAdvice numInstance : ℕ}
+    (columnCommitments : Fin numColumns → VestaG) (columnEvals : Fin numColumns → Fp)
+    (adviceIndex : Fin numAdvice → Fin numColumns) (instanceIndex : Fin numInstance → Fin numColumns)
     (fixedCols : ℕ → Polynomial Fp)
-    (decodeAdvice decodeInstance : (Fin (2 ^ urs.k) → Fp) → (ℕ → Polynomial Fp))
     (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
     (hz : ch.z ≠ 0) (hg0 : urs.g 0 ≠ 0) (hs : commit urs s = ps.ipaS)
     (hξ : ch.xi * innerProduct s (evalVector urs.k ch.x3) = 0)
-    (hquot : ∀ a, IpaRelation urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k ch.x3)
-        (multiopenValue vk ps ch) a →
-      quotientCheck (combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates) hpoly deg x)
-    (hgood : ∀ a, IpaRelation urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k ch.x3)
-        (multiopenValue vk ps ch) a →
-      combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates ≠ hpoly * (X ^ deg - 1) →
-      (combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates
+    (hbatch : MultiopenRewindForRelation urs (deployedCommitment urs hk vk ps ch)
+      (evalVector urs.k ch.x3) (multiopenValue vk ps ch) columnCommitments columnEvals)
+    (hquot : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps ch)
+        (evalVector urs.k ch.x3) (multiopenValue vk ps ch) a),
+      quotientCheck
+        (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates) hpoly deg x)
+    (hgood : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps ch)
+        (evalVector urs.k ch.x3) (multiopenValue vk ps ch) a),
+      combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
+        ≠ hpoly * (X ^ deg - 1) →
+      (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
         - hpoly * (X ^ deg - 1)).eval x ≠ 0)
     {S : Prop}
-    (hencodes : ∀ a, SnarkRelation urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k ch.x3)
-        (multiopenValue vk ps ch)
-      (circuitSatViaGates fixedCols decodeAdvice decodeInstance y gates hpoly deg) a → S)
+    (hencodes : ∀ a cols,
+      SnarkRelationWithDecodedColumns urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k ch.x3)
+        (multiopenValue vk ps ch) columnCommitments columnEvals adviceIndex instanceIndex fixedCols
+        y gates hpoly deg a cols → S)
     (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
         < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
             (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk
               (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2)
               {ch with ipaRound := χ}))) :
     S ∨ HasNontrivialRelation (F := Fp) urs.g urs.u urs.w := by
-  rcases orchard_verifier_vesta_forking_opening_adaptive urs hk vk ps ch s P hz hg0 hs hprob
-    with ⟨a, hrel'⟩ | hrel
-  · rw [hξ, sub_zero] at hrel'
-    have hsat : circuitSatViaGates fixedCols decodeAdvice decodeInstance y gates hpoly deg a :=
-      circuitSatViaGates_of_check fixedCols decodeAdvice decodeInstance y gates hpoly deg a x
-        (hquot a hrel') (hgood a hrel')
-    exact Or.inl (hencodes a ⟨hrel', hsat⟩)
-  · exact Or.inr hrel
+  have hopen := orchard_verifier_vesta_forking_opening_adaptive urs hk vk ps ch s P hz hg0 hs hprob
+  rw [hξ, sub_zero] at hopen
+  exact decoded_constraint_of_opening_or_relation (urs := urs)
+    (P := deployedCommitment urs hk vk ps ch) (b := evalVector urs.k ch.x3)
+    (v := multiopenValue vk ps ch) columnCommitments columnEvals adviceIndex instanceIndex fixedCols
+    y gates hpoly deg x hopen hbatch hquot hgood hencodes
 
 /-! ## The forking capstones: staged and rewound endpoints
 
@@ -772,711 +768,6 @@ theorem orchard_verifier_vesta_forking_opening_rewind [Fact (HasseBound Vesta.cu
 open Polynomial in
 open scoped ENNReal in
 open Classical in
-/-- The constraint companion of `orchard_verifier_vesta_forking_opening_rewind`:
-`orchard_verifier_vesta_forking_constraint_deployed` with the accept probability over reprogrammed-oracle
-runs, the round-vector semantics derived via `roChallenges_reprogramRounds` (issue #23). The `hquot`/`hgood`
-caveat is unchanged — see `orchard_verifier_deployed_constraint_reduction`'s caveat and the decoded
-capstone — and so
-is the constant rung's static-dichotomy scope (see `orchard_verifier_vesta_forking_opening_deployed`); the
-`_adaptive_rewind` pair is the attack-event form. -/
-theorem orchard_verifier_vesta_forking_constraint_rewind_legacy [Fact (HasseBound Vesta.curve)]
-    [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
-    (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG)
-    (O : List (TranscriptElt Fp VestaG) → Fp) (init : List (TranscriptElt Fp VestaG))
-    (s : Fin (2 ^ urs.k) → Fp)
-    (fixedCols : ℕ → Polynomial Fp)
-    (decodeAdvice decodeInstance : (Fin (2 ^ urs.k) → Fp) → (ℕ → Polynomial Fp))
-    (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
-    (hz : (roChallenges O init ps).z ≠ 0) (hg0 : urs.g 0 ≠ 0) (hs : commit urs s = ps.ipaS)
-    (hξ : (roChallenges O init ps).xi
-        * innerProduct s (evalVector urs.k (roChallenges O init ps).x3) = 0)
-    (hquot : ∀ a, IpaRelation urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
-        (evalVector urs.k (roChallenges O init ps).x3)
-        (multiopenValue vk ps (roChallenges O init ps)) a →
-      quotientCheck (combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates) hpoly deg x)
-    (hgood : ∀ a, IpaRelation urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
-        (evalVector urs.k (roChallenges O init ps).x3)
-        (multiopenValue vk ps (roChallenges O init ps)) a →
-      combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates ≠ hpoly * (X ^ deg - 1) →
-      (combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates
-        - hpoly * (X ^ deg - 1)).eval x ≠ 0)
-    {S : Prop}
-    (hencodes : ∀ a, SnarkRelation urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
-        (evalVector urs.k (roChallenges O init ps).x3) (multiopenValue vk ps (roChallenges O init ps))
-      (circuitSatViaGates fixedCols decodeAdvice decodeInstance y gates hpoly deg) a → S)
-    (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
-        < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
-            (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk ps
-              (roChallenges (reprogramRounds O init ps χ) init ps)))) :
-    S ∨ HasNontrivialRelation (F := Fp) urs.g urs.u urs.w := by
-  refine orchard_verifier_vesta_forking_constraint_deployed_legacy urs hk vk ps (roChallenges O init ps)
-    s fixedCols decodeAdvice decodeInstance y gates hpoly deg x hz hg0 hs hξ hquot hgood hencodes ?_
-  simpa only [roChallenges_reprogramRounds] using hprob
-
-open scoped ENNReal in
-open Classical in
-/-- **The staged Orchard opening over Vesta, from oracle rewinding.**
-This is `orchard_verifier_vesta_forking_opening_adaptive` with the adaptive accept probability stated over
-reprogrammed-oracle runs on each strategy-spliced proof. For each challenge path `χ`, the proof string is
-`spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2`; the oracle is reprogrammed at that
-spliced proof's IPA round prefixes and the deployed schedule is re-run. `roChallenges_reprogramRounds` turns
-that run into round-vector replacement, and `roChallenges_spliceIpa_pre` removes the irrelevant spliced
-pre-IPA fields. The residual is unchanged from the staged rung: the execution-semantics identification that a
-rewound random-oracle adversary induces such a strategy, with its RO-query loss, plus the uniformity axiom in
-`hprob`. -/
-theorem orchard_verifier_vesta_forking_opening_adaptive_rewind [Fact (HasseBound Vesta.curve)]
-    [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
-    (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG)
-    (O : List (TranscriptElt Fp VestaG) → Fp) (init : List (TranscriptElt Fp VestaG))
-    (s : Fin (2 ^ urs.k) → Fp) (P : Prover Fp VestaG shape.k)
-    (hz : (roChallenges O init ps).z ≠ 0) (hg0 : urs.g 0 ≠ 0) (hs : commit urs s = ps.ipaS)
-    (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
-        < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
-            (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk
-              (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2)
-              (roChallenges
-                (reprogramRounds O init
-                  (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2) χ)
-                init
-                (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2))))) :
-    (∃ a, IpaRelation urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
-        (evalVector urs.k (roChallenges O init ps).x3)
-        (multiopenValue vk ps (roChallenges O init ps)
-          - (roChallenges O init ps).xi * innerProduct s (evalVector urs.k (roChallenges O init ps).x3)) a)
-      ∨ HasNontrivialRelation (F := Fp) urs.g urs.u urs.w := by
-  refine orchard_verifier_vesta_forking_opening_adaptive urs hk vk ps (roChallenges O init ps)
-    s P hz hg0 hs ?_
-  simpa only [roChallenges_reprogramRounds, roChallenges_spliceIpa_pre] using hprob
-
-open Polynomial in
-open scoped ENNReal in
-open Classical in
-/-- The constraint companion of `orchard_verifier_vesta_forking_opening_adaptive_rewind`: the staged
-round-adaptive capstone with its accept event grounded in reprogrammed-oracle runs on each spliced proof. The
-`hquot`/`hgood` caveat is unchanged — see `orchard_verifier_deployed_constraint_reduction`'s caveat and
-the decoded capstone. -/
-theorem orchard_verifier_vesta_forking_constraint_adaptive_rewind_legacy [Fact (HasseBound Vesta.curve)]
-    [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
-    (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG)
-    (O : List (TranscriptElt Fp VestaG) → Fp) (init : List (TranscriptElt Fp VestaG))
-    (s : Fin (2 ^ urs.k) → Fp) (P : Prover Fp VestaG shape.k)
-    (fixedCols : ℕ → Polynomial Fp)
-    (decodeAdvice decodeInstance : (Fin (2 ^ urs.k) → Fp) → (ℕ → Polynomial Fp))
-    (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
-    (hz : (roChallenges O init ps).z ≠ 0) (hg0 : urs.g 0 ≠ 0) (hs : commit urs s = ps.ipaS)
-    (hξ : (roChallenges O init ps).xi
-        * innerProduct s (evalVector urs.k (roChallenges O init ps).x3) = 0)
-    (hquot : ∀ a, IpaRelation urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
-        (evalVector urs.k (roChallenges O init ps).x3)
-        (multiopenValue vk ps (roChallenges O init ps)) a →
-      quotientCheck (combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates) hpoly deg x)
-    (hgood : ∀ a, IpaRelation urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
-        (evalVector urs.k (roChallenges O init ps).x3)
-        (multiopenValue vk ps (roChallenges O init ps)) a →
-      combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates ≠ hpoly * (X ^ deg - 1) →
-      (combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates
-        - hpoly * (X ^ deg - 1)).eval x ≠ 0)
-    {S : Prop}
-    (hencodes : ∀ a, SnarkRelation urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
-        (evalVector urs.k (roChallenges O init ps).x3) (multiopenValue vk ps (roChallenges O init ps))
-      (circuitSatViaGates fixedCols decodeAdvice decodeInstance y gates hpoly deg) a → S)
-    (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
-        < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
-            (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk
-              (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2)
-              (roChallenges
-                (reprogramRounds O init
-                  (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2) χ)
-                init
-                (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2))))) :
-    S ∨ HasNontrivialRelation (F := Fp) urs.g urs.u urs.w := by
-  rcases orchard_verifier_vesta_forking_opening_adaptive_rewind urs hk vk ps O init s P hz hg0 hs hprob
-    with ⟨a, hrel'⟩ | hrel
-  · rw [hξ, sub_zero] at hrel'
-    have hsat : circuitSatViaGates fixedCols decodeAdvice decodeInstance y gates hpoly deg a :=
-      circuitSatViaGates_of_check fixedCols decodeAdvice decodeInstance y gates hpoly deg a x
-        (hquot a hrel') (hgood a hrel')
-    exact Or.inl (hencodes a ⟨hrel', hsat⟩)
-  · exact Or.inr hrel
-
-/-! ## AGM/DL wrappers of the forking capstones
-
-Each rung of the ladder above ends in `∨ HasNontrivialRelation urs.g urs.u urs.w`. The wrappers
-below consume that branch with the fixed-slot AGM adapter
-(`soundnessOrDLAt_of_soundnessOrRelation`): given a DL challenge pre-placed at an augmented basis
-slot `challenge` — fixed *before* the relation is seen — with known logs everywhere else
-(`FixedSlotEmbedding`), the relation branch becomes the discrete log of that slot, or the named
-failure event `RelationMissesSlot`.
-
-Standing caveat (inherited from the wrapped capstones; see `Soundness.AGM`'s module docs): at Vesta's
-prime order the trichotomy is propositionally `True` — a relation missing the slot always *exists* —
-so these are vacuous *as statements*; their content is the deterministic extraction chain. The
-hit-probability half of the computational force — a uniformly placed hidden slot is hit with
-probability ≥ `1/|ι|` — is now formalized in `Soundness.AGMProbability`; the residual out-of-Lean
-force is discrete-log hardness (no feasible adversary finds a relation) together with the
-algebraic-prover model that produces the witness. -/
-
-open scoped ENNReal in
-open Classical in
-/-- `orchard_verifier_vesta_forking_opening_deployed` with the relation branch consumed by the
-fixed-slot AGM adapter. Caveats of the underlying rung (static dichotomy) and of the AGM section
-header both apply. -/
-theorem orchard_verifier_vesta_forking_opening_deployed_agm_dl [Fact (HasseBound Vesta.curve)]
-    [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
-    (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
-    (s : Fin (2 ^ urs.k) → Fp)
-    (B : VestaG) (challenge : AugmentedIndex (2 ^ urs.k))
-    (embedding : FixedSlotEmbedding (F := Fp) B (augmentedBasis urs.g urs.u urs.w) challenge)
-    (hz : ch.z ≠ 0) (hg0 : urs.g 0 ≠ 0) (hs : commit urs s = ps.ipaS)
-    (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
-        < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
-            (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk ps
-              {ch with ipaRound := χ}))) :
-    (∃ a, IpaRelation urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k ch.x3)
-        (multiopenValue vk ps ch - ch.xi * innerProduct s (evalVector urs.k ch.x3)) a)
-      ∨ Nonempty (DiscreteLogRepresentation (F := Fp) B (augmentedBasis urs.g urs.u urs.w challenge))
-      ∨ RelationMissesSlot (F := Fp) urs.g urs.u urs.w challenge :=
-  soundnessOrDLAt_of_soundnessOrRelation B urs.g urs.u urs.w challenge embedding
-    (orchard_verifier_vesta_forking_opening_deployed urs hk vk ps ch s hz hg0 hs hprob)
-
-open Polynomial in
-open scoped ENNReal in
-open Classical in
-/-- `orchard_verifier_vesta_forking_constraint_deployed` with the relation branch consumed by the
-fixed-slot AGM adapter. Caveats of the underlying rung and of the AGM section header both apply. -/
-theorem orchard_verifier_vesta_forking_constraint_deployed_legacy_agm_dl [Fact (HasseBound Vesta.curve)]
-    [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
-    (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
-    (s : Fin (2 ^ urs.k) → Fp)
-    (fixedCols : ℕ → Polynomial Fp)
-    (decodeAdvice decodeInstance : (Fin (2 ^ urs.k) → Fp) → (ℕ → Polynomial Fp))
-    (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
-    (B : VestaG) (challenge : AugmentedIndex (2 ^ urs.k))
-    (embedding : FixedSlotEmbedding (F := Fp) B (augmentedBasis urs.g urs.u urs.w) challenge)
-    (hz : ch.z ≠ 0) (hg0 : urs.g 0 ≠ 0) (hs : commit urs s = ps.ipaS)
-    (hξ : ch.xi * innerProduct s (evalVector urs.k ch.x3) = 0)
-    (hquot : ∀ a, IpaRelation urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k ch.x3)
-        (multiopenValue vk ps ch) a →
-      quotientCheck (combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates) hpoly deg x)
-    (hgood : ∀ a, IpaRelation urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k ch.x3)
-        (multiopenValue vk ps ch) a →
-      combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates ≠ hpoly * (X ^ deg - 1) →
-      (combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates
-        - hpoly * (X ^ deg - 1)).eval x ≠ 0)
-    {S : Prop}
-    (hencodes : ∀ a, SnarkRelation urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k ch.x3)
-        (multiopenValue vk ps ch)
-      (circuitSatViaGates fixedCols decodeAdvice decodeInstance y gates hpoly deg) a → S)
-    (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
-        < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
-            (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk ps
-              {ch with ipaRound := χ}))) :
-    S ∨ Nonempty (DiscreteLogRepresentation (F := Fp) B (augmentedBasis urs.g urs.u urs.w challenge))
-      ∨ RelationMissesSlot (F := Fp) urs.g urs.u urs.w challenge :=
-  soundnessOrDLAt_of_soundnessOrRelation B urs.g urs.u urs.w challenge embedding
-    (orchard_verifier_vesta_forking_constraint_deployed_legacy urs hk vk ps ch s fixedCols decodeAdvice
-      decodeInstance y gates hpoly deg x hz hg0 hs hξ hquot hgood hencodes hprob)
-
-open scoped ENNReal in
-open Classical in
-/-- `orchard_verifier_vesta_forking_opening_adaptive` with the relation branch consumed by the
-fixed-slot AGM adapter. Caveats of the underlying rung and of the AGM section header both apply. -/
-theorem orchard_verifier_vesta_forking_opening_adaptive_agm_dl [Fact (HasseBound Vesta.curve)]
-    [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
-    (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
-    (s : Fin (2 ^ urs.k) → Fp) (P : Prover Fp VestaG shape.k)
-    (B : VestaG) (challenge : AugmentedIndex (2 ^ urs.k))
-    (embedding : FixedSlotEmbedding (F := Fp) B (augmentedBasis urs.g urs.u urs.w) challenge)
-    (hz : ch.z ≠ 0) (hg0 : urs.g 0 ≠ 0) (hs : commit urs s = ps.ipaS)
-    (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
-        < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
-            (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk
-              (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2)
-              {ch with ipaRound := χ}))) :
-    (∃ a, IpaRelation urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k ch.x3)
-        (multiopenValue vk ps ch - ch.xi * innerProduct s (evalVector urs.k ch.x3)) a)
-      ∨ Nonempty (DiscreteLogRepresentation (F := Fp) B (augmentedBasis urs.g urs.u urs.w challenge))
-      ∨ RelationMissesSlot (F := Fp) urs.g urs.u urs.w challenge :=
-  soundnessOrDLAt_of_soundnessOrRelation B urs.g urs.u urs.w challenge embedding
-    (orchard_verifier_vesta_forking_opening_adaptive urs hk vk ps ch s P hz hg0 hs hprob)
-
-open Polynomial in
-open scoped ENNReal in
-open Classical in
-/-- `orchard_verifier_vesta_forking_constraint_adaptive` with the relation branch consumed by the
-fixed-slot AGM adapter. Caveats of the underlying rung and of the AGM section header both apply. -/
-theorem orchard_verifier_vesta_forking_constraint_adaptive_legacy_agm_dl [Fact (HasseBound Vesta.curve)]
-    [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
-    (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
-    (s : Fin (2 ^ urs.k) → Fp) (P : Prover Fp VestaG shape.k)
-    (fixedCols : ℕ → Polynomial Fp)
-    (decodeAdvice decodeInstance : (Fin (2 ^ urs.k) → Fp) → (ℕ → Polynomial Fp))
-    (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
-    (B : VestaG) (challenge : AugmentedIndex (2 ^ urs.k))
-    (embedding : FixedSlotEmbedding (F := Fp) B (augmentedBasis urs.g urs.u urs.w) challenge)
-    (hz : ch.z ≠ 0) (hg0 : urs.g 0 ≠ 0) (hs : commit urs s = ps.ipaS)
-    (hξ : ch.xi * innerProduct s (evalVector urs.k ch.x3) = 0)
-    (hquot : ∀ a, IpaRelation urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k ch.x3)
-        (multiopenValue vk ps ch) a →
-      quotientCheck (combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates) hpoly deg x)
-    (hgood : ∀ a, IpaRelation urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k ch.x3)
-        (multiopenValue vk ps ch) a →
-      combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates ≠ hpoly * (X ^ deg - 1) →
-      (combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates
-        - hpoly * (X ^ deg - 1)).eval x ≠ 0)
-    {S : Prop}
-    (hencodes : ∀ a, SnarkRelation urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k ch.x3)
-        (multiopenValue vk ps ch)
-      (circuitSatViaGates fixedCols decodeAdvice decodeInstance y gates hpoly deg) a → S)
-    (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
-        < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
-            (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk
-              (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2)
-              {ch with ipaRound := χ}))) :
-    S ∨ Nonempty (DiscreteLogRepresentation (F := Fp) B (augmentedBasis urs.g urs.u urs.w challenge))
-      ∨ RelationMissesSlot (F := Fp) urs.g urs.u urs.w challenge :=
-  soundnessOrDLAt_of_soundnessOrRelation B urs.g urs.u urs.w challenge embedding
-    (orchard_verifier_vesta_forking_constraint_adaptive_legacy urs hk vk ps ch s P fixedCols decodeAdvice
-      decodeInstance y gates hpoly deg x hz hg0 hs hξ hquot hgood hencodes hprob)
-
-open scoped ENNReal in
-open Classical in
-/-- `orchard_verifier_vesta_forking_opening_rewind` with the relation branch consumed by the
-fixed-slot AGM adapter. Caveats of the underlying rung and of the AGM section header both apply. -/
-theorem orchard_verifier_vesta_forking_opening_rewind_agm_dl [Fact (HasseBound Vesta.curve)]
-    [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
-    (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG)
-    (O : List (TranscriptElt Fp VestaG) → Fp) (init : List (TranscriptElt Fp VestaG))
-    (s : Fin (2 ^ urs.k) → Fp)
-    (B : VestaG) (challenge : AugmentedIndex (2 ^ urs.k))
-    (embedding : FixedSlotEmbedding (F := Fp) B (augmentedBasis urs.g urs.u urs.w) challenge)
-    (hz : (roChallenges O init ps).z ≠ 0) (hg0 : urs.g 0 ≠ 0)
-    (hs : commit urs s = ps.ipaS)
-    (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
-        < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
-            (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk ps
-              (roChallenges (reprogramRounds O init ps χ) init ps)))) :
-    (∃ a, IpaRelation urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
-        (evalVector urs.k (roChallenges O init ps).x3)
-        (multiopenValue vk ps (roChallenges O init ps)
-          - (roChallenges O init ps).xi * innerProduct s (evalVector urs.k (roChallenges O init ps).x3)) a)
-      ∨ Nonempty (DiscreteLogRepresentation (F := Fp) B (augmentedBasis urs.g urs.u urs.w challenge))
-      ∨ RelationMissesSlot (F := Fp) urs.g urs.u urs.w challenge :=
-  soundnessOrDLAt_of_soundnessOrRelation B urs.g urs.u urs.w challenge embedding
-    (orchard_verifier_vesta_forking_opening_rewind urs hk vk ps O init s hz hg0 hs hprob)
-
-open Polynomial in
-open scoped ENNReal in
-open Classical in
-/-- `orchard_verifier_vesta_forking_constraint_rewind` with the relation branch consumed by the
-fixed-slot AGM adapter. Caveats of the underlying rung and of the AGM section header both apply. -/
-theorem orchard_verifier_vesta_forking_constraint_rewind_legacy_agm_dl [Fact (HasseBound Vesta.curve)]
-    [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
-    (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG)
-    (O : List (TranscriptElt Fp VestaG) → Fp) (init : List (TranscriptElt Fp VestaG))
-    (s : Fin (2 ^ urs.k) → Fp)
-    (fixedCols : ℕ → Polynomial Fp)
-    (decodeAdvice decodeInstance : (Fin (2 ^ urs.k) → Fp) → (ℕ → Polynomial Fp))
-    (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
-    (B : VestaG) (challenge : AugmentedIndex (2 ^ urs.k))
-    (embedding : FixedSlotEmbedding (F := Fp) B (augmentedBasis urs.g urs.u urs.w) challenge)
-    (hz : (roChallenges O init ps).z ≠ 0) (hg0 : urs.g 0 ≠ 0) (hs : commit urs s = ps.ipaS)
-    (hξ : (roChallenges O init ps).xi
-        * innerProduct s (evalVector urs.k (roChallenges O init ps).x3) = 0)
-    (hquot : ∀ a, IpaRelation urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
-        (evalVector urs.k (roChallenges O init ps).x3)
-        (multiopenValue vk ps (roChallenges O init ps)) a →
-      quotientCheck (combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates) hpoly deg x)
-    (hgood : ∀ a, IpaRelation urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
-        (evalVector urs.k (roChallenges O init ps).x3)
-        (multiopenValue vk ps (roChallenges O init ps)) a →
-      combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates ≠ hpoly * (X ^ deg - 1) →
-      (combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates
-        - hpoly * (X ^ deg - 1)).eval x ≠ 0)
-    {S : Prop}
-    (hencodes : ∀ a, SnarkRelation urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
-        (evalVector urs.k (roChallenges O init ps).x3) (multiopenValue vk ps (roChallenges O init ps))
-      (circuitSatViaGates fixedCols decodeAdvice decodeInstance y gates hpoly deg) a → S)
-    (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
-        < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
-            (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk ps
-              (roChallenges (reprogramRounds O init ps χ) init ps)))) :
-    S ∨ Nonempty (DiscreteLogRepresentation (F := Fp) B (augmentedBasis urs.g urs.u urs.w challenge))
-      ∨ RelationMissesSlot (F := Fp) urs.g urs.u urs.w challenge :=
-  soundnessOrDLAt_of_soundnessOrRelation B urs.g urs.u urs.w challenge embedding
-    (orchard_verifier_vesta_forking_constraint_rewind_legacy urs hk vk ps O init s fixedCols decodeAdvice
-      decodeInstance y gates hpoly deg x hz hg0 hs hξ hquot hgood hencodes hprob)
-
-open scoped ENNReal in
-open Classical in
-/-- `orchard_verifier_vesta_forking_opening_adaptive_rewind` with the relation branch consumed by the
-fixed-slot AGM adapter — the attack-event endpoint of the ladder, AGM/DL form. Caveats of the
-underlying rung and of the AGM section header both apply. -/
-theorem orchard_verifier_vesta_forking_opening_adaptive_rewind_agm_dl [Fact (HasseBound Vesta.curve)]
-    [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
-    (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG)
-    (O : List (TranscriptElt Fp VestaG) → Fp) (init : List (TranscriptElt Fp VestaG))
-    (s : Fin (2 ^ urs.k) → Fp) (P : Prover Fp VestaG shape.k)
-    (B : VestaG) (challenge : AugmentedIndex (2 ^ urs.k))
-    (embedding : FixedSlotEmbedding (F := Fp) B (augmentedBasis urs.g urs.u urs.w) challenge)
-    (hz : (roChallenges O init ps).z ≠ 0) (hg0 : urs.g 0 ≠ 0) (hs : commit urs s = ps.ipaS)
-    (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
-        < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
-            (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk
-              (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2)
-              (roChallenges
-                (reprogramRounds O init
-                  (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2) χ)
-                init
-                (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2))))) :
-    (∃ a, IpaRelation urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
-        (evalVector urs.k (roChallenges O init ps).x3)
-        (multiopenValue vk ps (roChallenges O init ps)
-          - (roChallenges O init ps).xi * innerProduct s (evalVector urs.k (roChallenges O init ps).x3)) a)
-      ∨ Nonempty (DiscreteLogRepresentation (F := Fp) B (augmentedBasis urs.g urs.u urs.w challenge))
-      ∨ RelationMissesSlot (F := Fp) urs.g urs.u urs.w challenge :=
-  soundnessOrDLAt_of_soundnessOrRelation B urs.g urs.u urs.w challenge embedding
-    (orchard_verifier_vesta_forking_opening_adaptive_rewind urs hk vk ps O init s P hz hg0 hs hprob)
-
-open Polynomial in
-open scoped ENNReal in
-open Classical in
-/-- `orchard_verifier_vesta_forking_constraint_adaptive_rewind` with the relation branch consumed by
-the fixed-slot AGM adapter — the attack-event constraint endpoint of the ladder, AGM/DL form.
-Caveats of the underlying rung and of the AGM section header both apply. -/
-theorem orchard_verifier_vesta_forking_constraint_adaptive_rewind_legacy_agm_dl [Fact (HasseBound Vesta.curve)]
-    [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
-    (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG)
-    (O : List (TranscriptElt Fp VestaG) → Fp) (init : List (TranscriptElt Fp VestaG))
-    (s : Fin (2 ^ urs.k) → Fp) (P : Prover Fp VestaG shape.k)
-    (fixedCols : ℕ → Polynomial Fp)
-    (decodeAdvice decodeInstance : (Fin (2 ^ urs.k) → Fp) → (ℕ → Polynomial Fp))
-    (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
-    (B : VestaG) (challenge : AugmentedIndex (2 ^ urs.k))
-    (embedding : FixedSlotEmbedding (F := Fp) B (augmentedBasis urs.g urs.u urs.w) challenge)
-    (hz : (roChallenges O init ps).z ≠ 0) (hg0 : urs.g 0 ≠ 0) (hs : commit urs s = ps.ipaS)
-    (hξ : (roChallenges O init ps).xi
-        * innerProduct s (evalVector urs.k (roChallenges O init ps).x3) = 0)
-    (hquot : ∀ a, IpaRelation urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
-        (evalVector urs.k (roChallenges O init ps).x3)
-        (multiopenValue vk ps (roChallenges O init ps)) a →
-      quotientCheck (combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates) hpoly deg x)
-    (hgood : ∀ a, IpaRelation urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
-        (evalVector urs.k (roChallenges O init ps).x3)
-        (multiopenValue vk ps (roChallenges O init ps)) a →
-      combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates ≠ hpoly * (X ^ deg - 1) →
-      (combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates
-        - hpoly * (X ^ deg - 1)).eval x ≠ 0)
-    {S : Prop}
-    (hencodes : ∀ a, SnarkRelation urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
-        (evalVector urs.k (roChallenges O init ps).x3) (multiopenValue vk ps (roChallenges O init ps))
-      (circuitSatViaGates fixedCols decodeAdvice decodeInstance y gates hpoly deg) a → S)
-    (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
-        < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
-            (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk
-              (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2)
-              (roChallenges
-                (reprogramRounds O init
-                  (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2) χ)
-                init
-                (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2))))) :
-    S ∨ Nonempty (DiscreteLogRepresentation (F := Fp) B (augmentedBasis urs.g urs.u urs.w challenge))
-      ∨ RelationMissesSlot (F := Fp) urs.g urs.u urs.w challenge :=
-  soundnessOrDLAt_of_soundnessOrRelation B urs.g urs.u urs.w challenge embedding
-    (orchard_verifier_vesta_forking_constraint_adaptive_rewind_legacy urs hk vk ps O init s P fixedCols
-      decodeAdvice decodeInstance y gates hpoly deg x hz hg0 hs hξ hquot hgood hencodes hprob)
-
-/-! ## Terminal constraint capstones
-
-These are the issue-18 decoded-column forms of the terminal constraint capstones. They keep the same
-forking/probability ladders, but once the ladder produces the final opened multiopen relation, they consume
-`MultiopenRewindForRelation`: the `x₁`/`x₄` batch rewinds for that same relation witness. The gate side is
-then checked over columns recovered from verifier-opened commitments/evaluations. Legacy free-decode forms
-remain above under `_legacy` names for comparison. -/
-
-section DecodedTerminalCapstones
-
-open Polynomial
-open scoped ENNReal
-open Classical
-
-/-- Bridge-level decoded constraint capstone: the deployed verifier relation is bridged through `hbridge`,
-then the final multiopen opening is decoded into real columns before the circuit gate check. -/
-theorem orchard_verifier_vesta_forking_constraint [Fact (HasseBound Vesta.curve)]
-    [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
-    (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
-    (xEval ξ z blind : Fp) (s : Fin (2 ^ urs.k) → Fp)
-    (Q : Prover Fp VestaG urs.k) (accepts : (Fin urs.k → Fp) → Prop)
-    {numColumns numAdvice numInstance : ℕ}
-    (columnCommitments : Fin numColumns → VestaG) (columnEvals : Fin numColumns → Fp)
-    (adviceIndex : Fin numAdvice → Fin numColumns) (instanceIndex : Fin numInstance → Fin numColumns)
-    (fixedCols : ℕ → Polynomial Fp)
-    (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
-    (hz : z ≠ 0) (hg0 : urs.g 0 ≠ 0)
-    (hξ : ξ * innerProduct s (evalVector urs.k xEval) = 0)
-    (hbridge : ∀ χ, accepts χ ↔ flatAccept Q urs.g (evalVector urs.k xEval) urs.u urs.w z
-        (deployedCommitment urs hk vk ps ch - multiopenValue vk ps ch • urs.g 0 + ξ • commit urs s
-          + (z * 0) • urs.u + blind • urs.w) χ)
-    (hbatch : MultiopenRewindForRelation urs (deployedCommitment urs hk vk ps ch)
-      (evalVector urs.k xEval) (multiopenValue vk ps ch) columnCommitments columnEvals)
-    (hquot : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps ch)
-        (evalVector urs.k xEval) (multiopenValue vk ps ch) a),
-      quotientCheck
-        (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
-          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates) hpoly deg x)
-    (hgood : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps ch)
-        (evalVector urs.k xEval) (multiopenValue vk ps ch) a),
-      combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
-          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
-        ≠ hpoly * (X ^ deg - 1) →
-      (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
-          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
-        - hpoly * (X ^ deg - 1)).eval x ≠ 0)
-    {S : Prop}
-    (hencodes : ∀ a cols,
-      SnarkRelationWithDecodedColumns urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k xEval)
-        (multiopenValue vk ps ch) columnCommitments columnEvals adviceIndex instanceIndex fixedCols
-        y gates hpoly deg a cols → S)
-    (hprob : (kerr (Fintype.card Fp) urs.k : ℝ≥0∞) / Fintype.card (Fin urs.k → Fp)
-        < (PMF.uniformOfFintype (Fin urs.k → Fp)).toOuterMeasure (Finset.univ.filter accepts)) :
-    S ∨ HasNontrivialRelation (F := Fp) urs.g urs.u urs.w := by
-  have hopen := orchard_verifier_vesta_forking_opening urs hk vk ps ch xEval ξ z blind s Q accepts
-    hz hg0 hbridge hprob
-  rw [hξ, sub_zero] at hopen
-  exact decoded_constraint_of_opening_or_relation (urs := urs)
-    (P := deployedCommitment urs hk vk ps ch) (b := evalVector urs.k xEval)
-    (v := multiopenValue vk ps ch) columnCommitments columnEvals adviceIndex instanceIndex fixedCols
-    y gates hpoly deg x hopen hbatch hquot hgood hencodes
-
-/-- AGM/DL wrapper for `orchard_verifier_vesta_forking_constraint`. -/
-theorem orchard_verifier_vesta_forking_constraint_agm_dl [Fact (HasseBound Vesta.curve)]
-    [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
-    (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
-    (xEval ξ z blind : Fp) (s : Fin (2 ^ urs.k) → Fp)
-    (Q : Prover Fp VestaG urs.k) (accepts : (Fin urs.k → Fp) → Prop)
-    {numColumns numAdvice numInstance : ℕ}
-    (columnCommitments : Fin numColumns → VestaG) (columnEvals : Fin numColumns → Fp)
-    (adviceIndex : Fin numAdvice → Fin numColumns) (instanceIndex : Fin numInstance → Fin numColumns)
-    (fixedCols : ℕ → Polynomial Fp)
-    (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
-    (B : VestaG) (challenge : AugmentedIndex (2 ^ urs.k))
-    (embedding : FixedSlotEmbedding (F := Fp) B (augmentedBasis urs.g urs.u urs.w) challenge)
-    (hz : z ≠ 0) (hg0 : urs.g 0 ≠ 0)
-    (hξ : ξ * innerProduct s (evalVector urs.k xEval) = 0)
-    (hbridge : ∀ χ, accepts χ ↔ flatAccept Q urs.g (evalVector urs.k xEval) urs.u urs.w z
-        (deployedCommitment urs hk vk ps ch - multiopenValue vk ps ch • urs.g 0 + ξ • commit urs s
-          + (z * 0) • urs.u + blind • urs.w) χ)
-    (hbatch : MultiopenRewindForRelation urs (deployedCommitment urs hk vk ps ch)
-      (evalVector urs.k xEval) (multiopenValue vk ps ch) columnCommitments columnEvals)
-    (hquot : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps ch)
-        (evalVector urs.k xEval) (multiopenValue vk ps ch) a),
-      quotientCheck
-        (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
-          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates) hpoly deg x)
-    (hgood : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps ch)
-        (evalVector urs.k xEval) (multiopenValue vk ps ch) a),
-      combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
-          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
-        ≠ hpoly * (X ^ deg - 1) →
-      (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
-          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
-        - hpoly * (X ^ deg - 1)).eval x ≠ 0)
-    {S : Prop}
-    (hencodes : ∀ a cols,
-      SnarkRelationWithDecodedColumns urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k xEval)
-        (multiopenValue vk ps ch) columnCommitments columnEvals adviceIndex instanceIndex fixedCols
-        y gates hpoly deg a cols → S)
-    (hprob : (kerr (Fintype.card Fp) urs.k : ℝ≥0∞) / Fintype.card (Fin urs.k → Fp)
-        < (PMF.uniformOfFintype (Fin urs.k → Fp)).toOuterMeasure (Finset.univ.filter accepts)) :
-    S ∨ Nonempty (DiscreteLogRepresentation (F := Fp) B (augmentedBasis urs.g urs.u urs.w challenge))
-      ∨ RelationMissesSlot (F := Fp) urs.g urs.u urs.w challenge :=
-  soundnessOrDLAt_of_soundnessOrRelation B urs.g urs.u urs.w challenge embedding
-    (orchard_verifier_vesta_forking_constraint urs hk vk ps ch xEval ξ z blind s Q accepts
-      columnCommitments columnEvals adviceIndex instanceIndex fixedCols y gates hpoly deg x hz hg0 hξ
-      hbridge hbatch hquot hgood hencodes hprob)
-
-/-- Deployed decoded constraint capstone: the constant-proof deployed probability rung, with the circuit
-side fed by columns recovered from the final multiopen opening. -/
-theorem orchard_verifier_vesta_forking_constraint_deployed [Fact (HasseBound Vesta.curve)]
-    [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
-    (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
-    (s : Fin (2 ^ urs.k) → Fp)
-    {numColumns numAdvice numInstance : ℕ}
-    (columnCommitments : Fin numColumns → VestaG) (columnEvals : Fin numColumns → Fp)
-    (adviceIndex : Fin numAdvice → Fin numColumns) (instanceIndex : Fin numInstance → Fin numColumns)
-    (fixedCols : ℕ → Polynomial Fp)
-    (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
-    (hz : ch.z ≠ 0) (hg0 : urs.g 0 ≠ 0) (hs : commit urs s = ps.ipaS)
-    (hξ : ch.xi * innerProduct s (evalVector urs.k ch.x3) = 0)
-    (hbatch : MultiopenRewindForRelation urs (deployedCommitment urs hk vk ps ch)
-      (evalVector urs.k ch.x3) (multiopenValue vk ps ch) columnCommitments columnEvals)
-    (hquot : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps ch)
-        (evalVector urs.k ch.x3) (multiopenValue vk ps ch) a),
-      quotientCheck
-        (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
-          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates) hpoly deg x)
-    (hgood : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps ch)
-        (evalVector urs.k ch.x3) (multiopenValue vk ps ch) a),
-      combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
-          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
-        ≠ hpoly * (X ^ deg - 1) →
-      (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
-          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
-        - hpoly * (X ^ deg - 1)).eval x ≠ 0)
-    {S : Prop}
-    (hencodes : ∀ a cols,
-      SnarkRelationWithDecodedColumns urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k ch.x3)
-        (multiopenValue vk ps ch) columnCommitments columnEvals adviceIndex instanceIndex fixedCols
-        y gates hpoly deg a cols → S)
-    (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
-        < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
-            (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk ps
-              {ch with ipaRound := χ}))) :
-    S ∨ HasNontrivialRelation (F := Fp) urs.g urs.u urs.w := by
-  have hopen := orchard_verifier_vesta_forking_opening_deployed urs hk vk ps ch s hz hg0 hs hprob
-  rw [hξ, sub_zero] at hopen
-  exact decoded_constraint_of_opening_or_relation (urs := urs)
-    (P := deployedCommitment urs hk vk ps ch) (b := evalVector urs.k ch.x3)
-    (v := multiopenValue vk ps ch) columnCommitments columnEvals adviceIndex instanceIndex fixedCols
-    y gates hpoly deg x hopen hbatch hquot hgood hencodes
-
-/-- AGM/DL wrapper for `orchard_verifier_vesta_forking_constraint_deployed`. -/
-theorem orchard_verifier_vesta_forking_constraint_deployed_agm_dl [Fact (HasseBound Vesta.curve)]
-    [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
-    (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
-    (s : Fin (2 ^ urs.k) → Fp)
-    {numColumns numAdvice numInstance : ℕ}
-    (columnCommitments : Fin numColumns → VestaG) (columnEvals : Fin numColumns → Fp)
-    (adviceIndex : Fin numAdvice → Fin numColumns) (instanceIndex : Fin numInstance → Fin numColumns)
-    (fixedCols : ℕ → Polynomial Fp)
-    (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
-    (B : VestaG) (challenge : AugmentedIndex (2 ^ urs.k))
-    (embedding : FixedSlotEmbedding (F := Fp) B (augmentedBasis urs.g urs.u urs.w) challenge)
-    (hz : ch.z ≠ 0) (hg0 : urs.g 0 ≠ 0) (hs : commit urs s = ps.ipaS)
-    (hξ : ch.xi * innerProduct s (evalVector urs.k ch.x3) = 0)
-    (hbatch : MultiopenRewindForRelation urs (deployedCommitment urs hk vk ps ch)
-      (evalVector urs.k ch.x3) (multiopenValue vk ps ch) columnCommitments columnEvals)
-    (hquot : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps ch)
-        (evalVector urs.k ch.x3) (multiopenValue vk ps ch) a),
-      quotientCheck
-        (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
-          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates) hpoly deg x)
-    (hgood : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps ch)
-        (evalVector urs.k ch.x3) (multiopenValue vk ps ch) a),
-      combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
-          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
-        ≠ hpoly * (X ^ deg - 1) →
-      (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
-          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
-        - hpoly * (X ^ deg - 1)).eval x ≠ 0)
-    {S : Prop}
-    (hencodes : ∀ a cols,
-      SnarkRelationWithDecodedColumns urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k ch.x3)
-        (multiopenValue vk ps ch) columnCommitments columnEvals adviceIndex instanceIndex fixedCols
-        y gates hpoly deg a cols → S)
-    (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
-        < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
-            (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk ps
-              {ch with ipaRound := χ}))) :
-    S ∨ Nonempty (DiscreteLogRepresentation (F := Fp) B (augmentedBasis urs.g urs.u urs.w challenge))
-      ∨ RelationMissesSlot (F := Fp) urs.g urs.u urs.w challenge :=
-  soundnessOrDLAt_of_soundnessOrRelation B urs.g urs.u urs.w challenge embedding
-    (orchard_verifier_vesta_forking_constraint_deployed urs hk vk ps ch s columnCommitments
-      columnEvals adviceIndex instanceIndex fixedCols y gates hpoly deg x hz hg0 hs hξ hbatch hquot hgood
-      hencodes hprob)
-
-/-- Adaptive-strategy decoded constraint capstone, with the staged prover accept event and decoded columns
-for the final multiopen relation. -/
-theorem orchard_verifier_vesta_forking_constraint_adaptive [Fact (HasseBound Vesta.curve)]
-    [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
-    (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
-    (s : Fin (2 ^ urs.k) → Fp) (P : Prover Fp VestaG shape.k)
-    {numColumns numAdvice numInstance : ℕ}
-    (columnCommitments : Fin numColumns → VestaG) (columnEvals : Fin numColumns → Fp)
-    (adviceIndex : Fin numAdvice → Fin numColumns) (instanceIndex : Fin numInstance → Fin numColumns)
-    (fixedCols : ℕ → Polynomial Fp)
-    (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
-    (hz : ch.z ≠ 0) (hg0 : urs.g 0 ≠ 0) (hs : commit urs s = ps.ipaS)
-    (hξ : ch.xi * innerProduct s (evalVector urs.k ch.x3) = 0)
-    (hbatch : MultiopenRewindForRelation urs (deployedCommitment urs hk vk ps ch)
-      (evalVector urs.k ch.x3) (multiopenValue vk ps ch) columnCommitments columnEvals)
-    (hquot : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps ch)
-        (evalVector urs.k ch.x3) (multiopenValue vk ps ch) a),
-      quotientCheck
-        (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
-          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates) hpoly deg x)
-    (hgood : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps ch)
-        (evalVector urs.k ch.x3) (multiopenValue vk ps ch) a),
-      combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
-          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
-        ≠ hpoly * (X ^ deg - 1) →
-      (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
-          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
-        - hpoly * (X ^ deg - 1)).eval x ≠ 0)
-    {S : Prop}
-    (hencodes : ∀ a cols,
-      SnarkRelationWithDecodedColumns urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k ch.x3)
-        (multiopenValue vk ps ch) columnCommitments columnEvals adviceIndex instanceIndex fixedCols
-        y gates hpoly deg a cols → S)
-    (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
-        < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
-            (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk
-              (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2)
-              {ch with ipaRound := χ}))) :
-    S ∨ HasNontrivialRelation (F := Fp) urs.g urs.u urs.w := by
-  have hopen := orchard_verifier_vesta_forking_opening_adaptive urs hk vk ps ch s P hz hg0 hs hprob
-  rw [hξ, sub_zero] at hopen
-  exact decoded_constraint_of_opening_or_relation (urs := urs)
-    (P := deployedCommitment urs hk vk ps ch) (b := evalVector urs.k ch.x3)
-    (v := multiopenValue vk ps ch) columnCommitments columnEvals adviceIndex instanceIndex fixedCols
-    y gates hpoly deg x hopen hbatch hquot hgood hencodes
-
-/-- AGM/DL wrapper for `orchard_verifier_vesta_forking_constraint_adaptive`. -/
-theorem orchard_verifier_vesta_forking_constraint_adaptive_agm_dl [Fact (HasseBound Vesta.curve)]
-    [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
-    (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
-    (s : Fin (2 ^ urs.k) → Fp) (P : Prover Fp VestaG shape.k)
-    {numColumns numAdvice numInstance : ℕ}
-    (columnCommitments : Fin numColumns → VestaG) (columnEvals : Fin numColumns → Fp)
-    (adviceIndex : Fin numAdvice → Fin numColumns) (instanceIndex : Fin numInstance → Fin numColumns)
-    (fixedCols : ℕ → Polynomial Fp)
-    (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
-    (B : VestaG) (challenge : AugmentedIndex (2 ^ urs.k))
-    (embedding : FixedSlotEmbedding (F := Fp) B (augmentedBasis urs.g urs.u urs.w) challenge)
-    (hz : ch.z ≠ 0) (hg0 : urs.g 0 ≠ 0) (hs : commit urs s = ps.ipaS)
-    (hξ : ch.xi * innerProduct s (evalVector urs.k ch.x3) = 0)
-    (hbatch : MultiopenRewindForRelation urs (deployedCommitment urs hk vk ps ch)
-      (evalVector urs.k ch.x3) (multiopenValue vk ps ch) columnCommitments columnEvals)
-    (hquot : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps ch)
-        (evalVector urs.k ch.x3) (multiopenValue vk ps ch) a),
-      quotientCheck
-        (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
-          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates) hpoly deg x)
-    (hgood : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps ch)
-        (evalVector urs.k ch.x3) (multiopenValue vk ps ch) a),
-      combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
-          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
-        ≠ hpoly * (X ^ deg - 1) →
-      (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
-          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
-        - hpoly * (X ^ deg - 1)).eval x ≠ 0)
-    {S : Prop}
-    (hencodes : ∀ a cols,
-      SnarkRelationWithDecodedColumns urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k ch.x3)
-        (multiopenValue vk ps ch) columnCommitments columnEvals adviceIndex instanceIndex fixedCols
-        y gates hpoly deg a cols → S)
-    (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
-        < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
-            (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk
-              (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2)
-              {ch with ipaRound := χ}))) :
-    S ∨ Nonempty (DiscreteLogRepresentation (F := Fp) B (augmentedBasis urs.g urs.u urs.w challenge))
-      ∨ RelationMissesSlot (F := Fp) urs.g urs.u urs.w challenge :=
-  soundnessOrDLAt_of_soundnessOrRelation B urs.g urs.u urs.w challenge embedding
-    (orchard_verifier_vesta_forking_constraint_adaptive urs hk vk ps ch s P columnCommitments
-      columnEvals adviceIndex instanceIndex fixedCols y gates hpoly deg x hz hg0 hs hξ hbatch hquot hgood
-      hencodes hprob)
-
 /-- Reprogrammed-oracle decoded constraint capstone for the constant-proof rung. -/
 theorem orchard_verifier_vesta_forking_constraint_rewind [Fact (HasseBound Vesta.curve)]
     [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
@@ -1525,54 +816,44 @@ theorem orchard_verifier_vesta_forking_constraint_rewind [Fact (HasseBound Vesta
     (v := multiopenValue vk ps (roChallenges O init ps)) columnCommitments columnEvals adviceIndex
     instanceIndex fixedCols y gates hpoly deg x hopen hbatch hquot hgood hencodes
 
-/-- AGM/DL wrapper for `orchard_verifier_vesta_forking_constraint_rewind`. -/
-theorem orchard_verifier_vesta_forking_constraint_rewind_agm_dl [Fact (HasseBound Vesta.curve)]
+open scoped ENNReal in
+open Classical in
+/-- **The staged Orchard opening over Vesta, from oracle rewinding.**
+This is `orchard_verifier_vesta_forking_opening_adaptive` with the adaptive accept probability stated over
+reprogrammed-oracle runs on each strategy-spliced proof. For each challenge path `χ`, the proof string is
+`spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2`; the oracle is reprogrammed at that
+spliced proof's IPA round prefixes and the deployed schedule is re-run. `roChallenges_reprogramRounds` turns
+that run into round-vector replacement, and `roChallenges_spliceIpa_pre` removes the irrelevant spliced
+pre-IPA fields. The residual is unchanged from the staged rung: the execution-semantics identification that a
+rewound random-oracle adversary induces such a strategy, with its RO-query loss, plus the uniformity axiom in
+`hprob`. -/
+theorem orchard_verifier_vesta_forking_opening_adaptive_rewind [Fact (HasseBound Vesta.curve)]
     [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG)
     (O : List (TranscriptElt Fp VestaG) → Fp) (init : List (TranscriptElt Fp VestaG))
-    (s : Fin (2 ^ urs.k) → Fp)
-    {numColumns numAdvice numInstance : ℕ}
-    (columnCommitments : Fin numColumns → VestaG) (columnEvals : Fin numColumns → Fp)
-    (adviceIndex : Fin numAdvice → Fin numColumns) (instanceIndex : Fin numInstance → Fin numColumns)
-    (fixedCols : ℕ → Polynomial Fp)
-    (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
-    (B : VestaG) (challenge : AugmentedIndex (2 ^ urs.k))
-    (embedding : FixedSlotEmbedding (F := Fp) B (augmentedBasis urs.g urs.u urs.w) challenge)
+    (s : Fin (2 ^ urs.k) → Fp) (P : Prover Fp VestaG shape.k)
     (hz : (roChallenges O init ps).z ≠ 0) (hg0 : urs.g 0 ≠ 0) (hs : commit urs s = ps.ipaS)
-    (hξ : (roChallenges O init ps).xi
-        * innerProduct s (evalVector urs.k (roChallenges O init ps).x3) = 0)
-    (hbatch : MultiopenRewindForRelation urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
-      (evalVector urs.k (roChallenges O init ps).x3) (multiopenValue vk ps (roChallenges O init ps))
-      columnCommitments columnEvals)
-    (hquot : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
-        (evalVector urs.k (roChallenges O init ps).x3) (multiopenValue vk ps (roChallenges O init ps)) a),
-      quotientCheck
-        (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
-          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates) hpoly deg x)
-    (hgood : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
-        (evalVector urs.k (roChallenges O init ps).x3) (multiopenValue vk ps (roChallenges O init ps)) a),
-      combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
-          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
-        ≠ hpoly * (X ^ deg - 1) →
-      (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
-          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
-        - hpoly * (X ^ deg - 1)).eval x ≠ 0)
-    {S : Prop}
-    (hencodes : ∀ a cols,
-      SnarkRelationWithDecodedColumns urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
-        (evalVector urs.k (roChallenges O init ps).x3) (multiopenValue vk ps (roChallenges O init ps))
-        columnCommitments columnEvals adviceIndex instanceIndex fixedCols y gates hpoly deg a cols → S)
     (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
         < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
-            (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk ps
-              (roChallenges (reprogramRounds O init ps χ) init ps)))) :
-    S ∨ Nonempty (DiscreteLogRepresentation (F := Fp) B (augmentedBasis urs.g urs.u urs.w challenge))
-      ∨ RelationMissesSlot (F := Fp) urs.g urs.u urs.w challenge :=
-  soundnessOrDLAt_of_soundnessOrRelation B urs.g urs.u urs.w challenge embedding
-    (orchard_verifier_vesta_forking_constraint_rewind urs hk vk ps O init s columnCommitments
-      columnEvals adviceIndex instanceIndex fixedCols y gates hpoly deg x hz hg0 hs hξ hbatch hquot hgood
-      hencodes hprob)
+            (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk
+              (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2)
+              (roChallenges
+                (reprogramRounds O init
+                  (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2) χ)
+                init
+                (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2))))) :
+    (∃ a, IpaRelation urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
+        (evalVector urs.k (roChallenges O init ps).x3)
+        (multiopenValue vk ps (roChallenges O init ps)
+          - (roChallenges O init ps).xi * innerProduct s (evalVector urs.k (roChallenges O init ps).x3)) a)
+      ∨ HasNontrivialRelation (F := Fp) urs.g urs.u urs.w := by
+  refine orchard_verifier_vesta_forking_opening_adaptive urs hk vk ps (roChallenges O init ps)
+    s P hz hg0 hs ?_
+  simpa only [roChallenges_reprogramRounds, roChallenges_spliceIpa_pre] using hprob
 
+open Polynomial in
+open scoped ENNReal in
+open Classical in
 /-- Attack-event decoded constraint capstone: adaptive strategy plus reprogrammed-oracle runs, with decoded
 columns recovered from the final multiopen relation. -/
 theorem orchard_verifier_vesta_forking_constraint_adaptive_rewind [Fact (HasseBound Vesta.curve)]
@@ -1628,6 +909,277 @@ theorem orchard_verifier_vesta_forking_constraint_adaptive_rewind [Fact (HasseBo
     (v := multiopenValue vk ps (roChallenges O init ps)) columnCommitments columnEvals adviceIndex
     instanceIndex fixedCols y gates hpoly deg x hopen hbatch hquot hgood hencodes
 
+/-! ## AGM/DL wrappers of the forking capstones
+
+Each rung of the ladder above ends in `∨ HasNontrivialRelation urs.g urs.u urs.w`. The wrappers
+below consume that branch with the fixed-slot AGM adapter
+(`soundnessOrDLAt_of_soundnessOrRelation`): given a DL challenge pre-placed at an augmented basis
+slot `challenge` — fixed *before* the relation is seen — with known logs everywhere else
+(`FixedSlotEmbedding`), the relation branch becomes the discrete log of that slot, or the named
+failure event `RelationMissesSlot`.
+
+Standing caveat (inherited from the wrapped capstones; see `Soundness.AGM`'s module docs): at Vesta's
+prime order the trichotomy is propositionally `True` — a relation missing the slot always *exists* —
+so these are vacuous *as statements*; their content is the deterministic extraction chain. The
+hit-probability half of the computational force — a uniformly placed hidden slot is hit with
+probability ≥ `1/|ι|` — is now formalized in `Soundness.AGMProbability`; the residual out-of-Lean
+force is discrete-log hardness (no feasible adversary finds a relation) together with the
+algebraic-prover model that produces the witness. -/
+
+open scoped ENNReal in
+open Classical in
+/-- `orchard_verifier_vesta_forking_opening_deployed` with the relation branch consumed by the
+fixed-slot AGM adapter. Caveats of the underlying rung (static dichotomy) and of the AGM section
+header both apply. -/
+theorem orchard_verifier_vesta_forking_opening_deployed_agm_dl [Fact (HasseBound Vesta.curve)]
+    [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
+    (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
+    (s : Fin (2 ^ urs.k) → Fp)
+    (B : VestaG) (challenge : AugmentedIndex (2 ^ urs.k))
+    (embedding : FixedSlotEmbedding (F := Fp) B (augmentedBasis urs.g urs.u urs.w) challenge)
+    (hz : ch.z ≠ 0) (hg0 : urs.g 0 ≠ 0) (hs : commit urs s = ps.ipaS)
+    (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
+        < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
+            (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk ps
+              {ch with ipaRound := χ}))) :
+    (∃ a, IpaRelation urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k ch.x3)
+        (multiopenValue vk ps ch - ch.xi * innerProduct s (evalVector urs.k ch.x3)) a)
+      ∨ Nonempty (DiscreteLogRepresentation (F := Fp) B (augmentedBasis urs.g urs.u urs.w challenge))
+      ∨ RelationMissesSlot (F := Fp) urs.g urs.u urs.w challenge :=
+  soundnessOrDLAt_of_soundnessOrRelation B urs.g urs.u urs.w challenge embedding
+    (orchard_verifier_vesta_forking_opening_deployed urs hk vk ps ch s hz hg0 hs hprob)
+
+open Polynomial in
+open scoped ENNReal in
+open Classical in
+/-- AGM/DL wrapper for `orchard_verifier_vesta_forking_constraint_deployed`. -/
+theorem orchard_verifier_vesta_forking_constraint_deployed_agm_dl [Fact (HasseBound Vesta.curve)]
+    [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
+    (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
+    (s : Fin (2 ^ urs.k) → Fp)
+    {numColumns numAdvice numInstance : ℕ}
+    (columnCommitments : Fin numColumns → VestaG) (columnEvals : Fin numColumns → Fp)
+    (adviceIndex : Fin numAdvice → Fin numColumns) (instanceIndex : Fin numInstance → Fin numColumns)
+    (fixedCols : ℕ → Polynomial Fp)
+    (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
+    (B : VestaG) (challenge : AugmentedIndex (2 ^ urs.k))
+    (embedding : FixedSlotEmbedding (F := Fp) B (augmentedBasis urs.g urs.u urs.w) challenge)
+    (hz : ch.z ≠ 0) (hg0 : urs.g 0 ≠ 0) (hs : commit urs s = ps.ipaS)
+    (hξ : ch.xi * innerProduct s (evalVector urs.k ch.x3) = 0)
+    (hbatch : MultiopenRewindForRelation urs (deployedCommitment urs hk vk ps ch)
+      (evalVector urs.k ch.x3) (multiopenValue vk ps ch) columnCommitments columnEvals)
+    (hquot : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps ch)
+        (evalVector urs.k ch.x3) (multiopenValue vk ps ch) a),
+      quotientCheck
+        (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates) hpoly deg x)
+    (hgood : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps ch)
+        (evalVector urs.k ch.x3) (multiopenValue vk ps ch) a),
+      combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
+        ≠ hpoly * (X ^ deg - 1) →
+      (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
+        - hpoly * (X ^ deg - 1)).eval x ≠ 0)
+    {S : Prop}
+    (hencodes : ∀ a cols,
+      SnarkRelationWithDecodedColumns urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k ch.x3)
+        (multiopenValue vk ps ch) columnCommitments columnEvals adviceIndex instanceIndex fixedCols
+        y gates hpoly deg a cols → S)
+    (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
+        < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
+            (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk ps
+              {ch with ipaRound := χ}))) :
+    S ∨ Nonempty (DiscreteLogRepresentation (F := Fp) B (augmentedBasis urs.g urs.u urs.w challenge))
+      ∨ RelationMissesSlot (F := Fp) urs.g urs.u urs.w challenge :=
+  soundnessOrDLAt_of_soundnessOrRelation B urs.g urs.u urs.w challenge embedding
+    (orchard_verifier_vesta_forking_constraint_deployed urs hk vk ps ch s columnCommitments
+      columnEvals adviceIndex instanceIndex fixedCols y gates hpoly deg x hz hg0 hs hξ hbatch hquot hgood
+      hencodes hprob)
+
+open scoped ENNReal in
+open Classical in
+/-- `orchard_verifier_vesta_forking_opening_adaptive` with the relation branch consumed by the
+fixed-slot AGM adapter. Caveats of the underlying rung and of the AGM section header both apply. -/
+theorem orchard_verifier_vesta_forking_opening_adaptive_agm_dl [Fact (HasseBound Vesta.curve)]
+    [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
+    (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
+    (s : Fin (2 ^ urs.k) → Fp) (P : Prover Fp VestaG shape.k)
+    (B : VestaG) (challenge : AugmentedIndex (2 ^ urs.k))
+    (embedding : FixedSlotEmbedding (F := Fp) B (augmentedBasis urs.g urs.u urs.w) challenge)
+    (hz : ch.z ≠ 0) (hg0 : urs.g 0 ≠ 0) (hs : commit urs s = ps.ipaS)
+    (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
+        < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
+            (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk
+              (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2)
+              {ch with ipaRound := χ}))) :
+    (∃ a, IpaRelation urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k ch.x3)
+        (multiopenValue vk ps ch - ch.xi * innerProduct s (evalVector urs.k ch.x3)) a)
+      ∨ Nonempty (DiscreteLogRepresentation (F := Fp) B (augmentedBasis urs.g urs.u urs.w challenge))
+      ∨ RelationMissesSlot (F := Fp) urs.g urs.u urs.w challenge :=
+  soundnessOrDLAt_of_soundnessOrRelation B urs.g urs.u urs.w challenge embedding
+    (orchard_verifier_vesta_forking_opening_adaptive urs hk vk ps ch s P hz hg0 hs hprob)
+
+open Polynomial in
+open scoped ENNReal in
+open Classical in
+/-- AGM/DL wrapper for `orchard_verifier_vesta_forking_constraint_adaptive`. -/
+theorem orchard_verifier_vesta_forking_constraint_adaptive_agm_dl [Fact (HasseBound Vesta.curve)]
+    [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
+    (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
+    (s : Fin (2 ^ urs.k) → Fp) (P : Prover Fp VestaG shape.k)
+    {numColumns numAdvice numInstance : ℕ}
+    (columnCommitments : Fin numColumns → VestaG) (columnEvals : Fin numColumns → Fp)
+    (adviceIndex : Fin numAdvice → Fin numColumns) (instanceIndex : Fin numInstance → Fin numColumns)
+    (fixedCols : ℕ → Polynomial Fp)
+    (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
+    (B : VestaG) (challenge : AugmentedIndex (2 ^ urs.k))
+    (embedding : FixedSlotEmbedding (F := Fp) B (augmentedBasis urs.g urs.u urs.w) challenge)
+    (hz : ch.z ≠ 0) (hg0 : urs.g 0 ≠ 0) (hs : commit urs s = ps.ipaS)
+    (hξ : ch.xi * innerProduct s (evalVector urs.k ch.x3) = 0)
+    (hbatch : MultiopenRewindForRelation urs (deployedCommitment urs hk vk ps ch)
+      (evalVector urs.k ch.x3) (multiopenValue vk ps ch) columnCommitments columnEvals)
+    (hquot : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps ch)
+        (evalVector urs.k ch.x3) (multiopenValue vk ps ch) a),
+      quotientCheck
+        (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates) hpoly deg x)
+    (hgood : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps ch)
+        (evalVector urs.k ch.x3) (multiopenValue vk ps ch) a),
+      combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
+        ≠ hpoly * (X ^ deg - 1) →
+      (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
+        - hpoly * (X ^ deg - 1)).eval x ≠ 0)
+    {S : Prop}
+    (hencodes : ∀ a cols,
+      SnarkRelationWithDecodedColumns urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k ch.x3)
+        (multiopenValue vk ps ch) columnCommitments columnEvals adviceIndex instanceIndex fixedCols
+        y gates hpoly deg a cols → S)
+    (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
+        < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
+            (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk
+              (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2)
+              {ch with ipaRound := χ}))) :
+    S ∨ Nonempty (DiscreteLogRepresentation (F := Fp) B (augmentedBasis urs.g urs.u urs.w challenge))
+      ∨ RelationMissesSlot (F := Fp) urs.g urs.u urs.w challenge :=
+  soundnessOrDLAt_of_soundnessOrRelation B urs.g urs.u urs.w challenge embedding
+    (orchard_verifier_vesta_forking_constraint_adaptive urs hk vk ps ch s P columnCommitments
+      columnEvals adviceIndex instanceIndex fixedCols y gates hpoly deg x hz hg0 hs hξ hbatch hquot hgood
+      hencodes hprob)
+
+open scoped ENNReal in
+open Classical in
+/-- `orchard_verifier_vesta_forking_opening_rewind` with the relation branch consumed by the
+fixed-slot AGM adapter. Caveats of the underlying rung and of the AGM section header both apply. -/
+theorem orchard_verifier_vesta_forking_opening_rewind_agm_dl [Fact (HasseBound Vesta.curve)]
+    [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
+    (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG)
+    (O : List (TranscriptElt Fp VestaG) → Fp) (init : List (TranscriptElt Fp VestaG))
+    (s : Fin (2 ^ urs.k) → Fp)
+    (B : VestaG) (challenge : AugmentedIndex (2 ^ urs.k))
+    (embedding : FixedSlotEmbedding (F := Fp) B (augmentedBasis urs.g urs.u urs.w) challenge)
+    (hz : (roChallenges O init ps).z ≠ 0) (hg0 : urs.g 0 ≠ 0)
+    (hs : commit urs s = ps.ipaS)
+    (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
+        < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
+            (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk ps
+              (roChallenges (reprogramRounds O init ps χ) init ps)))) :
+    (∃ a, IpaRelation urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
+        (evalVector urs.k (roChallenges O init ps).x3)
+        (multiopenValue vk ps (roChallenges O init ps)
+          - (roChallenges O init ps).xi * innerProduct s (evalVector urs.k (roChallenges O init ps).x3)) a)
+      ∨ Nonempty (DiscreteLogRepresentation (F := Fp) B (augmentedBasis urs.g urs.u urs.w challenge))
+      ∨ RelationMissesSlot (F := Fp) urs.g urs.u urs.w challenge :=
+  soundnessOrDLAt_of_soundnessOrRelation B urs.g urs.u urs.w challenge embedding
+    (orchard_verifier_vesta_forking_opening_rewind urs hk vk ps O init s hz hg0 hs hprob)
+
+open Polynomial in
+open scoped ENNReal in
+open Classical in
+/-- AGM/DL wrapper for `orchard_verifier_vesta_forking_constraint_rewind`. -/
+theorem orchard_verifier_vesta_forking_constraint_rewind_agm_dl [Fact (HasseBound Vesta.curve)]
+    [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
+    (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG)
+    (O : List (TranscriptElt Fp VestaG) → Fp) (init : List (TranscriptElt Fp VestaG))
+    (s : Fin (2 ^ urs.k) → Fp)
+    {numColumns numAdvice numInstance : ℕ}
+    (columnCommitments : Fin numColumns → VestaG) (columnEvals : Fin numColumns → Fp)
+    (adviceIndex : Fin numAdvice → Fin numColumns) (instanceIndex : Fin numInstance → Fin numColumns)
+    (fixedCols : ℕ → Polynomial Fp)
+    (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
+    (B : VestaG) (challenge : AugmentedIndex (2 ^ urs.k))
+    (embedding : FixedSlotEmbedding (F := Fp) B (augmentedBasis urs.g urs.u urs.w) challenge)
+    (hz : (roChallenges O init ps).z ≠ 0) (hg0 : urs.g 0 ≠ 0) (hs : commit urs s = ps.ipaS)
+    (hξ : (roChallenges O init ps).xi
+        * innerProduct s (evalVector urs.k (roChallenges O init ps).x3) = 0)
+    (hbatch : MultiopenRewindForRelation urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
+      (evalVector urs.k (roChallenges O init ps).x3) (multiopenValue vk ps (roChallenges O init ps))
+      columnCommitments columnEvals)
+    (hquot : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
+        (evalVector urs.k (roChallenges O init ps).x3) (multiopenValue vk ps (roChallenges O init ps)) a),
+      quotientCheck
+        (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates) hpoly deg x)
+    (hgood : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
+        (evalVector urs.k (roChallenges O init ps).x3) (multiopenValue vk ps (roChallenges O init ps)) a),
+      combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
+        ≠ hpoly * (X ^ deg - 1) →
+      (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
+        - hpoly * (X ^ deg - 1)).eval x ≠ 0)
+    {S : Prop}
+    (hencodes : ∀ a cols,
+      SnarkRelationWithDecodedColumns urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
+        (evalVector urs.k (roChallenges O init ps).x3) (multiopenValue vk ps (roChallenges O init ps))
+        columnCommitments columnEvals adviceIndex instanceIndex fixedCols y gates hpoly deg a cols → S)
+    (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
+        < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
+            (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk ps
+              (roChallenges (reprogramRounds O init ps χ) init ps)))) :
+    S ∨ Nonempty (DiscreteLogRepresentation (F := Fp) B (augmentedBasis urs.g urs.u urs.w challenge))
+      ∨ RelationMissesSlot (F := Fp) urs.g urs.u urs.w challenge :=
+  soundnessOrDLAt_of_soundnessOrRelation B urs.g urs.u urs.w challenge embedding
+    (orchard_verifier_vesta_forking_constraint_rewind urs hk vk ps O init s columnCommitments
+      columnEvals adviceIndex instanceIndex fixedCols y gates hpoly deg x hz hg0 hs hξ hbatch hquot hgood
+      hencodes hprob)
+
+open scoped ENNReal in
+open Classical in
+/-- `orchard_verifier_vesta_forking_opening_adaptive_rewind` with the relation branch consumed by the
+fixed-slot AGM adapter — the attack-event endpoint of the ladder, AGM/DL form. Caveats of the
+underlying rung and of the AGM section header both apply. -/
+theorem orchard_verifier_vesta_forking_opening_adaptive_rewind_agm_dl [Fact (HasseBound Vesta.curve)]
+    [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
+    (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG)
+    (O : List (TranscriptElt Fp VestaG) → Fp) (init : List (TranscriptElt Fp VestaG))
+    (s : Fin (2 ^ urs.k) → Fp) (P : Prover Fp VestaG shape.k)
+    (B : VestaG) (challenge : AugmentedIndex (2 ^ urs.k))
+    (embedding : FixedSlotEmbedding (F := Fp) B (augmentedBasis urs.g urs.u urs.w) challenge)
+    (hz : (roChallenges O init ps).z ≠ 0) (hg0 : urs.g 0 ≠ 0) (hs : commit urs s = ps.ipaS)
+    (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
+        < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
+            (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk
+              (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2)
+              (roChallenges
+                (reprogramRounds O init
+                  (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2) χ)
+                init
+                (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2))))) :
+    (∃ a, IpaRelation urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
+        (evalVector urs.k (roChallenges O init ps).x3)
+        (multiopenValue vk ps (roChallenges O init ps)
+          - (roChallenges O init ps).xi * innerProduct s (evalVector urs.k (roChallenges O init ps).x3)) a)
+      ∨ Nonempty (DiscreteLogRepresentation (F := Fp) B (augmentedBasis urs.g urs.u urs.w challenge))
+      ∨ RelationMissesSlot (F := Fp) urs.g urs.u urs.w challenge :=
+  soundnessOrDLAt_of_soundnessOrRelation B urs.g urs.u urs.w challenge embedding
+    (orchard_verifier_vesta_forking_opening_adaptive_rewind urs hk vk ps O init s P hz hg0 hs hprob)
+
+open Polynomial in
+open scoped ENNReal in
+open Classical in
 /-- AGM/DL wrapper for `orchard_verifier_vesta_forking_constraint_adaptive_rewind`. -/
 theorem orchard_verifier_vesta_forking_constraint_adaptive_rewind_agm_dl
     [Fact (HasseBound Vesta.curve)] [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape}
@@ -1681,7 +1233,5 @@ theorem orchard_verifier_vesta_forking_constraint_adaptive_rewind_agm_dl
     (orchard_verifier_vesta_forking_constraint_adaptive_rewind urs hk vk ps O init s P
       columnCommitments columnEvals adviceIndex instanceIndex fixedCols y gates hpoly deg x hz hg0 hs hξ
       hbatch hquot hgood hencodes hprob)
-
-end DecodedTerminalCapstones
 
 end Zcash.Snark

--- a/Zcash/Snark/Soundness/Vesta.lean
+++ b/Zcash/Snark/Soundness/Vesta.lean
@@ -398,7 +398,7 @@ computational DLR/AGM layer outside Lean (`Soundness.AGM` records only its deter
 core). `hquot`/`hgood` retain the ∀-openings shape —
 unsatisfiable at Vesta for any decode that genuinely reads the witness (see
 `orchard_verifier_deployed_constraint_reduction`'s caveat, and the decoded capstone above). -/
-theorem orchard_verifier_vesta_forking_constraint [Fact (HasseBound Vesta.curve)] [DecidableEq VestaG]
+theorem orchard_verifier_vesta_forking_constraint_legacy [Fact (HasseBound Vesta.curve)] [DecidableEq VestaG]
     [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
     (xEval ξ z blind : Fp) (s : Fin (2 ^ urs.k) → Fp)
@@ -441,7 +441,7 @@ open Classical in
 /-- The deployed Orchard constraint capstone over Vesta, with the augmented relation branch consumed
 by the fixed-slot AGM adapter (`soundnessOrDLAt_of_soundnessOrRelation`). Vacuity caveat as on
 `orchard_verifier_vesta_forking_opening_agm_dl`. -/
-theorem orchard_verifier_vesta_forking_constraint_agm_dl [Fact (HasseBound Vesta.curve)]
+theorem orchard_verifier_vesta_forking_constraint_legacy_agm_dl [Fact (HasseBound Vesta.curve)]
     [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG)
     (hk : shape.k = urs.k) (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG)
     (ch : Challenges shape.k Fp) (xEval ξ z blind : Fp) (s : Fin (2 ^ urs.k) → Fp)
@@ -473,7 +473,7 @@ theorem orchard_verifier_vesta_forking_constraint_agm_dl [Fact (HasseBound Vesta
     S ∨ Nonempty (DiscreteLogRepresentation (F := Fp) B (augmentedBasis urs.g urs.u urs.w challenge))
       ∨ RelationMissesSlot (F := Fp) urs.g urs.u urs.w challenge :=
   soundnessOrDLAt_of_soundnessOrRelation B urs.g urs.u urs.w challenge embedding
-    (orchard_verifier_vesta_forking_constraint urs hk vk ps ch xEval ξ z blind s Q accepts fixedCols
+    (orchard_verifier_vesta_forking_constraint_legacy urs hk vk ps ch xEval ξ z blind s Q accepts fixedCols
       decodeAdvice decodeInstance y gates hpoly deg x hz hg0 hξ hbridge hquot hgood hencodes hprob)
 
 /-- The deployed adjusted-commitment's value term `Σᵢ [-v].getD i • gᵢ` is `-v` on the single generator `g 0`
@@ -575,7 +575,7 @@ reprogrammed-oracle runs, use `orchard_verifier_vesta_forking_constraint_adaptiv
 retain the ∀-openings shape — unsatisfiable at Vesta for any decode that genuinely
 reads the witness (see `orchard_verifier_deployed_constraint_reduction`'s caveat, and the decoded
 capstone above). -/
-theorem orchard_verifier_vesta_forking_constraint_deployed [Fact (HasseBound Vesta.curve)] [DecidableEq VestaG]
+theorem orchard_verifier_vesta_forking_constraint_deployed_legacy [Fact (HasseBound Vesta.curve)] [DecidableEq VestaG]
     [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
     (s : Fin (2 ^ urs.k) → Fp)
@@ -672,7 +672,7 @@ random-oracle uniformity axiom in `hprob`, and the structural witnesses; the sta
 apply at this rung. Issue #23's transcript-ordering and reprogramming content is discharged by the staged
 rewinding capstones below. `hquot`/`hgood` retain the ∀-openings shape — unsatisfiable at Vesta for any decode
 that genuinely reads the witness; the decoded capstone above is the witness-to-columns endpoint. -/
-theorem orchard_verifier_vesta_forking_constraint_adaptive [Fact (HasseBound Vesta.curve)]
+theorem orchard_verifier_vesta_forking_constraint_adaptive_legacy [Fact (HasseBound Vesta.curve)]
     [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
     (s : Fin (2 ^ urs.k) → Fp) (P : Prover Fp VestaG shape.k)
@@ -779,7 +779,7 @@ caveat is unchanged — see `orchard_verifier_deployed_constraint_reduction`'s c
 capstone — and so
 is the constant rung's static-dichotomy scope (see `orchard_verifier_vesta_forking_opening_deployed`); the
 `_adaptive_rewind` pair is the attack-event form. -/
-theorem orchard_verifier_vesta_forking_constraint_rewind [Fact (HasseBound Vesta.curve)]
+theorem orchard_verifier_vesta_forking_constraint_rewind_legacy [Fact (HasseBound Vesta.curve)]
     [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG)
     (O : List (TranscriptElt Fp VestaG) → Fp) (init : List (TranscriptElt Fp VestaG))
@@ -809,7 +809,7 @@ theorem orchard_verifier_vesta_forking_constraint_rewind [Fact (HasseBound Vesta
             (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk ps
               (roChallenges (reprogramRounds O init ps χ) init ps)))) :
     S ∨ HasNontrivialRelation (F := Fp) urs.g urs.u urs.w := by
-  refine orchard_verifier_vesta_forking_constraint_deployed urs hk vk ps (roChallenges O init ps)
+  refine orchard_verifier_vesta_forking_constraint_deployed_legacy urs hk vk ps (roChallenges O init ps)
     s fixedCols decodeAdvice decodeInstance y gates hpoly deg x hz hg0 hs hξ hquot hgood hencodes ?_
   simpa only [roChallenges_reprogramRounds] using hprob
 
@@ -855,7 +855,7 @@ open Classical in
 round-adaptive capstone with its accept event grounded in reprogrammed-oracle runs on each spliced proof. The
 `hquot`/`hgood` caveat is unchanged — see `orchard_verifier_deployed_constraint_reduction`'s caveat and
 the decoded capstone. -/
-theorem orchard_verifier_vesta_forking_constraint_adaptive_rewind [Fact (HasseBound Vesta.curve)]
+theorem orchard_verifier_vesta_forking_constraint_adaptive_rewind_legacy [Fact (HasseBound Vesta.curve)]
     [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG)
     (O : List (TranscriptElt Fp VestaG) → Fp) (init : List (TranscriptElt Fp VestaG))
@@ -944,7 +944,7 @@ open scoped ENNReal in
 open Classical in
 /-- `orchard_verifier_vesta_forking_constraint_deployed` with the relation branch consumed by the
 fixed-slot AGM adapter. Caveats of the underlying rung and of the AGM section header both apply. -/
-theorem orchard_verifier_vesta_forking_constraint_deployed_agm_dl [Fact (HasseBound Vesta.curve)]
+theorem orchard_verifier_vesta_forking_constraint_deployed_legacy_agm_dl [Fact (HasseBound Vesta.curve)]
     [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
     (s : Fin (2 ^ urs.k) → Fp)
@@ -974,7 +974,7 @@ theorem orchard_verifier_vesta_forking_constraint_deployed_agm_dl [Fact (HasseBo
     S ∨ Nonempty (DiscreteLogRepresentation (F := Fp) B (augmentedBasis urs.g urs.u urs.w challenge))
       ∨ RelationMissesSlot (F := Fp) urs.g urs.u urs.w challenge :=
   soundnessOrDLAt_of_soundnessOrRelation B urs.g urs.u urs.w challenge embedding
-    (orchard_verifier_vesta_forking_constraint_deployed urs hk vk ps ch s fixedCols decodeAdvice
+    (orchard_verifier_vesta_forking_constraint_deployed_legacy urs hk vk ps ch s fixedCols decodeAdvice
       decodeInstance y gates hpoly deg x hz hg0 hs hξ hquot hgood hencodes hprob)
 
 open scoped ENNReal in
@@ -1005,7 +1005,7 @@ open scoped ENNReal in
 open Classical in
 /-- `orchard_verifier_vesta_forking_constraint_adaptive` with the relation branch consumed by the
 fixed-slot AGM adapter. Caveats of the underlying rung and of the AGM section header both apply. -/
-theorem orchard_verifier_vesta_forking_constraint_adaptive_agm_dl [Fact (HasseBound Vesta.curve)]
+theorem orchard_verifier_vesta_forking_constraint_adaptive_legacy_agm_dl [Fact (HasseBound Vesta.curve)]
     [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
     (s : Fin (2 ^ urs.k) → Fp) (P : Prover Fp VestaG shape.k)
@@ -1036,7 +1036,7 @@ theorem orchard_verifier_vesta_forking_constraint_adaptive_agm_dl [Fact (HasseBo
     S ∨ Nonempty (DiscreteLogRepresentation (F := Fp) B (augmentedBasis urs.g urs.u urs.w challenge))
       ∨ RelationMissesSlot (F := Fp) urs.g urs.u urs.w challenge :=
   soundnessOrDLAt_of_soundnessOrRelation B urs.g urs.u urs.w challenge embedding
-    (orchard_verifier_vesta_forking_constraint_adaptive urs hk vk ps ch s P fixedCols decodeAdvice
+    (orchard_verifier_vesta_forking_constraint_adaptive_legacy urs hk vk ps ch s P fixedCols decodeAdvice
       decodeInstance y gates hpoly deg x hz hg0 hs hξ hquot hgood hencodes hprob)
 
 open scoped ENNReal in
@@ -1070,7 +1070,7 @@ open scoped ENNReal in
 open Classical in
 /-- `orchard_verifier_vesta_forking_constraint_rewind` with the relation branch consumed by the
 fixed-slot AGM adapter. Caveats of the underlying rung and of the AGM section header both apply. -/
-theorem orchard_verifier_vesta_forking_constraint_rewind_agm_dl [Fact (HasseBound Vesta.curve)]
+theorem orchard_verifier_vesta_forking_constraint_rewind_legacy_agm_dl [Fact (HasseBound Vesta.curve)]
     [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG)
     (O : List (TranscriptElt Fp VestaG) → Fp) (init : List (TranscriptElt Fp VestaG))
@@ -1104,7 +1104,7 @@ theorem orchard_verifier_vesta_forking_constraint_rewind_agm_dl [Fact (HasseBoun
     S ∨ Nonempty (DiscreteLogRepresentation (F := Fp) B (augmentedBasis urs.g urs.u urs.w challenge))
       ∨ RelationMissesSlot (F := Fp) urs.g urs.u urs.w challenge :=
   soundnessOrDLAt_of_soundnessOrRelation B urs.g urs.u urs.w challenge embedding
-    (orchard_verifier_vesta_forking_constraint_rewind urs hk vk ps O init s fixedCols decodeAdvice
+    (orchard_verifier_vesta_forking_constraint_rewind_legacy urs hk vk ps O init s fixedCols decodeAdvice
       decodeInstance y gates hpoly deg x hz hg0 hs hξ hquot hgood hencodes hprob)
 
 open scoped ENNReal in
@@ -1144,7 +1144,7 @@ open Classical in
 /-- `orchard_verifier_vesta_forking_constraint_adaptive_rewind` with the relation branch consumed by
 the fixed-slot AGM adapter — the attack-event constraint endpoint of the ladder, AGM/DL form.
 Caveats of the underlying rung and of the AGM section header both apply. -/
-theorem orchard_verifier_vesta_forking_constraint_adaptive_rewind_agm_dl [Fact (HasseBound Vesta.curve)]
+theorem orchard_verifier_vesta_forking_constraint_adaptive_rewind_legacy_agm_dl [Fact (HasseBound Vesta.curve)]
     [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG)
     (O : List (TranscriptElt Fp VestaG) → Fp) (init : List (TranscriptElt Fp VestaG))
@@ -1183,7 +1183,505 @@ theorem orchard_verifier_vesta_forking_constraint_adaptive_rewind_agm_dl [Fact (
     S ∨ Nonempty (DiscreteLogRepresentation (F := Fp) B (augmentedBasis urs.g urs.u urs.w challenge))
       ∨ RelationMissesSlot (F := Fp) urs.g urs.u urs.w challenge :=
   soundnessOrDLAt_of_soundnessOrRelation B urs.g urs.u urs.w challenge embedding
-    (orchard_verifier_vesta_forking_constraint_adaptive_rewind urs hk vk ps O init s P fixedCols
+    (orchard_verifier_vesta_forking_constraint_adaptive_rewind_legacy urs hk vk ps O init s P fixedCols
       decodeAdvice decodeInstance y gates hpoly deg x hz hg0 hs hξ hquot hgood hencodes hprob)
+
+/-! ## Terminal constraint capstones
+
+These are the issue-18 decoded-column forms of the terminal constraint capstones. They keep the same
+forking/probability ladders, but once the ladder produces the final opened multiopen relation, they consume
+`MultiopenRewindForRelation`: the `x₁`/`x₄` batch rewinds for that same relation witness. The gate side is
+then checked over columns recovered from verifier-opened commitments/evaluations. Legacy free-decode forms
+remain above under `_legacy` names for comparison. -/
+
+section DecodedTerminalCapstones
+
+open Polynomial
+open scoped ENNReal
+open Classical
+
+/-- Bridge-level decoded constraint capstone: the deployed verifier relation is bridged through `hbridge`,
+then the final multiopen opening is decoded into real columns before the circuit gate check. -/
+theorem orchard_verifier_vesta_forking_constraint [Fact (HasseBound Vesta.curve)]
+    [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
+    (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
+    (xEval ξ z blind : Fp) (s : Fin (2 ^ urs.k) → Fp)
+    (Q : Prover Fp VestaG urs.k) (accepts : (Fin urs.k → Fp) → Prop)
+    {numColumns numAdvice numInstance : ℕ}
+    (columnCommitments : Fin numColumns → VestaG) (columnEvals : Fin numColumns → Fp)
+    (adviceIndex : Fin numAdvice → Fin numColumns) (instanceIndex : Fin numInstance → Fin numColumns)
+    (fixedCols : ℕ → Polynomial Fp)
+    (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
+    (hz : z ≠ 0) (hg0 : urs.g 0 ≠ 0)
+    (hξ : ξ * innerProduct s (evalVector urs.k xEval) = 0)
+    (hbridge : ∀ χ, accepts χ ↔ flatAccept Q urs.g (evalVector urs.k xEval) urs.u urs.w z
+        (deployedCommitment urs hk vk ps ch - multiopenValue vk ps ch • urs.g 0 + ξ • commit urs s
+          + (z * 0) • urs.u + blind • urs.w) χ)
+    (hbatch : MultiopenRewindForRelation urs (deployedCommitment urs hk vk ps ch)
+      (evalVector urs.k xEval) (multiopenValue vk ps ch) columnCommitments columnEvals)
+    (hquot : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps ch)
+        (evalVector urs.k xEval) (multiopenValue vk ps ch) a),
+      quotientCheck
+        (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates) hpoly deg x)
+    (hgood : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps ch)
+        (evalVector urs.k xEval) (multiopenValue vk ps ch) a),
+      combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
+        ≠ hpoly * (X ^ deg - 1) →
+      (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
+        - hpoly * (X ^ deg - 1)).eval x ≠ 0)
+    {S : Prop}
+    (hencodes : ∀ a cols,
+      SnarkRelationWithDecodedColumns urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k xEval)
+        (multiopenValue vk ps ch) columnCommitments columnEvals adviceIndex instanceIndex fixedCols
+        y gates hpoly deg a cols → S)
+    (hprob : (kerr (Fintype.card Fp) urs.k : ℝ≥0∞) / Fintype.card (Fin urs.k → Fp)
+        < (PMF.uniformOfFintype (Fin urs.k → Fp)).toOuterMeasure (Finset.univ.filter accepts)) :
+    S ∨ HasNontrivialRelation (F := Fp) urs.g urs.u urs.w := by
+  have hopen := orchard_verifier_vesta_forking_opening urs hk vk ps ch xEval ξ z blind s Q accepts
+    hz hg0 hbridge hprob
+  rw [hξ, sub_zero] at hopen
+  exact decoded_constraint_of_opening_or_relation (urs := urs)
+    (P := deployedCommitment urs hk vk ps ch) (b := evalVector urs.k xEval)
+    (v := multiopenValue vk ps ch) columnCommitments columnEvals adviceIndex instanceIndex fixedCols
+    y gates hpoly deg x hopen hbatch hquot hgood hencodes
+
+/-- AGM/DL wrapper for `orchard_verifier_vesta_forking_constraint`. -/
+theorem orchard_verifier_vesta_forking_constraint_agm_dl [Fact (HasseBound Vesta.curve)]
+    [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
+    (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
+    (xEval ξ z blind : Fp) (s : Fin (2 ^ urs.k) → Fp)
+    (Q : Prover Fp VestaG urs.k) (accepts : (Fin urs.k → Fp) → Prop)
+    {numColumns numAdvice numInstance : ℕ}
+    (columnCommitments : Fin numColumns → VestaG) (columnEvals : Fin numColumns → Fp)
+    (adviceIndex : Fin numAdvice → Fin numColumns) (instanceIndex : Fin numInstance → Fin numColumns)
+    (fixedCols : ℕ → Polynomial Fp)
+    (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
+    (B : VestaG) (challenge : AugmentedIndex (2 ^ urs.k))
+    (embedding : FixedSlotEmbedding (F := Fp) B (augmentedBasis urs.g urs.u urs.w) challenge)
+    (hz : z ≠ 0) (hg0 : urs.g 0 ≠ 0)
+    (hξ : ξ * innerProduct s (evalVector urs.k xEval) = 0)
+    (hbridge : ∀ χ, accepts χ ↔ flatAccept Q urs.g (evalVector urs.k xEval) urs.u urs.w z
+        (deployedCommitment urs hk vk ps ch - multiopenValue vk ps ch • urs.g 0 + ξ • commit urs s
+          + (z * 0) • urs.u + blind • urs.w) χ)
+    (hbatch : MultiopenRewindForRelation urs (deployedCommitment urs hk vk ps ch)
+      (evalVector urs.k xEval) (multiopenValue vk ps ch) columnCommitments columnEvals)
+    (hquot : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps ch)
+        (evalVector urs.k xEval) (multiopenValue vk ps ch) a),
+      quotientCheck
+        (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates) hpoly deg x)
+    (hgood : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps ch)
+        (evalVector urs.k xEval) (multiopenValue vk ps ch) a),
+      combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
+        ≠ hpoly * (X ^ deg - 1) →
+      (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
+        - hpoly * (X ^ deg - 1)).eval x ≠ 0)
+    {S : Prop}
+    (hencodes : ∀ a cols,
+      SnarkRelationWithDecodedColumns urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k xEval)
+        (multiopenValue vk ps ch) columnCommitments columnEvals adviceIndex instanceIndex fixedCols
+        y gates hpoly deg a cols → S)
+    (hprob : (kerr (Fintype.card Fp) urs.k : ℝ≥0∞) / Fintype.card (Fin urs.k → Fp)
+        < (PMF.uniformOfFintype (Fin urs.k → Fp)).toOuterMeasure (Finset.univ.filter accepts)) :
+    S ∨ Nonempty (DiscreteLogRepresentation (F := Fp) B (augmentedBasis urs.g urs.u urs.w challenge))
+      ∨ RelationMissesSlot (F := Fp) urs.g urs.u urs.w challenge :=
+  soundnessOrDLAt_of_soundnessOrRelation B urs.g urs.u urs.w challenge embedding
+    (orchard_verifier_vesta_forking_constraint urs hk vk ps ch xEval ξ z blind s Q accepts
+      columnCommitments columnEvals adviceIndex instanceIndex fixedCols y gates hpoly deg x hz hg0 hξ
+      hbridge hbatch hquot hgood hencodes hprob)
+
+/-- Deployed decoded constraint capstone: the constant-proof deployed probability rung, with the circuit
+side fed by columns recovered from the final multiopen opening. -/
+theorem orchard_verifier_vesta_forking_constraint_deployed [Fact (HasseBound Vesta.curve)]
+    [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
+    (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
+    (s : Fin (2 ^ urs.k) → Fp)
+    {numColumns numAdvice numInstance : ℕ}
+    (columnCommitments : Fin numColumns → VestaG) (columnEvals : Fin numColumns → Fp)
+    (adviceIndex : Fin numAdvice → Fin numColumns) (instanceIndex : Fin numInstance → Fin numColumns)
+    (fixedCols : ℕ → Polynomial Fp)
+    (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
+    (hz : ch.z ≠ 0) (hg0 : urs.g 0 ≠ 0) (hs : commit urs s = ps.ipaS)
+    (hξ : ch.xi * innerProduct s (evalVector urs.k ch.x3) = 0)
+    (hbatch : MultiopenRewindForRelation urs (deployedCommitment urs hk vk ps ch)
+      (evalVector urs.k ch.x3) (multiopenValue vk ps ch) columnCommitments columnEvals)
+    (hquot : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps ch)
+        (evalVector urs.k ch.x3) (multiopenValue vk ps ch) a),
+      quotientCheck
+        (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates) hpoly deg x)
+    (hgood : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps ch)
+        (evalVector urs.k ch.x3) (multiopenValue vk ps ch) a),
+      combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
+        ≠ hpoly * (X ^ deg - 1) →
+      (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
+        - hpoly * (X ^ deg - 1)).eval x ≠ 0)
+    {S : Prop}
+    (hencodes : ∀ a cols,
+      SnarkRelationWithDecodedColumns urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k ch.x3)
+        (multiopenValue vk ps ch) columnCommitments columnEvals adviceIndex instanceIndex fixedCols
+        y gates hpoly deg a cols → S)
+    (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
+        < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
+            (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk ps
+              {ch with ipaRound := χ}))) :
+    S ∨ HasNontrivialRelation (F := Fp) urs.g urs.u urs.w := by
+  have hopen := orchard_verifier_vesta_forking_opening_deployed urs hk vk ps ch s hz hg0 hs hprob
+  rw [hξ, sub_zero] at hopen
+  exact decoded_constraint_of_opening_or_relation (urs := urs)
+    (P := deployedCommitment urs hk vk ps ch) (b := evalVector urs.k ch.x3)
+    (v := multiopenValue vk ps ch) columnCommitments columnEvals adviceIndex instanceIndex fixedCols
+    y gates hpoly deg x hopen hbatch hquot hgood hencodes
+
+/-- AGM/DL wrapper for `orchard_verifier_vesta_forking_constraint_deployed`. -/
+theorem orchard_verifier_vesta_forking_constraint_deployed_agm_dl [Fact (HasseBound Vesta.curve)]
+    [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
+    (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
+    (s : Fin (2 ^ urs.k) → Fp)
+    {numColumns numAdvice numInstance : ℕ}
+    (columnCommitments : Fin numColumns → VestaG) (columnEvals : Fin numColumns → Fp)
+    (adviceIndex : Fin numAdvice → Fin numColumns) (instanceIndex : Fin numInstance → Fin numColumns)
+    (fixedCols : ℕ → Polynomial Fp)
+    (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
+    (B : VestaG) (challenge : AugmentedIndex (2 ^ urs.k))
+    (embedding : FixedSlotEmbedding (F := Fp) B (augmentedBasis urs.g urs.u urs.w) challenge)
+    (hz : ch.z ≠ 0) (hg0 : urs.g 0 ≠ 0) (hs : commit urs s = ps.ipaS)
+    (hξ : ch.xi * innerProduct s (evalVector urs.k ch.x3) = 0)
+    (hbatch : MultiopenRewindForRelation urs (deployedCommitment urs hk vk ps ch)
+      (evalVector urs.k ch.x3) (multiopenValue vk ps ch) columnCommitments columnEvals)
+    (hquot : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps ch)
+        (evalVector urs.k ch.x3) (multiopenValue vk ps ch) a),
+      quotientCheck
+        (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates) hpoly deg x)
+    (hgood : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps ch)
+        (evalVector urs.k ch.x3) (multiopenValue vk ps ch) a),
+      combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
+        ≠ hpoly * (X ^ deg - 1) →
+      (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
+        - hpoly * (X ^ deg - 1)).eval x ≠ 0)
+    {S : Prop}
+    (hencodes : ∀ a cols,
+      SnarkRelationWithDecodedColumns urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k ch.x3)
+        (multiopenValue vk ps ch) columnCommitments columnEvals adviceIndex instanceIndex fixedCols
+        y gates hpoly deg a cols → S)
+    (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
+        < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
+            (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk ps
+              {ch with ipaRound := χ}))) :
+    S ∨ Nonempty (DiscreteLogRepresentation (F := Fp) B (augmentedBasis urs.g urs.u urs.w challenge))
+      ∨ RelationMissesSlot (F := Fp) urs.g urs.u urs.w challenge :=
+  soundnessOrDLAt_of_soundnessOrRelation B urs.g urs.u urs.w challenge embedding
+    (orchard_verifier_vesta_forking_constraint_deployed urs hk vk ps ch s columnCommitments
+      columnEvals adviceIndex instanceIndex fixedCols y gates hpoly deg x hz hg0 hs hξ hbatch hquot hgood
+      hencodes hprob)
+
+/-- Adaptive-strategy decoded constraint capstone, with the staged prover accept event and decoded columns
+for the final multiopen relation. -/
+theorem orchard_verifier_vesta_forking_constraint_adaptive [Fact (HasseBound Vesta.curve)]
+    [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
+    (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
+    (s : Fin (2 ^ urs.k) → Fp) (P : Prover Fp VestaG shape.k)
+    {numColumns numAdvice numInstance : ℕ}
+    (columnCommitments : Fin numColumns → VestaG) (columnEvals : Fin numColumns → Fp)
+    (adviceIndex : Fin numAdvice → Fin numColumns) (instanceIndex : Fin numInstance → Fin numColumns)
+    (fixedCols : ℕ → Polynomial Fp)
+    (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
+    (hz : ch.z ≠ 0) (hg0 : urs.g 0 ≠ 0) (hs : commit urs s = ps.ipaS)
+    (hξ : ch.xi * innerProduct s (evalVector urs.k ch.x3) = 0)
+    (hbatch : MultiopenRewindForRelation urs (deployedCommitment urs hk vk ps ch)
+      (evalVector urs.k ch.x3) (multiopenValue vk ps ch) columnCommitments columnEvals)
+    (hquot : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps ch)
+        (evalVector urs.k ch.x3) (multiopenValue vk ps ch) a),
+      quotientCheck
+        (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates) hpoly deg x)
+    (hgood : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps ch)
+        (evalVector urs.k ch.x3) (multiopenValue vk ps ch) a),
+      combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
+        ≠ hpoly * (X ^ deg - 1) →
+      (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
+        - hpoly * (X ^ deg - 1)).eval x ≠ 0)
+    {S : Prop}
+    (hencodes : ∀ a cols,
+      SnarkRelationWithDecodedColumns urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k ch.x3)
+        (multiopenValue vk ps ch) columnCommitments columnEvals adviceIndex instanceIndex fixedCols
+        y gates hpoly deg a cols → S)
+    (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
+        < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
+            (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk
+              (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2)
+              {ch with ipaRound := χ}))) :
+    S ∨ HasNontrivialRelation (F := Fp) urs.g urs.u urs.w := by
+  have hopen := orchard_verifier_vesta_forking_opening_adaptive urs hk vk ps ch s P hz hg0 hs hprob
+  rw [hξ, sub_zero] at hopen
+  exact decoded_constraint_of_opening_or_relation (urs := urs)
+    (P := deployedCommitment urs hk vk ps ch) (b := evalVector urs.k ch.x3)
+    (v := multiopenValue vk ps ch) columnCommitments columnEvals adviceIndex instanceIndex fixedCols
+    y gates hpoly deg x hopen hbatch hquot hgood hencodes
+
+/-- AGM/DL wrapper for `orchard_verifier_vesta_forking_constraint_adaptive`. -/
+theorem orchard_verifier_vesta_forking_constraint_adaptive_agm_dl [Fact (HasseBound Vesta.curve)]
+    [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
+    (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
+    (s : Fin (2 ^ urs.k) → Fp) (P : Prover Fp VestaG shape.k)
+    {numColumns numAdvice numInstance : ℕ}
+    (columnCommitments : Fin numColumns → VestaG) (columnEvals : Fin numColumns → Fp)
+    (adviceIndex : Fin numAdvice → Fin numColumns) (instanceIndex : Fin numInstance → Fin numColumns)
+    (fixedCols : ℕ → Polynomial Fp)
+    (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
+    (B : VestaG) (challenge : AugmentedIndex (2 ^ urs.k))
+    (embedding : FixedSlotEmbedding (F := Fp) B (augmentedBasis urs.g urs.u urs.w) challenge)
+    (hz : ch.z ≠ 0) (hg0 : urs.g 0 ≠ 0) (hs : commit urs s = ps.ipaS)
+    (hξ : ch.xi * innerProduct s (evalVector urs.k ch.x3) = 0)
+    (hbatch : MultiopenRewindForRelation urs (deployedCommitment urs hk vk ps ch)
+      (evalVector urs.k ch.x3) (multiopenValue vk ps ch) columnCommitments columnEvals)
+    (hquot : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps ch)
+        (evalVector urs.k ch.x3) (multiopenValue vk ps ch) a),
+      quotientCheck
+        (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates) hpoly deg x)
+    (hgood : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps ch)
+        (evalVector urs.k ch.x3) (multiopenValue vk ps ch) a),
+      combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
+        ≠ hpoly * (X ^ deg - 1) →
+      (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
+        - hpoly * (X ^ deg - 1)).eval x ≠ 0)
+    {S : Prop}
+    (hencodes : ∀ a cols,
+      SnarkRelationWithDecodedColumns urs (deployedCommitment urs hk vk ps ch) (evalVector urs.k ch.x3)
+        (multiopenValue vk ps ch) columnCommitments columnEvals adviceIndex instanceIndex fixedCols
+        y gates hpoly deg a cols → S)
+    (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
+        < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
+            (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk
+              (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2)
+              {ch with ipaRound := χ}))) :
+    S ∨ Nonempty (DiscreteLogRepresentation (F := Fp) B (augmentedBasis urs.g urs.u urs.w challenge))
+      ∨ RelationMissesSlot (F := Fp) urs.g urs.u urs.w challenge :=
+  soundnessOrDLAt_of_soundnessOrRelation B urs.g urs.u urs.w challenge embedding
+    (orchard_verifier_vesta_forking_constraint_adaptive urs hk vk ps ch s P columnCommitments
+      columnEvals adviceIndex instanceIndex fixedCols y gates hpoly deg x hz hg0 hs hξ hbatch hquot hgood
+      hencodes hprob)
+
+/-- Reprogrammed-oracle decoded constraint capstone for the constant-proof rung. -/
+theorem orchard_verifier_vesta_forking_constraint_rewind [Fact (HasseBound Vesta.curve)]
+    [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
+    (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG)
+    (O : List (TranscriptElt Fp VestaG) → Fp) (init : List (TranscriptElt Fp VestaG))
+    (s : Fin (2 ^ urs.k) → Fp)
+    {numColumns numAdvice numInstance : ℕ}
+    (columnCommitments : Fin numColumns → VestaG) (columnEvals : Fin numColumns → Fp)
+    (adviceIndex : Fin numAdvice → Fin numColumns) (instanceIndex : Fin numInstance → Fin numColumns)
+    (fixedCols : ℕ → Polynomial Fp)
+    (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
+    (hz : (roChallenges O init ps).z ≠ 0) (hg0 : urs.g 0 ≠ 0) (hs : commit urs s = ps.ipaS)
+    (hξ : (roChallenges O init ps).xi
+        * innerProduct s (evalVector urs.k (roChallenges O init ps).x3) = 0)
+    (hbatch : MultiopenRewindForRelation urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
+      (evalVector urs.k (roChallenges O init ps).x3) (multiopenValue vk ps (roChallenges O init ps))
+      columnCommitments columnEvals)
+    (hquot : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
+        (evalVector urs.k (roChallenges O init ps).x3) (multiopenValue vk ps (roChallenges O init ps)) a),
+      quotientCheck
+        (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates) hpoly deg x)
+    (hgood : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
+        (evalVector urs.k (roChallenges O init ps).x3) (multiopenValue vk ps (roChallenges O init ps)) a),
+      combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
+        ≠ hpoly * (X ^ deg - 1) →
+      (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
+        - hpoly * (X ^ deg - 1)).eval x ≠ 0)
+    {S : Prop}
+    (hencodes : ∀ a cols,
+      SnarkRelationWithDecodedColumns urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
+        (evalVector urs.k (roChallenges O init ps).x3) (multiopenValue vk ps (roChallenges O init ps))
+        columnCommitments columnEvals adviceIndex instanceIndex fixedCols y gates hpoly deg a cols → S)
+    (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
+        < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
+            (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk ps
+              (roChallenges (reprogramRounds O init ps χ) init ps)))) :
+    S ∨ HasNontrivialRelation (F := Fp) urs.g urs.u urs.w := by
+  have hopen := orchard_verifier_vesta_forking_opening_rewind urs hk vk ps O init s hz hg0 hs hprob
+  rw [hξ, sub_zero] at hopen
+  exact decoded_constraint_of_opening_or_relation (urs := urs)
+    (P := deployedCommitment urs hk vk ps (roChallenges O init ps))
+    (b := evalVector urs.k (roChallenges O init ps).x3)
+    (v := multiopenValue vk ps (roChallenges O init ps)) columnCommitments columnEvals adviceIndex
+    instanceIndex fixedCols y gates hpoly deg x hopen hbatch hquot hgood hencodes
+
+/-- AGM/DL wrapper for `orchard_verifier_vesta_forking_constraint_rewind`. -/
+theorem orchard_verifier_vesta_forking_constraint_rewind_agm_dl [Fact (HasseBound Vesta.curve)]
+    [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
+    (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG)
+    (O : List (TranscriptElt Fp VestaG) → Fp) (init : List (TranscriptElt Fp VestaG))
+    (s : Fin (2 ^ urs.k) → Fp)
+    {numColumns numAdvice numInstance : ℕ}
+    (columnCommitments : Fin numColumns → VestaG) (columnEvals : Fin numColumns → Fp)
+    (adviceIndex : Fin numAdvice → Fin numColumns) (instanceIndex : Fin numInstance → Fin numColumns)
+    (fixedCols : ℕ → Polynomial Fp)
+    (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
+    (B : VestaG) (challenge : AugmentedIndex (2 ^ urs.k))
+    (embedding : FixedSlotEmbedding (F := Fp) B (augmentedBasis urs.g urs.u urs.w) challenge)
+    (hz : (roChallenges O init ps).z ≠ 0) (hg0 : urs.g 0 ≠ 0) (hs : commit urs s = ps.ipaS)
+    (hξ : (roChallenges O init ps).xi
+        * innerProduct s (evalVector urs.k (roChallenges O init ps).x3) = 0)
+    (hbatch : MultiopenRewindForRelation urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
+      (evalVector urs.k (roChallenges O init ps).x3) (multiopenValue vk ps (roChallenges O init ps))
+      columnCommitments columnEvals)
+    (hquot : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
+        (evalVector urs.k (roChallenges O init ps).x3) (multiopenValue vk ps (roChallenges O init ps)) a),
+      quotientCheck
+        (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates) hpoly deg x)
+    (hgood : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
+        (evalVector urs.k (roChallenges O init ps).x3) (multiopenValue vk ps (roChallenges O init ps)) a),
+      combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
+        ≠ hpoly * (X ^ deg - 1) →
+      (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
+        - hpoly * (X ^ deg - 1)).eval x ≠ 0)
+    {S : Prop}
+    (hencodes : ∀ a cols,
+      SnarkRelationWithDecodedColumns urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
+        (evalVector urs.k (roChallenges O init ps).x3) (multiopenValue vk ps (roChallenges O init ps))
+        columnCommitments columnEvals adviceIndex instanceIndex fixedCols y gates hpoly deg a cols → S)
+    (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
+        < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
+            (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk ps
+              (roChallenges (reprogramRounds O init ps χ) init ps)))) :
+    S ∨ Nonempty (DiscreteLogRepresentation (F := Fp) B (augmentedBasis urs.g urs.u urs.w challenge))
+      ∨ RelationMissesSlot (F := Fp) urs.g urs.u urs.w challenge :=
+  soundnessOrDLAt_of_soundnessOrRelation B urs.g urs.u urs.w challenge embedding
+    (orchard_verifier_vesta_forking_constraint_rewind urs hk vk ps O init s columnCommitments
+      columnEvals adviceIndex instanceIndex fixedCols y gates hpoly deg x hz hg0 hs hξ hbatch hquot hgood
+      hencodes hprob)
+
+/-- Attack-event decoded constraint capstone: adaptive strategy plus reprogrammed-oracle runs, with decoded
+columns recovered from the final multiopen relation. -/
+theorem orchard_verifier_vesta_forking_constraint_adaptive_rewind [Fact (HasseBound Vesta.curve)]
+    [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
+    (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG)
+    (O : List (TranscriptElt Fp VestaG) → Fp) (init : List (TranscriptElt Fp VestaG))
+    (s : Fin (2 ^ urs.k) → Fp) (P : Prover Fp VestaG shape.k)
+    {numColumns numAdvice numInstance : ℕ}
+    (columnCommitments : Fin numColumns → VestaG) (columnEvals : Fin numColumns → Fp)
+    (adviceIndex : Fin numAdvice → Fin numColumns) (instanceIndex : Fin numInstance → Fin numColumns)
+    (fixedCols : ℕ → Polynomial Fp)
+    (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
+    (hz : (roChallenges O init ps).z ≠ 0) (hg0 : urs.g 0 ≠ 0) (hs : commit urs s = ps.ipaS)
+    (hξ : (roChallenges O init ps).xi
+        * innerProduct s (evalVector urs.k (roChallenges O init ps).x3) = 0)
+    (hbatch : MultiopenRewindForRelation urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
+      (evalVector urs.k (roChallenges O init ps).x3) (multiopenValue vk ps (roChallenges O init ps))
+      columnCommitments columnEvals)
+    (hquot : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
+        (evalVector urs.k (roChallenges O init ps).x3) (multiopenValue vk ps (roChallenges O init ps)) a),
+      quotientCheck
+        (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates) hpoly deg x)
+    (hgood : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
+        (evalVector urs.k (roChallenges O init ps).x3) (multiopenValue vk ps (roChallenges O init ps)) a),
+      combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
+        ≠ hpoly * (X ^ deg - 1) →
+      (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
+        - hpoly * (X ^ deg - 1)).eval x ≠ 0)
+    {S : Prop}
+    (hencodes : ∀ a cols,
+      SnarkRelationWithDecodedColumns urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
+        (evalVector urs.k (roChallenges O init ps).x3) (multiopenValue vk ps (roChallenges O init ps))
+        columnCommitments columnEvals adviceIndex instanceIndex fixedCols y gates hpoly deg a cols → S)
+    (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
+        < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
+            (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk
+              (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2)
+              (roChallenges
+                (reprogramRounds O init
+                  (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2) χ)
+                init
+                (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2))))) :
+    S ∨ HasNontrivialRelation (F := Fp) urs.g urs.u urs.w := by
+  have hopen := orchard_verifier_vesta_forking_opening_adaptive_rewind urs hk vk ps O init s P
+    hz hg0 hs hprob
+  rw [hξ, sub_zero] at hopen
+  exact decoded_constraint_of_opening_or_relation (urs := urs)
+    (P := deployedCommitment urs hk vk ps (roChallenges O init ps))
+    (b := evalVector urs.k (roChallenges O init ps).x3)
+    (v := multiopenValue vk ps (roChallenges O init ps)) columnCommitments columnEvals adviceIndex
+    instanceIndex fixedCols y gates hpoly deg x hopen hbatch hquot hgood hencodes
+
+/-- AGM/DL wrapper for `orchard_verifier_vesta_forking_constraint_adaptive_rewind`. -/
+theorem orchard_verifier_vesta_forking_constraint_adaptive_rewind_agm_dl
+    [Fact (HasseBound Vesta.curve)] [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape}
+    (urs : URS VestaG) (hk : shape.k = urs.k) (vk : VerifyingKey shape Fp VestaG)
+    (ps : ProofString shape Fp VestaG)
+    (O : List (TranscriptElt Fp VestaG) → Fp) (init : List (TranscriptElt Fp VestaG))
+    (s : Fin (2 ^ urs.k) → Fp) (P : Prover Fp VestaG shape.k)
+    {numColumns numAdvice numInstance : ℕ}
+    (columnCommitments : Fin numColumns → VestaG) (columnEvals : Fin numColumns → Fp)
+    (adviceIndex : Fin numAdvice → Fin numColumns) (instanceIndex : Fin numInstance → Fin numColumns)
+    (fixedCols : ℕ → Polynomial Fp)
+    (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
+    (B : VestaG) (challenge : AugmentedIndex (2 ^ urs.k))
+    (embedding : FixedSlotEmbedding (F := Fp) B (augmentedBasis urs.g urs.u urs.w) challenge)
+    (hz : (roChallenges O init ps).z ≠ 0) (hg0 : urs.g 0 ≠ 0) (hs : commit urs s = ps.ipaS)
+    (hξ : (roChallenges O init ps).xi
+        * innerProduct s (evalVector urs.k (roChallenges O init ps).x3) = 0)
+    (hbatch : MultiopenRewindForRelation urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
+      (evalVector urs.k (roChallenges O init ps).x3) (multiopenValue vk ps (roChallenges O init ps))
+      columnCommitments columnEvals)
+    (hquot : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
+        (evalVector urs.k (roChallenges O init ps).x3) (multiopenValue vk ps (roChallenges O init ps)) a),
+      quotientCheck
+        (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates) hpoly deg x)
+    (hgood : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
+        (evalVector urs.k (roChallenges O init ps).x3) (multiopenValue vk ps (roChallenges O init ps)) a),
+      combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
+        ≠ hpoly * (X ^ deg - 1) →
+      (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
+        - hpoly * (X ^ deg - 1)).eval x ≠ 0)
+    {S : Prop}
+    (hencodes : ∀ a cols,
+      SnarkRelationWithDecodedColumns urs (deployedCommitment urs hk vk ps (roChallenges O init ps))
+        (evalVector urs.k (roChallenges O init ps).x3) (multiopenValue vk ps (roChallenges O init ps))
+        columnCommitments columnEvals adviceIndex instanceIndex fixedCols y gates hpoly deg a cols → S)
+    (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
+        < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
+            (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk
+              (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2)
+              (roChallenges
+                (reprogramRounds O init
+                  (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2) χ)
+                init
+                (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2))))) :
+    S ∨ Nonempty (DiscreteLogRepresentation (F := Fp) B (augmentedBasis urs.g urs.u urs.w challenge))
+      ∨ RelationMissesSlot (F := Fp) urs.g urs.u urs.w challenge :=
+  soundnessOrDLAt_of_soundnessOrRelation B urs.g urs.u urs.w challenge embedding
+    (orchard_verifier_vesta_forking_constraint_adaptive_rewind urs hk vk ps O init s P
+      columnCommitments columnEvals adviceIndex instanceIndex fixedCols y gates hpoly deg x hz hg0 hs hξ
+      hbatch hquot hgood hencodes hprob)
+
+end DecodedTerminalCapstones
 
 end Zcash.Snark

--- a/Zcash/Snark/Soundness/Vesta.lean
+++ b/Zcash/Snark/Soundness/Vesta.lean
@@ -204,6 +204,46 @@ theorem orchard_verifier_vesta_decoded_constraint_reduction [Fact (HasseBound Ve
   orchard_verifier_deployed_decoded_constraint_reduction urs hk vk ps ch columnCommitments columnEvals
     adviceIndex instanceIndex fixedCols y gates hpoly deg x hz haccepts hFS hbatch hquot hgood hencodes
 
+open Polynomial in
+/-- Vesta specialization of
+`orchard_verifier_deployed_decoded_constraint_reduction_of_multiopen_forking`: the issue-18 bridge consumes
+one explicit multiopen-forking output carrying both the deployed IPA tree and the decoded-column batch data
+for that tree. -/
+theorem orchard_verifier_vesta_decoded_constraint_reduction_of_multiopen_forking
+    [Fact (HasseBound Vesta.curve)] [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape}
+    (urs : URS VestaG) (hk : shape.k = urs.k) (vk : VerifyingKey shape Fp VestaG)
+    (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
+    {b : Fin (2 ^ urs.k) → Fp} {z blind : Fp}
+    {numColumns numAdvice numInstance : ℕ}
+    (columnCommitments : Fin numColumns → VestaG) (columnEvals : Fin numColumns → Fp)
+    (adviceIndex : Fin numAdvice → Fin numColumns) (instanceIndex : Fin numInstance → Fin numColumns)
+    (fixedCols : ℕ → Polynomial Fp)
+    (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
+    (hz : z ≠ 0)
+    (out : MultiopenForkingOutput urs hk vk ps ch b z blind columnCommitments columnEvals)
+    (hquot : quotientCheck
+      (combineGates fixedCols
+        (selectedPolys (decodedCols out.rewind.batchOpenings) adviceIndex)
+        (selectedPolys (decodedCols out.rewind.batchOpenings) instanceIndex) y gates)
+      hpoly deg x)
+    (hgood : combineGates fixedCols
+          (selectedPolys (decodedCols out.rewind.batchOpenings) adviceIndex)
+          (selectedPolys (decodedCols out.rewind.batchOpenings) instanceIndex) y gates
+        ≠ hpoly * (X ^ deg - 1) →
+      (combineGates fixedCols
+          (selectedPolys (decodedCols out.rewind.batchOpenings) adviceIndex)
+          (selectedPolys (decodedCols out.rewind.batchOpenings) instanceIndex) y gates
+        - hpoly * (X ^ deg - 1)).eval x ≠ 0)
+    {S : Prop}
+    (hencodes : ∀ a cols,
+      SnarkRelationWithDecodedColumns urs (deployedCommitment urs hk vk ps ch) b
+        (multiopenValue vk ps ch) columnCommitments columnEvals adviceIndex instanceIndex fixedCols
+        y gates hpoly deg a cols → S) :
+    S ∨ HasNontrivialRelation (F := Fp) urs.g urs.u urs.w :=
+  orchard_verifier_deployed_decoded_constraint_reduction_of_multiopen_forking urs hk vk ps ch
+    columnCommitments columnEvals adviceIndex instanceIndex fixedCols y gates hpoly deg x hz out
+    hquot hgood hencodes
+
 /-- The powers evaluation vector's leading entry is `1` (`b 0 = x⁰ = 1`), discharging the IPA's `hb0`
 structural fact for the concrete deployed `b = evalVector`. -/
 theorem evalVector_zero {F : Type*} [Field F] (k : ℕ) (x : F) : evalVector k x 0 = 1 := by

--- a/Zcash/Snark/Soundness/Vesta.lean
+++ b/Zcash/Snark/Soundness/Vesta.lean
@@ -154,9 +154,10 @@ open Polynomial in
 decoded into real columns. This is the Vesta specialization of
 `orchard_verifier_deployed_decoded_constraint_reduction`: the opening is still a binding reduction, but
 the gate side no longer asks for arbitrary witness-indexed decode functions. Instead, `hbatch` supplies the
-rewound batched openings containing the extracted witness, `batch_open_soundV` recovers the column
-polynomials, and `hquot`/`hgood` are stated for the canonical decode of the supplied batch
-(`decodedCols`; see the `MultiopenDecode` scope section).
+multiopen-rewinding output for the clean accepted IPA transcript, `batch_open_soundV` recovers the column
+polynomials, and `hquot`/`hgood` are stated for the canonical decode of the supplied batch (`decodedCols`;
+see the `MultiopenDecode` scope section). The batch's witness is identified with the transcript's own
+extracted witness, a mismatch yielding the relation branch.
 
 This is the endpoint to use for the issue #18 witness-to-columns bridge. The older
 `orchard_verifier_vesta_constraint_reduction` remains as a legacy, compatibility-shaped capstone. -/
@@ -173,20 +174,26 @@ theorem orchard_verifier_vesta_decoded_constraint_reduction [Fact (HasseBound Ve
     (hz : z ≠ 0)
     (haccepts : DeployedAccepts urs hk vk ps ch)
     (hFS : FiatShamirTree urs hk vk ps ch b z blind)
-    (hbatch : ∀ a, IpaRelation urs (deployedCommitment urs hk vk ps ch) b (multiopenValue vk ps ch) a →
-      BatchOpeningsForWitness urs b columnCommitments columnEvals a)
-    (hquot : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps ch) b
-        (multiopenValue vk ps ch) a),
+    (hbatch : ∀ t, IpaAcceptV urs.g b (deployedCommitment urs hk vk ps ch)
+      (multiopenValue vk ps ch) t →
+      MultiopenRewindBatch urs (deployedCommitment urs hk vk ps ch) b (multiopenValue vk ps ch)
+        columnCommitments columnEvals t)
+    (hquot : ∀ t (hacc : IpaAcceptV urs.g b (deployedCommitment urs hk vk ps ch)
+        (multiopenValue vk ps ch) t),
       quotientCheck
-        (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
-          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates) hpoly deg x)
-    (hgood : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps ch) b
-        (multiopenValue vk ps ch) a),
-      combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
-          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
+        (combineGates fixedCols
+          (selectedPolys (decodedCols (hbatch t hacc).batchOpenings) adviceIndex)
+          (selectedPolys (decodedCols (hbatch t hacc).batchOpenings) instanceIndex) y gates)
+        hpoly deg x)
+    (hgood : ∀ t (hacc : IpaAcceptV urs.g b (deployedCommitment urs hk vk ps ch)
+        (multiopenValue vk ps ch) t),
+      combineGates fixedCols
+          (selectedPolys (decodedCols (hbatch t hacc).batchOpenings) adviceIndex)
+          (selectedPolys (decodedCols (hbatch t hacc).batchOpenings) instanceIndex) y gates
         ≠ hpoly * (X ^ deg - 1) →
-      (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
-          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
+      (combineGates fixedCols
+          (selectedPolys (decodedCols (hbatch t hacc).batchOpenings) adviceIndex)
+          (selectedPolys (decodedCols (hbatch t hacc).batchOpenings) instanceIndex) y gates
         - hpoly * (X ^ deg - 1)).eval x ≠ 0)
     {S : Prop}
     (hencodes : ∀ a cols,

--- a/Zcash/Snark/Soundness/Vesta.lean
+++ b/Zcash/Snark/Soundness/Vesta.lean
@@ -94,8 +94,8 @@ specialization). Named assumptions:
 the residual bridge (`hFS`, superseded by the forking path), `z ≠ 0`, the circuit side (`hcirc`), the Hasse bound (`Fact (HasseBound Vesta.curve)`), and VK-correctness
 (`hencodes`). `hcirc` quantifies over every mathematical opening of the pinned `(P, b, v)` and is
 unsatisfiable at Vesta for any `circuitSat` that genuinely reads the witness — see the caveat on
-`orchard_verifier_deployed_opening_reduction`, and issue #18 for the restatement over the extracted
-witness. -/
+`orchard_verifier_deployed_opening_reduction`; use the decoded constraint capstone below for the
+witness-to-columns restatement. -/
 theorem orchard_verifier_vesta_opening_reduction [Fact (HasseBound Vesta.curve)] [DecidableEq VestaG] [Inhabited VestaG]
     {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k) (vk : VerifyingKey shape Fp VestaG)
     (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
@@ -125,8 +125,8 @@ assumptions: the residual bridge (`hFS`, superseded by the forking path), `z ≠
 (`hgood`), the Hasse bound (`Fact (HasseBound Vesta.curve)`), and VK-correctness (`hencodes`).
 `hquot`/`hgood` quantify over every mathematical opening of the pinned `(P, b, v)` and are unsatisfiable
 at Vesta for any decode that genuinely reads columns out of the witness — see the caveat on
-`orchard_verifier_deployed_constraint_reduction`, and issue #18 for the restatement over the extracted
-witness. -/
+`orchard_verifier_deployed_constraint_reduction`; use
+`orchard_verifier_vesta_decoded_constraint_reduction` for the witness-to-columns restatement. -/
 theorem orchard_verifier_vesta_constraint_reduction [Fact (HasseBound Vesta.curve)] [DecidableEq VestaG] [Inhabited VestaG]
     {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k) (vk : VerifyingKey shape Fp VestaG)
     (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
@@ -148,6 +148,54 @@ theorem orchard_verifier_vesta_constraint_reduction [Fact (HasseBound Vesta.curv
     S ∨ HasNontrivialRelation (F := Fp) urs.g urs.u urs.w :=
   orchard_verifier_deployed_constraint_reduction urs hk vk ps ch fixedCols decodeAdvice decodeInstance y gates
     hpoly deg x hz haccepts hFS hquot hgood hencodes
+
+open Polynomial in
+/-- The deployed Orchard verifier opening and constraint over Vesta, with the multiopen witness first
+decoded into real columns. This is the Vesta specialization of
+`orchard_verifier_deployed_decoded_constraint_reduction`: the opening is still a binding reduction, but
+the gate side no longer asks for arbitrary witness-indexed decode functions. Instead, `hbatch` supplies the
+rewound batched openings containing the extracted witness, `batch_open_soundV` recovers the column
+polynomials, and `hquot`/`hgood` are stated for the canonical decode of the supplied batch
+(`decodedCols`; see the `MultiopenDecode` scope section).
+
+This is the endpoint to use for the issue #18 witness-to-columns bridge. The older
+`orchard_verifier_vesta_constraint_reduction` remains as a legacy, compatibility-shaped capstone. -/
+theorem orchard_verifier_vesta_decoded_constraint_reduction [Fact (HasseBound Vesta.curve)]
+    [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG)
+    (hk : shape.k = urs.k) (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG)
+    (ch : Challenges shape.k Fp)
+    {b : Fin (2 ^ urs.k) → Fp} {z blind : Fp}
+    {numColumns numAdvice numInstance : ℕ}
+    (columnCommitments : Fin numColumns → VestaG) (columnEvals : Fin numColumns → Fp)
+    (adviceIndex : Fin numAdvice → Fin numColumns) (instanceIndex : Fin numInstance → Fin numColumns)
+    (fixedCols : ℕ → Polynomial Fp)
+    (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
+    (hz : z ≠ 0)
+    (haccepts : DeployedAccepts urs hk vk ps ch)
+    (hFS : FiatShamirTree urs hk vk ps ch b z blind)
+    (hbatch : ∀ a, IpaRelation urs (deployedCommitment urs hk vk ps ch) b (multiopenValue vk ps ch) a →
+      BatchOpeningsForWitness urs b columnCommitments columnEvals a)
+    (hquot : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps ch) b
+        (multiopenValue vk ps ch) a),
+      quotientCheck
+        (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates) hpoly deg x)
+    (hgood : ∀ a (hrel : IpaRelation urs (deployedCommitment urs hk vk ps ch) b
+        (multiopenValue vk ps ch) a),
+      combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
+        ≠ hpoly * (X ^ deg - 1) →
+      (combineGates fixedCols (selectedPolys (decodedCols (hbatch a hrel)) adviceIndex)
+          (selectedPolys (decodedCols (hbatch a hrel)) instanceIndex) y gates
+        - hpoly * (X ^ deg - 1)).eval x ≠ 0)
+    {S : Prop}
+    (hencodes : ∀ a cols,
+      SnarkRelationWithDecodedColumns urs (deployedCommitment urs hk vk ps ch) b
+        (multiopenValue vk ps ch) columnCommitments columnEvals adviceIndex instanceIndex fixedCols
+        y gates hpoly deg a cols → S) :
+    S ∨ HasNontrivialRelation (F := Fp) urs.g urs.u urs.w :=
+  orchard_verifier_deployed_decoded_constraint_reduction urs hk vk ps ch columnCommitments columnEvals
+    adviceIndex instanceIndex fixedCols y gates hpoly deg x hz haccepts hFS hbatch hquot hgood hencodes
 
 /-- The powers evaluation vector's leading entry is `1` (`b 0 = x⁰ = 1`), discharging the IPA's `hb0`
 structural fact for the concrete deployed `b = evalVector`. -/
@@ -302,7 +350,7 @@ discharged. The original `FiatShamirTree` reductions
 computational DLR/AGM layer outside Lean (`Soundness.AGM` records only its deterministic fixed-slot
 core). `hquot`/`hgood` retain the ∀-openings shape —
 unsatisfiable at Vesta for any decode that genuinely reads the witness (see
-`orchard_verifier_deployed_constraint_reduction`'s caveat; issue #18). -/
+`orchard_verifier_deployed_constraint_reduction`'s caveat, and the decoded capstone above). -/
 theorem orchard_verifier_vesta_forking_constraint [Fact (HasseBound Vesta.curve)] [DecidableEq VestaG]
     [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
@@ -478,7 +526,8 @@ the *fixed* proof's accept set over all round-challenge vectors, not the Fiat–
 adaptive form, use `orchard_verifier_vesta_forking_constraint_adaptive`; for the same statement over
 reprogrammed-oracle runs, use `orchard_verifier_vesta_forking_constraint_adaptive_rewind`. `hquot`/`hgood`
 retain the ∀-openings shape — unsatisfiable at Vesta for any decode that genuinely
-reads the witness (see `orchard_verifier_deployed_constraint_reduction`'s caveat; issue #18). -/
+reads the witness (see `orchard_verifier_deployed_constraint_reduction`'s caveat, and the decoded
+capstone above). -/
 theorem orchard_verifier_vesta_forking_constraint_deployed [Fact (HasseBound Vesta.curve)] [DecidableEq VestaG]
     [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
@@ -575,7 +624,7 @@ malicious blinder, `blinder_value_recovery_badSet`). Residual: the execution-sem
 random-oracle uniformity axiom in `hprob`, and the structural witnesses; the static-dichotomy caveat does not
 apply at this rung. Issue #23's transcript-ordering and reprogramming content is discharged by the staged
 rewinding capstones below. `hquot`/`hgood` retain the ∀-openings shape — unsatisfiable at Vesta for any decode
-that genuinely reads the witness (issue #18). -/
+that genuinely reads the witness; the decoded capstone above is the witness-to-columns endpoint. -/
 theorem orchard_verifier_vesta_forking_constraint_adaptive [Fact (HasseBound Vesta.curve)]
     [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
@@ -679,7 +728,8 @@ open Classical in
 /-- The constraint companion of `orchard_verifier_vesta_forking_opening_rewind`:
 `orchard_verifier_vesta_forking_constraint_deployed` with the accept probability over reprogrammed-oracle
 runs, the round-vector semantics derived via `roChallenges_reprogramRounds` (issue #23). The `hquot`/`hgood`
-caveat is unchanged — see `orchard_verifier_deployed_constraint_reduction`'s caveat and issue #18 — and so
+caveat is unchanged — see `orchard_verifier_deployed_constraint_reduction`'s caveat and the decoded
+capstone — and so
 is the constant rung's static-dichotomy scope (see `orchard_verifier_vesta_forking_opening_deployed`); the
 `_adaptive_rewind` pair is the attack-event form. -/
 theorem orchard_verifier_vesta_forking_constraint_rewind [Fact (HasseBound Vesta.curve)]
@@ -757,7 +807,7 @@ open Classical in
 /-- The constraint companion of `orchard_verifier_vesta_forking_opening_adaptive_rewind`: the staged
 round-adaptive capstone with its accept event grounded in reprogrammed-oracle runs on each spliced proof. The
 `hquot`/`hgood` caveat is unchanged — see `orchard_verifier_deployed_constraint_reduction`'s caveat and
-issue #18. -/
+the decoded capstone. -/
 theorem orchard_verifier_vesta_forking_constraint_adaptive_rewind [Fact (HasseBound Vesta.curve)]
     [DecidableEq VestaG] [Inhabited VestaG] {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k)
     (vk : VerifyingKey shape Fp VestaG) (ps : ProofString shape Fp VestaG)


### PR DESCRIPTION
**Human Summary:**

Closes https://github.com/zcash/ironwood/issues/18.

Binds the multiopen witness to decoded columns: the constraint-side capstones now
check the circuit gates on column polynomials recovered from the extracted IPA
witness's batch openings, instead of quantifying over arbitrary decode functions.

----------

**AI Summary:**

This PR closes the witness-to-columns half of the issue-#18 constraint-side
bridge. Mental model: the IPA extractor returns *one* coefficient vector for the
batched multiopen commitment, but the gate check speaks about individual column
polynomials — and the old `hquot`/`hgood` hypotheses quantified over every
mathematical opening, which is unsatisfiable at a prime-order curve for any
decode that genuinely reads the witness. The fix is a decode layer: rewound
openings of the same batched commitment at distinct batching challenges
Vandermonde-invert into the real columns, the extracted witness is pinned as
their batch-challenge combination, and the gate check is stated over exactly
that canonical decode.

## What Is Proven

- **Decode layer** (`MultiopenDecode.lean`): `BatchOpeningsForWitness` models
  rewound batched openings at pairwise-distinct challenges;
  `decodedColumnFamily_of_batch_openings` recovers the columns via the explicit
  Vandermonde inverse (no `Classical.choice`), and the `reconstruct` field pins
  every rewound witness — hence the extracted one (`currentWitness_eq`) — as the
  challenge-power combination of the decoded coefficients: witness-level
  binding, not merely same-commitment openings.
- **Canonical-decode hypotheses**: all decoded capstones state `hquot`/`hgood`
  for `decodedCols` of the *supplied* batch — the family their proofs construct.
  Quantifying over every decoded family instead is jointly unsatisfiable (only
  the commitment and one evaluation pin a column; a kernel tweak vanishing at
  the opened point and `x` defeats the pair) — the argument is recorded in the
  module doc's scope section.
- **Witness tie**: the transcript-tied capstones extract the transcript's own
  witness (`ipaRelation_of_acceptV`) and identify it with the batch's — a
  mismatch is a `commit` collision, returned as the relation branch
  (`hasNontrivialRelation_of_two_openings`) — so `hencodes` only ever receives
  the extracted witness.
- **Three bridge granularities**, one conclusion shape: transcript-tied
  (`hbatch : ∀ t, IpaAcceptV … t → MultiopenRewindBatch … t`), bundled
  (`MultiopenForkingOutput` via the data-producing `FiatShamirMultiopenForking`),
  and terminal (`MultiopenRewindForRelation`) for the forking ladder, whose five
  constraint rungs are restated over decoded columns under their original names
  (each with an `_agm_dl` wrapper); the prior ∀-openings forms are deleted, not
  kept as parallel endpoints.
- **Rewinding derivation for the terminal form**: `AcceptedBatchFamily` (accepting
  clean IPA transcripts at distinct batching challenges for the power-form
  statements) yields `MultiopenRewindForRelation` by per-run extraction plus the
  current-slot swap (`multiopenRewindForRelation_of_acceptedFamily`); the swap —
  the "∀-witness costs nothing" claim — is machine-checked
  (`multiopenRewindForRelation_of_batch`).
- **Discharge fixture** (`MultiopenDecodeFixture.lean`): every hypothesis of both
  terminal decoded lemmas is discharged concretely on a `k = 0` toy (trivial
  `commit` kernel, one zero column, one-gate circuit), with `hbatch` *derived*
  from accepting transcripts rather than assumed — a regression guard against
  unsatisfiable hypothesis shapes.
- **Multiopen-squeeze ordering** (`TranscriptOrdering.lean`, `Forking.lean`):
  issue #18's closing note — extend the round-by-round transcript-ordering
  treatment (#23) to the `x₁`/`x₄` squeeze points — is discharged.
  `preX3Transcript`/`preX4Transcript` name the squeeze prefixes, the
  `deriveChallenges_x3_eq`/`_x4_eq` seals pin the deployed `x₃`/`x₄` to them,
  `qPrime_mem_preX3Transcript`/`multiopenU_mem_preX4Transcript` are the
  commit-before-challenge facts, and `reprogramX4` (with `reprogramX4_apply_x4`/
  `_short`/`_long`) identifies the `{ch with x4 := ξ}` redraw with oracle
  reprogramming field by field — the batching-challenge analogue of
  `reprogramRounds`. `acceptedBatchFamily_of_rewinds` turns the resulting
  accepting reprogrammed runs into the `AcceptedBatchFamily` the terminal
  bridge consumes.

## Remaining Floor

- `hquot`/`hgood` stay assumptions: the deployed quotient fact for the canonical
  decode and Schwartz–Zippel freshness of the opened point.
- The accept-probability accounting over the reprogrammed `{ch with x4 := ξ}`
  runs (the measure step feeding `acceptedBatchFamily_of_rewinds`) is outside
  Lean, as is packaging `reprogramX4`'s field-wise identification into a single
  `Challenges`-record equality (each field projection forces whnf of the whole
  `deriveChallenges` record; the pointwise apply lemmas are the operative form).
- The model is single-point, rotation-free, flat-power batching; the deployed
  assembly is multi-point (`ωⁱ·x` queries), two-level (`x₁` within point sets,
  `x₄` across, over multiopen aggregates), with the gate check at `ch.x` and the
  opening at `x₃`. The module doc's scope section records the gap; discharging
  `hbatch`/`hquot` against the deployed verifier needs that generalization
  (tracked as follow-up).
- The `∨ HasNontrivialRelation` branch keeps its usual prime-order status, with
  the computational force in the AGM layer (#28).

## Issue Scope Check

Issue #18 asks that the constraint side constrain the *extracted* witness via
the then-unused `batch_open_soundV`. This PR does exactly that half — decode,
witness-level binding, capstones restated, hypotheses kept satisfiable — and
records the multi-point/rotation generalization needed to discharge the decode
against the deployed assembly as separate follow-up work.
