### PR TITLE
chore(docs): document lean verification in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,24 @@ of the Action circuit used by the *Orchard* and *Ironwood pools*, before the NU6
 upgrade that activates the latter. An important part of this effort will be to clearly
 and accurately document the scope of what is and is not formally verified.
 
+## Verifying the proofs
+
+The formalization is a Lean 4 development over Mathlib, and building it
+re-elaborates every proof — a successful build *is* the verification. The single
+command is `lake build`, with two one-time prerequisites: install
+[`elan`](https://github.com/leanprover/elan) (the Lean toolchain manager, which
+reads [`lean-toolchain`](lean-toolchain) and installs the pinned toolchain
+automatically), then, from the repository root, fetch Mathlib's prebuilt
+artifacts so it need not be recompiled from source:
+
+```sh
+lake exe cache get   # one-time: download prebuilt Mathlib artifacts
+lake build           # verify everything (exactly what CI runs)
+```
+
 ## Documentation
 
-- [$\textsf{The Ironwood Book}$](https://zcash.github.io/ironwood/)
+- [The Ironwood Book](https://zcash.github.io/ironwood/)
 
 ## License
 


### PR DESCRIPTION
Add a "Verifying the proofs" section explaining that `lake build` is the single command that re-checks the whole formalization, with the one-time `elan` install and `lake exe cache get` prerequisites, and noting what the build additionally enforces (no-sorry/axiom trust boundaries and the `native_decide` fixture verifier run).

Closes #63.