### PR TITLE
fv: SNARK binding relation as computed data

### DIFF
--- a/Zcash/Snark.lean
+++ b/Zcash/Snark.lean
@@ -32,6 +32,7 @@ import Zcash.Snark.Soundness.Lookup
 import Zcash.Snark.Soundness.Permutation
 import Zcash.Snark.Soundness.PermutationConstruction
 import Zcash.Snark.Soundness.InnerProduct
+import Zcash.Snark.Soundness.TrustBoundary
 import Zcash.Snark.Soundness.Extraction
 import Zcash.Snark.Soundness.Constraints
 import Zcash.Snark.Soundness.CommitFold

--- a/Zcash/Snark/Soundness/CommitFold.lean
+++ b/Zcash/Snark/Soundness/CommitFold.lean
@@ -52,7 +52,8 @@ theorem commitGen_smul_gen {n : ℕ} (c : F) (g : Fin n → G) (a : Fin n → F)
 /-- **One IPA round's commitment fold (completeness).** Folding the witness by `u⁻¹` and the generators
 by `u` sends the parent commitment to the folded commitment plus the two cross terms `⟨aLo, gHi⟩` and
 `⟨aHi, gLo⟩` — exactly the `L`/`R` the verifier accounts for. So the honest witness folds consistently;
-with `ipaRelation_unique` (binding), the prover's response must be this fold. -/
+a prover response deviating from this fold exhibits a computed discrete-log relation
+(`NontrivialDLRelation.ofIpaOpenings`). -/
 theorem commitGen_round {m : ℕ} (gLo gHi : Fin m → G) (aLo aHi : Fin m → F) {u : F} (hu : u ≠ 0) :
     commitGen (gLo + u • gHi) (aLo + u⁻¹ • aHi)
       = (commitGen gLo aLo + commitGen gHi aHi)
