### PR TITLE
fv: key-binding birthday bound in the whole-table ROM

### DIFF
--- a/Zcash/Security.lean
+++ b/Zcash/Security.lean
@@ -10,3 +10,4 @@ import Zcash.Security.Common.RandomOracle
 import Zcash.Security.Common.Birthday
 import Zcash.Security.KeyBinding.Basic
 import Zcash.Security.KeyBinding.Instance
+import Zcash.Security.KeyBinding.Probability

--- a/Zcash/Security/Common/RandomOracle.lean
+++ b/Zcash/Security/Common/RandomOracle.lean
@@ -3,11 +3,11 @@ import Mathlib
 /-!
 # Random-oracle collision vocabulary (classical ROM)
 
-Shared Layer-A foundation for the classical-ROM security arguments (key-binding `H^*`, and — reused
-by the Layer-B games — note-commitment / nullifier `H^rcm`). We follow the *deterministic-exhibition*
+Shared foundation for the classical-ROM security arguments (key-binding `H^*`, and — reused
+by the ledger-model games — note-commitment / nullifier `H^rcm`). We follow the *deterministic-exhibition*
 style of `BindingSignature/Balance.lean`: a security theorem reduces a break to an *exhibited*
 random-oracle collision, and the probability that such a collision occurs within `q` oracle queries —
-the birthday bound `q(q-1)/|F|` — is a separate concern (Layer C), carried as a named quantity
+the birthday bound `q(q-1)/|F|` — is a separate concern, carried as a named quantity
 until discharged.
 
 An abstract oracle is any function `O : Q → F` from queries to field outputs; "randomness" enters only

