### PR TITLE
chore(fv): track security bounds

### DIFF
--- a/Zcash/Snark.lean
+++ b/Zcash/Snark.lean
@@ -52,6 +52,8 @@ import Zcash.Snark.Soundness.Deployed.Verification
 import Zcash.Snark.Soundness.Forking
 import Zcash.Snark.Soundness.Main
 import Zcash.Snark.Soundness.Vesta
+-- Concrete fork-tree knowledge error over the deployed Orchard parameters (#25).
+import Zcash.Snark.Soundness.Deployed.ConcreteBounds
 -- AGM binding reduction: consume computed deployed relations through the fixed-slot discrete-log
 -- adapter and representation-carrying algebraic-prover model (#15).
 import Zcash.Snark.Soundness.AGM.Adapter

--- a/Zcash/Snark/Soundness/Deployed/ConcreteBounds.lean
+++ b/Zcash/Snark/Soundness/Deployed/ConcreteBounds.lean
@@ -1,0 +1,44 @@
+import Zcash.Snark.Core.Field
+import Zcash.Snark.Soundness.Forking.KnowledgeError
+
+/-!
+# Concrete fork-tree knowledge error over the deployed Orchard parameters
+
+Orchard is a single deployed protocol, not an asymptotic family: the verifier runs over the fixed
+field `F_p` (`Fintype.card Fp = scalarFieldOrder = PALLAS_BASE_CARD ≈ 2²⁵⁴`) with the captured shape,
+whose IPA recursion depth is `k = 11`. This module reads the fork-tree knowledge error off the
+deployed parameters as a concrete number.
+
+The `Soundness.Vesta` capstones state their acceptance hypothesis directly against the concrete floor
+`3·k/|F_p|` (using `kerr_div_card` to relate it to the recursive `Forking.Tree.kerr` count). This
+module records what that floor evaluates to:
+
+* `deployed_forking_knowledge_error` — at any IPA depth `k`, the fork-tree threshold
+  `(kerr |F_p| k)/|F_p|ᵏ` equals `3·k/|F_p|`.
+* `deployed_forking_knowledge_error_captured` — at the captured Orchard depth `k = 11` it is
+  `33/scalarFieldOrder`. With `scalarFieldOrder ≈ 2²⁵⁴` this is `≈ 2⁻²⁴⁹`.
+-/
+
+namespace Zcash.Snark
+
+open scoped ENNReal
+
+/-- **The deployed fork-tree knowledge error is exactly `3k/|F_p|`.** At any IPA depth `k` the
+threshold the Vesta forking capstones compare the accept probability against,
+`(kerr |F_p| k)/|F_p|ᵏ`, is the concrete fraction `3·k/|F_p|`. Specialisation of `kerr_div_card` to
+the deployed field `F_p`. -/
+theorem deployed_forking_knowledge_error (k : ℕ) :
+    (kerr (Fintype.card Fp) k : ℝ≥0∞) / Fintype.card (Fin k → Fp)
+      = 3 * k / Fintype.card Fp :=
+  kerr_div_card (α := Fp) k
+
+/-- The deployed floor at the **captured Orchard depth** `k = 11`: `33/scalarFieldOrder`. Since
+`scalarFieldOrder = PALLAS_BASE_CARD ≈ 2²⁵⁴`, this is `≈ 2⁻²⁴⁹` — the concrete soundness error the
+fork-tree extraction charges, over the actual deployed parameters. -/
+theorem deployed_forking_knowledge_error_captured :
+    (kerr (Fintype.card Fp) 11 : ℝ≥0∞) / Fintype.card (Fin 11 → Fp)
+      = 33 / (scalarFieldOrder : ℝ≥0∞) := by
+  rw [deployed_forking_knowledge_error, card_Fp]
+  norm_num
+
+end Zcash.Snark

--- a/Zcash/Snark/Soundness/Forking/KnowledgeError.lean
+++ b/Zcash/Snark/Soundness/Forking/KnowledgeError.lean
@@ -1,0 +1,66 @@
+import Zcash.Snark.Soundness.Forking.Tree
+
+/-!
+# Closed form of the fork-tree knowledge error
+
+`Tree.kerr` is defined by the recursion `kerr N 0 = 0`, `kerr N (d+1) = 3·Nᵈ + N·kerr N d`. Its
+docstring records the intended reading of the threshold fraction `kerr N d / Nᵈ` as `3d/N`, but that
+closed form was only asserted in prose. This module proves it, so the abstract knowledge-error
+threshold can be replaced by a concrete quantity in the deployed parameters (`Deployed.ConcreteBounds`
+specialises `d = 11`, `N = |F_p|`).
+
+* `kerr_mul_card` — the exact natural-number identity `kerr N d · N = 3·d·Nᵈ`, stated multiplied
+  through by `N` so it needs neither `1 ≤ N` nor truncated subtraction.
+* `kerr_eq` — the divided form `kerr N d = 3·d·Nᵈ⁻¹` (for `0 < N`).
+* `kerr_div_card` — the probability form: the threshold `extractable_of_prob` compares against,
+  `(kerr N d)/Nᵈ` with `Nᵈ = |Fin d → α|`, is exactly `3d/N` in `ℝ≥0∞`.
+-/
+
+namespace Zcash.Snark
+
+variable {α : Type*}
+
+/-- The exact natural-number closed form of the knowledge-error count: `kerr N d · N = 3·d·Nᵈ`.
+
+This is `kerr N d = 3·d·Nᵈ⁻¹` cleared of the truncated exponent; the induction is immediate from the
+defining recursion `kerr N (d+1) = 3·Nᵈ + N·kerr N d`. -/
+theorem kerr_mul_card (N d : ℕ) : kerr N d * N = 3 * d * N ^ d := by
+  induction d with
+  | zero => simp [kerr]
+  | succ d ih =>
+      simp only [kerr]
+      rw [add_mul, mul_assoc N (kerr N d) N, ih]
+      ring
+
+/-- The divided closed form `kerr N d = 3·d·Nᵈ⁻¹`, valid once `N` is nonzero (so `N` cancels). At
+`d = 0` both sides are `0`; for `d ≥ 1` this is `kerr_mul_card` divided by `N`. -/
+theorem kerr_eq {N : ℕ} (hN : 0 < N) (d : ℕ) : kerr N d = 3 * d * N ^ (d - 1) := by
+  rcases Nat.eq_zero_or_pos d with hd | hd
+  · subst hd; simp [kerr]
+  · apply Nat.eq_of_mul_eq_mul_right hN
+    rw [kerr_mul_card, mul_assoc (3 * d), ← pow_succ, Nat.sub_add_cancel hd]
+
+open scoped ENNReal in
+/-- **The fork-tree knowledge error is exactly `3d/N`.** The threshold `extractable_of_prob` (and
+every capstone `hprob`) compares the accept probability against is `(kerr N d)/|Fin d → α|`; since
+`|Fin d → α| = Nᵈ` for `N = |α|`, this equals `3·d/N` in `ℝ≥0∞`. Turning the recursive `kerr` into
+this concrete fraction is what lets the deployed soundness floor be read off directly. -/
+theorem kerr_div_card [Fintype α] [Nonempty α] (d : ℕ) :
+    (kerr (Fintype.card α) d : ℝ≥0∞) / Fintype.card (Fin d → α)
+      = 3 * d / Fintype.card α := by
+  classical
+  have hcard : Fintype.card (Fin d → α) = Fintype.card α ^ d := by
+    rw [Fintype.card_fun, Fintype.card_fin]
+  have hpos : 0 < Fintype.card α := Fintype.card_pos
+  have hNe : (Fintype.card α : ℝ≥0∞) ≠ 0 := by exact_mod_cast hpos.ne'
+  have hNt : (Fintype.card α : ℝ≥0∞) ≠ ∞ := ENNReal.natCast_ne_top _
+  have hPe : ((Fintype.card α ^ d : ℕ) : ℝ≥0∞) ≠ 0 := by exact_mod_cast (pow_pos hpos d).ne'
+  have hPt : ((Fintype.card α ^ d : ℕ) : ℝ≥0∞) ≠ ∞ := ENNReal.natCast_ne_top _
+  rw [hcard, ENNReal.div_eq_div_iff hNe hNt hPe hPt]
+  have h : (kerr (Fintype.card α) d : ℝ≥0∞) * Fintype.card α
+      = 3 * d * (Fintype.card α : ℝ≥0∞) ^ d := by exact_mod_cast kerr_mul_card (Fintype.card α) d
+  push_cast
+  rw [mul_comm (Fintype.card α : ℝ≥0∞) (kerr (Fintype.card α) d : ℝ≥0∞), h]
+  ring
+
+end Zcash.Snark

--- a/Zcash/Snark/Soundness/Vesta.lean
+++ b/Zcash/Snark/Soundness/Vesta.lean
@@ -1,6 +1,7 @@
 import Mathlib
 import Zcash.Snark.Soundness.Main
 import Zcash.Snark.Soundness.Forking.Rewind
+import Zcash.Snark.Soundness.Forking.KnowledgeError
 import CompElliptic.Curves.Pasta
 import CompElliptic.Curves.PastaOrder
 
@@ -176,7 +177,7 @@ noncomputable def legacy_orchard_verifier_vesta_forking_opening [DecidableEq Ves
         (deployedCommitment urs hk vk ps ch - pU • urs.u - pW • urs.w
           - multiopenValue vk ps ch • urs.g 0 + ξ • commit urs s
           + (z * 0) • urs.u + blind • urs.w) χ)
-    (hprob : (kerr (Fintype.card Fp) urs.k : ℝ≥0∞) / Fintype.card (Fin urs.k → Fp)
+    (hprob : (3 * urs.k : ℝ≥0∞) / Fintype.card Fp
         < (PMF.uniformOfFintype (Fin urs.k → Fp)).toOuterMeasure (Finset.univ.filter accepts)) :
     (∃ a, IpaRelation urs (deployedCommitment urs hk vk ps ch - pU • urs.u - pW • urs.w)
         (evalVector urs.k xEval)
@@ -192,7 +193,7 @@ noncomputable def legacy_orchard_verifier_vesta_forking_opening [DecidableEq Ves
     (multiopenValue vk ps ch) ξ z
     blind aMulti (adjustedWitness aMulti s (multiopenValue vk ps ch) ξ) s Q accepts hz
     (evalVector_zero urs.k xEval) (commit_adjustedWitness urs aMulti s (multiopenValue vk ps ch) ξ)
-    hbr hprob
+    hbr (by rw [kerr_div_card]; exact hprob)
   rwa [hcommit] at h
 
 open Polynomial in
@@ -226,7 +227,7 @@ noncomputable def legacy_orchard_verifier_vesta_forking_constraint [DecidableEq 
     (hencodes : ∀ a, SnarkRelation urs (deployedCommitment urs hk vk ps ch - pU • urs.u - pW • urs.w)
         (evalVector urs.k xEval) (multiopenValue vk ps ch)
       (circuitSatViaGates fixedCols decodeAdvice decodeInstance y gates hpoly deg) a → S)
-    (hprob : (kerr (Fintype.card Fp) urs.k : ℝ≥0∞) / Fintype.card (Fin urs.k → Fp)
+    (hprob : (3 * urs.k : ℝ≥0∞) / Fintype.card Fp
         < (PMF.uniformOfFintype (Fin urs.k → Fp)).toOuterMeasure (Finset.univ.filter accepts)) :
     S ⊕' NontrivialRelation (F := Fp) urs.g urs.u urs.w := by
   rcases legacy_orchard_verifier_vesta_forking_opening urs hk vk ps ch xEval ξ z blind pU pW s aMulti Q
@@ -263,7 +264,7 @@ noncomputable def legacy_orchard_verifier_vesta_forking_opening_deployed [Decida
     (hU : pU + ch.xi * sU = 0)
     (hcommit : commit urs aMulti = deployedCommitment urs hk vk ps ch - pU • urs.u - pW • urs.w)
     (hs : commit urs s = ps.ipaS - sU • urs.u - sW • urs.w)
-    (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
+    (hprob : (3 * shape.k : ℝ≥0∞) / Fintype.card Fp
         < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
             (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk ps
               {ch with ipaRound := χ}))) :
@@ -327,7 +328,7 @@ noncomputable def legacy_orchard_verifier_vesta_forking_constraint_deployed [Dec
     (hencodes : ∀ a, SnarkRelation urs (deployedCommitment urs hk vk ps ch - pU • urs.u - pW • urs.w)
         (evalVector urs.k ch.x3) (multiopenValue vk ps ch)
       (circuitSatViaGates fixedCols decodeAdvice decodeInstance y gates hpoly deg) a → S)
-    (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
+    (hprob : (3 * shape.k : ℝ≥0∞) / Fintype.card Fp
         < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
             (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk ps
               {ch with ipaRound := χ}))) :
@@ -354,7 +355,7 @@ noncomputable def legacy_orchard_verifier_vesta_forking_opening_adaptive [Decida
     (hU : pU + ch.xi * sU = 0)
     (hcommit : commit urs aMulti = deployedCommitment urs hk vk ps ch - pU • urs.u - pW • urs.w)
     (hs : commit urs s = ps.ipaS - sU • urs.u - sW • urs.w)
-    (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
+    (hprob : (3 * shape.k : ℝ≥0∞) / Fintype.card Fp
         < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
             (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk
               (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2)
@@ -414,7 +415,7 @@ noncomputable def legacy_orchard_verifier_vesta_forking_constraint_adaptive
     (hencodes : ∀ a, SnarkRelation urs (deployedCommitment urs hk vk ps ch - pU • urs.u - pW • urs.w)
         (evalVector urs.k ch.x3) (multiopenValue vk ps ch)
       (circuitSatViaGates fixedCols decodeAdvice decodeInstance y gates hpoly deg) a → S)
-    (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
+    (hprob : (3 * shape.k : ℝ≥0∞) / Fintype.card Fp
         < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
             (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk
               (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2)
@@ -448,7 +449,7 @@ noncomputable def legacy_orchard_verifier_vesta_forking_opening_rewind [Decidabl
     (hcommit : commit urs aMulti
       = deployedCommitment urs hk vk ps (roChallenges O init ps) - pU • urs.u - pW • urs.w)
     (hs : commit urs s = ps.ipaS - sU • urs.u - sW • urs.w)
-    (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
+    (hprob : (3 * shape.k : ℝ≥0∞) / Fintype.card Fp
         < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
             (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk ps
               (roChallenges (reprogramRounds O init ps χ) init ps)))) :
@@ -498,7 +499,7 @@ noncomputable def legacy_orchard_verifier_vesta_forking_constraint_rewind
         (deployedCommitment urs hk vk ps (roChallenges O init ps) - pU • urs.u - pW • urs.w)
         (evalVector urs.k (roChallenges O init ps).x3) (multiopenValue vk ps (roChallenges O init ps))
       (circuitSatViaGates fixedCols decodeAdvice decodeInstance y gates hpoly deg) a → S)
-    (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
+    (hprob : (3 * shape.k : ℝ≥0∞) / Fintype.card Fp
         < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
             (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk ps
               (roChallenges (reprogramRounds O init ps χ) init ps)))) :
@@ -521,7 +522,7 @@ noncomputable def legacy_orchard_verifier_vesta_forking_opening_adaptive_rewind
     (hcommit : commit urs aMulti
       = deployedCommitment urs hk vk ps (roChallenges O init ps) - pU • urs.u - pW • urs.w)
     (hs : commit urs s = ps.ipaS - sU • urs.u - sW • urs.w)
-    (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
+    (hprob : (3 * shape.k : ℝ≥0∞) / Fintype.card Fp
         < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
             (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk
               (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2)
@@ -576,7 +577,7 @@ noncomputable def legacy_orchard_verifier_vesta_forking_constraint_adaptive_rewi
         (deployedCommitment urs hk vk ps (roChallenges O init ps) - pU • urs.u - pW • urs.w)
         (evalVector urs.k (roChallenges O init ps).x3) (multiopenValue vk ps (roChallenges O init ps))
       (circuitSatViaGates fixedCols decodeAdvice decodeInstance y gates hpoly deg) a → S)
-    (hprob : (kerr (Fintype.card Fp) shape.k : ℝ≥0∞) / Fintype.card (Fin shape.k → Fp)
+    (hprob : (3 * shape.k : ℝ≥0∞) / Fintype.card Fp
         < (PMF.uniformOfFintype (Fin shape.k → Fp)).toOuterMeasure
             (Finset.univ.filter (fun χ => DeployedIpaVerifierEq (hk ▸ urs.g) urs.w urs.u vk
               (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2)


### PR DESCRIPTION
Closes #25.

Orchard is a single deployed protocol with fixed parameters, so its soundness error should be stated **concretely over those parameters** rather than as an asymptotic threshold indexed by a security parameter. (**personal note**: this makes sense to have the signature be explicitly defined like this, and then internally in the body call the wrapper like `kerr_div_card`).

This PR makes the **fork-tree knowledge error** concrete. The Vesta soundness capstones previously carried it as the hypothesis `(kerr |F_p| k) / |F_p|^k < acceptProb`, with the intended reading `3d/N` only asserted in a docstring on `Forking.Tree.kerr`. This PR proves that closed form and **consumes it directly in the top-level capstones**: the public `legacy_orchard_verifier_vesta_forking_*` statements now take the concrete floor `3k/|F_p|` as their acceptance hypothesis, so the concrete bound is what a caller sees, not an auxiliary lemma sitting beside an unchanged abstract statement.

## What's added / changed

**`Zcash/Snark/Soundness/Forking/KnowledgeError.lean`** (new) — the closed form of `kerr`:
- `kerr_mul_card` : `kerr N d * N = 3 * d * N^d` (exact ℕ identity, no truncated subtraction)
- `kerr_eq` : `kerr N d = 3 * d * N^(d-1)` (for `0 < N`)
- `kerr_div_card` : `(kerr N d) / N^d = 3 * d / N` in `ℝ≥0∞` — the exact threshold `extractable_of_prob` and every capstone `hprob` divides by.

**`Zcash/Snark/Soundness/Vesta.lean`** (changed) — all **10** `legacy_orchard_verifier_vesta_forking_*` capstones now state their acceptance hypothesis directly against the concrete floor:

```
hprob : (3 * k : ℝ≥0∞) / |F_p| < acceptProb
```

in place of the recursive `kerr` threshold. The abstract `kerr` is discharged once, via `kerr_div_card`, at the base opening capstone (`legacy_orchard_verifier_vesta_forking_opening`); the other nine forward the concrete hypothesis to a sibling capstone, so no other proof step changes. Extraction conclusions are unchanged.

**`Zcash/Snark/Soundness/Deployed/ConcreteBounds.lean`** (new) — the deployed value:
- `deployed_forking_knowledge_error` : at any depth `k`, the floor is exactly `3 * k / |F_p|`.
- `deployed_forking_knowledge_error_captured` : at the captured Orchard depth `k = 11` it is `33 / scalarFieldOrder`. With `scalarFieldOrder = PALLAS_BASE_CARD ≈ 2^254`, this is `≈ 2^-249`.

## Scope

This concretises the fork-tree knowledge error only. The other components of the soundness budget — the Schwartz–Zippel gate/fingerprint term, the random-oracle / Fiat–Shamir query loss, and the key-binding birthday bound — remain to be pinned to the deployed parameters and aggregated into a single end-to-end `ε_total`. Tracked under #25.

## Verification

Compiles locally under `lake build`: the recompiled `Soundness.Vesta` (all 10 capstones), its `assert_no_sorry` checks in `Deployed.TrustBoundary`, and both new modules. CI on this PR exercises the full build.