@@ -91,52 +92,47 @@ theorem accepting_fold_eq_foldVec {m : ℕ} (gLo gHi : Fin m → G) (aLo aHi a' 
 The trust boundary underlying commitment binding: rather than assuming the commitment is binding
 outright, binding is modelled as a reduction to discrete-log-relation (DLR) hardness at the URS
 generators — the same shape as the binding-signature argument's `NontrivialRelation.ofImbalance`.
-`relation_of_collision` proves the counterfactual (breaking binding produces a nontrivial
-relation among the generators), and `commitmentBinding_iff_no_relation` makes precise that
-`CommitmentBinding` is exactly DLR hardness — so the assumption is the standard, named one, with
-the reduction itself proven. These results are the seed for migrating the deployed binding to a
-DLR reduction (extending to the `U`, `W` generators), in place of an independence assumption.
-Discharging the relation against DLR hardness — the computational/AGM layer — is outside this
+`NontrivialDLRelation` carries such a relation as data (breaks as computed data — see the
+Ironwood Book,
+<https://zcash.github.io/ironwood/formal-verification.html#breaks-as-computed-data>); an
+∃-closed relation Prop would be vacuously true, since relations always exist among the
+generators of a compressing commitment. `NontrivialDLRelation.ofCollision` computes the
+relation from a binding collision, and `.ofIpaOpenings` from two distinct IPA openings of
+one commitment — so opening uniqueness holds up to a computed relation. Discharging the
+relation against DLR hardness — the computational/AGM layer — is outside this
 development. -/
-
-/-- A discrete-log relation among the URS generators: a coefficient vector the generators send to `0`.
-It is nontrivial when `r ≠ 0`. DLR hardness is the assumption that no feasible adversary can find a
-nontrivial relation. -/
-@[reducible] def DLRelation (urs : URS G) (r : Fin (2 ^ urs.k) → F) : Prop :=
-  commitGen urs.g r = 0
 
 /-- Additivity over subtraction in the witness. -/
 theorem commitGen_sub {n : ℕ} (g : Fin n → G) (a a' : Fin n → F) :
     commitGen g (a - a') = commitGen g a - commitGen g a' := by
   simp only [commitGen, Pi.sub_apply, sub_smul, Finset.sum_sub_distrib]
 
-/-- **The binding reduction (counterfactual).** A binding collision — two distinct openings of one
-commitment — yields a nontrivial discrete-log relation `a − a'` among the URS generators. So DLR hardness
-closes binding, exactly as `NontrivialRelation.ofImbalance` closes the binding-signature argument: the collision
-is reduced to a relation the hardness assumption forbids. -/
-theorem relation_of_collision (urs : URS G) {a a' : Fin (2 ^ urs.k) → F}
-    (hcol : commit urs a = commit urs a') (hne : a ≠ a') :
-    a - a' ≠ 0 ∧ DLRelation urs (a - a') := by
-  refine ⟨sub_ne_zero.mpr hne, ?_⟩
-  show commitGen urs.g (a - a') = 0
-  rw [commitGen_sub, ← commit_eq_commitGen, ← commit_eq_commitGen, hcol, sub_self]
+/-- A nontrivial discrete-log relation among the URS generators, as data: a nonzero coefficient
+vector the generators send to `0`. DLR hardness is the assumption that no feasible adversary can
+find one; the reductions below compute it from the corresponding break. -/
+structure NontrivialDLRelation (urs : URS G) where
+  coeffs : Fin (2 ^ urs.k) → F
+  nontrivial : coeffs ≠ 0
+  relation : commitGen urs.g coeffs = 0
 
-/-- **Binding is exactly DLR hardness.** The commitment is binding iff every discrete-log relation among
-the generators is trivial — so assuming DLR hardness is assuming `CommitmentBinding`, and the binding
-hypothesis used by `ipaRelation_unique` / `knowledge_sound` is precisely the standard, named hardness
-assumption (with `relation_of_collision` the proven reduction). -/
-theorem commitmentBinding_iff_no_relation (urs : URS G) :
-    CommitmentBinding (F := F) urs ↔ ∀ r : Fin (2 ^ urs.k) → F, DLRelation urs r → r = 0 := by
-  constructor
-  · intro hb r hr
-    have hr' : commitGen urs.g r = 0 := hr
-    apply hb
-    rw [commit_eq_commitGen, commit_eq_commitGen, hr']
-    simp [commitGen]
-  · intro hnr a a' hcol
-    have hr : DLRelation urs (a - a') := by
-      show commitGen urs.g (a - a') = 0
-      rw [commitGen_sub, ← commit_eq_commitGen, ← commit_eq_commitGen, hcol, sub_self]
-    exact sub_eq_zero.mp (hnr _ hr)
+/-- **The binding reduction, as a computed relation.** A binding collision — two distinct
+openings of one commitment — yields the nontrivial discrete-log relation `a − a'` among the URS
+generators, exactly as `NontrivialRelation.ofImbalance` closes the binding-signature argument.
+DLR hardness closes binding as the contrapositive: the collision is reduced to a relation the
+hardness assumption forbids. -/
+def NontrivialDLRelation.ofCollision (urs : URS G) {a a' : Fin (2 ^ urs.k) → F}
+    (hcol : commit urs a = commit urs a') (hne : a ≠ a') :
+    NontrivialDLRelation (F := F) urs :=
+  ⟨a - a', sub_ne_zero.mpr hne, by
+    rw [commitGen_sub, ← commit_eq_commitGen, ← commit_eq_commitGen, hcol, sub_self]⟩
+
+/-- **IPA opening uniqueness, up to a computed relation.** Two distinct witnesses opening the
+same commitment to the same value yield a computed nontrivial discrete-log relation among the
+URS generators. Special-soundness extraction therefore pins down the witness up to such a
+relation. -/
+def NontrivialDLRelation.ofIpaOpenings {urs : URS G} {P : G} {b : Fin (2 ^ urs.k) → F} {v : F}
+    {a a' : Fin (2 ^ urs.k) → F} (h : IpaRelation urs P b v a) (h' : IpaRelation urs P b v a')
+    (hne : a ≠ a') : NontrivialDLRelation (F := F) urs :=
+  .ofCollision urs (h.1.trans h'.1.symm) hne
 
 end Zcash.Snark

--- a/Zcash/Snark/Soundness/InnerProduct.lean
+++ b/Zcash/Snark/Soundness/InnerProduct.lean
@@ -25,8 +25,9 @@ The IPA's witness fold is 2-special-sound per round: from two accepting transcri
 round commitments `(Lⱼ, Rⱼ)` but answer distinct challenges `uⱼ`, the round's witness is uniquely
 recoverable, and recursing over the `k` rounds extracts an `a` satisfying `IpaRelation`. The
 extractor is built in `Zcash.Snark.Soundness.Extraction`; the per-round folding rests on the
-linearity proved here. Curve-group binding stays an explicit assumption — modelled as
-discrete-log-relation (DLR) hardness (`commitmentBinding_iff_no_relation`), per project scope.
+linearity proved here. Opening uniqueness holds up to a computed discrete-log relation
+(`NontrivialDLRelation.ofIpaOpenings` in `Zcash.Snark.Soundness.CommitFold`); DLR hardness is
+consumed only at the computational layer.
 -/
 
 namespace Zcash.Snark
@@ -110,18 +111,5 @@ knowledge of exactly one polynomial. The complementary constraint layer — that
 polynomials satisfy the circuit's identities — is the Schwartz–Zippel bound (`quotientCheck_sound`
 in `Soundness/Constraints.lean`): a violated identity passes the random-point check only with
 probability `≤ d/p`. -/
-
-/-- Commitment binding (the curve assumption, kept explicit): the URS commitment is injective,
-i.e. the generators `g` are `F`-linearly independent. On Vesta this is discrete-log-relation
-(DLR) hardness (`commitmentBinding_iff_no_relation`). -/
-@[reducible] def CommitmentBinding (urs : URS G) : Prop :=
-  Function.Injective (commit (F := F) urs)
-
-/-- **Under binding, the IPA opening is unique.** Two witnesses opening the same commitment to the same
-value are equal. So special-soundness extraction (which yields an opening) pins down the witness. -/
-theorem ipaRelation_unique {urs : URS G} {P : G} {b : Fin (2 ^ urs.k) → F} {v : F}
-    {a a' : Fin (2 ^ urs.k) → F} (hb : CommitmentBinding (F := F) urs)
-    (h : IpaRelation urs P b v a) (h' : IpaRelation urs P b v a') : a = a' :=
-  hb (h.1.trans h'.1.symm)
 
 end Zcash.Snark

--- a/Zcash/Snark/Soundness/IpaSoundness.lean
+++ b/Zcash/Snark/Soundness/IpaSoundness.lean
@@ -153,7 +153,8 @@ def IpaAccept : {d : ℕ} → (Fin (2 ^ d) → G) → G → IpaTree F G d → Pr
 a witness opening the commitment: `∃ a, commit g a = P`. By induction on the tree: the leaf gives
 `a = const c` directly; a node takes the three sub-witnesses from the IH, pins the parent commitment with
 `ipa_round_commit_sound`, and reassembles via `commitGen_append`. The whole argument uses no binding —
-3-special soundness alone pins the opening. (Binding/DLR enters only for uniqueness, `ipaRelation_unique`.) -/
+3-special soundness alone pins the opening. (Uniqueness holds up to a computed discrete-log
+relation, `NontrivialDLRelation.ofIpaOpenings`.) -/
 theorem ipa_sound : {d : ℕ} → (g : Fin (2 ^ d) → G) → (P : G) → (t : IpaTree F G d) →
     IpaAccept g P t → ∃ a : Fin (2 ^ d) → F, commitGen g a = P
   | 0, g, P, .leaf c, h => ⟨fun _ => c, h.symm⟩

--- a/Zcash/Snark/Soundness/KnowledgeSoundness.lean
+++ b/Zcash/Snark/Soundness/KnowledgeSoundness.lean
@@ -11,24 +11,25 @@ The capstone: an accepting proof demonstrates knowledge of a witness satisfying 
 composes the proven pieces of the soundness layer —
 
 * `extract_correct` — the IPA extractor recovers the witness from an accepting transcript tree;
-* `commitGen_round` + `ipaRelation_unique` — folding preserves the commitment and the opening is unique
-  under binding (so an accepting transcript yields a consistent tree);
+* `commitGen_round` — folding preserves the commitment (so an accepting transcript yields a
+  consistent tree); opening uniqueness holds up to a computed discrete-log relation
+  (`NontrivialDLRelation.ofIpaOpenings`);
 * `quotientCheck_sound` + `Expr.eval_toPoly` — the verifier's gate check, via Schwartz–Zippel, forces the
   committed polynomials to satisfy the circuit's constraint identity (off a `≤ d/p` bad set).
 
 `SnarkRelation` is the relation the SNARK proves (the witness opens the commitment and the committed
 polynomials satisfy the constraint identity); `knowledge_sound` assembles the proven lemmas into "the
-extractor recovers the unique witness satisfying the relation"; `soundness_error` is the residual
-`≤ d/p` Schwartz–Zippel error.
+extractor recovers a witness satisfying the relation, unique up to a computed discrete-log
+relation"; `soundness_error` is the residual `≤ d/p` Schwartz–Zippel error.
 
 ## Assumptions
 
 This layer is sound relative to the following, each kept explicit rather than hidden:
 
-* **DLR hardness** (discrete-log relations on the Vesta generators) — the binding hypothesis
-  `CommitmentBinding`. Modeled as a reduction: `relation_of_collision` proves a binding violation yields
-  a nontrivial relation, and `commitmentBinding_iff_no_relation` proves binding is exactly DLR hardness
-  (the reduction is proven; only the hardness is claimed).
+* **DLR hardness** (discrete-log relations on the Vesta generators) — consumed only at the
+  computational layer: a second distinct opening yields a computed nontrivial relation
+  (`NontrivialDLRelation.ofIpaOpenings`), the object the hardness assumption forbids an
+  efficient adversary to produce.
 * **Fiat–Shamir / Blake2b** as a random oracle — challenges are treated as uniform and unpredictable; the
   hash and the random-oracle reduction are not modeled. The capstone's current assumption
   (`ExtractableFromAcceptance`) is in fact stronger — it bundles the IPA knowledge-soundness conclusion,
@@ -95,18 +96,18 @@ theorem circuitSatViaGates_of_check {k : ℕ} (fixedCols : ℕ → Polynomial Fp
   constraint_identity_of_accept _ hpoly deg x hcheck hgood
 
 /-- **Knowledge soundness**, relative to its named hypotheses: given a consistent transcript tree
-(`hcons`), an opening (`hopen`), and circuit satisfaction (`hsat`), the extractor recovers the
-unique witness satisfying `SnarkRelation` — `extract_correct` for extraction,
-`ipaRelation_unique` (binding) for uniqueness. `hcons` and `hsat` are assumed, not derived from
-acceptance; deriving them (`accepting_fold_eq`, `constraint_identity_of_accept`) is the open
+(`hcons`), an opening (`hopen`), and circuit satisfaction (`hsat`), the extractor recovers a
+witness satisfying `SnarkRelation` — `extract_correct` for extraction. The witness is unique up
+to a computed discrete-log relation: a second distinct opening yields
+`NontrivialDLRelation.ofIpaOpenings`. `hcons` and `hsat` are assumed, not derived from
+acceptance; deriving them (`accepting_fold_eq`, `constraint_identity_of_accept`) is open
 composition work. -/
-theorem knowledge_sound (urs : URS G) (hbind : CommitmentBinding (F := Fp) urs)
+theorem knowledge_sound (urs : URS G)
     {t : Tree Fp urs.k} {a : Fin (2 ^ urs.k) → Fp} (hcons : Consistent t a)
     {P : G} {b : Fin (2 ^ urs.k) → Fp} {v : Fp} (hopen : IpaRelation urs P b v a)
     {circuitSat : (Fin (2 ^ urs.k) → Fp) → Prop} (hsat : circuitSat a) :
-    extract t = a ∧ SnarkRelation urs P b v circuitSat a
-      ∧ ∀ a', IpaRelation urs P b v a' → a' = a :=
-  ⟨extract_correct t a hcons, ⟨hopen, hsat⟩, fun _ h' => ipaRelation_unique hbind h' hopen⟩
+    extract t = a ∧ SnarkRelation urs P b v circuitSat a :=
+  ⟨extract_correct t a hcons, ⟨hopen, hsat⟩⟩
 
 /-- The residual soundness error of the constraint layer (re-export of `quotientCheck_sound`): a
 committed-polynomial set that violates the constraint identity is accepted for at most a `deg / |F|`

--- a/Zcash/Snark/Soundness/Main.lean
+++ b/Zcash/Snark/Soundness/Main.lean
@@ -19,8 +19,7 @@ verifier. Its endpoint theorems — the *capstones* — come in two layers:
 The deployed `_opening`/`_constraint` theorems derive the IPA opening (via `ipa_soundV`) and the
 gate constraint from the accept, under the Fiat–Shamir bridge `hFS`. An earlier deployed layer
 that peeled the blinding terms off the transcript (the URS generators `U`, `W` and the blinding
-commitment `S`) was removed; re-expressing binding as a DLR-hardness reduction (see
-`relation_of_collision` in `Zcash.Snark.Soundness.CommitFold`) is the planned follow-up.
+commitment `S`) was removed.
 
 ## Assumptions (the conditional family)
 
@@ -31,11 +30,10 @@ commitment `S`) was removed; re-expressing binding as a DLR-hardness reduction (
   `extract_correct`) are off this path.
 * **Circuit satisfaction assumed.** It also supplies `circuitSat a` rather than deriving it from
   the deployed gate check (`constraint_identity_of_accept` + the multiopen decode).
-* **Binding inert.** `hbind` (DLR hardness) reaches `knowledge_sound` but only feeds its
-  uniqueness conjunct, which this proof discards.
 
 What is proven lives in the component lemmas (`extract_correct`, `accepting_fold_eq`,
-`quotientCheck_sound`, `ipaRelation_unique`, and the binding reduction); the open work is wiring
+`quotientCheck_sound`, and the computed binding reduction `NontrivialDLRelation.ofCollision`);
+the open work is wiring
 them onto this path. `Soundness.Vesta` instantiates the capstones at the concrete curve;
 `Soundness.KnowledgeSoundness` lists the assumptions.
 -/
@@ -65,14 +63,14 @@ def ExtractableFromAcceptance (urs : URS G) (P : G) (b : Fin (2 ^ urs.k) → Fp)
 extraction is assumed (see the module docstring's assumption list); the deployed
 `_opening`/`_constraint` theorems below take the concrete accept and derive what is assumed
 here. -/
-theorem orchard_verifier_sound_conditional (urs : URS G) (hbind : CommitmentBinding (F := Fp) urs)
+theorem orchard_verifier_sound_conditional (urs : URS G)
     {P : G} {b : Fin (2 ^ urs.k) → Fp} {v : Fp} {circuitSat : (Fin (2 ^ urs.k) → Fp) → Prop}
     {accepts : Prop} (haccepts : accepts)
     (hextract : ExtractableFromAcceptance urs P b v circuitSat accepts)
     {S : Prop} (hencodes : ∀ a, SnarkRelation urs P b v circuitSat a → S) :
     S := by
   obtain ⟨t, a, hcons, hopen, hsat⟩ := hextract haccepts
-  exact hencodes a (knowledge_sound urs hbind hcons hopen hsat).2.1
+  exact hencodes a (knowledge_sound urs hcons hopen hsat).2
 
 /-- The deployed verifier's accept condition: `assemble? vk ps ch` succeeds and the assembled MSM
 evaluates to the group identity against the URS. Proof data that `assemble?` rejects (duplicate

--- a/Zcash/Snark/Soundness/TrustBoundary.lean
+++ b/Zcash/Snark/Soundness/TrustBoundary.lean
@@ -1,0 +1,27 @@
+import Zcash.Snark.Soundness.CommitFold
+import Mathlib.Util.AssertNoSorry
+
+/-!
+# Checked trust boundary of the SNARK binding reductions
+
+Build-time enforcement of the breaks-as-computed-data discipline (see
+`Zcash.Security.RandomOracle` and the Ironwood Book's Formal Verification page) for the
+`NontrivialDLRelation` reductions: `assert_no_sorry` walks the elaborated dependency graph
+of each reduction, and `#guard_msgs`-pinned `#print axioms` freezes their axiom sets.
+Computability is compiler-enforced (plain `def`s). `Classical.choice` enters only through
+erased `Prop` certificate fields; the relation coefficients are direct terms of the inputs,
+so the data cannot have been conjured from mere propositional existence.
+-/
+
+open Zcash.Snark
+
+assert_no_sorry NontrivialDLRelation.ofCollision
+assert_no_sorry NontrivialDLRelation.ofIpaOpenings
+
+/-- info: 'Zcash.Snark.NontrivialDLRelation.ofCollision' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs (whitespace := lax) in
+#print axioms NontrivialDLRelation.ofCollision
+
+/-- info: 'Zcash.Snark.NontrivialDLRelation.ofIpaOpenings' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs (whitespace := lax) in
+#print axioms NontrivialDLRelation.ofIpaOpenings

--- a/Zcash/Snark/Soundness/Vesta.lean
+++ b/Zcash/Snark/Soundness/Vesta.lean
@@ -66,13 +66,13 @@ noncomputable instance vestaFpModule [h : Fact VestaOrder] : Module Fp VestaG :=
 hence the `Fp`-module structure, follows). Inherits the conditional status — see that docstring.
 The deployed Vesta capstones are `orchard_verifier_sound_vesta_opening`/`_constraint` below. -/
 theorem orchard_verifier_sound_vesta_conditional [Fact (HasseBound Vesta.curve)]
-    (urs : URS VestaG) (hbind : CommitmentBinding (F := Fp) urs)
+    (urs : URS VestaG)
     {P : VestaG} {b : Fin (2 ^ urs.k) → Fp} {v : Fp} {circuitSat : (Fin (2 ^ urs.k) → Fp) → Prop}
     {accepts : Prop} (haccepts : accepts)
     (hextract : ExtractableFromAcceptance urs P b v circuitSat accepts)
     {S : Prop} (hencodes : ∀ a, SnarkRelation urs P b v circuitSat a → S) :
     S :=
-  orchard_verifier_sound_conditional urs hbind haccepts hextract hencodes
+  orchard_verifier_sound_conditional urs haccepts hextract hencodes
 
 /-- **Deployed Vesta soundness, opening derived.** `orchard_verifier_sound_deployed_opening`
 specialised to `SWPoint Vesta.curve`, the curve's `Fp`-module structure supplied by the Hasse

--- a/book/src/formal-verification/proof-map-embed.html
+++ b/book/src/formal-verification/proof-map-embed.html
@@ -262,7 +262,7 @@ const nodes = [
     anchor:'Ipa.Soundness.IpaAcceptV',
     role:'A clean IPA transcript tree over the URS generators, ready for special-soundness extraction.' },
   { id:'relation', c:0,r:5, label:'relation (g,U,W)', status:'object',
-    anchor:'CommitFold.DLRelation',
+    anchor:'CommitFold.NontrivialDLRelation',
     role:'The bad branch of the peel: a nontrivial discrete-log relation on the augmented generators (g, U, W). A relation always exists in a prime-order group, so as a statement this branch is trivially true — its real content is the computational claim that no efficient adversary can find one, the DL-hardness the AGM reduction leans on.' },
   { id:'ipa_soundV', c:1,r:6, label:'ipa_soundV', status:'proven',
     anchor:'Ipa.Soundness.ipa_soundV',


### PR DESCRIPTION
Applies the [breaks-as-computed-data convention](https://zcash.github.io/ironwood/formal-verification.html#breaks-as-computed-data) for the binding shapes in `Soundness/CommitFold.lean`.

## The problem being fixed

`CommitmentBinding urs := Function.Injective (commit urs)` is information-theoretically false at any instantiation — the commitment compresses `2^k` coefficients into one group element — so every theorem taking `hbind : CommitmentBinding urs` was vacuous at the group (unsatisfiable hypothesis). Dually, `commitmentBinding_iff_no_relation`'s right-hand side ("every relation is trivial") is false there, and `relation_of_collision`'s content, while stated with explicit coefficients, was only consumable through those vacuous forms.

## Changes

* `Soundness/CommitFold.lean`: `NontrivialDLRelation` — the relation coefficients as data with `Prop` certificates; `NontrivialDLRelation.ofCollision` (computed from a binding collision: two distinct openings of one commitment) and `NontrivialDLRelation.ofIpaOpenings` (computed from two distinct IPA openings, via the commitment components). `relation_of_collision` and `commitmentBinding_iff_no_relation` are subsumed and removed.
* `Soundness/InnerProduct.lean`: `CommitmentBinding` and `ipaRelation_unique` removed; opening uniqueness holds up to a computed relation.
* `Soundness/KnowledgeSoundness.lean`: `knowledge_sound` drops the binding hypothesis and the `∀ a', IpaRelation … → a' = a` conjunct (which was usable only under the unsatisfiable hypothesis); uniqueness-up-to-a-computed-relation is delivered by `ofIpaOpenings`. This is the API-visible change.
* `Soundness/Main.lean`, `Soundness/Vesta.lean`: the conditional capstones drop `hbind` — their proofs never used the uniqueness conjunct, so their conclusions are unchanged.
* `Soundness/TrustBoundary.lean` (new, wired into the aggregator): `assert_no_sorry` plus `#guard_msgs`-pinned `#print axioms` for both reductions; `Classical.choice` enters only through erased `Prop` certificate fields, with computability compiler-enforced.
* Docstring updates in the touched files describe the present boundary (DLR hardness consumed only at the computational layer) without prescribing future work.

The deployed `_opening`/`_constraint` capstones and the Fiat–Shamir / forking territory are untouched; the corresponding shapes in the in-flight AGM work (#28) are that PR's to align.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