--- a/Zcash/Security/KeyBinding/Probability.lean
+++ b/Zcash/Security/KeyBinding/Probability.lean
@@ -1,0 +1,249 @@
+import Zcash.Security.KeyBinding.Basic
+import Zcash.Security.Common.Birthday
+import Zcash.Snark.Soundness.Forking.Probability
+
+/-!
+# Key binding in the whole-table random-oracle model (Layer C)
+
+The deterministic key-binding layer ends at a computed event: `CollisionUpToSign.ofBreak` turns
+any key-binding `Break` into a ±-collision of the shifted combined final oracle at two distinct
+queries, and `collision_mem_shifted_pm` places its output pair in the set `Birthday.lean` counts.
+This module adds the probabilistic model that turns those counting facts into a probability
+bound.
+
+The model samples the combined final `rivk`-derivation oracle `H^*` as one uniform table
+`O : FinalQuery QK SK B F → F`. A uniform table is the same as independent uniform outputs at
+every query — the product structure of the uniform measure. (In Markov-category terms `PMF` is a
+commutative monad, so samples reorder freely; see Fritz [eprint arXiv:1908.07021] and
+`Mathlib.CategoryTheory.MarkovCategory` for the abstract setting.) The three constituent oracles
+are the table's restrictions along the `FinalQuery` constructors (`FinalQuery.eval_restrict`).
+
+The remaining data (`Extract`, the bases, `hfn`, `Hask`, `Hnk`) are fixed parameters. The shift
+`shiftOf` reads only the query and these parameters, never the sampled table — so a shifted read
+of the table at distinct queries is still a uniform pair. (The shift is a deterministic, a.k.a.
+copy-preserving, map in the Markov-category sense.) The pair and union lemmas below are stated
+for an arbitrary finite query domain and arbitrary shift function, for reuse by the Spendability
+`H^rcm` collision.
+
+Results (milestone 1 — a *static* query set, fixed before the table is sampled):
+
+* `pair_shifted_collision_measure_le` — a shifted ±-collision at one distinct query pair has
+  probability at most `2/|F|`.
+* `finset_shifted_collision_measure_le` — union bound over the `C(q,2)` unordered pairs of a
+  query set of size at most `q`: probability at most `q·(q−1)/|F|`.
+* `break_measure_le` — the key-binding capstone: an adversary whose witnesses' derivation
+  queries land in the static set produces a `Break` with probability at most `q·(q−1)/|F|`
+  (ZIP 2005's `ε_kb` at `|F| = r`).
+
+The more realistic adaptive attack model —a bounded-query machine choosing queries after seeing
+earlier answers— is the next milestone (issue #68). The fresh-read conditioning it needs is in
+`Snark.Soundness.Forking.Probability`, which this module already imports for the uniform-table
+lemmas.
+-/
+
+namespace Zcash.Security.KeyBinding
+
+open Finset Zcash.Security.RandomOracle Zcash.Security.Birthday Zcash.Snark
+open scoped ENNReal
+
+variable {G F B SK QK : Type*}
+
+/-! ## Finiteness of the query space -/
+
+/-- `FinalQuery` as the sum of its constructors' data. -/
+def finalQueryEquiv : FinalQuery QK SK B F ≃ (QK × B × B) ⊕ SK ⊕ (F × B × B) where
+  toFun
+    | .ext qk ak nk => .inl (qk, ak, nk)
+    | .legacy sk => .inr (.inl sk)
+    | .int rivk_ext ak nk => .inr (.inr (rivk_ext, ak, nk))
+  invFun
+    | .inl (qk, ak, nk) => .ext qk ak nk
+    | .inr (.inl sk) => .legacy sk
+    | .inr (.inr (rivk_ext, ak, nk)) => .int rivk_ext ak nk
+  left_inv q := by cases q <;> rfl
+  right_inv x := by rcases x with ⟨qk, ak, nk⟩ | sk | ⟨rivk_ext, ak, nk⟩ <;> rfl
+
+instance [Fintype QK] [Fintype SK] [Fintype B] [Fintype F] :
+    Fintype (FinalQuery QK SK B F) :=
+  Fintype.ofEquiv _ finalQueryEquiv.symm
+
+/-- Assembling the combined final oracle from a table's constructor restrictions gives back the
+table. -/
+theorem eval_restrict (O : FinalQuery QK SK B F → F) :
+    FinalQuery.eval (fun sk => O (.legacy sk)) (fun qk ak nk => O (.ext qk ak nk))
+      (fun rivk_ext ak nk => O (.int rivk_ext ak nk)) = O := by
+  funext q; cases q <;> rfl
+
+/-! ## The per-pair and union bounds, over an arbitrary finite query domain -/
+
+section Generic
+
+variable {Q : Type*} [Fintype Q] [DecidableEq Q] [Field F] [Fintype F] [DecidableEq F]
+
+/-- **Non-adaptive per-pair bound.** For distinct queries `a ≠ b` and any shift `s` fixed
+independently of the table, a uniform table's shifted outputs at `a` and `b` ±-collide with
+probability at most `2/|F|`: the pair read is uniform on `F × F`
+(`uniformOfFintype_map_precomp_injective`), and the shifted collision set has at most
+`2·|F|` elements (`card_shifted_pm_collision_le`). -/
+theorem pair_shifted_collision_measure_le (s : Q → F) {a b : Q} (hne : a ≠ b) :
+    (PMF.uniformOfFintype (Q → F)).toOuterMeasure
+        {O : Q → F | s a + O a =± s b + O b}
+      ≤ 2 / Fintype.card F := by
+  have hφ : Function.Injective (![a, b] : Fin 2 → Q) := by
+    intro i j hij
+    fin_cases i <;> fin_cases j <;> simp_all
+  have hpre : {O : Q → F | s a + O a =± s b + O b}
+      = (fun O : Q → F => (piFinTwoEquiv fun _ => F) (O ∘ ![a, b])) ⁻¹'
+          {p : F × F | s a + p.1 =± s b + p.2} := rfl
+  rw [hpre, ← PMF.toOuterMeasure_map_apply]
+  have hmap : (PMF.uniformOfFintype (Q → F)).map
+        (fun O : Q → F => (piFinTwoEquiv fun _ => F) (O ∘ ![a, b]))
+      = PMF.uniformOfFintype (F × F) := by
+    rw [show (fun O : Q → F => (piFinTwoEquiv fun _ => F) (O ∘ ![a, b]))
+          = ⇑(piFinTwoEquiv fun _ => F) ∘ (fun O : Q → F => O ∘ ![a, b]) from rfl,
+      ← PMF.map_comp, uniformOfFintype_map_precomp_injective _ hφ,
+      map_uniformOfFintype_equiv]
+  rw [hmap, uniformOfFintype_toOuterMeasure_set]
+  have hcard : Nat.card {p : F × F | s a + p.1 =± s b + p.2} ≤ 2 * Fintype.card F := by
+    rw [Nat.card_coe_set_eq, Set.ncard_eq_toFinset_card', Set.toFinset_setOf]
+    exact card_shifted_pm_collision_le (s a) (s b)
+  calc (Nat.card {p : F × F | s a + p.1 =± s b + p.2} : ℝ≥0∞) / Fintype.card (F × F)
+      ≤ (2 * Fintype.card F : ℕ) / Fintype.card (F × F) := by
+        gcongr
+    _ = 2 / Fintype.card F := by
+        rw [Fintype.card_prod]
+        push_cast
+        rw [ENNReal.mul_div_mul_right _ _ (by exact_mod_cast Fintype.card_pos.ne')
+          (ENNReal.natCast_ne_top _)]
+
+/-- **Non-adaptive union bound.** A query set of size at most `q`, fixed before the table is
+sampled, contains a shifted ±-colliding pair with probability at most `q·(q−1)/|F|`: sum the
+per-pair bound over the `C(q,2)` unordered pairs (`Finset.powersetCard 2`). -/
+theorem finset_shifted_collision_measure_le (s : Q → F) (Qs : Finset Q) {q : ℕ}
+    (hq : Qs.card ≤ q) :
+    (PMF.uniformOfFintype (Q → F)).toOuterMeasure
+        {O : Q → F | ∃ a ∈ Qs, ∃ b ∈ Qs, a ≠ b ∧ s a + O a =± s b + O b}
+      ≤ (q * (q - 1) : ℕ) / Fintype.card F := by
+  have hsymm : ∀ x y : F, x =± y → y =± x := fun x y h =>
+    h.elim (fun h => Or.inl h.symm) (fun h => Or.inr (by rw [h, neg_neg]))
+  have hcover : {O : Q → F | ∃ a ∈ Qs, ∃ b ∈ Qs, a ≠ b ∧ s a + O a =± s b + O b}
+      ⊆ ⋃ t : ↥(Qs.powersetCard 2),
+          {O : Q → F | ∃ a ∈ t.1, ∃ b ∈ t.1, a ≠ b ∧ s a + O a =± s b + O b} := by
+    rintro O ⟨a, ha, b, hb, hab, hpm⟩
+    refine Set.mem_iUnion.2 ⟨⟨{a, b}, Finset.mem_powersetCard.2 ⟨?_, Finset.card_pair hab⟩⟩,
+      ⟨a, ?_, b, ?_, hab, hpm⟩⟩
+    · exact Finset.insert_subset ha (Finset.singleton_subset_iff.2 hb)
+    · simp
+    · simp
+  have hpair : ∀ t : ↥(Qs.powersetCard 2),
+      (PMF.uniformOfFintype (Q → F)).toOuterMeasure
+          {O : Q → F | ∃ a ∈ t.1, ∃ b ∈ t.1, a ≠ b ∧ s a + O a =± s b + O b}
+        ≤ 2 / Fintype.card F := by
+    rintro ⟨t, ht⟩
+    obtain ⟨-, hcard⟩ := Finset.mem_powersetCard.1 ht
+    obtain ⟨a, b, hab, rfl⟩ := Finset.card_eq_two.1 hcard
+    refine le_trans (MeasureTheory.measure_mono ?_) (pair_shifted_collision_measure_le s hab)
+    rintro O ⟨x, hx, y, hy, hxy, hpm⟩
+    simp only [Finset.mem_insert, Finset.mem_singleton] at hx hy
+    rcases hx with rfl | rfl <;> rcases hy with rfl | rfl
+    · exact absurd rfl hxy
+    · exact hpm
+    · exact hsymm _ _ hpm
+    · exact absurd rfl hxy
+  have hdvd : 2 ∣ q * (q - 1) := by
+    rcases q with _ | m
+    · simp
+    · simpa [Nat.succ_sub_one, mul_comm] using (Nat.even_mul_succ_self m).two_dvd
+  have h2 : q * (q - 1) = q.choose 2 * 2 := by
+    rw [Nat.choose_two_right, Nat.div_mul_cancel hdvd]
+  calc (PMF.uniformOfFintype (Q → F)).toOuterMeasure
+        {O : Q → F | ∃ a ∈ Qs, ∃ b ∈ Qs, a ≠ b ∧ s a + O a =± s b + O b}
+      ≤ (PMF.uniformOfFintype (Q → F)).toOuterMeasure
+          (⋃ t : ↥(Qs.powersetCard 2),
+            {O : Q → F | ∃ a ∈ t.1, ∃ b ∈ t.1, a ≠ b ∧ s a + O a =± s b + O b}) :=
+        MeasureTheory.measure_mono hcover
+    _ ≤ ∑' t : ↥(Qs.powersetCard 2), (PMF.uniformOfFintype (Q → F)).toOuterMeasure
+          {O : Q → F | ∃ a ∈ t.1, ∃ b ∈ t.1, a ≠ b ∧ s a + O a =± s b + O b} :=
+        MeasureTheory.measure_iUnion_le _
+    _ ≤ ∑' _t : ↥(Qs.powersetCard 2), (2 / Fintype.card F : ℝ≥0∞) :=
+        ENNReal.tsum_le_tsum hpair
+    _ = ((Qs.powersetCard 2).card : ℝ≥0∞) * (2 / Fintype.card F) := by
+        rw [tsum_fintype, Finset.sum_const, Finset.card_univ, Fintype.card_coe, nsmul_eq_mul]
+    _ ≤ (q.choose 2 : ℝ≥0∞) * (2 / Fintype.card F) := by
+        gcongr
+        rw [Finset.card_powersetCard]
+        exact_mod_cast Nat.choose_le_choose 2 hq
+    _ = (q * (q - 1) : ℕ) / Fintype.card F := by
+        rw [h2]
+        push_cast
+        rw [mul_div_assoc]
+
+end Generic
+
+/-! ## The key-binding capstone -/
+
+section Capstone
+
+variable [AddCommGroup G] [Field F] [Field B] [Module F G] [NoZeroSMulDivisors F G]
+variable [Fintype QK] [Fintype SK] [Fintype B] [Fintype F]
+variable [DecidableEq QK] [DecidableEq SK] [DecidableEq B] [DecidableEq F]
+
+omit [Fintype QK] [Fintype SK] [Fintype B] [Fintype F] in
+/-- The queries at which `CollisionUpToSign.ofBreak` exhibits its collision are the witnesses'
+derivation queries: the `rivk_ext`-derivation pair in the residual case, the final-query pair
+otherwise. Stated over any `c` equal to the computed collision (`hc`), so that a consumer's
+`set c := CollisionUpToSign.ofBreak ... with hc` supplies `hc` directly. -/
+theorem ofBreak_queries {Extract : G → B} {S : G} {hfn : B → B → F} {Ggen : G}
+    {hExt : ∀ P R : G, Extract P = Extract R ↔ P =± R} {hS : S ≠ 0}
+    {Hask : SK → F} {Hnk : SK → B} {Hrivk_legacy : SK → F}
+    {Hrivk_ext : QK → B → B → F} {Hrivk_int : F → B → B → F}
+    {w₁ w₂ : Witness G F B SK QK}
+    {hbrk : Break Extract S hfn Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int w₁ w₂}
+    {c : RandomOracle.CollisionUpToSign
+      (shiftedFinalOracle Extract Ggen hfn Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int
+        (QK := QK) (SK := SK))}
+    (hc : c = CollisionUpToSign.ofBreak Extract S hfn Ggen hExt hS Hask Hnk Hrivk_legacy
+      Hrivk_ext Hrivk_int hbrk) :
+    (c.q₁ = extQueryOf Extract w₁ ∧ c.q₂ = extQueryOf Extract w₂) ∨
+      (c.q₁ = finalQueryOf Extract w₁ ∧ c.q₂ = finalQueryOf Extract w₂) := by
+  subst hc
+  unfold CollisionUpToSign.ofBreak
+  split
+  · exact Or.inl ⟨rfl, rfl⟩
+  · exact Or.inr ⟨rfl, rfl⟩
+
+/-- **Non-adaptive key-binding birthday bound.** Sample the combined final oracle as a uniform
+table. An adversary —here, any pair of witness choices depending on the whole table— whose
+witnesses' derivation queries lie in a set `Qs` of at most `q` queries *fixed in advance*,
+produces a key-binding `Break` with probability at most `q·(q−1)/|F|`. This is ZIP 2005's
+`ε_kb` at `|F| = r`. -/
+theorem break_measure_le (Extract : G → B) (S : G) (hfn : B → B → F) (Ggen : G)
+    (hExt : ∀ P R : G, Extract P = Extract R ↔ P =± R) (hS : S ≠ 0)
+    (Hask : SK → F) (Hnk : SK → B)
+    (w₁ w₂ : (FinalQuery QK SK B F → F) → Witness G F B SK QK)
+    (Qs : Finset (FinalQuery QK SK B F)) {q : ℕ} (hq : Qs.card ≤ q)
+    (hqueries : ∀ O, finalQueryOf Extract (w₁ O) ∈ Qs ∧ finalQueryOf Extract (w₂ O) ∈ Qs ∧
+      extQueryOf Extract (w₁ O) ∈ Qs ∧ extQueryOf Extract (w₂ O) ∈ Qs) :
+    (PMF.uniformOfFintype (FinalQuery QK SK B F → F)).toOuterMeasure
+        {O : FinalQuery QK SK B F → F |
+          Break Extract S hfn Ggen Hask Hnk
+            (fun sk => O (.legacy sk)) (fun qk ak nk => O (.ext qk ak nk))
+            (fun rivk_ext ak nk => O (.int rivk_ext ak nk)) (w₁ O) (w₂ O)}
+      ≤ (q * (q - 1) : ℕ) / Fintype.card F := by
+  refine le_trans (MeasureTheory.measure_mono ?_)
+    (finset_shifted_collision_measure_le (shiftOf Extract Ggen hfn Hask Hnk) Qs hq)
+  intro O hO
+  obtain ⟨hf₁, hf₂, he₁, he₂⟩ := hqueries O
+  set c := CollisionUpToSign.ofBreak Extract S hfn Ggen hExt hS Hask Hnk _ _ _ hO with hc
+  have hq12 := ofBreak_queries hc
+  have hpm : shiftOf Extract Ggen hfn Hask Hnk c.q₁ + O c.q₁
+      =± shiftOf Extract Ggen hfn Hask Hnk c.q₂ + O c.q₂ := by
+    have hp := c.pm
+    simpa only [shiftedFinalOracle, eval_restrict] using hp
+  refine ⟨c.q₁, ?_, c.q₂, ?_, c.ne, hpm⟩
+  · rcases hq12 with ⟨h1, -⟩ | ⟨h1, -⟩ <;> rw [h1] <;> assumption
+  · rcases hq12 with ⟨-, h2⟩ | ⟨-, h2⟩ <;> rw [h2] <;> assumption
+
+end Capstone
+
+end Zcash.Security.KeyBinding

--- a/Zcash/Security/KeyBinding/Probability.lean
+++ b/Zcash/Security/KeyBinding/Probability.lean
@@ -1,9 +1,10 @@
 import Zcash.Security.KeyBinding.Basic
 import Zcash.Security.Common.Birthday
 import Zcash.Snark.Soundness.Forking.Probability
+import Zcash.Snark.Soundness.Forking.Adversary.OracleComp
 
 /-!
-# Key binding in the whole-table random-oracle model (Layer C)
+# Key binding in the whole-table random-oracle model
 
 The deterministic key-binding layer ends at a computed event: `CollisionUpToSign.ofBreak` turns
 any key-binding `Break` into a ±-collision of the shifted combined final oracle at two distinct
@@ -25,7 +26,7 @@ copy-preserving, map in the Markov-category sense.) The pair and union lemmas be
 for an arbitrary finite query domain and arbitrary shift function, for reuse by the Spendability
 `H^rcm` collision.
 
-Results (milestone 1 — a *static* query set, fixed before the table is sampled):
+Results (static model — the query set is fixed before the table is sampled):
 
 * `pair_shifted_collision_measure_le` — a shifted ±-collision at one distinct query pair has
   probability at most `2/|F|`.
@@ -35,10 +36,22 @@ Results (milestone 1 — a *static* query set, fixed before the table is sampled
   queries land in the static set produces a `Break` with probability at most `q·(q−1)/|F|`
   (ZIP 2005's `ε_kb` at `|F| = r`).
 
-The more realistic adaptive attack model —a bounded-query machine choosing queries after seeing
-earlier answers— is the next milestone (issue #68). The fresh-read conditioning it needs is in
-`Snark.Soundness.Forking.Probability`, which this module already imports for the uniform-table
-lemmas.
+Results (adaptive — a bounded-query machine choosing queries after seeing earlier answers, as
+an `OracleComp` from the Fiat–Shamir layer):
+
+* `CollidesDuring` / `collidesDuring_measure_le` — the history-carrying collision event, and
+  the sum-over-steps bound `(2·m·Q + Q·(Q−1))/|F|` for a cache-avoiding `Q`-query machine with
+  `m` recorded answers: the triangle sum `Σ 2·(j−1)` recovers the non-adaptive constant
+  exactly.
+* `queries_pair_collision_measure_le` — a `Q`-query machine's trace contains a shifted
+  ±-colliding pair with probability at most `Q·(Q−1)/|F|`.
+* `break_measure_le_adaptive` — the adaptive capstone, for a machine that queries its output
+  witnesses' derivation inputs: `Q·(Q−1)/|F|` (ZIP 2005's accounting).
+* `break_measure_le_of_queryBound` — hypothesis-free: any `Q`-query machine, via
+  `OracleComp.completing` appending the four derivation queries: `(Q+4)·(Q+3)/|F|`.
+
+The remaining modelling steps toward the full ZIP 2005 key-binding theorem are tracked in
+issue #68.
 -/
 
 namespace Zcash.Security.KeyBinding
@@ -79,6 +92,11 @@ theorem eval_restrict (O : FinalQuery QK SK B F → F) :
 section Generic
 
 variable {Q : Type*} [Fintype Q] [DecidableEq Q] [Field F] [Fintype F] [DecidableEq F]
+
+omit [Fintype Q] [DecidableEq Q] [Fintype F] [DecidableEq F] in
+/-- `=±` is symmetric. -/
+theorem eqUpToSign_symm {x y : F} (h : x =± y) : y =± x :=
+  h.elim (fun h => Or.inl h.symm) (fun h => Or.inr (by rw [h, neg_neg]))
 
 /-- **Non-adaptive per-pair bound.** For distinct queries `a ≠ b` and any shift `s` fixed
 independently of the table, a uniform table's shifted outputs at `a` and `b` ±-collide with
@@ -124,8 +142,6 @@ theorem finset_shifted_collision_measure_le (s : Q → F) (Qs : Finset Q) {q : �
     (PMF.uniformOfFintype (Q → F)).toOuterMeasure
         {O : Q → F | ∃ a ∈ Qs, ∃ b ∈ Qs, a ≠ b ∧ s a + O a =± s b + O b}
       ≤ (q * (q - 1) : ℕ) / Fintype.card F := by
-  have hsymm : ∀ x y : F, x =± y → y =± x := fun x y h =>
-    h.elim (fun h => Or.inl h.symm) (fun h => Or.inr (by rw [h, neg_neg]))
   have hcover : {O : Q → F | ∃ a ∈ Qs, ∃ b ∈ Qs, a ≠ b ∧ s a + O a =± s b + O b}
       ⊆ ⋃ t : ↥(Qs.powersetCard 2),
           {O : Q → F | ∃ a ∈ t.1, ∃ b ∈ t.1, a ≠ b ∧ s a + O a =± s b + O b} := by
@@ -148,7 +164,7 @@ theorem finset_shifted_collision_measure_le (s : Q → F) (Qs : Finset Q) {q : �
     rcases hx with rfl | rfl <;> rcases hy with rfl | rfl
     · exact absurd rfl hxy
     · exact hpm
-    · exact hsymm _ _ hpm
+    · exact eqUpToSign_symm hpm
     · exact absurd rfl hxy
   have hdvd : 2 ∣ q * (q - 1) := by
     rcases q with _ | m
@@ -177,6 +193,305 @@ theorem finset_shifted_collision_measure_le (s : Q → F) (Qs : Finset Q) {q : �
         rw [h2]
         push_cast
         rw [mul_div_assoc]
+
+/-! ### The adaptive model
+
+The adversary is now a bounded-query machine (`OracleComp`, shared with the Fiat–Shamir layer)
+choosing each query after seeing earlier answers, run against the whole table. The event
+carries the query history: at each step the fresh answer must avoid the at most `2·m` values
+that ±-collide with one of the `m` recorded earlier answers, and summing the per-step budgets
+over a `Q`-query run recovers the non-adaptive constant exactly — the triangle sum `Σ 2·(j−1)`
+counts each unordered pair once. The measure induction mirrors `escapesDuringC_measure_le`
+(fresh-answer conditioning via `uniformOfFintype_cond_point`); recording answers as history
+*data* is what keeps each step's bad set independent of the sampled table.
+
+This is the standard bad-event analysis of adaptive random-oracle queries. A close
+textbook instance is the Davies–Meyer collision bound — Boneh and Shoup, *A Graduate Course
+in Applied Cryptography*, v0.6, https://toc.cryptobook.us/, §8.5.3, Theorem 8.4. Their event `Z`
+(some distinct query pair with colliding derived values) is this module's trace collision,
+and their "reasonable adversary" normalization (`q' := q + 2` there, `n + 4` here) is the
+`OracleComp.completing` transformation. The rendering differs in one respect: lazy sampling's
+"each fresh answer is uniform" becomes conditioning at an unread coordinate of the eager
+whole table. -/
+
+/-- The answers at `t` that would ±-collide with a recorded `(query, answer)` pair: two
+candidate values per pair, one per sign. A list representing the step's *bad set* (only
+membership matters, but it is more convenient to use the list length `2·|σ|` to bound the
+set's cardinality; coinciding candidates only slacken the bound). -/
+def badList (s : Q → F) (σ : List (Q × F)) (t : Q) : List F :=
+  σ.map (fun p => s p.1 + p.2 - s t) ++ σ.map (fun p => -(s p.1 + p.2) - s t)
+
+omit [Fintype Q] [DecidableEq Q] [Fintype F] [DecidableEq F] in
+theorem mem_badList {s : Q → F} {σ : List (Q × F)} {t : Q} {y : F} :
+    y ∈ badList s σ t ↔ ∃ p ∈ σ, s t + y =± s p.1 + p.2 := by
+  simp only [badList, List.mem_append, List.mem_map, EqUpToSign]
+  constructor
+  · rintro (⟨p, hp, rfl⟩ | ⟨p, hp, rfl⟩)
+    · exact ⟨p, hp, Or.inl (by ring)⟩
+    · exact ⟨p, hp, Or.inr (by ring)⟩
+  · rintro ⟨p, hp, h | h⟩
+    · exact Or.inl ⟨p, hp, by linear_combination -h⟩
+    · exact Or.inr ⟨p, hp, by linear_combination -h⟩
+
+omit [Fintype Q] [DecidableEq Q] in
+/-- One step's bad set has probability at most `2·m/|F|` for a history of length `m`. -/
+theorem badList_measure_le (s : Q → F) (σ : List (Q × F)) (t : Q) :
+    (PMF.uniformOfFintype F).toOuterMeasure {y : F | y ∈ badList s σ t}
+      ≤ (2 * σ.length : ℕ) / Fintype.card F := by
+  rw [uniformOfFintype_toOuterMeasure_set]
+  have hcard : Nat.card {y : F | y ∈ badList s σ t} ≤ 2 * σ.length := by
+    rw [Nat.card_coe_set_eq, Set.ncard_eq_toFinset_card', Set.toFinset_setOf]
+    calc (univ.filter fun y : F => y ∈ badList s σ t).card
+        ≤ (badList s σ t).toFinset.card := by
+          apply card_le_card
+          intro y hy
+          rw [mem_filter] at hy
+          simpa [List.mem_toFinset] using hy.2
+      _ ≤ (badList s σ t).length := (badList s σ t).toFinset_card_le
+      _ ≤ 2 * σ.length := le_of_eq (by simp [badList, two_mul])
+  gcongr
+
+/-- Some query's answer lands in the escape set determined by the accumulated history: the
+history-indexed generalization of `escapesDuringC` (which is the constant-budget case). The
+history `σ` accumulates `(query, answer)` pairs as the run proceeds; recording answers as
+history *data* keeps each step's escape set independent of the sampled table. -/
+def escapesWithHistory {α : Type*} (esc : List (Q × F) → Q → Set F) :
+    List (Q × F) → OracleComp Q F α → (Q → F) → Prop
+  | _, .pure _, _ => False
+  | σ, .query t k, O => O t ∈ esc σ t ∨ escapesWithHistory esc ((t, O t) :: σ) (k (O t)) O
+
+omit [DecidableEq F] in
+/-- **History-indexed escape bound.** If the escape set at history length `m` has probability
+at most `f m`, a cache-avoiding `n`-query machine starting from history `σ` escapes with
+probability at most `Σ_{i<n} f (|σ| + i)`: condition on each fresh answer in turn, mirroring
+`escapesDuringC_measure_le`. -/
+theorem escapesWithHistory_measure_le {α : Type*} (esc : List (Q × F) → Q → Set F)
+    {f : ℕ → ℝ≥0∞} (hesc : ∀ (σ : List (Q × F)) (t : Q),
+      (PMF.uniformOfFintype F).toOuterMeasure (esc σ t) ≤ f σ.length)
+    {A : OracleComp Q F α} {n : ℕ} (hQ : A.QueryBound n)
+    {σ : List (Q × F)} (hσ : OracleComp.AvoidsCache σ A) :
+    (PMF.uniformOfFintype (Q → F)).toOuterMeasure
+      {O : Q → F | escapesWithHistory esc σ A (applyUpdates σ O)}
+      ≤ ∑ i ∈ Finset.range n, f (σ.length + i) := by
+  induction hQ generalizing σ with
+  | pure a n =>
+      have hempty : {O : Q → F |
+          escapesWithHistory esc σ (OracleComp.pure a) (applyUpdates σ O)} = ∅ := by
+        ext O; simp [escapesWithHistory]
+      rw [hempty]; simp
+  | @query t k n h ih =>
+      cases hσ with
+      | query ht hk =>
+      have happ : ∀ O : Q → F, applyUpdates σ O t = O t :=
+        fun O => applyUpdates_apply_not_mem ht O
+      have hsub : {O : Q → F |
+            escapesWithHistory esc σ (OracleComp.query t k) (applyUpdates σ O)}
+          ⊆ {O : Q → F | O t ∈ esc σ t}
+            ∪ ⋃ u : F, {O : Q → F | O t = u ∧
+                O ∈ {O' : Q → F | escapesWithHistory esc ((t, u) :: σ) (k u)
+                  (applyUpdates ((t, u) :: σ) O')}} := by
+        intro O hO
+        simp only [escapesWithHistory, Set.mem_setOf_eq, happ O] at hO
+        rcases hO with h1 | h2
+        · exact Or.inl h1
+        · refine Or.inr (Set.mem_iUnion.mpr ⟨O t, rfl, ?_⟩)
+          have hcons : applyUpdates ((t, O t) :: σ) O = applyUpdates σ O := by
+            rw [applyUpdates_cons, Function.update_eq_self]
+          simp only [Set.mem_setOf_eq, hcons]
+          exact h2
+      refine le_trans (MeasureTheory.measure_mono hsub) ?_
+      refine le_trans (MeasureTheory.measure_union_le _ _) ?_
+      have hfirst : (PMF.uniformOfFintype (Q → F)).toOuterMeasure
+          {O : Q → F | O t ∈ esc σ t} ≤ f σ.length :=
+        uniformOfFintype_point_mem_blind_le t (fun _ => esc σ t)
+          (fun _ _ => rfl) (fun _ => hesc σ t)
+      have hsecond : (PMF.uniformOfFintype (Q → F)).toOuterMeasure
+          (⋃ u : F, {O : Q → F | O t = u ∧
+            O ∈ {O' : Q → F | escapesWithHistory esc ((t, u) :: σ) (k u)
+              (applyUpdates ((t, u) :: σ) O')}})
+          ≤ ∑ i ∈ Finset.range n, f (σ.length + (i + 1)) := by
+        refine le_trans (MeasureTheory.measure_iUnion_le _) ?_
+        rw [tsum_fintype]
+        have hper : ∀ u : F, (PMF.uniformOfFintype (Q → F)).toOuterMeasure
+            {O : Q → F | O t = u ∧
+              O ∈ {O' : Q → F | escapesWithHistory esc ((t, u) :: σ) (k u)
+                (applyUpdates ((t, u) :: σ) O')}}
+            ≤ (∑ i ∈ Finset.range n, f (σ.length + (i + 1))) / Fintype.card F := by
+          intro u
+          have hblindE : ∀ (O : Q → F) (v : F),
+              Function.update O t v ∈ {O' : Q → F | escapesWithHistory esc ((t, u) :: σ)
+                (k u) (applyUpdates ((t, u) :: σ) O')}
+              ↔ O ∈ {O' : Q → F | escapesWithHistory esc ((t, u) :: σ) (k u)
+                (applyUpdates ((t, u) :: σ) O')} := by
+            intro O v
+            have hcons : applyUpdates ((t, u) :: σ) (Function.update O t v)
+                = applyUpdates ((t, u) :: σ) O := by
+              rw [applyUpdates_cons, applyUpdates_cons, Function.update_idem]
+            simp only [Set.mem_setOf_eq, hcons]
+          rw [uniformOfFintype_cond_point t u _ hblindE]
+          refine ENNReal.div_le_div_right ?_ _
+          have hlen := ih u (hk u)
+          simpa [Nat.add_assoc, Nat.add_comm, Nat.add_left_comm] using hlen
+        refine le_trans (Finset.sum_le_sum fun u _ => hper u) ?_
+        rw [Finset.sum_const, Finset.card_univ, nsmul_eq_mul, mul_comm,
+          ENNReal.div_mul_cancel (Nat.cast_ne_zero.mpr Fintype.card_ne_zero)
+            (ENNReal.natCast_ne_top _)]
+      calc (PMF.uniformOfFintype (Q → F)).toOuterMeasure {O : Q → F | O t ∈ esc σ t}
+          + (PMF.uniformOfFintype (Q → F)).toOuterMeasure (⋃ u : F, _)
+          ≤ f σ.length + ∑ i ∈ Finset.range n, f (σ.length + (i + 1)) :=
+            add_le_add hfirst hsecond
+        _ = ∑ i ∈ Finset.range (n + 1), f (σ.length + i) := by
+            rw [Finset.sum_range_succ', add_comm]
+            simp
+
+/-- The run ±-collides during execution: the history-escape event at the `badList` sets. -/
+def CollidesDuring {α : Type*} (s : Q → F) :
+    List (Q × F) → OracleComp Q F α → (Q → F) → Prop :=
+  escapesWithHistory (fun σ t => {y : F | y ∈ badList s σ t})
+
+omit [Fintype Q] [DecidableEq Q] [Fintype F] [DecidableEq F] in
+/-- A ±-colliding pair of distinct points, each either queried on the run or recorded in a
+table-consistent history (but not both recorded), forces a collision during the run. -/
+theorem CollidesDuring.of_pair {α : Type*} {s : Q → F} {O : Q → F} {A : OracleComp Q F α}
+    {σ : List (Q × F)} (hσ : ∀ p ∈ σ, O p.1 = p.2) {a b : Q} (hab : a ≠ b)
+    (ha : a ∈ A.queries O ∨ a ∈ σ.map Prod.fst)
+    (hb : b ∈ A.queries O ∨ b ∈ σ.map Prod.fst)
+    (hnot : a ∉ σ.map Prod.fst ∨ b ∉ σ.map Prod.fst)
+    (hpm : s a + O a =± s b + O b) :
+    CollidesDuring s σ A O := by
+  induction A generalizing σ with
+  | pure c =>
+      simp only [OracleComp.queries, List.not_mem_nil, false_or] at ha hb
+      rcases hnot with h | h
+      · exact absurd ha h
+      · exact absurd hb h
+  | query t k ih =>
+      have hconsist : ∀ p ∈ (t, O t) :: σ, O p.1 = p.2 := by
+        intro p hp
+        rcases List.mem_cons.1 hp with rfl | hp
+        · rfl
+        · exact hσ p hp
+      simp only [OracleComp.queries, List.mem_cons] at ha hb
+      show (O t ∈ {y : F | y ∈ badList s σ t}) ∨
+        CollidesDuring s ((t, O t) :: σ) (k (O t)) O
+      by_cases hat : a = t
+      · subst hat
+        by_cases hbh : b ∈ σ.map Prod.fst
+        · obtain ⟨p, hp, hpfst⟩ := List.mem_map.1 hbh
+          refine Or.inl (mem_badList.2 ⟨p, hp, ?_⟩)
+          rw [← hσ p hp, hpfst]
+          exact hpm
+        · have hbtail : b ∈ (k (O a)).queries O := by
+            rcases hb with hb | hb
+            · rcases hb with rfl | hb
+              · exact absurd rfl hab
+              · exact hb
+            · exact absurd hb hbh
+          refine Or.inr (ih (O a) hconsist ?_ ?_ ?_)
+          · exact Or.inr (by simp)
+          · exact Or.inl hbtail
+          · refine Or.inr ?_
+            simp only [List.map_cons, List.mem_cons, not_or]
+            exact ⟨Ne.symm hab, hbh⟩
+      · by_cases hbt : b = t
+        · subst hbt
+          by_cases hah : a ∈ σ.map Prod.fst
+          · obtain ⟨p, hp, hpfst⟩ := List.mem_map.1 hah
+            refine Or.inl (mem_badList.2 ⟨p, hp, ?_⟩)
+            rw [← hσ p hp, hpfst]
+            exact eqUpToSign_symm hpm
+          · have hatail : a ∈ (k (O b)).queries O := by
+              rcases ha with ha | ha
+              · rcases ha with rfl | ha
+                · exact absurd rfl hat
+                · exact ha
+              · exact absurd ha hah
+            refine Or.inr (ih (O b) hconsist ?_ ?_ ?_)
+            · exact Or.inl hatail
+            · exact Or.inr (by simp)
+            · refine Or.inl ?_
+              simp only [List.map_cons, List.mem_cons, not_or]
+              exact ⟨hat, hah⟩
+        · have ha' : a ∈ (k (O t)).queries O ∨ a ∈ ((t, O t) :: σ).map Prod.fst := by
+            rcases ha with ha | ha
+            · rcases ha with rfl | ha
+              · exact absurd rfl hat
+              · exact Or.inl ha
+            · exact Or.inr (by simp [ha])
+          have hb' : b ∈ (k (O t)).queries O ∨ b ∈ ((t, O t) :: σ).map Prod.fst := by
+            rcases hb with hb | hb
+            · rcases hb with rfl | hb
+              · exact absurd rfl hbt
+              · exact Or.inl hb
+            · exact Or.inr (by simp [hb])
+          have hnot' : a ∉ ((t, O t) :: σ).map Prod.fst
+              ∨ b ∉ ((t, O t) :: σ).map Prod.fst := by
+            rcases hnot with h | h
+            · refine Or.inl ?_
+              simp only [List.map_cons, List.mem_cons, not_or]
+              exact ⟨hat, h⟩
+            · refine Or.inr ?_
+              simp only [List.map_cons, List.mem_cons, not_or]
+              exact ⟨hbt, h⟩
+          exact Or.inr (ih (O t) hconsist ha' hb' hnot')
+
+omit [Fintype Q] [DecidableEq Q] [Fintype F] [DecidableEq F] in
+/-- Gauss closed form for the collision budgets: `Σ_{i<n} 2·(m+i) = 2·m·n + n·(n−1)`. -/
+theorem sum_two_mul_add (m n : ℕ) :
+    ∑ i ∈ Finset.range n, 2 * (m + i) = 2 * m * n + n * (n - 1) := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+      rw [Finset.sum_range_succ, ih, Nat.succ_sub_one]
+      cases n with
+      | zero => ring
+      | succ k => rw [Nat.succ_sub_one]; ring
+
+/-- **Adaptive sum-over-steps bound.** A cache-avoiding `n`-query machine with `m` recorded
+answers collides during its run with probability at most `(2·m·n + n·(n−1))/|F|`: instantiate
+the history-escape bound at the `badList` sets and close the Gauss sum. -/
+theorem collidesDuring_measure_le {α : Type*} (s : Q → F)
+    {A : OracleComp Q F α} {n : ℕ} (hQ : A.QueryBound n)
+    {σ : List (Q × F)} (hσ : OracleComp.AvoidsCache σ A) :
+    (PMF.uniformOfFintype (Q → F)).toOuterMeasure
+      {O : Q → F | CollidesDuring s σ A (applyUpdates σ O)}
+      ≤ (2 * σ.length * n + n * (n - 1) : ℕ) / Fintype.card F := by
+  refine le_trans (escapesWithHistory_measure_le _
+    (f := fun m => (2 * m : ℕ) / Fintype.card F)
+    (fun σ' t => badList_measure_le s σ' t) hQ hσ) (le_of_eq ?_)
+  simp only [div_eq_mul_inv, ← Finset.sum_mul, ← Nat.cast_sum, sum_two_mul_add]
+
+/-- **Adaptive trace bound.** An `n`-query machine's trace contains a shifted ±-colliding
+distinct pair with probability at most `n·(n−1)/|F|` — the non-adaptive constant, adaptively. -/
+theorem queries_pair_collision_measure_le {α : Type*} (s : Q → F)
+    {A : OracleComp Q F α} {n : ℕ} (hQ : A.QueryBound n) :
+    (PMF.uniformOfFintype (Q → F)).toOuterMeasure
+      {O : Q → F | ∃ a ∈ A.queries O, ∃ b ∈ A.queries O, a ≠ b ∧ s a + O a =± s b + O b}
+      ≤ (n * (n - 1) : ℕ) / Fintype.card F := by
+  have hsub : {O : Q → F | ∃ a ∈ A.queries O, ∃ b ∈ A.queries O,
+        a ≠ b ∧ s a + O a =± s b + O b}
+      ⊆ {O : Q → F | CollidesDuring s [] (OracleComp.dedup [] A) O} := by
+    rintro O ⟨a, ha, b, hb, hab, hpm⟩
+    have ha' : a ∈ (OracleComp.dedup [] A).queries O :=
+      mem_queries_dedup (by simp) (by simp) ha
+    have hb' : b ∈ (OracleComp.dedup [] A).queries O :=
+      mem_queries_dedup (by simp) (by simp) hb
+    exact CollidesDuring.of_pair (by simp) hab (Or.inl ha') (Or.inl hb')
+      (Or.inl (by simp)) hpm
+  refine le_trans (MeasureTheory.measure_mono hsub) ?_
+  have hmain := collidesDuring_measure_le s (OracleComp.dedup_queryBound hQ [])
+    (OracleComp.dedup_avoidsCache [] A)
+  simpa using hmain
+
+omit [Fintype Q] [DecidableEq Q] [Field F] [Fintype F] [DecidableEq F] in
+/-- Queries of a sequenced machine: the first machine's, then the continuation's on its
+output. -/
+theorem queries_bind {α β : Type*} (A : OracleComp Q F α) (f : α → OracleComp Q F β)
+    (O : Q → F) :
+    (A.bind f).queries O = A.queries O ++ ((f (A.run O)).queries O) := by
+  induction A with
+  | pure a => simp [OracleComp.bind, OracleComp.queries]
+  | query t k ih => simp [OracleComp.bind, OracleComp.queries, ih]
 
 end Generic
 
@@ -243,6 +558,76 @@ theorem break_measure_le (Extract : G → B) (S : G) (hfn : B → B → F) (Ggen
   refine ⟨c.q₁, ?_, c.q₂, ?_, c.ne, hpm⟩
   · rcases hq12 with ⟨h1, -⟩ | ⟨h1, -⟩ <;> rw [h1] <;> assumption
   · rcases hq12 with ⟨-, h2⟩ | ⟨-, h2⟩ <;> rw [h2] <;> assumption
+
+/-! ### Adaptive capstones -/
+
+/-- The derivation queries of an output witness pair: the final and `rivk_ext`-derivation
+queries of both witnesses — the four points at which `CollisionUpToSign.ofBreak` can exhibit
+its collision. -/
+def derivQueries (Extract : G → B)
+    (w : Witness G F B SK QK × Witness G F B SK QK) : Fin 4 → FinalQuery QK SK B F :=
+  ![finalQueryOf Extract w.1, finalQueryOf Extract w.2,
+    extQueryOf Extract w.1, extQueryOf Extract w.2]
+
+/-- **Adaptive key-binding bound (ZIP 2005 accounting).** An `n`-query machine that queries its
+output witnesses' derivation inputs produces a key-binding `Break` with probability at most
+`n·(n−1)/|F|` — ZIP 2005's `ε_kb` at `|F| = r`, with the adversary's queries chosen adaptively. -/
+theorem break_measure_le_adaptive (Extract : G → B) (S : G) (hfn : B → B → F) (Ggen : G)
+    (hExt : ∀ P R : G, Extract P = Extract R ↔ P =± R) (hS : S ≠ 0)
+    (Hask : SK → F) (Hnk : SK → B)
+    {A : OracleComp (FinalQuery QK SK B F) F (Witness G F B SK QK × Witness G F B SK QK)}
+    {n : ℕ} (hQ : A.QueryBound n)
+    (hqueries : ∀ (O : FinalQuery QK SK B F → F) (i : Fin 4),
+      derivQueries Extract (A.run O) i ∈ A.queries O) :
+    (PMF.uniformOfFintype (FinalQuery QK SK B F → F)).toOuterMeasure
+        {O : FinalQuery QK SK B F → F |
+          Break Extract S hfn Ggen Hask Hnk
+            (fun sk => O (.legacy sk)) (fun qk ak nk => O (.ext qk ak nk))
+            (fun rivk_ext ak nk => O (.int rivk_ext ak nk)) (A.run O).1 (A.run O).2}
+      ≤ (n * (n - 1) : ℕ) / Fintype.card F := by
+  refine le_trans (MeasureTheory.measure_mono ?_)
+    (queries_pair_collision_measure_le (shiftOf Extract Ggen hfn Hask Hnk) hQ)
+  intro O hO
+  set c := CollisionUpToSign.ofBreak Extract S hfn Ggen hExt hS Hask Hnk _ _ _ hO with hc
+  have hq12 := ofBreak_queries hc
+  have hpm : shiftOf Extract Ggen hfn Hask Hnk c.q₁ + O c.q₁
+      =± shiftOf Extract Ggen hfn Hask Hnk c.q₂ + O c.q₂ := by
+    have hp := c.pm
+    simpa only [shiftedFinalOracle, eval_restrict] using hp
+  refine ⟨c.q₁, ?_, c.q₂, ?_, c.ne, hpm⟩
+  · rcases hq12 with ⟨h1, -⟩ | ⟨h1, -⟩
+    · simpa [derivQueries, h1] using hqueries O 2
+    · simpa [derivQueries, h1] using hqueries O 0
+  · rcases hq12 with ⟨-, h2⟩ | ⟨-, h2⟩
+    · simpa [derivQueries, h2] using hqueries O 3
+    · simpa [derivQueries, h2] using hqueries O 1
+
+/-- **Adaptive key-binding bound, hypothesis-free.** Any `n`-query machine produces a
+key-binding `Break` with probability at most `(n+4)·(n+3)/|F|`: complete the machine with its
+output witnesses' four derivation queries (`OracleComp.completing`) and apply the adaptive
+bound at budget `n + 4`. -/
+theorem break_measure_le_of_queryBound (Extract : G → B) (S : G) (hfn : B → B → F) (Ggen : G)
+    (hExt : ∀ P R : G, Extract P = Extract R ↔ P =± R) (hS : S ≠ 0)
+    (Hask : SK → F) (Hnk : SK → B)
+    {A : OracleComp (FinalQuery QK SK B F) F (Witness G F B SK QK × Witness G F B SK QK)}
+    {n : ℕ} (hQ : A.QueryBound n) :
+    (PMF.uniformOfFintype (FinalQuery QK SK B F → F)).toOuterMeasure
+        {O : FinalQuery QK SK B F → F |
+          Break Extract S hfn Ggen Hask Hnk
+            (fun sk => O (.legacy sk)) (fun qk ak nk => O (.ext qk ak nk))
+            (fun rivk_ext ak nk => O (.int rivk_ext ak nk)) (A.run O).1 (A.run O).2}
+      ≤ ((n + 4) * (n + 3) : ℕ) / Fintype.card F := by
+  have hqueries : ∀ (O : FinalQuery QK SK B F → F) (i : Fin 4),
+      derivQueries Extract ((A.completing (derivQueries Extract)).run O) i
+        ∈ (A.completing (derivQueries Extract)).queries O := by
+    intro O i
+    rw [OracleComp.run_completing, OracleComp.completing, queries_bind,
+      OracleComp.queries_queryList]
+    exact List.mem_append.2 (Or.inr (List.mem_ofFn.2 ⟨i, rfl⟩))
+  have hbound := break_measure_le_adaptive Extract S hfn Ggen hExt hS Hask Hnk
+    (OracleComp.queryBound_completing (derivQueries Extract) hQ) hqueries
+  have h43 : n + 4 - 1 = n + 3 := by omega
+  simpa [OracleComp.run_completing, h43] using hbound
 
 end Capstone
 

--- a/Zcash/Security/KeyBinding/Probability.lean
+++ b/Zcash/Security/KeyBinding/Probability.lean
@@ -483,16 +483,6 @@ theorem queries_pair_collision_measure_le {α : Type*} (s : Q → F)
     (OracleComp.dedup_avoidsCache [] A)
   simpa using hmain
 
-omit [Fintype Q] [DecidableEq Q] [Field F] [Fintype F] [DecidableEq F] in
-/-- Queries of a sequenced machine: the first machine's, then the continuation's on its
-output. -/
-theorem queries_bind {α β : Type*} (A : OracleComp Q F α) (f : α → OracleComp Q F β)
-    (O : Q → F) :
-    (A.bind f).queries O = A.queries O ++ ((f (A.run O)).queries O) := by
-  induction A with
-  | pure a => simp [OracleComp.bind, OracleComp.queries]
-  | query t k ih => simp [OracleComp.bind, OracleComp.queries, ih]
-
 end Generic
 
 /-! ## The key-binding capstone -/
@@ -621,13 +611,14 @@ theorem break_measure_le_of_queryBound (Extract : G → B) (S : G) (hfn : B → 
       derivQueries Extract ((A.completing (derivQueries Extract)).run O) i
         ∈ (A.completing (derivQueries Extract)).queries O := by
     intro O i
-    rw [OracleComp.run_completing, OracleComp.completing, queries_bind,
+    rw [OracleComp.run_completing, OracleComp.completing, OracleComp.queries_bind,
       OracleComp.queries_queryList]
     exact List.mem_append.2 (Or.inr (List.mem_ofFn.2 ⟨i, rfl⟩))
   have hbound := break_measure_le_adaptive Extract S hfn Ggen hExt hS Hask Hnk
     (OracleComp.queryBound_completing (derivQueries Extract) hQ) hqueries
   have h43 : n + 4 - 1 = n + 3 := by omega
   simpa [OracleComp.run_completing, h43] using hbound
+
 
 end Capstone
 

--- a/Zcash/Security/KeyBinding/Probability.lean
+++ b/Zcash/Security/KeyBinding/Probability.lean
@@ -485,6 +485,18 @@ theorem queries_pair_collision_measure_le {α : Type*} (s : Q → F)
 
 end Generic
 
+/-! ## Averaging a pointwise bound -/
+
+/-- A measure bound that holds for every conditioned slice survives averaging: if each
+component `f a` gives the event measure at most `ε`, so does the mixture `p.bind f`. -/
+theorem toOuterMeasure_bind_le {α β : Type*} (p : PMF α) (f : α → PMF β) (s : Set β)
+    {ε : ℝ≥0∞} (h : ∀ a, (f a).toOuterMeasure s ≤ ε) :
+    (p.bind f).toOuterMeasure s ≤ ε := by
+  rw [PMF.toOuterMeasure_bind_apply]
+  calc ∑' a, p a * (f a).toOuterMeasure s
+      ≤ ∑' a, p a * ε := ENNReal.tsum_le_tsum fun a => mul_le_mul_right (h a) _
+    _ = ε := by rw [ENNReal.tsum_mul_right, PMF.tsum_coe, one_mul]
+
 /-! ## The key-binding capstone -/
 
 section Capstone
@@ -619,6 +631,28 @@ theorem break_measure_le_of_queryBound (Extract : G → B) (S : G) (hfn : B → 
   have h43 : n + 4 - 1 = n + 3 := by omega
   simpa [OracleComp.run_completing, h43] using hbound
 
+
+/-- **Adaptive key-binding bound over adversary randomness and the outer oracles.** The
+pointwise capstone conditions on the adversary's private randomness and the `H^ask`/`H^nk`
+tables; this lifts it to the mixture. The index `ι` bundles everything the pointwise bound
+fixes — private coins and both outer tables, under any joint distribution `p` — and the
+bound is uniform in the slice, so averaging preserves it. -/
+theorem break_measure_le_mixture {ι : Type*} (Extract : G → B) (S : G) (hfn : B → B → F)
+    (Ggen : G) (hExt : ∀ P R : G, Extract P = Extract R ↔ P =± R) (hS : S ≠ 0)
+    (p : PMF ι) (Hask : ι → SK → F) (Hnk : ι → SK → B)
+    {A : ι → OracleComp (FinalQuery QK SK B F) F (Witness G F B SK QK × Witness G F B SK QK)}
+    {n : ℕ} (hQ : ∀ i, (A i).QueryBound n) :
+    ((p.bind fun i => (PMF.uniformOfFintype (FinalQuery QK SK B F → F)).map
+        (Prod.mk i))).toOuterMeasure
+        {x : ι × (FinalQuery QK SK B F → F) |
+          Break Extract S hfn Ggen (Hask x.1) (Hnk x.1)
+            (fun sk => x.2 (.legacy sk)) (fun qk ak nk => x.2 (.ext qk ak nk))
+            (fun rivk_ext ak nk => x.2 (.int rivk_ext ak nk))
+            ((A x.1).run x.2).1 ((A x.1).run x.2).2}
+      ≤ ((n + 4) * (n + 3) : ℕ) / Fintype.card F := by
+  refine toOuterMeasure_bind_le _ _ _ fun i => ?_
+  rw [PMF.toOuterMeasure_map_apply]
+  exact break_measure_le_of_queryBound Extract S hfn Ggen hExt hS (Hask i) (Hnk i) (hQ i)
 
 end Capstone
 

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -74,6 +74,8 @@ assert_axioms Zcash.Security.KeyBinding.queries_pair_collision_measure_le
 assert_computable Zcash.Security.KeyBinding.derivQueries
 assert_axioms Zcash.Security.KeyBinding.break_measure_le_adaptive
 assert_axioms Zcash.Security.KeyBinding.break_measure_le_of_queryBound
+assert_axioms Zcash.Security.KeyBinding.toOuterMeasure_bind_le
+assert_axioms Zcash.Security.KeyBinding.break_measure_le_mixture
 
 /-! ## Ledger-layer break reductions
 

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -53,7 +53,7 @@ assert_axioms Zcash.Security.Birthday.card_shifted_pm_collision_le
 assert_axioms Zcash.Security.Birthday.shifted_pm_collision_fraction_le
 assert_axioms Zcash.Security.Birthday.birthday_closed_form
 
-/-! ## Key binding — whole-table random-oracle model (Layer C, static query set) -/
+/-! ## Key binding — whole-table random-oracle model -/
 
 assert_computable Zcash.Security.KeyBinding.finalQueryEquiv
 assert_axioms Zcash.Security.KeyBinding.eval_restrict
@@ -61,6 +61,20 @@ assert_axioms Zcash.Security.KeyBinding.pair_shifted_collision_measure_le
 assert_axioms Zcash.Security.KeyBinding.finset_shifted_collision_measure_le
 assert_axioms Zcash.Security.KeyBinding.ofBreak_queries
 assert_axioms Zcash.Security.KeyBinding.break_measure_le
+assert_computable Zcash.Security.KeyBinding.badList
+assert_axioms Zcash.Security.KeyBinding.mem_badList
+assert_axioms Zcash.Security.KeyBinding.badList_measure_le
+assert_axioms Zcash.Security.KeyBinding.escapesWithHistory
+assert_axioms Zcash.Security.KeyBinding.escapesWithHistory_measure_le
+assert_axioms Zcash.Security.KeyBinding.CollidesDuring
+assert_axioms Zcash.Security.KeyBinding.CollidesDuring.of_pair
+assert_axioms Zcash.Security.KeyBinding.sum_two_mul_add
+assert_axioms Zcash.Security.KeyBinding.collidesDuring_measure_le
+assert_axioms Zcash.Security.KeyBinding.queries_pair_collision_measure_le
+assert_axioms Zcash.Security.KeyBinding.queries_bind
+assert_computable Zcash.Security.KeyBinding.derivQueries
+assert_axioms Zcash.Security.KeyBinding.break_measure_le_adaptive
+assert_axioms Zcash.Security.KeyBinding.break_measure_le_of_queryBound
 
 /-! ## Ledger-layer break reductions
 

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -1,4 +1,5 @@
 import Zcash.Security.KeyBinding.Instance
+import Zcash.Security.KeyBinding.Probability
 import Zcash.Security.Common.Birthday
 import Zcash.Security.BindingSignature.Orchard
 import Zcash.Security.BindingSignature.Sapling
@@ -51,6 +52,15 @@ assert_axioms Zcash.Security.KeyBinding.toInterface
 assert_axioms Zcash.Security.Birthday.card_shifted_pm_collision_le
 assert_axioms Zcash.Security.Birthday.shifted_pm_collision_fraction_le
 assert_axioms Zcash.Security.Birthday.birthday_closed_form
+
+/-! ## Key binding — whole-table random-oracle model (Layer C, static query set) -/
+
+assert_computable Zcash.Security.KeyBinding.finalQueryEquiv
+assert_axioms Zcash.Security.KeyBinding.eval_restrict
+assert_axioms Zcash.Security.KeyBinding.pair_shifted_collision_measure_le
+assert_axioms Zcash.Security.KeyBinding.finset_shifted_collision_measure_le
+assert_axioms Zcash.Security.KeyBinding.ofBreak_queries
+assert_axioms Zcash.Security.KeyBinding.break_measure_le
 
 /-! ## Ledger-layer break reductions
 

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -71,7 +71,6 @@ assert_axioms Zcash.Security.KeyBinding.CollidesDuring.of_pair
 assert_axioms Zcash.Security.KeyBinding.sum_two_mul_add
 assert_axioms Zcash.Security.KeyBinding.collidesDuring_measure_le
 assert_axioms Zcash.Security.KeyBinding.queries_pair_collision_measure_le
-assert_axioms Zcash.Security.KeyBinding.queries_bind
 assert_computable Zcash.Security.KeyBinding.derivQueries
 assert_axioms Zcash.Security.KeyBinding.break_measure_le_adaptive
 assert_axioms Zcash.Security.KeyBinding.break_measure_le_of_queryBound


### PR DESCRIPTION
The probabilistic layer of the key-binding formalization (tracking issue #68). It turns the deterministic layer's computed collision event (#50) and the `Birthday.lean` counting facts into probability bounds, in two stages — a static (non-adaptive) model and the full adaptive bounded-query model.

**Model.** The combined final `rivk`-derivation oracle is sampled as one uniform table `O : FinalQuery QK SK B F → F` (`Fintype` via the constructor partition `finalQueryEquiv`). The three constituent oracles are its constructor restrictions (`eval_restrict`). A uniform table has independent uniform outputs at every query, and the shift `shiftOf` reads only the query and the fixed parameters, so a shifted pair read at distinct queries is still uniform. The uniform-table and conditioning lemmas come from `Snark.Soundness.Forking.Probability` (#56) — generic content imported across the Security/Snark boundary. Relocating it to a shared home is possible follow-up.

**Non-adaptive results** (the query set is fixed before the table is sampled):
- `pair_shifted_collision_measure_le` — shifted ±-collision at one distinct pair: ≤ `2/|F|`. Stated for an arbitrary finite query domain and arbitrary table-independent shift, for reuse by the Spendability `H^rcm` collision.
- `finset_shifted_collision_measure_le` — union over the `C(q,2)` unordered pairs of a query set of size ≤ q: ≤ `q·(q−1)/|F|` (exact, via `powersetCard 2`).
- `break_measure_le` — an adversary whose witnesses' derivation queries lie in the static set produces a key-binding `Break` with probability ≤ `q·(q−1)/|F|` — ZIP 2005's ε_kb at `|F| = r`.

**Adaptive results** (the adversary is a bounded-query `OracleComp` machine choosing each query after seeing earlier answers):
- `escapesWithHistory_measure_le` — a history-indexed escape bound: per-step escape probability `f(history length)` gives `≤ Σ_{i<n} f(m+i)` for a cache-avoiding n-query machine. This generalizes `escapesDuringC_measure_le` (the constant-budget case); #74 tracks unifying them once the stack's in-flight work has landed.
- `queries_pair_collision_measure_le` — at the `badList` sets (at most two candidate answers per recorded pair, one per sign) the triangle sum recovers the non-adaptive constant exactly: a trace ±-collision has probability ≤ `n·(n−1)/|F|`.
- `break_measure_le_adaptive` — the key-binding break, for a machine that queries its output witnesses' derivation inputs: ≤ `n·(n−1)/|F|` (ZIP 2005's accounting convention).
- `break_measure_le_of_queryBound` — hypothesis-free, for any n-query machine: ≤ `(n+4)·(n+3)/|F|`, via `OracleComp.completing` appending the four derivation queries — the textbook "wlog the adversary queries what it outputs" as a construction rather than an assumption.

The adaptive argument follows the Davies–Meyer collision analysis (Boneh–Shoup, *A Graduate Course in Applied Cryptography* v0.6, §8.5.3, Theorem 8.4). Their "reasonable adversary" normalization is the completion; their event Z is the trace collision, with the same per-pair factor 2 (from ⊕ there, ± here). The corresponding prose for ZIP 2005 is drafted in the working notes.

**Trust boundary.** `Zcash/TrustBoundary.lean` extends the census over the whole new surface (`assert_computable` for the data definitions, `assert_axioms` at the standard tier for the theorems). Full build green.

**Known deferrals** (per #68):
- The triple-of-oracles ↔ single-table uniformity transport as a stated `PMF` equality (currently the identification is definitional via `eval_restrict`).
- Distinguishing the domains of `ak`/`nk`/`rivk` etc. (not all `B` in practice).
- Wiring the bounds into the ledger-games layer.

🤖 Claude Fable 5

