### PR TITLE
Fixing unsatisfiable ∀ a quantification in the deployed-verifier reduction theorems

### DIFF
--- a/Zcash/Snark/Soundness/Main.lean
+++ b/Zcash/Snark/Soundness/Main.lean
@@ -313,25 +313,20 @@ def NontrivialRelation.ofUnopenedFork [DecidableEq G] [Inhabited G] {shape : Sha
 cleanly accepted, `ipa_soundV` extracts the opening witness for the declared opening
 `fs.openedCommitment` — the blinded opening of the pinned commitment,
 `deployedCommitment = ⟨a, g⟩ + [pU]u + [pW]w` with `⟨a, b⟩ = multiopenValue`; the circuit side
-(`hcirc`) and VK-correctness (`hencodes`) conclude `S`. The clean-accept hypothesis `hclean` is
-what DLR hardness forces — its failure computes a relation
-(`NontrivialRelation.ofUnopenedFork`). `hcirc` has the unsatisfiable shape described in the
-section note above. -/
+(`hcirc`) and VK-correctness (`hencodes`) conclude `S`. The opening witness `a` and the `IpaRelation`
+certificate `hrel` are supplied by the caller (derived from the clean accept via
+`ipaRelation_of_acceptV`). -/
 theorem orchard_verifier_deployed_opening_of_forked [DecidableEq G] [Inhabited G] {shape : Shape}
     (urs : URS G) (hk : shape.k = urs.k) (vk : VerifyingKey shape Fp G) (ps : ProofString shape Fp G)
     (ch : Challenges shape.k Fp) {b : Fin (2 ^ urs.k) → Fp} {z blind : Fp}
-    {circuitSat : (Fin (2 ^ urs.k) → Fp) → Prop}
+    (a : Fin (2 ^ urs.k) → Fp) {circuitSat : (Fin (2 ^ urs.k) → Fp) → Prop}
     (fs : ForkedTranscript urs hk vk ps ch b z blind)
-    (hclean : IpaAcceptV urs.g b fs.openedCommitment (multiopenValue vk ps ch)
-      (projTree fs.tree))
-    (hcirc : ∀ a, IpaRelation urs fs.openedCommitment b (multiopenValue vk ps ch) a →
-      circuitSat a)
+    (hrel : IpaRelation urs fs.openedCommitment b (multiopenValue vk ps ch) a)
+    (hcirc : circuitSat a)
     {S : Prop} (hencodes : ∀ a, SnarkRelation urs fs.openedCommitment b
       (multiopenValue vk ps ch) circuitSat a → S) :
-    S := by
-  obtain ⟨a, hrel⟩ := ipaRelation_of_acceptV urs b fs.openedCommitment
-    (multiopenValue vk ps ch) (projTree fs.tree) hclean
-  exact hencodes a ⟨hrel, hcirc a hrel⟩
+    S :=
+  hencodes a ⟨hrel, hcirc⟩
 
 /-! ## `circuitSat` is derived from the verifier's gate check + Schwartz–Zippel
 

--- a/Zcash/Snark/Soundness/Main.lean
+++ b/Zcash/Snark/Soundness/Main.lean
@@ -343,33 +343,28 @@ open Polynomial in
 `orchard_verifier_deployed_opening_of_forked`, with the circuit side derived too: `circuitSat` —
 instantiated to `circuitSatViaGates` — from the verifier's gate point-check `hquot` at the
 challenge `x`, lifted to the polynomial identity by Schwartz–Zippel (`hgood`), via
-`circuitSatViaGates_of_check`. `hquot`/`hgood` share `hcirc`'s unsatisfiable shape (see the
-section note above): the verifier's actual gate check constrains the *claimed* evaluations, not
-every opening's decode. -/
+`circuitSatViaGates_of_check`. `hquot`/`hgood` now constrain the single extracted witness `a` — lifted to the constraint
+identity by Schwartz–Zippel. The multiopen decode (`batch_open_soundV`), binding
+`decodeAdvice`/`decodeInstance` to the committed columns, is still open. -/
 theorem orchard_verifier_deployed_constraint_of_forked [DecidableEq G] [Inhabited G] {shape : Shape}
     (urs : URS G) (hk : shape.k = urs.k) (vk : VerifyingKey shape Fp G) (ps : ProofString shape Fp G)
     (ch : Challenges shape.k Fp) {b : Fin (2 ^ urs.k) → Fp} {z blind : Fp}
     (fixedCols : ℕ → Polynomial Fp)
     (decodeAdvice decodeInstance : (Fin (2 ^ urs.k) → Fp) → (ℕ → Polynomial Fp))
     (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
+    (a : Fin (2 ^ urs.k) → Fp)
     (fs : ForkedTranscript urs hk vk ps ch b z blind)
-    (hclean : IpaAcceptV urs.g b fs.openedCommitment (multiopenValue vk ps ch)
-      (projTree fs.tree))
-    (hquot : ∀ a, IpaRelation urs fs.openedCommitment b (multiopenValue vk ps ch) a →
-      quotientCheck (combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates) hpoly deg x)
-    (hgood : ∀ a, IpaRelation urs fs.openedCommitment b (multiopenValue vk ps ch) a →
-      combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates ≠ hpoly * (X ^ deg - 1) →
+    (hrel : IpaRelation urs fs.openedCommitment b (multiopenValue vk ps ch) a)
+    (hquot : quotientCheck (combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates) hpoly deg x)
+    (hgood : combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates ≠ hpoly * (X ^ deg - 1) →
       (combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates
         - hpoly * (X ^ deg - 1)).eval x ≠ 0)
     {S : Prop}
     (hencodes : ∀ a, SnarkRelation urs fs.openedCommitment b (multiopenValue vk ps ch)
       (circuitSatViaGates fixedCols decodeAdvice decodeInstance y gates hpoly deg) a → S) :
     S := by
-  obtain ⟨a, hrel⟩ := ipaRelation_of_acceptV urs b fs.openedCommitment
-    (multiopenValue vk ps ch) (projTree fs.tree) hclean
   have hsat : circuitSatViaGates fixedCols decodeAdvice decodeInstance y gates hpoly deg a :=
-    circuitSatViaGates_of_check fixedCols decodeAdvice decodeInstance y gates hpoly deg a x
-      (hquot a hrel) (hgood a hrel)
+    circuitSatViaGates_of_check fixedCols decodeAdvice decodeInstance y gates hpoly deg a x hquot hgood
   exact hencodes a ⟨hrel, hsat⟩
 
 end Zcash.Snark

--- a/Zcash/Snark/Soundness/Vesta.lean
+++ b/Zcash/Snark/Soundness/Vesta.lean
@@ -90,30 +90,30 @@ def NontrivialRelation.ofUnopenedForkVesta [DecidableEq VestaG]
 
 /-- **Deployed opening over Vesta, given a clean fork.**
 `orchard_verifier_deployed_opening_of_forked` specialised to `SWPoint Vesta.curve`: same
-hypotheses as the abstract theorem (the Vesta order is unconditional). The clean-accept hypothesis is what
-DLR hardness forces (`NontrivialRelation.ofUnopenedForkVesta`); for `hcirc`'s unsatisfiable
-shape see the section note in `Soundness.Main`. -/
+hypotheses as the abstract theorem (the Vesta order is unconditional). The opening witness `a` and
+`IpaRelation` certificate `hrel` are supplied by the caller (derived from the clean accept via
+`ipaRelation_of_acceptV`). -/
 theorem orchard_verifier_vesta_opening_of_forked [DecidableEq VestaG] [Inhabited VestaG]
     {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k) (vk : VerifyingKey shape Fp VestaG)
     (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
-    {b : Fin (2 ^ urs.k) → Fp} {z blind : Fp} {circuitSat : (Fin (2 ^ urs.k) → Fp) → Prop}
+    {b : Fin (2 ^ urs.k) → Fp} {z blind : Fp}
+    (a : Fin (2 ^ urs.k) → Fp) {circuitSat : (Fin (2 ^ urs.k) → Fp) → Prop}
     (fs : ForkedTranscript urs hk vk ps ch b z blind)
-    (hclean : IpaAcceptV urs.g b fs.openedCommitment (multiopenValue vk ps ch)
-      (projTree fs.tree))
-    (hcirc : ∀ a, IpaRelation urs fs.openedCommitment b (multiopenValue vk ps ch) a →
-      circuitSat a)
+    (hrel : IpaRelation urs fs.openedCommitment b (multiopenValue vk ps ch) a)
+    (hcirc : circuitSat a)
     {S : Prop} (hencodes : ∀ a, SnarkRelation urs fs.openedCommitment b
       (multiopenValue vk ps ch) circuitSat a → S) :
     S :=
-  orchard_verifier_deployed_opening_of_forked urs hk vk ps ch fs hclean hcirc hencodes
+  orchard_verifier_deployed_opening_of_forked urs hk vk ps ch a fs hrel hcirc hencodes
 
 open Polynomial in
 /-- **Deployed opening and constraint over Vesta, given a clean fork.**
 `orchard_verifier_deployed_constraint_of_forked` specialised to `SWPoint Vesta.curve`: the opening
 for the declared `fs.openedCommitment` and the pinned `multiopenValue`, and `circuitSat` (concrete
-`circuitSatViaGates`) from the verifier's gate point-check `hquot` lifted by Schwartz–Zippel
-(`hgood`). Same hypotheses as the abstract theorem (the Vesta order is unconditional); `hquot`/`hgood` share
-`hcirc`'s unsatisfiable shape (see the section note in `Soundness.Main`). -/
+`circuitSatViaGates`) from the verifier's gate point-check `hquot` at the challenge `x`, lifted
+to the polynomial identity by Schwartz–Zippel (`hgood`). The `hquot`/`hgood` checks now constrain
+the single extracted witness `a`. Same hypotheses as the abstract theorem (the Vesta order is
+unconditional). -/
 theorem orchard_verifier_vesta_constraint_of_forked [DecidableEq VestaG] [Inhabited VestaG]
     {shape : Shape} (urs : URS VestaG) (hk : shape.k = urs.k) (vk : VerifyingKey shape Fp VestaG)
     (ps : ProofString shape Fp VestaG) (ch : Challenges shape.k Fp)
@@ -121,13 +121,11 @@ theorem orchard_verifier_vesta_constraint_of_forked [DecidableEq VestaG] [Inhabi
     (fixedCols : ℕ → Polynomial Fp)
     (decodeAdvice decodeInstance : (Fin (2 ^ urs.k) → Fp) → (ℕ → Polynomial Fp))
     (y : Fp) {ng : ℕ} (gates : Fin ng → Expr Fp) (hpoly : Polynomial Fp) (deg : ℕ) (x : Fp)
+    (a : Fin (2 ^ urs.k) → Fp)
     (fs : ForkedTranscript urs hk vk ps ch b z blind)
-    (hclean : IpaAcceptV urs.g b fs.openedCommitment (multiopenValue vk ps ch)
-      (projTree fs.tree))
-    (hquot : ∀ a, IpaRelation urs fs.openedCommitment b (multiopenValue vk ps ch) a →
-      quotientCheck (combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates) hpoly deg x)
-    (hgood : ∀ a, IpaRelation urs fs.openedCommitment b (multiopenValue vk ps ch) a →
-      combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates ≠ hpoly * (X ^ deg - 1) →
+    (hrel : IpaRelation urs fs.openedCommitment b (multiopenValue vk ps ch) a)
+    (hquot : quotientCheck (combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates) hpoly deg x)
+    (hgood : combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates ≠ hpoly * (X ^ deg - 1) →
       (combineGates fixedCols (decodeAdvice a) (decodeInstance a) y gates
         - hpoly * (X ^ deg - 1)).eval x ≠ 0)
     {S : Prop}
@@ -135,6 +133,6 @@ theorem orchard_verifier_vesta_constraint_of_forked [DecidableEq VestaG] [Inhabi
       (circuitSatViaGates fixedCols decodeAdvice decodeInstance y gates hpoly deg) a → S) :
     S :=
   orchard_verifier_deployed_constraint_of_forked urs hk vk ps ch fixedCols decodeAdvice
-    decodeInstance y gates hpoly deg x fs hclean hquot hgood hencodes
+    decodeInstance y gates hpoly deg x a fs hrel hquot hgood hencodes
 
 end Zcash.Snark


### PR DESCRIPTION
This is a fix for #60 

### What changed

- `hcirc` changed from `∀ a, IpaRelation ... a → circuitSat a` → `circuitSat a`
- `hquot` changed from `∀ a, IpaRelation ... a → quotientCheck ...` → `quotientCheck ...`
- `hgood` changed from `∀ a, IpaRelation ... a → ...` → `...`
- `hclean` parameter dropped (it only fed `ipaRelation_of_acceptV`; caller now passes `hrel` directly)
- `hrel : IpaRelation ... a` added as explicit parameter
- `a : Fin (2 ^ urs.k) → Fp` added as explicit binder

### What stayed

- `hencodes` stays `∀ a`-quantified — `S` is a free `Prop` and the caller says "for ANY witness satisfying the SNARK relation, conclude `S`". This was not the problem.

# Explaining the fix

After the fix, `circuitSatViaGates_of_check` (KnowledgeSoundness.lean:84) can meaningfully derive `circuitSat` from the verifier's gate check for the one extracted witness `a`. The hypotheses `hquot`/`hgood` now constrain exactly that single `a`, no longer an unsatisfiable`∀` quantifier over an affine subspace.

The tracked decode gap (linking `decodeAdvice`/`decodeInstance` to the multiopen via `batch_open_soundV`) remains separate work and is no longer blocked by this unsatisfiable premise.