### PR TITLE
Remove unneeded `classical` and `open Classical`

### DIFF
--- a/Zcash/Snark/Soundness/AGM/Adapter.lean
+++ b/Zcash/Snark/Soundness/AGM/Adapter.lean
@@ -107,7 +107,6 @@ def toAlgebraicPoint {ι : Type*} [Fintype ι] {basis : ι → G}
 theorem exists_nonzero_coeff {ι : Type*} [Fintype ι] {basis : ι → G}
     (r : AlgebraicRelationWitness (F := F) basis) :
     ∃ i, r.coeffs i ≠ 0 := by
-  classical
   by_contra h
   apply r.nontrivial
   funext i
@@ -123,14 +122,12 @@ noncomputable def nonzeroCoeffSlots {ι : Type*} [Fintype ι] [DecidableEq ι] {
 @[simp] theorem mem_nonzeroCoeffSlots {ι : Type*} [Fintype ι] [DecidableEq ι]
     {basis : ι → G} (r : AlgebraicRelationWitness (F := F) basis) (i : ι) :
     i ∈ r.nonzeroCoeffSlots ↔ r.coeffs i ≠ 0 := by
-  classical
   simp [nonzeroCoeffSlots]
 
 /-- A nontrivial relation has at least one slot from which extraction succeeds. -/
 theorem nonzeroCoeffSlots_nonempty {ι : Type*} [Fintype ι] [DecidableEq ι] {basis : ι → G}
     (r : AlgebraicRelationWitness (F := F) basis) :
     r.nonzeroCoeffSlots.Nonempty := by
-  classical
   obtain ⟨i, hi⟩ := r.exists_nonzero_coeff
   exact ⟨i, by simp [nonzeroCoeffSlots, hi]⟩
 
@@ -145,14 +142,12 @@ noncomputable def challengeHitCount {ι : Type*} [Fintype ι] [DecidableEq ι] {
 theorem challengeHitCount_pos {ι : Type*} [Fintype ι] [DecidableEq ι] {basis : ι → G}
     (r : AlgebraicRelationWitness (F := F) basis) :
     0 < r.challengeHitCount := by
-  classical
   exact Finset.card_pos.mpr r.nonzeroCoeffSlots_nonempty
 
 /-- The number of successful challenge placements is bounded by the number of public basis slots. -/
 theorem challengeHitCount_le_total {ι : Type*} [Fintype ι] [DecidableEq ι] {basis : ι → G}
     (r : AlgebraicRelationWitness (F := F) basis) :
     r.challengeHitCount ≤ Fintype.card ι := by
-  classical
   dsimp [challengeHitCount, nonzeroCoeffSlots]
   apply Finset.card_le_card
   intro i hi
@@ -180,7 +175,6 @@ theorem representationEval_eq_challenge_add_known {ι : Type*} [Fintype ι] [Dec
     (hknown : ∀ i, i ≠ challenge → basis i = logs i • B) :
     representationEval basis coeffs =
       coeffs challenge • basis challenge + relationLogExcept logs coeffs challenge • B := by
-  classical
   have hsum : ((Finset.univ.erase challenge).sum fun i => coeffs i • basis i)
       = relationLogExcept logs coeffs challenge • B := by
     calc

--- a/Zcash/Snark/Soundness/AGM/ProbabilityCoins.lean
+++ b/Zcash/Snark/Soundness/AGM/ProbabilityCoins.lean
@@ -35,7 +35,6 @@ theorem independentProductPMF_uniform {A B : Type*} [Fintype A] [Fintype B]
     [Nonempty A] [Nonempty B] :
     independentProductPMF (PMF.uniformOfFintype A) (PMF.uniformOfFintype B) =
       PMF.uniformOfFintype (A × B) := by
-  classical
   apply PMF.ext
   rintro ⟨a, b⟩
   rw [independentProductPMF, PMF.bind_apply, tsum_fintype]

--- a/Zcash/Snark/Soundness/AGM/ProbabilityVesta.lean
+++ b/Zcash/Snark/Soundness/AGM/ProbabilityVesta.lean
@@ -56,7 +56,6 @@ theorem orchard_deployed_relation_set_eq_relSet (k : ℕ) (B : VestaG)
       Option (DeployedAlgebraicForkingInstance (G := VestaG) k basis)) :
     orchardDeployedRelationSet k B instances =
       relSet B (deployedAlgebraicRelationFinder instances) := by
-  classical
   ext scalars
   simp only [orchardDeployedRelationSet, relSet, Finset.mem_filter, Finset.mem_univ, true_and]
   exact (deployedAlgebraicRelationFinder_isSome_iff instances (scalarBasis B scalars)).symm
@@ -126,7 +125,6 @@ theorem orchard_uniformURSIdentification_of_generatorRO {T : Type*} [DecidableEq
     OrchardUniformURSIdentification
       (orchardGeneratorROSetup query) k B
       (orchardGeneratorROBasis query) := by
-  classical
   letI : Fintype VestaG := Fintype.ofFinite VestaG
   have hinj : Function.Injective (fun c : Fp => c • B) := by
     intro c c' h

--- a/Zcash/Snark/Soundness/Forking/Adversary/Adaptive.lean
+++ b/Zcash/Snark/Soundness/Forking/Adversary/Adaptive.lean
@@ -31,7 +31,6 @@ def fsWinsFull (A : OracleComp T F P) (accept : P → (Fin m → F) → (Fin k �
     (prefixesPre : P → Fin m → T) (prefixes : P → Fin k → T) (O : T → F) : Prop :=
   accept (A.run O) (fun i => O (prefixesPre (A.run O) i)) (fun j => O (prefixes (A.run O) j))
 
-open Classical in
 /-- The slice on which one adversary-chosen pre-IPA challenge is zero has probability at most
 `(Q+1)/|F|`. The extra query reads that challenge from the output's own prefix. -/
 theorem fsAdvantageFull_zero_slice_le (A : OracleComp T F P)
@@ -63,7 +62,6 @@ end AdaptiveGame
 
 section DomainRestriction
 
-open Classical in
 /-- Conditioning on junk oracle values reduces the split-domain game to a machine on `T` with the
 same query bound. -/
 theorem fsWinsFull_restrictSum_le {T J F P : Type*} [Fintype T] [DecidableEq T]

--- a/Zcash/Snark/Soundness/Forking/Adversary/Algebraic.lean
+++ b/Zcash/Snark/Soundness/Forking/Adversary/Algebraic.lean
@@ -1227,7 +1227,6 @@ theorem snarkFailure_prob_le_of_textbookDL
             ¬ family.hasCleanOpening (scalarBasis B p.1) p.2}
       ≤ (family.Q + shape.k) * (3 / Fintype.card Fp) +
         Fintype.card (AugmentedIndex (2 ^ shape.k)) * bound := by
-  classical
   refine le_trans (MeasureTheory.measure_mono
     (show {p : (AugmentedIndex (2 ^ shape.k) → Fp) × family.Coins |
         fsWinsFull (family.adversary (scalarBasis B p.1))
@@ -1270,7 +1269,6 @@ theorem snarkFailure_prob_le_of_textbookDL_full
       ≤ (family.Q + shape.k) * (3 / Fintype.card Fp) +
         (family.Q + 1 : ℕ) * (1 / Fintype.card Fp) +
         Fintype.card (AugmentedIndex (2 ^ shape.k)) * bound := by
-  classical
   refine le_trans (MeasureTheory.measure_mono
     (show {p : (AugmentedIndex (2 ^ shape.k) → Fp) × family.Coins |
         fsWinsFull (family.adversary (scalarBasis B p.1))
@@ -1413,7 +1411,6 @@ def ReductionEfficient (family : ComputedAlgebraicFSFamily shape) (R : ℕ) : Pr
 /-- Every fixed family has a finite call bound; this is not a uniform asymptotic bound. -/
 theorem reductionEfficient_exists (family : ComputedAlgebraicFSFamily shape) :
     ∃ R, family.ReductionEfficient R := by
-  classical
   refine ⟨Finset.univ.sup fun basis => ∑ coins : family.Coins,
       (family.instanceAttempt basis coins).runs, fun basis => ?_⟩
   calc ∑ coins : family.Coins, (family.instanceAttempt basis coins).runs
@@ -1565,7 +1562,6 @@ abbrev Coins (fam : ComputedAlgebraicFSFamilyRand shape R) :=
   (BTranscript Fp VestaG (preIpaLen shape fam.init.length 10 + 3 * shape.k) → Fp) ×
     RecursiveForkTape Fp shape.k
 
-open Classical in
 /-- Average the binding bound over private coins. -/
 theorem binding_prob_le_of_textbookDL_rand [Fintype R] [Nonempty R]
     (B : VestaG) (fam : ComputedAlgebraicFSFamilyRand shape R) {bound : ℝ≥0∞}
@@ -1590,7 +1586,6 @@ def foldedRelationFinder (fam : ComputedAlgebraicFSFamilyRand shape R) :
       Option (AlgebraicRelationWitness (F := Fp) basis) :=
   fun basis p => (fam.determinize p.2).relationFinder basis p.1
 
-open Classical in
 /-- Bound averaged binding from one DL bound on the private-coin-folded solver. -/
 theorem binding_prob_le_of_foldedTextbookDL_rand [Fintype R] [Nonempty R]
     (B : VestaG) (fam : ComputedAlgebraicFSFamilyRand shape R) {bound : ℝ≥0∞}
@@ -1603,7 +1598,6 @@ theorem binding_prob_le_of_foldedTextbookDL_rand [Fintype R] [Nonempty R]
       ≤ (fam.Q + shape.k) * (3 / Fintype.card Fp) +
         (fam.Q + 1 : ℕ) * (1 / Fintype.card Fp) +
         Fintype.card (AugmentedIndex (2 ^ shape.k)) * bound := by
-  classical
   refine le_trans (MeasureTheory.measure_mono
     (show {p : (AugmentedIndex (2 ^ shape.k) → Fp) × (fam.Coins × R) |
         ComputedAlgebraicFSFamily.bindingWin (fam.determinize p.2.2)
@@ -1662,7 +1656,6 @@ theorem binding_prob_le_of_foldedTextbookDL_rand [Fintype R] [Nonempty R]
       (scalarBasis B coeffs)
   exact (add_le_add hsucc hfail).trans_eq (by ac_rfl)
 
-open Classical in
 /-- Average the full-acceptance clean-opening bound over private coins. -/
 theorem snarkFailure_prob_le_of_textbookDL_rand [Fintype R] [Nonempty R]
     (B : VestaG) (fam : ComputedAlgebraicFSFamilyRand shape R) {bound : ℝ≥0∞}
@@ -1696,7 +1689,6 @@ def foldedSnarkRelationFinder (fam : ComputedAlgebraicFSFamilyRand shape R) :
       Option (AlgebraicRelationWitness (F := Fp) basis) :=
   fun basis p => (fam.determinize p.2).snarkRelationFinder basis p.1
 
-open Classical in
 /-- Bound averaged clean-opening failure from one DL bound on the private-coin-folded solver. -/
 theorem snarkFailure_prob_le_of_foldedTextbookDL_rand [Fintype R] [Nonempty R]
     (B : VestaG) (fam : ComputedAlgebraicFSFamilyRand shape R) {bound : ℝ≥0∞}
@@ -1713,7 +1705,6 @@ theorem snarkFailure_prob_le_of_foldedTextbookDL_rand [Fintype R] [Nonempty R]
       ≤ (fam.Q + shape.k) * (3 / Fintype.card Fp) +
         (fam.Q + 1 : ℕ) * (1 / Fintype.card Fp) +
         Fintype.card (AugmentedIndex (2 ^ shape.k)) * bound := by
-  classical
   refine le_trans (MeasureTheory.measure_mono
     (show {p : (AugmentedIndex (2 ^ shape.k) → Fp) × (fam.Coins × R) |
         fsWinsFull ((fam.determinize p.2.2).adversary (scalarBasis B p.1))
@@ -1777,7 +1768,6 @@ structure ComputedAlgebraicFSFamilyUnbounded (shape : Shape) where
   Q : ℕ
   queryBound : ∀ basis, (adversary basis).QueryBound Q
 
-open Classical in
 /-- Transfer any finite-coin event across a uniform-URS basis identification. -/
 theorem uniformURS_basis_transfer {k : ℕ} {C : Type*} [Fintype C] [Nonempty C]
     {Ω : Type*} (setup : PMF Ω) (B : VestaG)
@@ -1820,11 +1810,9 @@ variable {shape : Shape}
 /-- One finite support containing the reachable support of every basis-indexed adversary. -/
 def globalReachSet (family : ComputedAlgebraicFSFamilyUnbounded shape) :
     Finset (List (TranscriptElt Fp VestaG)) := by
-  classical
   exact Finset.univ.biUnion fun basis : AugmentedIndex (2 ^ shape.k) → VestaG =>
     (family.adversary basis).reachSet
 
-open Classical in
 theorem reachSet_subset_globalReachSet (family : ComputedAlgebraicFSFamilyUnbounded shape)
     (basis : AugmentedIndex (2 ^ shape.k) → VestaG) :
     (family.adversary basis).reachSet ⊆ family.globalReachSet := by
@@ -1836,7 +1824,6 @@ component, then fix the junk table as private randomness. -/
 def splitFamilyRand (family : ComputedAlgebraicFSFamilyUnbounded shape) :
     ComputedAlgebraicFSFamilyRand shape
       ({t // t ∈ family.globalReachSet} → Fp) := by
-  classical
   let L := preIpaLen shape family.init.length 10 + 3 * shape.k
   exact
     { init := family.init
@@ -1870,7 +1857,6 @@ theorem run_splitFamilyRand_adversary (family : ComputedAlgebraicFSFamilyUnbound
         (truncateTranscript (preIpaLen shape family.init.length 10 + 3 * shape.k))
         family.globalReachSet (family.reachSet_subset_globalReachSet basis)).run
           (Sum.elim O junk) := by
-  classical
   change (OracleComp.restrictSum junk
     ((family.adversary basis).splitDomain
       (Subtype.val : BTranscript Fp VestaG
@@ -2042,11 +2028,9 @@ def determinize (family : ComputedAlgebraicFSFamilyUnboundedRand shape R) (r : R
 def globalReachSet [Fintype R]
     (family : ComputedAlgebraicFSFamilyUnboundedRand shape R) :
     Finset (List (TranscriptElt Fp VestaG)) := by
-  classical
   exact Finset.univ.biUnion fun basis : AugmentedIndex (2 ^ shape.k) → VestaG =>
     Finset.univ.biUnion fun r : R => (family.adversary basis r).reachSet
 
-open Classical in
 theorem reachSet_subset_globalReachSet [Fintype R]
     (family : ComputedAlgebraicFSFamilyUnboundedRand shape R)
     (basis : AugmentedIndex (2 ^ shape.k) → VestaG) (r : R) :
@@ -2061,7 +2045,6 @@ def splitFamilyRand [Fintype R]
     (family : ComputedAlgebraicFSFamilyUnboundedRand shape R) :
     ComputedAlgebraicFSFamilyRand shape
       (R × ({t // t ∈ family.globalReachSet} → Fp)) := by
-  classical
   let L := preIpaLen shape family.init.length 10 + 3 * shape.k
   exact
     { init := family.init
@@ -2096,7 +2079,6 @@ theorem run_splitFamilyRand_adversary [Fintype R]
         (truncateTranscript (preIpaLen shape family.init.length 10 + 3 * shape.k))
         family.globalReachSet (family.reachSet_subset_globalReachSet basis r)).run
           (Sum.elim O junk) := by
-  classical
   change (OracleComp.restrictSum junk
     ((family.adversary basis r).splitDomain
       (Subtype.val : BTranscript Fp VestaG

--- a/Zcash/Snark/Soundness/Forking/Adversary/DomainReduction.lean
+++ b/Zcash/Snark/Soundness/Forking/Adversary/DomainReduction.lean
@@ -139,7 +139,6 @@ variable {T F α : Type*} [DecidableEq T] [Fintype F]
 def extendOn (S : Finset T) (assign : {t // t ∈ S} → F) (f₀ : F) : T → F :=
   fun t => if h : t ∈ S then assign ⟨t, h⟩ else f₀
 
-open Classical in
 /-- The finite set of game points of a machine's attainable outputs: attainable outputs are runs
 over the finitely many reach-set assignments. -/
 noncomputable def gamePoints {n : ℕ} (A : OracleComp T F α) (pts : α → Fin n → T)
@@ -147,7 +146,6 @@ noncomputable def gamePoints {n : ℕ} (A : OracleComp T F α) (pts : α → Fin
   Finset.univ.biUnion fun assign : {t // t ∈ A.reachSet} → F =>
     Finset.univ.image fun j : Fin n => pts (A.run (extendOn A.reachSet assign f₀)) j
 
-open Classical in
 /-- Every run's game points land in the finite game-point set: the run agrees with the run over
 its own reach-set assignment. -/
 theorem pts_run_mem_gamePoints {n : ℕ} (A : OracleComp T F α) (pts : α → Fin n → T)
@@ -167,7 +165,6 @@ section Reduction
 
 variable {T F P : Type*} [DecidableEq T] [Fintype F] [Nonempty F]
 
-open Classical in
 /-- Restrict an adversary to a finite set containing every reachable query and attainable game
 point, preserving its query bound and outcome. -/
 theorem finite_domain_restriction {m k : ℕ} (hm : 0 < m)
@@ -180,7 +177,6 @@ theorem finite_domain_restriction {m k : ℕ} (hm : 0 < m)
       ∀ O : T → F,
         fsWinsFull A accept prefixesPre prefixes O
           ↔ fsWinsFull A₀ accept preS ptsS (fun t => O t.1) := by
-  classical
   obtain ⟨f₀⟩ := ‹Nonempty F›
   set S : Finset T := A.reachSet ∪ gamePoints A prefixesPre f₀ ∪ gamePoints A prefixes f₀
     with hSdef
@@ -217,7 +213,6 @@ theorem finite_domain_restriction {m k : ℕ} (hm : 0 < m)
     rw [dif_pos (hptsS O j)]
   rw [h1, h2]
 
-open Classical in
 /-- Adding independent junk coordinates to a finite game preserves its win probability. -/
 theorem fsWinsFull_mapDomain_measure_eq {T₀ J : Type*} [Fintype T₀] [DecidableEq T₀]
     [Fintype J] [DecidableEq J] {m k : ℕ}
@@ -238,7 +233,6 @@ theorem fsWinsFull_mapDomain_measure_eq {T₀ J : Type*} [Fintype T₀] [Decidab
   rw [hset, ← PMF.toOuterMeasure_map_apply,
     uniformOfFintype_map_precomp_injective Sum.inl Sum.inl_injective]
 
-open Classical in
 omit [Fintype F] [Nonempty F] in
 /-- Split and original machines have the same outcome on agreeing tables when all game points lie
 in the designated component. -/
@@ -266,7 +260,6 @@ theorem fsWinsFull_splitDomain {T T_D : Type*} [DecidableEq T] [Fintype F]
     exact (hD (ptsD (A.run Ofull) j)).symm
   rw [h1, h2]
 
-open Classical in
 /-- A bound for all `Q`-query machines on the designated finite domain also bounds a `Q`-query
 machine on an arbitrary domain. -/
 theorem fsWinsFull_unbounded_measure_le {T T_D : Type*} [DecidableEq T]

--- a/Zcash/Snark/Soundness/Forking/Adversary/ExpectedRuns.lean
+++ b/Zcash/Snark/Soundness/Forking/Adversary/ExpectedRuns.lean
@@ -38,7 +38,6 @@ omit [DecidableEq F] in
 /-- At most `j` members of `A` have rank below `j`: ranks are injective on `A`. -/
 theorem card_filter_scanRank_lt_le (e : Fin n ≃ F) (A : Finset F) (j : ℕ) :
     (A.filter (fun x => scanRank e A x < j)).card ≤ j := by
-  classical
   have hinj : Set.InjOn (scanRank e A) (A.filter (fun x => scanRank e A x < j)) := by
     intro x hx y hy hxy
     rw [Finset.coe_filter, Set.mem_setOf_eq] at hx hy
@@ -83,7 +82,6 @@ carries the rank of `x` to the rank of `y`. -/
 theorem scanRank_trans_swap (e : Fin n ≃ F) (A : Finset F) {x y : F}
     (hx : x ∈ A) (hy : y ∈ A) :
     scanRank (e.trans (Equiv.swap x y)) A x = scanRank e A y := by
-  classical
   have hsymm : ∀ a : F, (e.trans (Equiv.swap x y)).symm a = e.symm (Equiv.swap x y a) := by
     intro a
     rw [Equiv.symm_trans_apply, Equiv.symm_swap]
@@ -106,7 +104,6 @@ theorem scanRank_trans_swap (e : Fin n ≃ F) (A : Finset F) {x y : F}
 
 variable [Fintype F]
 
-open Classical in
 /-- Two members of `A` are low-rank in equally many orders: composing with the swap is a bijection
 of the order space exchanging the two events. -/
 theorem card_orders_scanRank_lt_congr (A : Finset F) {x y : F} (hx : x ∈ A) (hy : y ∈ A)
@@ -134,7 +131,6 @@ theorem card_orders_scanRank_lt_congr (A : Finset F) {x y : F} (hx : x ∈ A) (h
   have := congrArg (fun e : Fin n ≃ F => Equiv.swap x y (e i)) h
   simpa [Equiv.swap_apply_self] using this
 
-open Classical in
 /-- A member of `A` has rank below `j` in at most a `j/|A|` fraction of sampling orders. -/
 theorem card_scanRank_lt_mul_le (A : Finset F) {x : F} (hx : x ∈ A) (j : ℕ) :
     A.card * (Finset.univ.filter (fun e : Fin n ≃ F => scanRank e A x < j)).card
@@ -164,7 +160,6 @@ the coordinate appears in `|β|^(|α|−1)` assignments. -/
 theorem sum_eval_pi {α β : Type*} [Fintype α] [DecidableEq α] [Fintype β]
     (a : α) (g : β → ℕ) :
     ∑ f : α → β, g (f a) = Fintype.card β ^ (Fintype.card α - 1) * ∑ b : β, g b := by
-  classical
   rw [← Equiv.sum_comp (Equiv.piSplitAt a (fun _ : α => β)).symm (fun f => g (f a))]
   have happ : ∀ p : β × ({a' // a' ≠ a} → β),
       ((Equiv.piSplitAt a (fun _ : α => β)).symm p) a = p.1 := by
@@ -363,7 +358,6 @@ section ScanRankBound
 
 variable {F : Type*} [Zero F] [DecidableEq F] [Fintype F]
 
-open Classical in
 /-- A scan pays only candidates preceded by fewer than two good challenges. -/
 theorem nextForkChallenge_runs_le_rank_sum {α : Type*}
     (attempt : F → RecursiveForkAttempt α) (order : Fin (Fintype.card F) ≃ F)
@@ -435,14 +429,12 @@ def scanCandidate {d : ℕ} (m : ℕ) (hmk : m + (d + 1) = k) (O : T → F)
       (m + 1) (by omega) O' p' (childC u)
   else { output := none, runs := 1 }
 
-open Classical in
 /-- The node's good set: nonzero challenges whose reprogrammed candidate returns a certificate. -/
 noncomputable def goodChallenges [Fintype F] {d : ℕ} (m : ℕ) (hmk : m + (d + 1) = k)
     (O : T → F) (childC : F → RecursiveForkCoins F d) : Finset F :=
   Finset.univ.filter (fun u : F => u ≠ 0 ∧
     (scanCandidate basis k A prefixes rounds final win decideWin m hmk O childC u).output.isSome)
 
-open Classical in
 /-- One extractor node pays the abort unit, its first branch, and at most twice its low-rank
 candidates. -/
 theorem recursiveAlgebraicForkFrom_node_runs_le [Fintype F] {d m : ℕ}
@@ -577,14 +569,12 @@ variable (basis : ι → G) (k : ℕ) (A : OracleComp T F P) (prefixes : P → F
   (rounds : P → Fin k → AlgebraicPoint (F := F) basis × AlgebraicPoint (F := F) basis)
   (final : P → F × F) (win : (T → F) → P → Prop) (decideWin : ∀ O p, Decidable (win O p))
 
-open Classical in
 /-- Every reachable node has at least `σ₀` nonzero, trunk-stable successful continuations. The run
 bound uses density `(σ₀−1)/|F|` after excluding the incumbent branch. -/
 def ForkSpread (σ₀ : ℕ) : Prop :=
   ∀ (d m : ℕ) (hmk : m + (d + 1) = k) (O : T → F) (childC : F → RecursiveForkCoins F d),
     σ₀ ≤ (goodChallenges basis k A prefixes rounds final win decideWin m hmk O childC).card
 
-open Classical in
 /-- Under fork spread, the depth-`d` expected run count is at most
 `(6·|F|/(σ₀−1))^d`. -/
 theorem recursiveAlgebraicForkFrom_sum_runs_le_of_forkSpread {σ₀ : ℕ} (h2 : 2 ≤ σ₀)
@@ -896,7 +886,6 @@ theorem recursiveAlgebraicForkFrom_sum_runs_le_of_forkSpread {σ₀ : ℕ} (h2 :
             rw [hcard, Nat.pow_succ]
             ring
 
-open Classical in
 /-- Over the uniform tape, fork spread gives `E[runs] ≤ (6·|F|/(σ₀−1))^k`, or `(6/δ)^k`
 for `δ = (σ₀−1)/|F|`. -/
 theorem recursiveAlgebraicFork_sum_runs_le_of_forkSpread {σ₀ : ℕ} (h2 : 2 ≤ σ₀)

--- a/Zcash/Snark/Soundness/Forking/Adversary/ExpectedRunsPoly.lean
+++ b/Zcash/Snark/Soundness/Forking/Adversary/ExpectedRunsPoly.lean
@@ -65,7 +65,6 @@ theorem scanRank_insert_erase {n : ℕ} (e : Fin n ≃ F) (M : Finset F) (u : F)
     · exact Or.inl rfl
     · exact Or.inr ha
 
-open Classical in
 /-- Pointwise node accounting in which scan costs are paid only under the gate
 `u₁ ≠ 0 ∧ first extracts` — the event whose probability the pairing argument prices. -/
 theorem recursiveAlgebraicForkFrom_node_runs_le_gated [Fintype F] {d m : ℕ}
@@ -132,7 +131,6 @@ theorem scanCandidateAt_update (t₀ : T) {d : ℕ} (m : ℕ) (hmk : m + (d + 1)
       = scanCandidateAt basis k A prefixes rounds final win decideWin t₀ m hmk O childC u := by
   simp only [scanCandidateAt, Function.update_idem]
 
-open Classical in
 /-- The good set with the reprogramming anchor explicit: blind at the anchor and independent of
 the anchor's table value. -/
 noncomputable def goodChallengesAt (t₀ : T) {d : ℕ} (m : ℕ) (hmk : m + (d + 1) = k)
@@ -141,7 +139,6 @@ noncomputable def goodChallengesAt (t₀ : T) {d : ℕ} (m : ℕ) (hmk : m + (d 
     (scanCandidateAt basis k A prefixes rounds final win decideWin
       t₀ m hmk O childC u).output.isSome)
 
-open Classical in
 theorem goodChallengesAt_fork [Fintype F] {d : ℕ} (m : ℕ) (hmk : m + (d + 1) = k) (O : T → F)
     (childC : F → RecursiveForkCoins F d) :
     goodChallengesAt basis k A prefixes rounds final win decideWin
@@ -151,7 +148,6 @@ theorem goodChallengesAt_fork [Fintype F] {d : ℕ} (m : ℕ) (hmk : m + (d + 1)
   simp [goodChallengesAt, goodChallenges,
     scanCandidateAt_fork basis k A prefixes rounds final win decideWin m hmk O childC]
 
-open Classical in
 theorem goodChallengesAt_update [Fintype F] (t₀ : T) {d : ℕ} (m : ℕ) (hmk : m + (d + 1) = k)
     (O : T → F) (x : F) (childC : F → RecursiveForkCoins F d) :
     goodChallengesAt basis k A prefixes rounds final win decideWin t₀ m hmk
@@ -172,14 +168,12 @@ theorem scanRank_insert_eq_filter {n : ℕ} (e : Fin n ≃ F) (S : Finset F) (u 
   unfold scanRank
   rw [Finset.filter_insert, if_neg (lt_irrefl _)]
 
-open Classical in
 /-- A fixed candidate is low-rank against the punctured good set at most four orders' worth of
 times, summed over punctures and sampling orders. -/
 theorem sum_card_scanRank_erase_lt_le [Fintype F] (G : Finset F) (u : F) :
     ∑ x ∈ G, (Finset.univ.filter (fun order : Fin (Fintype.card F) ≃ F =>
         scanRank order (insert u ((G.erase x).erase u)) u < 2)).card
       ≤ 4 * Fintype.card (Fin (Fintype.card F) ≃ F) := by
-  classical
   -- swap to per-order counting
   have hswap : ∑ x ∈ G, (Finset.univ.filter (fun order : Fin (Fintype.card F) ≃ F =>
       scanRank order (insert u ((G.erase x).erase u)) u < 2)).card

--- a/Zcash/Snark/Soundness/Forking/Adversary/OracleComp.lean
+++ b/Zcash/Snark/Soundness/Forking/Adversary/OracleComp.lean
@@ -439,7 +439,6 @@ theorem card_win_eq_sum_forkIdx [Fintype T] [DecidableEq T] [Fintype F] [Decidab
     (Finset.univ.filter win).card
       = ∑ i ∈ Finset.range Q,
           (Finset.univ.filter (fun O => win O ∧ forkIdx A fp O = i)).card := by
-  classical
   rw [Finset.card_eq_sum_card_fiberwise
     (f := fun O => forkIdx A fp O) (t := Finset.range Q) ?_]
   · refine Finset.sum_congr rfl fun i _ => ?_
@@ -536,7 +535,6 @@ theorem applyUpdates_update_of_mem {σ : List (T × F)} {t : T}
         · rw [Function.update_comm hp]
           exact ih h _
 
-open Classical in
 /-- A `Q`-query machine enters pointwise `ε`-escape sets with probability at most `Q·ε`. -/
 theorem escapesDuring_measure_le {T F : Type*} [Fintype T] [DecidableEq T] [Fintype F]
     [Nonempty F] {α : Type*} (esc : T → Set F) {ε : ℝ≥0∞}
@@ -645,7 +643,6 @@ theorem escapesDuring_measure_le {T F : Type*} [Fintype T] [DecidableEq T] [Fint
           _ = (Q + 1) * ε := by ring
           _ = ((Q + 1 : ℕ) : ℝ≥0∞) * ε := by push_cast; ring
 
-open Classical in
 /-- A `Q`-query cache-avoiding machine enters table-dependent blind escape sets of measure `ε` with
 probability at most `Q · ε`. -/
 theorem escapesDuringC_measure_le {T F : Type*} [Fintype T] [DecidableEq T] [Fintype F]
@@ -722,7 +719,6 @@ theorem escapesDuringC_measure_le {T F : Type*} [Fintype T] [DecidableEq T] [Fin
         _ = (Q + 1) * ε := by ring
         _ = ((Q + 1 : ℕ) : ℝ≥0∞) * ε := by push_cast; ring
 
-open Classical in
 /-- The conditional escape bound for an arbitrary machine: deduplicate
 (`OracleComp.escapesDuringC_dedup`), then apply the fresh-query bound. -/
 theorem escapesDuringC_measure_le' {T F : Type*} [Fintype T] [DecidableEq T] [Fintype F]
@@ -757,7 +753,6 @@ theorem sum_table_fiberwise {T F : Type*} [Fintype T] [DecidableEq T] [Fintype F
     [DecidableEq F] (t : T) (g : (T → F) → ℕ) :
     ∑ O : T → F, g O
       = ∑ u : F, ∑ O ∈ Finset.univ.filter (fun O : T → F => O t = u), g O := by
-  classical
   calc ∑ O : T → F, g O = ∑ O : T → F, ∑ u : F, if O t = u then g O else 0 := by
         refine Finset.sum_congr rfl fun O _ => ?_
         simp
@@ -770,7 +765,6 @@ theorem sum_table_fiber_blind {T F : Type*} [Fintype T] [DecidableEq T] [Fintype
     (hblind : ∀ (O : T → F) (v : F), g (Function.update O t v) = g O) (u u' : F) :
     ∑ O ∈ Finset.univ.filter (fun O : T → F => O t = u), g O
       = ∑ O ∈ Finset.univ.filter (fun O : T → F => O t = u'), g O := by
-  classical
   refine Finset.sum_nbij' (fun O => Function.update O t u') (fun O => Function.update O t u)
     (fun O hO => ?_) (fun O hO => ?_) (fun O hO => ?_) (fun O hO => ?_) (fun O hO => ?_)
   · simp
@@ -792,7 +786,6 @@ theorem sum_table_fiber_mul_card {T F : Type*} [Fintype T] [DecidableEq T] [Fint
     Finset.sum_congr rfl fun u' _ => sum_table_fiber_blind t g hblind u' u,
     Finset.sum_const, Finset.card_univ, smul_eq_mul, mul_comm]
 
-open Classical in
 /-- A `Q`-query machine's total blind charge is at most `Q` times its average per-point budget,
 stated after clearing the factor `|F|`.  The budget must hold uniformly over every override
 context `σ'`, not just the ambient one; `queryCharge_sum_mul_le_table_budget` trades this for a
@@ -872,7 +865,6 @@ theorem queryCharge_sum_mul_le {T F α : Type*} [Fintype T] [DecidableEq T] [Fin
           _ = Q * M * Fintype.card (T → F) * Fintype.card F := by
               rw [Finset.sum_const, Finset.card_univ, smul_eq_mul, mul_comm]
 
-open Classical in
 /-- Table-indexed query-charge bound, charging the budget sum at the original override context. -/
 theorem queryCharge_sum_mul_le_table_budget {T F α : Type*} [Fintype T] [DecidableEq T]
     [Fintype F] [DecidableEq F] [Nonempty F] (v : T → (T → F) → F → ℕ)
@@ -1037,7 +1029,6 @@ theorem applyUpdates_apply_mem_nodup {T F : Type*} [DecidableEq T] {σ : List (T
       · rw [applyUpdates_cons]
         exact ih hnodup.2 hp _
 
-open Classical in
 /-- Bound the charge at an adaptively selected queried point under a reprogrammed table by the
 query budget times the average per-point budget. -/
 theorem steeredCharge_context_sum_mul_le {T F α : Type*} [Fintype T] [DecidableEq T] [Fintype F]
@@ -1066,7 +1057,6 @@ theorem steeredCharge_context_sum_mul_le {T F α : Type*} [Fintype T] [Decidable
         queryCharge_sum_mul_le v hblind hbudget (OracleComp.dedup_queryBound hQ σ)
           (OracleComp.dedup_avoidsCache σ A)
 
-open Classical in
 /-- Table-indexed form of `steeredCharge_context_sum_mul_le`. -/
 theorem steeredCharge_context_sum_mul_le_table_budget {T F α : Type*} [Fintype T]
     [DecidableEq T] [Fintype F] [DecidableEq F] [Nonempty F] (v : T → (T → F) → F → ℕ)
@@ -1093,7 +1083,6 @@ theorem steeredCharge_context_sum_mul_le_table_budget {T F α : Type*} [Fintype 
         queryCharge_sum_mul_le_table_budget v hblind B hB (OracleComp.dedup_queryBound hQ σ)
           (OracleComp.dedup_avoidsCache σ A)
 
-open Classical in
 /-- Context-free form of `steeredCharge_context_sum_mul_le`. -/
 theorem steeredCharge_sum_mul_le {T F α : Type*} [Fintype T] [DecidableEq T] [Fintype F]
     [DecidableEq F] [Nonempty F] (v : T → (T → F) → F → ℕ)
@@ -1166,7 +1155,6 @@ theorem read_eq_iff : {k : ℕ} → (s : AdSched T F k) → (O : T → F) → (�
 /-- Freshness along `χ`: the χ-determined points are pairwise distinct. -/
 def Fresh {k : ℕ} (s : AdSched T F k) : Prop := ∀ χ : Fin k → F, Function.Injective (s.points χ)
 
-open Classical in
 /-- A fresh adaptive schedule reads a uniform table to a uniform answer vector. -/
 theorem map_read_uniform [Fintype T] [DecidableEq T] [Fintype F] [Nonempty F] {k : ℕ}
     (s : AdSched T F k) (hs : s.Fresh) :
@@ -1295,7 +1283,6 @@ theorem schedule_fork_bound {T F : Type*} [Fintype T] [DecidableEq T] [Fintype F
                 ∧ O (pt₁ (s.read O)) ≠ O (pt₂ (s.read O))}
         + (PMF.uniformOfFintype (T → F)).toOuterMeasure
             {O | acc (s.read O) (O (pt₁ (s.read O)))} / Fintype.card F := by
-  classical
   set sd := (s.snoc pt₁).snoc (fun χ : Fin (k + 1) → F => pt₂ (Fin.init χ)) with hsd
   have hs1 : (s.snoc pt₁).Fresh := AdSched.Fresh.of_snoc hd
   have hread1 : ∀ O, (s.snoc pt₁).read O = Fin.snoc (s.read O) (O (pt₁ (s.read O))) :=
@@ -1535,7 +1522,6 @@ theorem win_forces [DecidableEq T] (D : StagedDecode T F P k accept prefixes)
     rw [D.stateAt_prefixes, D.roundOf_prefixes, D.chainAt_prefixes]
     exact hj
 
-open Classical in
 /-- A staged `Q`-query adversary with no extractable output has advantage at most
 `(Q + k) · 3/|F|`. -/
 theorem fsAdvantage_le [Fintype T] [DecidableEq T] [Fintype F] [Nonempty F]
@@ -1554,7 +1540,6 @@ theorem fsAdvantage_le [Fintype T] [DecidableEq T] [Fintype F] [Nonempty F]
     (OracleComp.queryBound_completing prefixes hQ)
   exact_mod_cast h
 
-open Classical in
 /-- Advantage above `(Q+k)·3/|F|` yields an extractable output. -/
 theorem extractable_of_lt_fsAdvantage [Fintype T] [DecidableEq T] [Fintype F] [Nonempty F]
     (D : StagedDecode T F P k accept prefixes) {A : OracleComp T F P} {Q : ℕ}
@@ -1568,7 +1553,6 @@ theorem extractable_of_lt_fsAdvantage [Fintype T] [DecidableEq T] [Fintype F] [N
 end StagedDecode
 
 
-open Classical in
 /-- Legacy staged-adversary wrapper: advantage above `(Q + k) · 3/p` yields an IPA opening or
 relation. -/
 noncomputable def legacy_deployed_forking_soundness_of_adversary

--- a/Zcash/Snark/Soundness/Forking/Adversary/PreIpa.lean
+++ b/Zcash/Snark/Soundness/Forking/Adversary/PreIpa.lean
@@ -262,7 +262,6 @@ private theorem length_permSetBlock {n : ℕ} (g : Fin n → PermSetEval Fp)
     (hg : ∀ s : Fin n, (g s).lastEval.isSome = ((s : ℕ) + 1 < n)) :
     ((List.ofFn (fun s => absorbPermSet (G := G) (g s))).flatten).length
       = 2 * n + (n - 1) := by
-  classical
   have hterm : ∀ s : Fin n, ((List.length ∘ fun s => absorbPermSet (G := G) (g s)) s)
       = 2 + (if (s : ℕ) + 1 < n then 1 else 0) := by
     intro s

--- a/Zcash/Snark/Soundness/Forking/Adversary/Recursive.lean
+++ b/Zcash/Snark/Soundness/Forking/Adversary/Recursive.lean
@@ -178,7 +178,6 @@ noncomputable def recursiveForkEscape {F : Type*} [Zero F] (good : F → Prop) :
 /-- A recursive extractor escape set contains at most three challenges. -/
 theorem recursiveForkEscape_subset_triple {F : Type*} [Zero F]
     (good : F → Prop) : ∃ a b : F, recursiveForkEscape good ⊆ {0, a, b} := by
-  classical
   by_cases hthree : ThreeForkSuccess good
   · refine ⟨0, 0, ?_⟩
     rw [recursiveForkEscape, if_pos hthree]
@@ -674,7 +673,6 @@ theorem recursiveAlgebraicFork_runs_le
   exact recursiveAlgebraicForkFrom_runs_le basis k A prefixes rounds final win decideWin
     (Fintype.card F) 0 (by omega) O (A.run O) tape.toCoins tape.toCoins_bounded
 
-open Classical in
 /-- The complete-tape expectation is at most `(2·|F|+1)^k`, not polynomial AFK. -/
 theorem recursiveAlgebraicFork_sum_runs_le_unconditional
     (basis : ι → G) (k : ℕ)
@@ -693,7 +691,6 @@ theorem recursiveAlgebraicFork_sum_runs_le_unconditional
         recursiveAlgebraicFork_runs_le basis k A prefixes rounds final win decideWin O tape)
     _ = _ := by rw [Finset.sum_const, Finset.card_univ, smul_eq_mul, Nat.mul_comm]
 
-open Classical in
 /-- The unconditional run bound over uniform oracle-table and extractor-tape coins. -/
 theorem recursiveAlgebraicFork_oracle_tape_sum_runs_le_unconditional [Fintype T]
     (basis : ι → G) (k : ℕ)
@@ -1110,7 +1107,6 @@ noncomputable def recursiveForkEscapeSet
     (decideWin : ∀ O p, Decidable (win O p))
     (D : PrefixDecode T k prefixes) (root : RecursiveForkCoins F k) :
     T → (T → F) → Set F := by
-  classical
   intro t O
   if hm : D.roundOf t < k then
     let j : Fin k := ⟨D.roundOf t, hm⟩
@@ -1141,7 +1137,6 @@ theorem recursiveForkEscapeSet_blind
     recursiveForkEscapeSet basis k A prefixes rounds final win decideWin D root t
         (Function.update O t v) =
       recursiveForkEscapeSet basis k A prefixes rounds final win decideWin D root t O := by
-  classical
   rw [recursiveForkEscapeSet, recursiveForkEscapeSet]
   by_cases hm : D.roundOf t < k
   · simp only [dif_pos hm]
@@ -1185,7 +1180,6 @@ theorem recursiveForkEscapeSet_measure_le [Fintype F]
     (PMF.uniformOfFintype F).toOuterMeasure
         (recursiveForkEscapeSet basis k A prefixes rounds final win decideWin D root t O)
       ≤ 3 / Fintype.card F := by
-  classical
   rw [recursiveForkEscapeSet]
   by_cases hm : D.roundOf t < k
   · simp only [dif_pos hm]
@@ -1229,7 +1223,6 @@ theorem recursiveForkEscapeSet_prefix
         prefixes p' ⟨m, by omega⟩ = t ∧
           (recursiveAlgebraicForkFrom basis k A prefixes rounds final win decideWin
             (m + 1) (by omega) O' p' (child u)).output.isSome := by
-  classical
   rw [recursiveForkEscapeSet]
   have hm : D.roundOf (prefixes p ⟨m, by omega⟩) < k := by
     rw [D.roundOf_prefixes]
@@ -1404,7 +1397,6 @@ theorem recursiveForkFailure_measure_le [Fintype T] [Fintype F] [Nonempty F]
     (PMF.uniformOfFintype (T → F)).toOuterMeasure
         (recursiveForkFailureSet basis k A prefixes rounds final win decideWin coins)
       ≤ (Q + k) * (3 / Fintype.card F) := by
-  classical
   let esc := recursiveForkEscapeSet basis k A prefixes rounds final win decideWin D coins
   have hsub : recursiveForkFailureSet basis k A prefixes rounds final win decideWin coins ⊆
       {O : T → F | (A.completing prefixes).escapesDuringC esc O} := by

--- a/Zcash/Snark/Soundness/Forking/KnowledgeError.lean
+++ b/Zcash/Snark/Soundness/Forking/KnowledgeError.lean
@@ -48,7 +48,6 @@ this concrete fraction is what lets the deployed soundness floor be read off dir
 theorem kerr_div_card [Fintype α] [Nonempty α] (d : ℕ) :
     (kerr (Fintype.card α) d : ℝ≥0∞) / Fintype.card (Fin d → α)
       = 3 * d / Fintype.card α := by
-  classical
   have hcard : Fintype.card (Fin d → α) = Fintype.card α ^ d := by
     rw [Fintype.card_fun, Fintype.card_fin]
   have hpos : 0 < Fintype.card α := Fintype.card_pos

--- a/Zcash/Snark/Soundness/Forking/Probability.lean
+++ b/Zcash/Snark/Soundness/Forking/Probability.lean
@@ -71,7 +71,6 @@ theorem uniformOfFintype_map_precomp_injective {ι T F : Type*} [Fintype ι] [De
     [Fintype T] [DecidableEq T] [Fintype F] [Nonempty F]
     (φ : ι → T) (hφ : Function.Injective φ) :
     (PMF.uniformOfFintype (T → F)).map (fun O => O ∘ φ) = PMF.uniformOfFintype (ι → F) := by
-  classical
   have hsplit : (fun O : T → F => O ∘ φ)
       = (fun O' : ↥(Set.range φ) → F => fun i => O' (Equiv.ofInjective φ hφ i))
         ∘ Prod.fst
@@ -151,7 +150,6 @@ theorem uniformOfFintype_prod_fiber_bound_right {A B : Type*} [Fintype A] [Finty
     _ = β * ((Fintype.card A : ℝ≥0∞) * Fintype.card B) := by ring
     _ = β * Fintype.card (A × B) := by rw [Fintype.card_prod]; push_cast; ring
 
-open Classical in
 /-- Unread oracle coordinates remain uniform after choosing a target from the other coordinates. -/
 theorem uniformOfFintype_fresh_read_bound {ι T F X : Type*} [Fintype ι] [DecidableEq ι]
     [Fintype T] [DecidableEq T] [Fintype F] [Nonempty F]
@@ -206,7 +204,6 @@ theorem uniformOfFintype_toOuterMeasure_singleton {α : Type*} [Fintype α] [Non
 theorem map_eval_uniformOfFintype {T F : Type*} [Fintype T] [DecidableEq T] [Fintype F]
     [Nonempty F] (t : T) :
     (PMF.uniformOfFintype (T → F)).map (fun O => O t) = PMF.uniformOfFintype F := by
-  classical
   have h : (fun O : T → F => O t)
       = (Equiv.funUnique {x : T // x = t} F)
         ∘ Prod.fst
@@ -230,7 +227,6 @@ theorem uniformOfFintype_cond_point {T F : Type*} [Fintype T] [DecidableEq T] [F
     (hE : ∀ (O : T → F) (v : F), Function.update O t v ∈ E ↔ O ∈ E) :
     (PMF.uniformOfFintype (T → F)).toOuterMeasure {O : T → F | O t = u ∧ O ∈ E}
       = (PMF.uniformOfFintype (T → F)).toOuterMeasure E / Fintype.card F := by
-  classical
   set e := Equiv.piSplitAt t (fun _ : T => F) with he
   have hsymm : ∀ (O : T → F) (v : F), e.symm (v, (e O).2) = Function.update O t v := by
     intro O v
@@ -302,7 +298,6 @@ theorem sum_point_mem_measure_le {T F : Type*} [Fintype T] [DecidableEq T] [Fint
           ENNReal.mul_div_cancel_right (Nat.cast_ne_zero.mpr Fintype.card_ne_zero)
             (ENNReal.natCast_ne_top _)]
 
-open Classical in
 /-- An update-blind set contains `O t` with at most its uniform-measure bound. -/
 theorem uniformOfFintype_point_mem_blind_le {T F : Type*} [Fintype T] [DecidableEq T] [Fintype F]
     [Nonempty F] (t : T) (S : (T → F) → Set F)
@@ -384,7 +379,6 @@ theorem acc_pair_card {F : Type*} [Fintype F] [DecidableEq F] (P : F → Prop) [
     (Finset.univ.filter P).card * (Finset.univ.filter P).card
       = (Finset.univ.filter (fun p : F × F => P p.1 ∧ P p.2 ∧ p.1 ≠ p.2)).card
         + (Finset.univ.filter P).card := by
-  classical
   set A := Finset.univ.filter P with hA
   have hoff : (Finset.univ.filter (fun p : F × F => P p.1 ∧ P p.2 ∧ p.1 ≠ p.2)) = A.offDiag := by
     ext p
@@ -404,7 +398,6 @@ theorem forking_card_bound {Ψ F : Type*} [Fintype Ψ] [Fintype F] [DecidableEq 
           * ((∑ ψ : Ψ,
                 (Finset.univ.filter (fun p : F × F => acc ψ p.1 ∧ acc ψ p.2 ∧ p.1 ≠ p.2)).card)
               + ∑ ψ : Ψ, (Finset.univ.filter (acc ψ)).card) := by
-  classical
   set E : Ψ → ℕ := fun ψ => (Finset.univ.filter (acc ψ)).card with hE
   set D : Ψ → ℕ :=
     fun ψ => (Finset.univ.filter (fun p : F × F => acc ψ p.1 ∧ acc ψ p.2 ∧ p.1 ≠ p.2)).card with hD
@@ -433,7 +426,6 @@ theorem forking_card_bound {Ψ F : Type*} [Fintype Ψ] [Fintype F] [DecidableEq 
 theorem card_acc_pairs {Ψ F : Type*} [Fintype Ψ] [Fintype F] (acc : Ψ → F → Prop)
     [∀ ψ, DecidablePred (acc ψ)] :
     Nat.card {x : Ψ × F | acc x.1 x.2} = ∑ ψ : Ψ, (Finset.univ.filter (acc ψ)).card := by
-  classical
   rw [Nat.card_coe_set_eq, Set.ncard_eq_toFinset_card', Set.toFinset_setOf,
     Finset.card_filter, Fintype.sum_prod_type]
   refine Finset.sum_congr rfl fun ψ _ => ?_
@@ -445,7 +437,6 @@ theorem card_acc_distinct {Ψ F : Type*} [Fintype Ψ] [Fintype F] [DecidableEq F
     Nat.card {x : Ψ × F × F | acc x.1 x.2.1 ∧ acc x.1 x.2.2 ∧ x.2.1 ≠ x.2.2}
       = ∑ ψ : Ψ,
           (Finset.univ.filter (fun p : F × F => acc ψ p.1 ∧ acc ψ p.2 ∧ p.1 ≠ p.2)).card := by
-  classical
   rw [Nat.card_coe_set_eq, Set.ncard_eq_toFinset_card', Set.toFinset_setOf,
     Finset.card_filter, Fintype.sum_prod_type]
   refine Finset.sum_congr rfl fun ψ _ => ?_
@@ -460,7 +451,6 @@ theorem forking_measure_bound {Ψ F : Type*} [Fintype Ψ] [Nonempty Ψ] [Fintype
           {x : Ψ × F × F | acc x.1 x.2.1 ∧ acc x.1 x.2.2 ∧ x.2.1 ≠ x.2.2}
         + (PMF.uniformOfFintype (Ψ × F)).toOuterMeasure {x : Ψ × F | acc x.1 x.2}
             / Fintype.card F := by
-  classical
   set Nψ : ℝ≥0∞ := (Fintype.card Ψ : ℝ≥0∞) with hNψ
   set Nf : ℝ≥0∞ := (Fintype.card F : ℝ≥0∞) with hNf
   set E : ℕ := ∑ ψ : Ψ, (Finset.univ.filter (acc ψ)).card with hEdef

--- a/Zcash/Snark/Soundness/Forking/Rewind.lean
+++ b/Zcash/Snark/Soundness/Forking/Rewind.lean
@@ -495,7 +495,6 @@ theorem flatAccept_pathData {U W : G} {z : Fp} : {d : ℕ} → (P : Prover Fp G 
       simp only [Fin.cons_zero, Fin.tail_cons]
       rw [flatAccept]
 
-open Classical in
 /-- Halo2's verifier equation on a path-spliced proof equals `flatAccept P` on that path. -/
 theorem deployedVerifierEq_iff_flatAccept_adaptive {shape : Shape} [DecidableEq G] [Inhabited G]
     (g : Fin (2 ^ shape.k) → G) (w u : G) (vk : VerifyingKey shape Fp G) (instanceCommitment : Fin shape.numProofs → ℕ → G) (ps : ProofString shape Fp G)

--- a/Zcash/Snark/Soundness/Forking/Tree.lean
+++ b/Zcash/Snark/Soundness/Forking/Tree.lean
@@ -67,7 +67,6 @@ theorem escapeSet_subset_triple [Zero α] {d : ℕ} {acc : (Fin (d + 1) → α) 
     (hdoom : ¬ Extractable acc) :
     ∃ a b : α, {u : α | u = 0 ∨ Extractable (fun rest => acc (Fin.cons u rest))}
       ⊆ {0, a, b} := by
-  classical
   by_cases hne : ∃ a : α, a ≠ 0 ∧ Extractable (fun rest => acc (Fin.cons a rest))
   · obtain ⟨a, ha0, haE⟩ := hne
     by_cases hb : ∃ b : α, b ≠ 0 ∧ b ≠ a ∧ Extractable (fun rest => acc (Fin.cons b rest))
@@ -108,7 +107,6 @@ def ladderEscapeSet [Zero α] : {d : ℕ} → ((Fin d → α) → Prop) → (Fin
       else {u : α | u = 0 ∨ Extractable (fun rest => acc (Fin.cons u rest))}
   | _ + 1, acc, χ, j + 1 => ladderEscapeSet (fun rest => acc (Fin.cons (χ 0) rest)) (Fin.tail χ) j
 
-open Classical in
 /-- The round-`j` escape set reads only the challenges before round `j`. -/
 theorem ladderEscapeSet_congr [Zero α] :
     {d : ℕ} → (acc : (Fin d → α) → Prop) → (χ χ' : Fin d → α) → (j : ℕ) →
@@ -140,7 +138,6 @@ theorem exists_mem_ladderEscapeSet [Zero α] :
           (fun rest => acc (Fin.cons (χ 0) rest)) (Fin.tail χ) h
         exact ⟨j.succ, hj⟩
 
-open Classical in
 /-- Every round's escape set lies in at most three challenges. -/
 theorem ladderEscapeSet_subset_triple [Zero α] :
     {d : ℕ} → (acc : (Fin d → α) → Prop) → (χ : Fin d → α) → (j : ℕ) →
@@ -180,7 +177,6 @@ theorem extractable_of_kerr_lt [Fintype α] [DecidableEq α] [Zero α] :
       rw [Subsingleton.elim Fin.elim0 x]
       exact hx.2
   | d + 1, acc, _, h => by
-      classical
       have hslice : (Finset.univ.filter acc).card
           = ∑ u : α, (Finset.univ.filter (fun rest : Fin d → α => acc (Fin.cons u rest))).card :=
         card_filter_eq_sum_slice acc


### PR DESCRIPTION
Removes `classical` tactics and `open Classical in` modifiers that rederive instances the sections already provide, across the Forking/AGM stack (per the instance-hygiene convention: assume the section's instances; rederiving them just lengthens proofs).

Full build green under the warning-strict linting from #79.

🤖 Claude Fable 5
