### PR TITLE
fv: complete the key-binding ROM model

### DIFF
--- a/Zcash/Security/KeyBinding/Basic.lean
+++ b/Zcash/Security/KeyBinding/Basic.lean
@@ -99,7 +99,7 @@ structure Extractor (G IVK AK : Type*) [Neg G] where
   toIVK_pm : ∀ P Q : G, toIVK P = toIVK Q ↔ P =± Q
 
 section Algebra
-variable [AddCommGroup G] [Field RIVK] [Field IVK] [Module RIVK G] [NoZeroSMulDivisors RIVK G]
+variable [AddCommGroup G] [Field IVK] [Field RIVK] [Module RIVK G] [NoZeroSMulDivisors RIVK G]
 
 /-- The `ivk` commitment as a Pedersen lift:
 `Commitivk rivk ak nk = Extract.toIVK ((h ak nk + rivk) • S)`, with `h` abstract-but-non-querying and `S`
@@ -182,7 +182,7 @@ structure Oracles (AK NK RIVK ASK QK SK : Type*) where
   rivk_int : RIVK → AK → NK → RIVK
 
 section Derivation
-variable [AddCommGroup G] [Field RIVK] [Field IVK] [Module RIVK G] [SMul ASK G]
+variable [AddCommGroup G] [Field IVK] [Field RIVK] [Module RIVK G] [SMul ASK G]
 
 /-- `BindKeys^sk` (ZIP 2005): the `sk`-branch derivation constraints. -/
 structure BindKeysSk (Ggen : G) (H : Oracles AK NK RIVK ASK QK SK)
@@ -206,7 +206,7 @@ structure KBDerivation (Extract : Extractor G IVK AK) (Ggen : G)
 end Derivation
 
 section Full
-variable [AddCommGroup G] [Field RIVK] [Field IVK] [Module RIVK G] [SMul ASK G]
+variable [AddCommGroup G] [Field IVK] [Field RIVK] [Module RIVK G] [SMul ASK G]
 
 /-- The full key-binding condition: commitment opening and key derivation constraints. -/
 structure KB (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK) (Ggen : G)
@@ -290,7 +290,7 @@ theorem qk_or_sk_pinned (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK 
 end Full
 
 section Onward
-variable [AddCommGroup G] [Field RIVK] [Field IVK] [Module RIVK G] [SMul ASK G] [DecidableEq RIVK]
+variable [AddCommGroup G] [Field IVK] [Field RIVK] [Module RIVK G] [SMul ASK G] [DecidableEq RIVK]
 
 /-- The `rivk_ext`-derivation query of a witness: the query at which the combined final oracle
 produces its `rivk_ext`, selected by the branch. Never `.int` (`extQueryOf_ne_int`). -/
@@ -375,8 +375,8 @@ theorem shiftedFinalOracle_finalQueryOf
 end Onward
 
 section OnwardCollision
-variable [AddCommGroup G] [Field RIVK] [Field IVK] [Module RIVK G] [SMul ASK G]
-variable [NoZeroSMulDivisors RIVK G] [DecidableEq RIVK]
+variable [AddCommGroup G] [Field IVK] [Field RIVK] [Module RIVK G] [NoZeroSMulDivisors RIVK G]
+variable [SMul ASK G] [DecidableEq RIVK]
 
 /-- **Same-`ivk` ±-equation over `H^*`.** Two witnesses opening the same `ivk` (`KBOpening`), both
 satisfying the derivation constraints, give the ZIP 2005 break equation with the final-oracle
@@ -448,13 +448,13 @@ def branchOfQuery : FinalQuery AK NK RIVK QK SK → Option (Branch QK SK)
   | .legacy sk => some (.sk sk)
   | .int _ _ _ => none
 
-omit [Field RIVK] [Field IVK] [NoZeroSMulDivisors RIVK G] [DecidableEq RIVK] in
+omit [Field IVK] [Field RIVK] [NoZeroSMulDivisors RIVK G] [DecidableEq RIVK] in
 /-- A witness's Branch data is recoverable from its `rivk_ext`-derivation query. -/
 theorem branch_eq_branchOfQuery {w : Witness G IVK AK NK RIVK QK SK} (Extract : Extractor G IVK AK) :
     some w.qk_or_sk = branchOfQuery (extQueryOf Extract w) := by
   rcases hb : w.qk_or_sk with qk | sk <;> simp [extQueryOf, branchOfQuery, hb]
 
-omit [Field RIVK] [Field IVK] [NoZeroSMulDivisors RIVK G] [DecidableEq RIVK] in
+omit [Field IVK] [Field RIVK] [NoZeroSMulDivisors RIVK G] [DecidableEq RIVK] in
 /-- A witness's `rivk_ext`-derivation query is never `.int`. -/
 theorem extQueryOf_ne_int {w : Witness G IVK AK NK RIVK QK SK} (Extract : Extractor G IVK AK) (rivk_ext : RIVK) (ak : AK) (nk : NK) :
     extQueryOf Extract w ≠ .int rivk_ext ak nk := by
@@ -558,7 +558,7 @@ coincide. What the birthday bound then adds is that inhabiting this event is har
 non-querying, so a fixed shift cannot be steered to manufacture collisions, and ±-colliding the
 shifted oracle at distinct queries has probability at most `q(q-1)/r` (`Birthday.lean`). -/
 def _root_.Zcash.Security.RandomOracle.CollisionUpToSign.ofBreak
-    [DecidableEq QK] [DecidableEq SK] [DecidableEq AK] [DecidableEq NK]
+    [DecidableEq AK] [DecidableEq NK] [DecidableEq QK] [DecidableEq SK]
     (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK) (Ggen : G) (hS : S ≠ 0)
     (H : Oracles AK NK RIVK ASK QK SK)
     {w₁ w₂ : Witness G IVK AK NK RIVK QK SK}

--- a/Zcash/Security/KeyBinding/Basic.lean
+++ b/Zcash/Security/KeyBinding/Basic.lean
@@ -18,11 +18,11 @@ The route, each step proven here:
 3. `CollisionUpToSign.ofBreak` — a full `Break` computes a ±-collision of the shifted combined
    oracle at distinct queries; `residual_of_finalQuery_eq` handles coinciding queries.
 4. `nk_pinned` / `ak_pinned` / `qk_or_sk_pinned` — without a break, the components agree
-   (Balance's and Spend Authorization's imports).
+   (consumed by the Balance and Spend Authorization arguments).
 
 The probabilistic side — producing the computed collision is hard — is the birthday bound
 `ε_kb ≤ q(q-1)/r` (`Birthday.lean`), ZIP 2005's `ε_kb` as sharpened in zcash/zips#1338.
-`PRF^nf`-pinning, Spendability's import, is not here yet.
+`PRF^nf`-pinning, which the Spendability argument consumes, is not here yet.
 
 Abstract setting: a prime-order group `G` as an `RIVK`-vector space. The scalar types are
 `RIVK` (rivk values and the rivk-derivation oracle outputs) and `ASK` (`H^ask` outputs, acting
@@ -267,9 +267,9 @@ structure Break (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK
   /-- The witnesses differ in the break projection. -/
   proj_ne : w₁.breakProj Extract ≠ w₂.breakProj Extract
 
-/-- `nk`-pinning (Balance's import): two valid witnesses with the same `ivk` that do **not** form a
-key-binding break must share the same nullifier key `nk`. (The probability that a break *does* occur
-is the birthday bound.) -/
+/-- `nk`-pinning (consumed by the Balance argument): two valid witnesses with the same `ivk`
+that do **not** form a key-binding break must share the same nullifier key `nk`. (The
+probability that a break *does* occur is the birthday bound.) -/
 theorem nk_pinned (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK) (Ggen : G)
     (H : Oracles AK NK RIVK ASK QK SK)
     {w₁ w₂ : Witness G IVK AK NK RIVK QK SK}
@@ -283,9 +283,10 @@ theorem nk_pinned (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RI
   refine ⟨h₁, h₂, hivk, fun heq => hne ?_⟩
   exact congrArg BreakProj.nk heq
 
-/-- `ak`-pinning up to y-sign (Spend Authorization's import): two valid witnesses with the same `ivk`
-that do *not* form a key-binding break share the same `ak = Extract.toAK ak^ℙ` — i.e. `ak^ℙ` is pinned up
-to its y-sign, matching the protocol's choice to consume `ak` as a single x-coordinate. -/
+/-- `ak`-pinning up to y-sign (consumed by the Spend Authorization argument): two valid
+witnesses with the same `ivk` that do *not* form a key-binding break share the same
+`ak = Extract.toAK ak^ℙ` — i.e. `ak^ℙ` is pinned up to its y-sign, matching the protocol's
+choice to consume `ak` as a single x-coordinate. -/
 theorem ak_pinned (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK) (Ggen : G)
     (H : Oracles AK NK RIVK ASK QK SK)
     {w₁ w₂ : Witness G IVK AK NK RIVK QK SK}
@@ -299,10 +300,11 @@ theorem ak_pinned (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RI
   refine ⟨h₁, h₂, hivk, fun heq => hne ?_⟩
   exact congrArg BreakProj.ak heq
 
-/-- `qk`/`sk`-pinning (Spend Authorization's import): two valid witnesses with the same `ivk` that do
-*not* form a key-binding break share the same branch — the same `qk` or the same `sk`, including
-*which* of the two backs the witness. This is stronger than ZIP 2005's former "`qk` determined by
-`ivk` when `qk ≠ ⊥`". -/
+/-- `qk`/`sk`-pinning (consumed by the Spend Authorization argument): two valid witnesses
+with the same `ivk` that do *not* form a key-binding break share the same branch — the same
+`qk` or the same `sk`, including *which* of the two backs the witness. This is stronger than
+ZIP 2005's former statement, which determined `qk`'s value when present but not which branch
+backs the witness. -/
 theorem qk_or_sk_pinned (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK) (Ggen : G)
     (H : Oracles AK NK RIVK ASK QK SK)
     {w₁ w₂ : Witness G IVK AK NK RIVK QK SK}

--- a/Zcash/Security/KeyBinding/Basic.lean
+++ b/Zcash/Security/KeyBinding/Basic.lean
@@ -25,7 +25,7 @@ The probabilistic side — producing the computed collision is hard — is the b
 
 Abstract setting: a prime-order group `G` as an `F`-vector space (`F = ZMod r` the scalar field),
 base-field types `IVK`, `AK`, and `NK` (all `= ZMod q` concretely), and an `Extract` structure
-bundling the two extract maps — `toIVK : G → IVK` carrying the ±-property (`hExt`), and
+bundling the two extract maps — `toIVK : G → IVK` carrying the ±-property (`toIVK_pm`), and
 `toAK : G → AK` for the derivation side; both instantiate to `Extract_P`. `ivk`'s nonzeroness
 is the `KBOpening.nonzero` hypothesis, not a type refinement (`Commit^ivk` can return 0 in
 circuit contexts, §4.1.8).
@@ -87,11 +87,13 @@ def FinalQuery.eval (Hrivk_legacy : SK → F) (Hrivk_ext : QK → AK → NK → 
   | .int rivk_ext ak nk => Hrivk_int rivk_ext ak nk
 
 /-- The two extract maps of the key-binding model; both instantiate to `Extract_P`
-concretely. `toIVK` carries the ±-property (`hExt`); `toAK` serves the derivation and
+concretely. `toIVK` carries the ±-property (`toIVK_pm`); `toAK` serves the derivation and
 projection side. -/
-structure Extractor (G IVK AK : Type*) where
+structure Extractor (G IVK AK : Type*) [Neg G] where
   toIVK : G → IVK
   toAK : G → AK
+  /-- `toIVK` identifies exactly the ±-pairs (the x-coordinate property). -/
+  toIVK_pm : ∀ P Q : G, toIVK P = toIVK Q ↔ P =± Q
 
 section Algebra
 variable [AddCommGroup G] [Field F] [Field IVK] [Module F G] [NoZeroSMulDivisors F G]
@@ -108,13 +110,12 @@ equal or negatives — the deterministic content the whole key-binding reduction
 from the `toIVK` ±-property and injectivity of `· • S` for `S ≠ 0` (`smul_left_injective`;
 `G` is an `F`-vector space). -/
 theorem commit_scalar_pm
-    (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F)
-    (hExt : ∀ P Q : G, Extract.toIVK P = Extract.toIVK Q ↔ P =± Q) (hS : S ≠ 0)
+    (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (hS : S ≠ 0)
     {rivk₁ rivk₂ : F} {ak₁ ak₂ : AK} {nk₁ nk₂ : NK}
     (hcm : Commitivk Extract S hfn rivk₁ ak₁ nk₁ = Commitivk Extract S hfn rivk₂ ak₂ nk₂) :
     hfn ak₁ nk₁ + rivk₁ =± hfn ak₂ nk₂ + rivk₂ := by
   unfold Commitivk at hcm
-  rw [hExt] at hcm
+  rw [Extract.toIVK_pm] at hcm
   rcases hcm with hcm | hcm
   · exact Or.inl (smul_left_injective F hS hcm)
   · refine Or.inr (smul_left_injective F hS ?_)
@@ -151,8 +152,7 @@ standalone inhabitant is computable outright. The security content is conditiona
 `OpeningBreak` hypothesis; hardness enters per-instantiation, where `rivk` is an `H^*` output
 (`KBDerivation`) and the birthday bound applies. -/
 def _root_.Zcash.Security.RandomOracle.CollisionUpToSign.ofOpeningBreak
-    (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F)
-    (hExt : ∀ P Q : G, Extract.toIVK P = Extract.toIVK Q ↔ P =± Q) (hS : S ≠ 0)
+    (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (hS : S ≠ 0)
     {w₁ w₂ : Witness G F IVK AK NK SK QK} (hbrk : OpeningBreak Extract S hfn w₁ w₂) :
     RandomOracle.CollisionUpToSign (pedersenScalar hfn) where
   q₁ := (Extract.toAK w₁.akP, w₁.nk, w₁.rivk)
@@ -161,7 +161,7 @@ def _root_.Zcash.Security.RandomOracle.CollisionUpToSign.ofOpeningBreak
   pm := by
     -- Commitivk(w₁) = w₁.ivk = w₂.ivk = Commitivk(w₂)
     simpa [pedersenScalar] using
-      commit_scalar_pm Extract S hfn hExt hS
+      commit_scalar_pm Extract S hfn hS
         (hbrk.opening₁.commit.symm.trans (hbrk.ivk_eq.trans hbrk.opening₂.commit))
 
 end Algebra
@@ -384,8 +384,7 @@ notions (`OpeningBreak`, `Break`) carry a distinctness witness. That is why this
 equation rather than a full `CollisionUpToSign`; the `ne` field arrives with
 `CollisionUpToSign.ofBreak`'s case split. -/
 theorem sameIvk_finalOracle_pm
-    (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
-    (hExt : ∀ P Q : G, Extract.toIVK P = Extract.toIVK Q ↔ P =± Q) (hS : S ≠ 0)
+    (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (Ggen : G) (hS : S ≠ 0)
     (H : Oracles F AK NK SK QK)
     {w₁ w₂ : Witness G F IVK AK NK SK QK}
     (hop₁ : KBOpening Extract S hfn w₁) (hop₂ : KBOpening Extract S hfn w₂)
@@ -397,7 +396,7 @@ theorem sameIvk_finalOracle_pm
   have hcm : Commitivk Extract S hfn w₁.rivk (Extract.toAK w₁.akP) w₁.nk
       = Commitivk Extract S hfn w₂.rivk (Extract.toAK w₂.akP) w₂.nk :=
     hop₁.commit.symm.trans (hivk.trans hop₂.commit)
-  have hpm := commit_scalar_pm Extract S hfn hExt hS hcm
+  have hpm := commit_scalar_pm Extract S hfn hS hcm
   rw [rivk_eq_finalOracle Extract Ggen H hd₁,
       rivk_eq_finalOracle Extract Ggen H hd₂] at hpm
   exact hpm
@@ -405,8 +404,7 @@ theorem sameIvk_finalOracle_pm
 /-- The `H^*` ±-equation from an `OpeningBreak` (the object the games produce): the same-`ivk`
 core `sameIvk_finalOracle_pm` applied to the break's two openings. -/
 theorem openingBreak_finalOracle_pm
-    (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
-    (hExt : ∀ P Q : G, Extract.toIVK P = Extract.toIVK Q ↔ P =± Q) (hS : S ≠ 0)
+    (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (Ggen : G) (hS : S ≠ 0)
     (H : Oracles F AK NK SK QK)
     {w₁ w₂ : Witness G F IVK AK NK SK QK}
     (hbrk : OpeningBreak Extract S hfn w₁ w₂)
@@ -414,7 +412,7 @@ theorem openingBreak_finalOracle_pm
     (hd₂ : KBDerivation Extract Ggen H w₂) :
     hfn (Extract.toAK w₁.akP) w₁.nk + (finalQueryOf Extract w₁).eval H.rivk_legacy H.rivk_ext H.rivk_int
       =± hfn (Extract.toAK w₂.akP) w₂.nk + (finalQueryOf Extract w₂).eval H.rivk_legacy H.rivk_ext H.rivk_int :=
-  sameIvk_finalOracle_pm Extract S hfn Ggen hExt hS H
+  sameIvk_finalOracle_pm Extract S hfn Ggen hS H
     hbrk.opening₁ hbrk.opening₂ hbrk.ivk_eq hd₁ hd₂
 
 /-- The `H^*` ±-equation from a full key-binding `Break` (break projections differing). The
@@ -422,14 +420,13 @@ derivation constraints are already inside the `Break` (via `KB`), and *no* `Brea
 upgrade is needed: the equation depends only on the openings and `ivk`-equality, never on how the
 projections differ. `CollisionUpToSign.ofBreak` builds its case split on this. -/
 theorem break_finalOracle_pm
-    (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
-    (hExt : ∀ P Q : G, Extract.toIVK P = Extract.toIVK Q ↔ P =± Q) (hS : S ≠ 0)
+    (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (Ggen : G) (hS : S ≠ 0)
     (H : Oracles F AK NK SK QK)
     {w₁ w₂ : Witness G F IVK AK NK SK QK}
     (hbrk : Break Extract S hfn Ggen H w₁ w₂) :
     hfn (Extract.toAK w₁.akP) w₁.nk + (finalQueryOf Extract w₁).eval H.rivk_legacy H.rivk_ext H.rivk_int
       =± hfn (Extract.toAK w₂.akP) w₂.nk + (finalQueryOf Extract w₂).eval H.rivk_legacy H.rivk_ext H.rivk_int :=
-  sameIvk_finalOracle_pm Extract S hfn Ggen hExt hS H
+  sameIvk_finalOracle_pm Extract S hfn Ggen hS H
     hbrk.kb₁.opening hbrk.kb₂.opening hbrk.ivk_eq hbrk.kb₁.derivation hbrk.kb₂.derivation
 
 /-- The break projection an *externally-decoded* witness must have, read off its
@@ -447,13 +444,13 @@ def branchOfQuery : FinalQuery QK SK AK NK F → Option (Branch QK SK)
   | .legacy sk => some (.sk sk)
   | .int _ _ _ => none
 
-omit [AddCommGroup G] [Field F] [Field IVK] [NoZeroSMulDivisors F G] [DecidableEq F] in
+omit [Field F] [Field IVK] [NoZeroSMulDivisors F G] [DecidableEq F] in
 /-- A witness's Branch data is recoverable from its `rivk_ext`-derivation query. -/
 theorem branch_eq_branchOfQuery {w : Witness G F IVK AK NK SK QK} (Extract : Extractor G IVK AK) :
     some w.qk_or_sk = branchOfQuery (extQueryOf Extract w) := by
   rcases hb : w.qk_or_sk with qk | sk <;> simp [extQueryOf, branchOfQuery, hb]
 
-omit [AddCommGroup G] [Field F] [Field IVK] [NoZeroSMulDivisors F G] [DecidableEq F] in
+omit [Field F] [Field IVK] [NoZeroSMulDivisors F G] [DecidableEq F] in
 /-- A witness's `rivk_ext`-derivation query is never `.int`. -/
 theorem extQueryOf_ne_int {w : Witness G F IVK AK NK SK QK} (Extract : Extractor G IVK AK) (rivk_ext : F) (ak : AK) (nk : NK) :
     extQueryOf Extract w ≠ .int rivk_ext ak nk := by
@@ -558,8 +555,7 @@ non-querying, so a fixed shift cannot be steered to manufacture collisions, and 
 shifted oracle at distinct queries has probability at most `q(q-1)/r` (`Birthday.lean`). -/
 def _root_.Zcash.Security.RandomOracle.CollisionUpToSign.ofBreak
     [DecidableEq QK] [DecidableEq SK] [DecidableEq AK] [DecidableEq NK]
-    (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
-    (hExt : ∀ P Q : G, Extract.toIVK P = Extract.toIVK Q ↔ P =± Q) (hS : S ≠ 0)
+    (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (Ggen : G) (hS : S ≠ 0)
     (H : Oracles F AK NK SK QK)
     {w₁ w₂ : Witness G F IVK AK NK SK QK}
     (hbrk : Break Extract S hfn Ggen H w₁ w₂) :
@@ -578,7 +574,7 @@ def _root_.Zcash.Security.RandomOracle.CollisionUpToSign.ofBreak
       pm := by
         rw [shiftedFinalOracle_finalQueryOf Extract Ggen hfn H hbrk.kb₁.derivation,
             shiftedFinalOracle_finalQueryOf Extract Ggen hfn H hbrk.kb₂.derivation]
-        exact break_finalOracle_pm Extract S hfn Ggen hExt hS H hbrk }
+        exact break_finalOracle_pm Extract S hfn Ggen hS H hbrk }
 
 omit [Field IVK] [NoZeroSMulDivisors F G] in
 /-- **The bridge to the birthday counting**: the pair of `H^*` outputs at a shifted-oracle

--- a/Zcash/Security/KeyBinding/Basic.lean
+++ b/Zcash/Security/KeyBinding/Basic.lean
@@ -22,7 +22,8 @@ The route, each step proven here:
 
 The probabilistic side — producing the computed collision is hard — is the birthday bound
 `ε_kb ≤ q(q-1)/r` (`Birthday.lean`), ZIP 2005's `ε_kb` as sharpened in zcash/zips#1338.
-`PRF^nf`-pinning, which the Spendability argument consumes, is not here yet.
+nf-pinning, which the Spendability argument consumes, is the games'
+`nfOldEqOrBreak` (`Security/Ledger/Statement.lean`).
 
 Abstract setting: a prime-order group `G` as an `RIVK`-vector space. The scalar types are
 `RIVK` (rivk values and the rivk-derivation oracle outputs) and `ASK` (`H^ask` outputs, acting

--- a/Zcash/Security/KeyBinding/Basic.lean
+++ b/Zcash/Security/KeyBinding/Basic.lean
@@ -70,9 +70,9 @@ def pedersenScalar [Add F] (hfn : AK → NK → F) (t : AK × NK × F) : F :=
 the query at which `rivk` is that oracle's output, selected by the `qk`/`sk` branch and the
 external/internal ivk choice. -/
 inductive FinalQuery (QK SK AK NK F : Type*) where
-  /-- qk-branch, external ivk: `rivk = Hrivk_ext qk ak nk`. -/
+  /-- qk-branch, external ivk: `rivk = H.rivk_ext qk ak nk`. -/
   | ext : QK → AK → NK → FinalQuery QK SK AK NK F
-  /-- sk-branch, external ivk: `rivk = Hrivk_legacy sk`. -/
+  /-- sk-branch, external ivk: `rivk = H.rivk_legacy sk`. -/
   | legacy : SK → FinalQuery QK SK AK NK F
   /-- internal ivk: `rivk = Hrivk_int rivk_ext ak nk`. -/
   | int : F → AK → NK → FinalQuery QK SK AK NK F
@@ -158,28 +158,39 @@ def _root_.Zcash.Security.RandomOracle.CollisionUpToSign.ofOpeningBreak
 
 end Algebra
 
+
+/-- The five random oracles of the key-binding model (ZIP 2005): `H^ask`, `H^nk`, and the
+three final `rivk`-derivation oracles. Bundled so the derivation layer's signatures carry
+one parameter; the probabilistic capstones assemble the bundle from `H^ask`/`H^nk` and the
+sampled table's restrictions. -/
+structure Oracles (F AK NK SK QK : Type*) where
+  ask : SK → F
+  nk : SK → NK
+  rivk_legacy : SK → F
+  rivk_ext : QK → AK → NK → F
+  rivk_int : F → AK → NK → F
+
 section Derivation
 variable [AddCommGroup G] [Field F] [Field AK] [Module F G]
 
 /-- `BindKeys^sk` (ZIP 2005): the `sk`-branch derivation constraints. -/
-structure BindKeysSk (Ggen : G) (Hask : SK → F) (Hnk : SK → NK) (Hrivk_legacy : SK → F)
+structure BindKeysSk (Ggen : G) (H : Oracles F AK NK SK QK)
     (sk : SK) (akP : G) (nk : NK) (rivk_ext : F) : Prop where
-  akP_eq : akP = (Hask sk) • Ggen
-  nk_eq : nk = Hnk sk
-  rivk_ext_eq : rivk_ext = Hrivk_legacy sk
+  akP_eq : akP = (H.ask sk) • Ggen
+  nk_eq : nk = H.nk sk
+  rivk_ext_eq : rivk_ext = H.rivk_legacy sk
 
 /-- `KBDerivation` — the ZIP 2005 derivation constraints (the `qk_or_sk` branch structure is
 enforced by the `Branch` type). -/
 structure KBDerivation (Extract : G → AK) (Ggen : G)
-    (Hask : SK → F) (Hnk : SK → NK) (Hrivk_legacy : SK → F)
-    (Hrivk_ext : QK → AK → NK → F) (Hrivk_int : F → AK → NK → F)
+    (H : Oracles F AK NK SK QK)
     (w : Witness G F AK NK SK QK) : Prop where
   /-- The per-branch constraint: `Hrivk_ext` on the qk-branch, `BindKeys^sk` on the sk-branch. -/
   branch : match w.qk_or_sk with
-    | .qk qk => w.rivk_ext = Hrivk_ext qk (Extract w.akP) w.nk
-    | .sk sk => BindKeysSk Ggen Hask Hnk Hrivk_legacy sk w.akP w.nk w.rivk_ext
+    | .qk qk => w.rivk_ext = H.rivk_ext qk (Extract w.akP) w.nk
+    | .sk sk => BindKeysSk Ggen H sk w.akP w.nk w.rivk_ext
   /-- `rivk ∈ {rivk_ext, Hrivk_int ...}`. -/
-  rivk_choice : w.rivk = w.rivk_ext ∨ w.rivk = Hrivk_int w.rivk_ext (Extract w.akP) w.nk
+  rivk_choice : w.rivk = w.rivk_ext ∨ w.rivk = H.rivk_int w.rivk_ext (Extract w.akP) w.nk
 
 end Derivation
 
@@ -188,11 +199,10 @@ variable [AddCommGroup G] [Field F] [Field AK] [Module F G]
 
 /-- The full key-binding condition: commitment opening and key derivation constraints. -/
 structure KB (Extract : G → AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
-    (Hask : SK → F) (Hnk : SK → NK) (Hrivk_legacy : SK → F)
-    (Hrivk_ext : QK → AK → NK → F) (Hrivk_int : F → AK → NK → F)
+    (H : Oracles F AK NK SK QK)
     (w : Witness G F AK NK SK QK) : Prop where
   opening : KBOpening Extract S hfn w
-  derivation : KBDerivation Extract Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int w
+  derivation : KBDerivation Extract Ggen H w
 
 /-- The break projection of a witness: the components a key-binding break must differ in. Using
 `ak = Extract ak^ℙ` quotients the y-sign of `ak^ℙ`. -/
@@ -209,11 +219,10 @@ def Witness.breakProj (Extract : G → AK) (w : Witness G F AK NK SK QK) : Break
 /-- A full key-binding break (ZIP 2005): two valid witnesses with equal `ivk` and differing
 break projections. -/
 structure Break (Extract : G → AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
-    (Hask : SK → F) (Hnk : SK → NK) (Hrivk_legacy : SK → F)
-    (Hrivk_ext : QK → AK → NK → F) (Hrivk_int : F → AK → NK → F)
+    (H : Oracles F AK NK SK QK)
     (w₁ w₂ : Witness G F AK NK SK QK) : Prop where
-  kb₁ : KB Extract S hfn Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int w₁
-  kb₂ : KB Extract S hfn Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int w₂
+  kb₁ : KB Extract S hfn Ggen H w₁
+  kb₂ : KB Extract S hfn Ggen H w₂
   ivk_eq : w₁.ivk = w₂.ivk
   /-- The witnesses differ in the break projection. -/
   proj_ne : w₁.breakProj Extract ≠ w₂.breakProj Extract
@@ -222,13 +231,12 @@ structure Break (Extract : G → AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
 key-binding break must share the same nullifier key `nk`. (The probability that a break *does* occur
 is the birthday bound.) -/
 theorem nk_pinned (Extract : G → AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
-    (Hask : SK → F) (Hnk : SK → NK) (Hrivk_legacy : SK → F)
-    (Hrivk_ext : QK → AK → NK → F) (Hrivk_int : F → AK → NK → F)
+    (H : Oracles F AK NK SK QK)
     {w₁ w₂ : Witness G F AK NK SK QK}
-    (h₁ : KB Extract S hfn Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int w₁)
-    (h₂ : KB Extract S hfn Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int w₂)
+    (h₁ : KB Extract S hfn Ggen H w₁)
+    (h₂ : KB Extract S hfn Ggen H w₂)
     (hivk : w₁.ivk = w₂.ivk)
-    (hnb : ¬ Break Extract S hfn Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int w₁ w₂) :
+    (hnb : ¬ Break Extract S hfn Ggen H w₁ w₂) :
     w₁.nk = w₂.nk := by
   by_contra hne
   apply hnb
@@ -239,13 +247,12 @@ theorem nk_pinned (Extract : G → AK) (S : G) (hfn : AK → NK → F) (Ggen : G
 that do *not* form a key-binding break share the same `ak = Extract ak^ℙ` — i.e. `ak^ℙ` is pinned up
 to its y-sign, matching the protocol's choice to consume `ak` as a single x-coordinate. -/
 theorem ak_pinned (Extract : G → AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
-    (Hask : SK → F) (Hnk : SK → NK) (Hrivk_legacy : SK → F)
-    (Hrivk_ext : QK → AK → NK → F) (Hrivk_int : F → AK → NK → F)
+    (H : Oracles F AK NK SK QK)
     {w₁ w₂ : Witness G F AK NK SK QK}
-    (h₁ : KB Extract S hfn Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int w₁)
-    (h₂ : KB Extract S hfn Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int w₂)
+    (h₁ : KB Extract S hfn Ggen H w₁)
+    (h₂ : KB Extract S hfn Ggen H w₂)
     (hivk : w₁.ivk = w₂.ivk)
-    (hnb : ¬ Break Extract S hfn Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int w₁ w₂) :
+    (hnb : ¬ Break Extract S hfn Ggen H w₁ w₂) :
     Extract w₁.akP = Extract w₂.akP := by
   by_contra hne
   apply hnb
@@ -257,13 +264,12 @@ theorem ak_pinned (Extract : G → AK) (S : G) (hfn : AK → NK → F) (Ggen : G
 *which* of the two backs the witness. This is stronger than ZIP 2005's former "`qk` determined by
 `ivk` when `qk ≠ ⊥`". -/
 theorem qk_or_sk_pinned (Extract : G → AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
-    (Hask : SK → F) (Hnk : SK → NK) (Hrivk_legacy : SK → F)
-    (Hrivk_ext : QK → AK → NK → F) (Hrivk_int : F → AK → NK → F)
+    (H : Oracles F AK NK SK QK)
     {w₁ w₂ : Witness G F AK NK SK QK}
-    (h₁ : KB Extract S hfn Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int w₁)
-    (h₂ : KB Extract S hfn Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int w₂)
+    (h₁ : KB Extract S hfn Ggen H w₁)
+    (h₂ : KB Extract S hfn Ggen H w₂)
     (hivk : w₁.ivk = w₂.ivk)
-    (hnb : ¬ Break Extract S hfn Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int w₁ w₂) :
+    (hnb : ¬ Break Extract S hfn Ggen H w₁ w₂) :
     w₁.qk_or_sk = w₂.qk_or_sk := by
   by_contra hne
   apply hnb
@@ -301,11 +307,10 @@ the witness's `finalQueryOf`. It bridges the Pedersen-scalar collision
 probabilistic is only the birthday bound over the final-query space. -/
 theorem rivk_eq_finalOracle
     (Extract : G → AK) (Ggen : G)
-    (Hask : SK → F) (Hnk : SK → NK) (Hrivk_legacy : SK → F)
-    (Hrivk_ext : QK → AK → NK → F) (Hrivk_int : F → AK → NK → F)
+    (H : Oracles F AK NK SK QK)
     {w : Witness G F AK NK SK QK}
-    (hd : KBDerivation Extract Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int w) :
-    w.rivk = (finalQueryOf Extract w).eval Hrivk_legacy Hrivk_ext Hrivk_int := by
+    (hd : KBDerivation Extract Ggen H w) :
+    w.rivk = (finalQueryOf Extract w).eval H.rivk_legacy H.rivk_ext H.rivk_int := by
   obtain ⟨hbc, hrivk⟩ := hd
   unfold finalQueryOf extQueryOf
   by_cases hext : w.rivk = w.rivk_ext
@@ -329,24 +334,22 @@ def shiftOf (Extract : G → AK) (Ggen : G) (hfn : AK → NK → F) (Hask : SK �
 The ±-collision a `Break` computes (`CollisionUpToSign.ofBreak`) is of this map — the event
 the birthday layer bounds. -/
 def shiftedFinalOracle (Extract : G → AK) (Ggen : G) (hfn : AK → NK → F)
-    (Hask : SK → F) (Hnk : SK → NK) (Hrivk_legacy : SK → F)
-    (Hrivk_ext : QK → AK → NK → F) (Hrivk_int : F → AK → NK → F)
+    (H : Oracles F AK NK SK QK)
     (q : FinalQuery QK SK AK NK F) : F :=
-  shiftOf Extract Ggen hfn Hask Hnk q + q.eval Hrivk_legacy Hrivk_ext Hrivk_int
+  shiftOf Extract Ggen hfn H.ask H.nk q + q.eval H.rivk_legacy H.rivk_ext H.rivk_int
 
 omit [Field AK] in
 /-- On a witness's `finalQueryOf`, the shifted oracle is the shift plus the `H^*` output — the form
 `sameIvk_finalOracle_pm`'s equation is stated in. -/
 theorem shiftedFinalOracle_finalQueryOf
     (Extract : G → AK) (Ggen : G) (hfn : AK → NK → F)
-    (Hask : SK → F) (Hnk : SK → NK) (Hrivk_legacy : SK → F)
-    (Hrivk_ext : QK → AK → NK → F) (Hrivk_int : F → AK → NK → F)
+    (H : Oracles F AK NK SK QK)
     {w : Witness G F AK NK SK QK}
-    (hd : KBDerivation Extract Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int w) :
-    shiftedFinalOracle Extract Ggen hfn Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int
+    (hd : KBDerivation Extract Ggen H w) :
+    shiftedFinalOracle Extract Ggen hfn H
         (finalQueryOf Extract w)
       = hfn (Extract w.akP) w.nk
-          + (finalQueryOf Extract w).eval Hrivk_legacy Hrivk_ext Hrivk_int := by
+          + (finalQueryOf Extract w).eval H.rivk_legacy H.rivk_ext H.rivk_int := by
   obtain ⟨hbc, hrivk⟩ := hd
   unfold finalQueryOf extQueryOf
   by_cases hext : w.rivk = w.rivk_ext
@@ -375,21 +378,20 @@ equation rather than a full `CollisionUpToSign`; the `ne` field arrives with
 theorem sameIvk_finalOracle_pm
     (Extract : G → AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
     (hExt : ∀ P Q : G, Extract P = Extract Q ↔ P =± Q) (hS : S ≠ 0)
-    (Hask : SK → F) (Hnk : SK → NK) (Hrivk_legacy : SK → F)
-    (Hrivk_ext : QK → AK → NK → F) (Hrivk_int : F → AK → NK → F)
+    (H : Oracles F AK NK SK QK)
     {w₁ w₂ : Witness G F AK NK SK QK}
     (hop₁ : KBOpening Extract S hfn w₁) (hop₂ : KBOpening Extract S hfn w₂)
     (hivk : w₁.ivk = w₂.ivk)
-    (hd₁ : KBDerivation Extract Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int w₁)
-    (hd₂ : KBDerivation Extract Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int w₂) :
-    hfn (Extract w₁.akP) w₁.nk + (finalQueryOf Extract w₁).eval Hrivk_legacy Hrivk_ext Hrivk_int
-      =± hfn (Extract w₂.akP) w₂.nk + (finalQueryOf Extract w₂).eval Hrivk_legacy Hrivk_ext Hrivk_int := by
+    (hd₁ : KBDerivation Extract Ggen H w₁)
+    (hd₂ : KBDerivation Extract Ggen H w₂) :
+    hfn (Extract w₁.akP) w₁.nk + (finalQueryOf Extract w₁).eval H.rivk_legacy H.rivk_ext H.rivk_int
+      =± hfn (Extract w₂.akP) w₂.nk + (finalQueryOf Extract w₂).eval H.rivk_legacy H.rivk_ext H.rivk_int := by
   have hcm : Commitivk Extract S hfn w₁.rivk (Extract w₁.akP) w₁.nk
       = Commitivk Extract S hfn w₂.rivk (Extract w₂.akP) w₂.nk :=
     hop₁.commit.symm.trans (hivk.trans hop₂.commit)
   have hpm := commit_scalar_pm Extract S hfn hExt hS hcm
-  rw [rivk_eq_finalOracle Extract Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int hd₁,
-      rivk_eq_finalOracle Extract Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int hd₂] at hpm
+  rw [rivk_eq_finalOracle Extract Ggen H hd₁,
+      rivk_eq_finalOracle Extract Ggen H hd₂] at hpm
   exact hpm
 
 /-- The `H^*` ±-equation from an `OpeningBreak` (the object the games produce): the same-`ivk`
@@ -397,15 +399,14 @@ core `sameIvk_finalOracle_pm` applied to the break's two openings. -/
 theorem openingBreak_finalOracle_pm
     (Extract : G → AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
     (hExt : ∀ P Q : G, Extract P = Extract Q ↔ P =± Q) (hS : S ≠ 0)
-    (Hask : SK → F) (Hnk : SK → NK) (Hrivk_legacy : SK → F)
-    (Hrivk_ext : QK → AK → NK → F) (Hrivk_int : F → AK → NK → F)
+    (H : Oracles F AK NK SK QK)
     {w₁ w₂ : Witness G F AK NK SK QK}
     (hbrk : OpeningBreak Extract S hfn w₁ w₂)
-    (hd₁ : KBDerivation Extract Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int w₁)
-    (hd₂ : KBDerivation Extract Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int w₂) :
-    hfn (Extract w₁.akP) w₁.nk + (finalQueryOf Extract w₁).eval Hrivk_legacy Hrivk_ext Hrivk_int
-      =± hfn (Extract w₂.akP) w₂.nk + (finalQueryOf Extract w₂).eval Hrivk_legacy Hrivk_ext Hrivk_int :=
-  sameIvk_finalOracle_pm Extract S hfn Ggen hExt hS Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int
+    (hd₁ : KBDerivation Extract Ggen H w₁)
+    (hd₂ : KBDerivation Extract Ggen H w₂) :
+    hfn (Extract w₁.akP) w₁.nk + (finalQueryOf Extract w₁).eval H.rivk_legacy H.rivk_ext H.rivk_int
+      =± hfn (Extract w₂.akP) w₂.nk + (finalQueryOf Extract w₂).eval H.rivk_legacy H.rivk_ext H.rivk_int :=
+  sameIvk_finalOracle_pm Extract S hfn Ggen hExt hS H
     hbrk.opening₁ hbrk.opening₂ hbrk.ivk_eq hd₁ hd₂
 
 /-- The `H^*` ±-equation from a full key-binding `Break` (break projections differing). The
@@ -415,22 +416,20 @@ projections differ. `CollisionUpToSign.ofBreak` builds its case split on this. -
 theorem break_finalOracle_pm
     (Extract : G → AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
     (hExt : ∀ P Q : G, Extract P = Extract Q ↔ P =± Q) (hS : S ≠ 0)
-    (Hask : SK → F) (Hnk : SK → NK) (Hrivk_legacy : SK → F)
-    (Hrivk_ext : QK → AK → NK → F) (Hrivk_int : F → AK → NK → F)
+    (H : Oracles F AK NK SK QK)
     {w₁ w₂ : Witness G F AK NK SK QK}
-    (hbrk : Break Extract S hfn Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int w₁ w₂) :
-    hfn (Extract w₁.akP) w₁.nk + (finalQueryOf Extract w₁).eval Hrivk_legacy Hrivk_ext Hrivk_int
-      =± hfn (Extract w₂.akP) w₂.nk + (finalQueryOf Extract w₂).eval Hrivk_legacy Hrivk_ext Hrivk_int :=
-  sameIvk_finalOracle_pm Extract S hfn Ggen hExt hS Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int
+    (hbrk : Break Extract S hfn Ggen H w₁ w₂) :
+    hfn (Extract w₁.akP) w₁.nk + (finalQueryOf Extract w₁).eval H.rivk_legacy H.rivk_ext H.rivk_int
+      =± hfn (Extract w₂.akP) w₂.nk + (finalQueryOf Extract w₂).eval H.rivk_legacy H.rivk_ext H.rivk_int :=
+  sameIvk_finalOracle_pm Extract S hfn Ggen hExt hS H
     hbrk.kb₁.opening hbrk.kb₂.opening hbrk.ivk_eq hbrk.kb₁.derivation hbrk.kb₂.derivation
 
 /-- The break projection an *externally-decoded* witness must have, read off its
 `rivk_ext`-derivation query (`proj_eq_projOfQuery`); `.int` is not in `extQueryOf`'s image. -/
-def projOfQuery (Extract : G → AK) (Ggen : G) (Hask : SK → F) (Hnk : SK → NK)
-    (Hrivk_legacy : SK → F) (Hrivk_ext : QK → AK → NK → F) :
+def projOfQuery (Extract : G → AK) (Ggen : G) (H : Oracles F AK NK SK QK) :
     FinalQuery QK SK AK NK F → Option (BreakProj QK SK AK NK F)
-  | .ext qk ak nk => some ⟨.qk qk, ak, nk, Hrivk_ext qk ak nk⟩
-  | .legacy sk => some ⟨.sk sk, Extract ((Hask sk) • Ggen), Hnk sk, Hrivk_legacy sk⟩
+  | .ext qk ak nk => some ⟨.qk qk, ak, nk, H.rivk_ext qk ak nk⟩
+  | .legacy sk => some ⟨.sk sk, Extract ((H.ask sk) • Ggen), H.nk sk, H.rivk_legacy sk⟩
   | .int _ _ _ => none
 
 /-- The Branch data of a witness, read off its `rivk_ext`-derivation query
@@ -457,13 +456,12 @@ omit [Field AK] [NoZeroSMulDivisors F G] [DecidableEq F] in
 query: the derivation constraints determine every component from the query. -/
 theorem proj_eq_projOfQuery
     (Extract : G → AK) (Ggen : G)
-    (Hask : SK → F) (Hnk : SK → NK) (Hrivk_legacy : SK → F)
-    (Hrivk_ext : QK → AK → NK → F) (Hrivk_int : F → AK → NK → F)
+    (H : Oracles F AK NK SK QK)
     {w : Witness G F AK NK SK QK}
-    (hd : KBDerivation Extract Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int w)
+    (hd : KBDerivation Extract Ggen H w)
     (hext : w.rivk = w.rivk_ext) :
     some (w.breakProj Extract)
-      = projOfQuery Extract Ggen Hask Hnk Hrivk_legacy Hrivk_ext (extQueryOf Extract w) := by
+      = projOfQuery Extract Ggen H (extQueryOf Extract w) := by
   obtain ⟨hbc, _⟩ := hd
   rcases hb : w.qk_or_sk with qk | sk <;> simp only [Witness.breakProj, hb] at hbc ⊢ <;>
     simp only [extQueryOf, hb, projOfQuery]
@@ -477,11 +475,10 @@ omit [Field AK] [NoZeroSMulDivisors F G] [DecidableEq F] in
 witness's own key data. -/
 theorem shiftedFinalOracle_extQueryOf
     (Extract : G → AK) (Ggen : G) (hfn : AK → NK → F)
-    (Hask : SK → F) (Hnk : SK → NK) (Hrivk_legacy : SK → F)
-    (Hrivk_ext : QK → AK → NK → F) (Hrivk_int : F → AK → NK → F)
+    (H : Oracles F AK NK SK QK)
     {w : Witness G F AK NK SK QK}
-    (hd : KBDerivation Extract Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int w) :
-    shiftedFinalOracle Extract Ggen hfn Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int
+    (hd : KBDerivation Extract Ggen H w) :
+    shiftedFinalOracle Extract Ggen hfn H
         (extQueryOf Extract w)
       = hfn (Extract w.akP) w.nk + w.rivk_ext := by
   obtain ⟨hbc, _⟩ := hd
@@ -498,15 +495,14 @@ The collision then relocates to the `rivk_ext`-derivation queries, at which the 
 outputs are *equal* and the queries are *distinct*. -/
 theorem residual_of_finalQuery_eq
     (Extract : G → AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
-    (Hask : SK → F) (Hnk : SK → NK) (Hrivk_legacy : SK → F)
-    (Hrivk_ext : QK → AK → NK → F) (Hrivk_int : F → AK → NK → F)
+    (H : Oracles F AK NK SK QK)
     {w₁ w₂ : Witness G F AK NK SK QK}
-    (hbrk : Break Extract S hfn Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int w₁ w₂)
+    (hbrk : Break Extract S hfn Ggen H w₁ w₂)
     (hq : finalQueryOf Extract w₁ = finalQueryOf Extract w₂) :
     extQueryOf Extract w₁ ≠ extQueryOf Extract w₂ ∧
-    shiftedFinalOracle Extract Ggen hfn Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int
+    shiftedFinalOracle Extract Ggen hfn H
         (extQueryOf Extract w₁)
-      = shiftedFinalOracle Extract Ggen hfn Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int
+      = shiftedFinalOracle Extract Ggen hfn H
         (extQueryOf Extract w₂) := by
   obtain ⟨⟨hop₁, hd₁⟩, ⟨hop₂, hd₂⟩, hivk, hne5⟩ := hbrk
   unfold finalQueryOf at hq
@@ -516,9 +512,9 @@ theorem residual_of_finalQuery_eq
     · -- external × external: the projections coincide, contradicting the break's distinctness
       rw [if_pos hext₂] at hq
       exact absurd (Option.some_inj.mp
-        (((proj_eq_projOfQuery Extract Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int
+        (((proj_eq_projOfQuery Extract Ggen H
             hd₁ hext₁).trans (by rw [hq])).trans
-          (proj_eq_projOfQuery Extract Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int
+          (proj_eq_projOfQuery Extract Ggen H
             hd₂ hext₂).symm)) hne5
     · -- external × internal: constructor clash
       rw [if_neg hext₂] at hq
@@ -542,10 +538,8 @@ theorem residual_of_finalQuery_eq
             ((congrArg branchOfQuery h).trans (branch_eq_branchOfQuery (w := w₂) Extract).symm))
         simp only [Witness.breakProj]
         rw [hbr, hak, hnk, hrv]
-      · rw [shiftedFinalOracle_extQueryOf Extract Ggen hfn Hask Hnk Hrivk_legacy Hrivk_ext
-            Hrivk_int hd₁,
-          shiftedFinalOracle_extQueryOf Extract Ggen hfn Hask Hnk Hrivk_legacy Hrivk_ext
-            Hrivk_int hd₂, hak, hnk, hre]
+      · rw [shiftedFinalOracle_extQueryOf Extract Ggen hfn H hd₁,
+          shiftedFinalOracle_extQueryOf Extract Ggen hfn H hd₂, hak, hnk, hre]
 
 /-- **The ZIP 2005 break event, as a computed random-oracle ±-collision** — the terminal object of
 the deterministic layer. A full key-binding `Break` computes a `CollisionUpToSign` of the shifted
@@ -558,31 +552,25 @@ def _root_.Zcash.Security.RandomOracle.CollisionUpToSign.ofBreak
     [DecidableEq QK] [DecidableEq SK] [DecidableEq AK] [DecidableEq NK]
     (Extract : G → AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
     (hExt : ∀ P Q : G, Extract P = Extract Q ↔ P =± Q) (hS : S ≠ 0)
-    (Hask : SK → F) (Hnk : SK → NK) (Hrivk_legacy : SK → F)
-    (Hrivk_ext : QK → AK → NK → F) (Hrivk_int : F → AK → NK → F)
+    (H : Oracles F AK NK SK QK)
     {w₁ w₂ : Witness G F AK NK SK QK}
-    (hbrk : Break Extract S hfn Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int w₁ w₂) :
+    (hbrk : Break Extract S hfn Ggen H w₁ w₂) :
     RandomOracle.CollisionUpToSign
-      (shiftedFinalOracle Extract Ggen hfn Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int
+      (shiftedFinalOracle Extract Ggen hfn H
         (QK := QK) (SK := SK)) :=
   if hq : finalQueryOf Extract w₁ = finalQueryOf Extract w₂ then
     { q₁ := extQueryOf Extract w₁
       q₂ := extQueryOf Extract w₂
-      ne := (residual_of_finalQuery_eq Extract S hfn Ggen Hask Hnk Hrivk_legacy Hrivk_ext
-        Hrivk_int hbrk hq).1
-      pm := Or.inl (residual_of_finalQuery_eq Extract S hfn Ggen Hask Hnk Hrivk_legacy Hrivk_ext
-        Hrivk_int hbrk hq).2 }
+      ne := (residual_of_finalQuery_eq Extract S hfn Ggen H hbrk hq).1
+      pm := Or.inl (residual_of_finalQuery_eq Extract S hfn Ggen H hbrk hq).2 }
   else
     { q₁ := finalQueryOf Extract w₁
       q₂ := finalQueryOf Extract w₂
       ne := hq
       pm := by
-        rw [shiftedFinalOracle_finalQueryOf Extract Ggen hfn Hask Hnk Hrivk_legacy Hrivk_ext
-              Hrivk_int hbrk.kb₁.derivation,
-            shiftedFinalOracle_finalQueryOf Extract Ggen hfn Hask Hnk Hrivk_legacy Hrivk_ext
-              Hrivk_int hbrk.kb₂.derivation]
-        exact break_finalOracle_pm Extract S hfn Ggen hExt hS Hask Hnk Hrivk_legacy Hrivk_ext
-          Hrivk_int hbrk }
+        rw [shiftedFinalOracle_finalQueryOf Extract Ggen hfn H hbrk.kb₁.derivation,
+            shiftedFinalOracle_finalQueryOf Extract Ggen hfn H hbrk.kb₂.derivation]
+        exact break_finalOracle_pm Extract S hfn Ggen hExt hS H hbrk }
 
 omit [Field AK] [NoZeroSMulDivisors F G] in
 /-- **The bridge to the birthday counting**: the pair of `H^*` outputs at a shifted-oracle
@@ -592,15 +580,14 @@ with the collision's `ne` field (distinct queries) this is the per-pair event wh
 birthday layer bounds by `2/|F|`. -/
 theorem collision_mem_shifted_pm [Fintype F]
     (Extract : G → AK) (Ggen : G) (hfn : AK → NK → F)
-    (Hask : SK → F) (Hnk : SK → NK) (Hrivk_legacy : SK → F)
-    (Hrivk_ext : QK → AK → NK → F) (Hrivk_int : F → AK → NK → F)
+    (H : Oracles F AK NK SK QK)
     (c : RandomOracle.CollisionUpToSign
-      (shiftedFinalOracle Extract Ggen hfn Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int
+      (shiftedFinalOracle Extract Ggen hfn H
         (QK := QK) (SK := SK))) :
-    (c.q₁.eval Hrivk_legacy Hrivk_ext Hrivk_int, c.q₂.eval Hrivk_legacy Hrivk_ext Hrivk_int)
+    (c.q₁.eval H.rivk_legacy H.rivk_ext H.rivk_int, c.q₂.eval H.rivk_legacy H.rivk_ext H.rivk_int)
       ∈ Finset.univ.filter (fun p : F × F =>
-          shiftOf Extract Ggen hfn Hask Hnk c.q₁ + p.1
-            =± shiftOf Extract Ggen hfn Hask Hnk c.q₂ + p.2) := by
+          shiftOf Extract Ggen hfn H.ask H.nk c.q₁ + p.1
+            =± shiftOf Extract Ggen hfn H.ask H.nk c.q₂ + p.2) := by
   simpa [shiftedFinalOracle] using c.pm
 
 end OnwardCollision

--- a/Zcash/Security/KeyBinding/Basic.lean
+++ b/Zcash/Security/KeyBinding/Basic.lean
@@ -23,12 +23,15 @@ The route, each step proven here:
 The probabilistic side — producing the computed collision is hard — is the birthday bound
 `ε_kb ≤ q(q-1)/r` (`Birthday.lean`). `PRF^nf`-pinning, Spendability's import, is not here yet.
 
-Abstract setting: a prime-order group `G` as an `F`-vector space (`F = ZMod r` the scalar field),
-base-field types `IVK`, `AK`, and `NK` (all `= ZMod q` concretely), and an `Extract` structure
-bundling the two extract maps — `toIVK : G → IVK` carrying the ±-property (`toIVK_pm`), and
-`toAK : G → AK` for the derivation side; both instantiate to `Extract_P`. `ivk`'s nonzeroness
-is the `KBOpening.nonzero` hypothesis, not a type refinement (`Commit^ivk` can return 0 in
-circuit contexts, §4.1.8).
+Abstract setting: a prime-order group `G` as an `RIVK`-vector space. The scalar types are
+`RIVK` (rivk values and the rivk-derivation oracle outputs) and `ASK` (`H^ask` outputs, acting
+on `G` via `SMul`); both are `= ZMod r` concretely. The base-field types are `IVK`, `AK`, and
+`NK` (all `= ZMod q` concretely). An `Extractor` bundles the two extract maps:
+`toIVK : G → IVK` carrying the ±-property (`toIVK_pm`), and `toAK : G → AK` for the
+derivation side; both instantiate to `Extract_P`. `ivk`'s nonzeroness is the
+`KBOpening.nonzero` hypothesis, not a type refinement (`Commit^ivk` can return 0 in circuit
+contexts, §4.1.8).
+
 `Commitivk` is required to have the Pedersen structure (not opaque), which is what makes the break
 reduction provable; no Pallas instantiation is included (the intended concrete route is via
 CompElliptic).
@@ -50,38 +53,38 @@ inductive Branch (QK SK : Type*) where
 /-- A Recovery-Statement / Orchard key witness (ZIP 2005 §"key binding"). `use_qsk` is encoded by
 the `qk_or_sk` constructor. The internal-vs-external `ivk` choice is encoded by `rivk`'s value,
 not a tag (see `finalQueryOf`). -/
-structure Witness (G F IVK AK NK SK QK : Type*) where
+structure Witness (G IVK AK NK RIVK QK SK : Type*) where
   ivk      : IVK
-  qk_or_sk : Branch QK SK
   akP      : G
   nk       : NK
-  rivk_ext : F
-  rivk     : F
+  rivk_ext : RIVK
+  rivk     : RIVK
+  qk_or_sk : Branch QK SK
 
-variable {G F IVK AK NK SK QK : Type*}
+variable {G IVK AK NK RIVK ASK QK SK : Type*}
 
 /-- The Pedersen-scalar map a `Commitivk` opening reduces to: `(ak, nk, rivk) ↦ h ak nk + rivk`.
 An `OpeningBreak` is exhibited as a `CollisionUpToSign` of this map by
 `CollisionUpToSign.ofOpeningBreak`. -/
-def pedersenScalar [Add F] (hfn : AK → NK → F) (t : AK × NK × F) : F :=
+def pedersenScalar [Add RIVK] (hfn : AK → NK → RIVK) (t : AK × NK × RIVK) : RIVK :=
   let (ak, nk, rivk) := t
   hfn ak nk + rivk
 
 /-- The "final input" to the final `rivk`-derivation random oracle (ZIP 2005 key-binding proof):
 the query at which `rivk` is that oracle's output, selected by the `qk`/`sk` branch and the
 external/internal ivk choice. -/
-inductive FinalQuery (QK SK AK NK F : Type*) where
+inductive FinalQuery (AK NK RIVK QK SK : Type*) where
   /-- qk-branch, external ivk: `rivk = H.rivk_ext qk ak nk`. -/
-  | ext : QK → AK → NK → FinalQuery QK SK AK NK F
+  | ext : QK → AK → NK → FinalQuery AK NK RIVK QK SK
   /-- sk-branch, external ivk: `rivk = H.rivk_legacy sk`. -/
-  | legacy : SK → FinalQuery QK SK AK NK F
+  | legacy : SK → FinalQuery AK NK RIVK QK SK
   /-- internal ivk: `rivk = Hrivk_int rivk_ext ak nk`. -/
-  | int : F → AK → NK → FinalQuery QK SK AK NK F
+  | int : RIVK → AK → NK → FinalQuery AK NK RIVK QK SK
   deriving DecidableEq
 
 /-- The combined final `rivk`-derivation random oracle: dispatch each final query to its oracle. -/
-def FinalQuery.eval (Hrivk_legacy : SK → F) (Hrivk_ext : QK → AK → NK → F) (Hrivk_int : F → AK → NK → F) :
-    FinalQuery QK SK AK NK F → F
+def FinalQuery.eval (Hrivk_legacy : SK → RIVK) (Hrivk_ext : QK → AK → NK → RIVK) (Hrivk_int : RIVK → AK → NK → RIVK) :
+    FinalQuery AK NK RIVK QK SK → RIVK
   | .ext qk ak nk => Hrivk_ext qk ak nk
   | .legacy sk => Hrivk_legacy sk
   | .int rivk_ext ak nk => Hrivk_int rivk_ext ak nk
@@ -96,12 +99,12 @@ structure Extractor (G IVK AK : Type*) [Neg G] where
   toIVK_pm : ∀ P Q : G, toIVK P = toIVK Q ↔ P =± Q
 
 section Algebra
-variable [AddCommGroup G] [Field F] [Field IVK] [Module F G] [NoZeroSMulDivisors F G]
+variable [AddCommGroup G] [Field RIVK] [Field IVK] [Module RIVK G] [NoZeroSMulDivisors RIVK G]
 
 /-- The `ivk` commitment as a Pedersen lift:
 `Commitivk rivk ak nk = Extract.toIVK ((h ak nk + rivk) • S)`, with `h` abstract-but-non-querying and `S`
 a fixed base. Mirrors the `NoteCommit` repair `(H^rcm + f) • R`. -/
-def Commitivk (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (rivk : F) (ak : AK) (nk : NK) : IVK :=
+def Commitivk (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK) (rivk : RIVK) (ak : AK) (nk : NK) : IVK :=
   Extract.toIVK ((hfn ak nk + rivk) • S)
 
 omit [Field IVK] in
@@ -110,23 +113,23 @@ equal or negatives — the deterministic content the whole key-binding reduction
 from the `toIVK` ±-property and injectivity of `· • S` for `S ≠ 0` (`smul_left_injective`;
 `G` is an `F`-vector space). -/
 theorem commit_scalar_pm
-    (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (hS : S ≠ 0)
-    {rivk₁ rivk₂ : F} {ak₁ ak₂ : AK} {nk₁ nk₂ : NK}
+    (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK) (hS : S ≠ 0)
+    {rivk₁ rivk₂ : RIVK} {ak₁ ak₂ : AK} {nk₁ nk₂ : NK}
     (hcm : Commitivk Extract S hfn rivk₁ ak₁ nk₁ = Commitivk Extract S hfn rivk₂ ak₂ nk₂) :
     hfn ak₁ nk₁ + rivk₁ =± hfn ak₂ nk₂ + rivk₂ := by
   unfold Commitivk at hcm
   rw [Extract.toIVK_pm] at hcm
   rcases hcm with hcm | hcm
-  · exact Or.inl (smul_left_injective F hS hcm)
-  · refine Or.inr (smul_left_injective F hS ?_)
+  · exact Or.inl (smul_left_injective RIVK hS hcm)
+  · refine Or.inr (smul_left_injective RIVK hS ?_)
     show (hfn ak₁ nk₁ + rivk₁) • S = (-(hfn ak₂ nk₂ + rivk₂)) • S
     rw [neg_smul]
     exact hcm
 
 /-- `KBOpening` — the commitment-opening core of the key-binding condition (what statement-validity
 yields). -/
-structure KBOpening (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F)
-    (w : Witness G F IVK AK NK SK QK) : Prop where
+structure KBOpening (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK)
+    (w : Witness G IVK AK NK RIVK QK SK) : Prop where
   /-- `ivk` opens as `Commitivk` at `(rivk, ak, nk)`. -/
   commit : w.ivk = Commitivk Extract S hfn w.rivk (Extract.toAK w.akP) w.nk
   /-- `ivk ≠ 0`. -/
@@ -134,8 +137,8 @@ structure KBOpening (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → 
 
 /-- `OpeningBreak` — a `Commitivk`-opening collision (produced by the games layer): two valid
 `KBOpening` witnesses with the same `ivk` but differing `(ak, nk, rivk)`. -/
-structure OpeningBreak (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F)
-    (w₁ w₂ : Witness G F IVK AK NK SK QK) : Prop where
+structure OpeningBreak (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK)
+    (w₁ w₂ : Witness G IVK AK NK RIVK QK SK) : Prop where
   opening₁ : KBOpening Extract S hfn w₁
   opening₂ : KBOpening Extract S hfn w₂
   ivk_eq : w₁.ivk = w₂.ivk
@@ -152,8 +155,8 @@ standalone inhabitant is computable outright. The security content is conditiona
 `OpeningBreak` hypothesis; hardness enters per-instantiation, where `rivk` is an `H^*` output
 (`KBDerivation`) and the birthday bound applies. -/
 def _root_.Zcash.Security.RandomOracle.CollisionUpToSign.ofOpeningBreak
-    (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (hS : S ≠ 0)
-    {w₁ w₂ : Witness G F IVK AK NK SK QK} (hbrk : OpeningBreak Extract S hfn w₁ w₂) :
+    (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK) (hS : S ≠ 0)
+    {w₁ w₂ : Witness G IVK AK NK RIVK QK SK} (hbrk : OpeningBreak Extract S hfn w₁ w₂) :
     RandomOracle.CollisionUpToSign (pedersenScalar hfn) where
   q₁ := (Extract.toAK w₁.akP, w₁.nk, w₁.rivk)
   q₂ := (Extract.toAK w₂.akP, w₂.nk, w₂.rivk)
@@ -171,19 +174,19 @@ end Algebra
 three final `rivk`-derivation oracles. Bundled so the derivation layer's signatures carry
 one parameter; the probabilistic capstones assemble the bundle from `H^ask`/`H^nk` and the
 sampled table's restrictions. -/
-structure Oracles (F AK NK SK QK : Type*) where
-  ask : SK → F
+structure Oracles (AK NK RIVK ASK QK SK : Type*) where
+  ask : SK → ASK
   nk : SK → NK
-  rivk_legacy : SK → F
-  rivk_ext : QK → AK → NK → F
-  rivk_int : F → AK → NK → F
+  rivk_legacy : SK → RIVK
+  rivk_ext : QK → AK → NK → RIVK
+  rivk_int : RIVK → AK → NK → RIVK
 
 section Derivation
-variable [AddCommGroup G] [Field F] [Field IVK] [Module F G]
+variable [AddCommGroup G] [Field RIVK] [Field IVK] [Module RIVK G] [SMul ASK G]
 
 /-- `BindKeys^sk` (ZIP 2005): the `sk`-branch derivation constraints. -/
-structure BindKeysSk (Ggen : G) (H : Oracles F AK NK SK QK)
-    (sk : SK) (akP : G) (nk : NK) (rivk_ext : F) : Prop where
+structure BindKeysSk (Ggen : G) (H : Oracles AK NK RIVK ASK QK SK)
+    (sk : SK) (akP : G) (nk : NK) (rivk_ext : RIVK) : Prop where
   akP_eq : akP = (H.ask sk) • Ggen
   nk_eq : nk = H.nk sk
   rivk_ext_eq : rivk_ext = H.rivk_legacy sk
@@ -191,8 +194,8 @@ structure BindKeysSk (Ggen : G) (H : Oracles F AK NK SK QK)
 /-- `KBDerivation` — the ZIP 2005 derivation constraints (the `qk_or_sk` branch structure is
 enforced by the `Branch` type). -/
 structure KBDerivation (Extract : Extractor G IVK AK) (Ggen : G)
-    (H : Oracles F AK NK SK QK)
-    (w : Witness G F IVK AK NK SK QK) : Prop where
+    (H : Oracles AK NK RIVK ASK QK SK)
+    (w : Witness G IVK AK NK RIVK QK SK) : Prop where
   /-- The per-branch constraint: `Hrivk_ext` on the qk-branch, `BindKeys^sk` on the sk-branch. -/
   branch : match w.qk_or_sk with
     | .qk qk => w.rivk_ext = H.rivk_ext qk (Extract.toAK w.akP) w.nk
@@ -203,32 +206,32 @@ structure KBDerivation (Extract : Extractor G IVK AK) (Ggen : G)
 end Derivation
 
 section Full
-variable [AddCommGroup G] [Field F] [Field IVK] [Module F G]
+variable [AddCommGroup G] [Field RIVK] [Field IVK] [Module RIVK G] [SMul ASK G]
 
 /-- The full key-binding condition: commitment opening and key derivation constraints. -/
-structure KB (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
-    (H : Oracles F AK NK SK QK)
-    (w : Witness G F IVK AK NK SK QK) : Prop where
+structure KB (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK) (Ggen : G)
+    (H : Oracles AK NK RIVK ASK QK SK)
+    (w : Witness G IVK AK NK RIVK QK SK) : Prop where
   opening : KBOpening Extract S hfn w
   derivation : KBDerivation Extract Ggen H w
 
 /-- The break projection of a witness: the components a key-binding break must differ in. Using
 `ak = Extract.toAK ak^ℙ` quotients the y-sign of `ak^ℙ`. -/
-structure BreakProj (QK SK AK NK F : Type*) where
-  qk_or_sk : Branch QK SK
+structure BreakProj (AK NK RIVK QK SK : Type*) where
   ak : AK
   nk : NK
-  rivk : F
+  rivk : RIVK
+  qk_or_sk : Branch QK SK
 
 /-- The break projection, read off a witness. -/
-def Witness.breakProj (Extract : Extractor G IVK AK) (w : Witness G F IVK AK NK SK QK) : BreakProj QK SK AK NK F :=
-  ⟨w.qk_or_sk, Extract.toAK w.akP, w.nk, w.rivk⟩
+def Witness.breakProj (Extract : Extractor G IVK AK) (w : Witness G IVK AK NK RIVK QK SK) : BreakProj AK NK RIVK QK SK :=
+  ⟨Extract.toAK w.akP, w.nk, w.rivk, w.qk_or_sk⟩
 
 /-- A full key-binding break (ZIP 2005): two valid witnesses with equal `ivk` and differing
 break projections. -/
-structure Break (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
-    (H : Oracles F AK NK SK QK)
-    (w₁ w₂ : Witness G F IVK AK NK SK QK) : Prop where
+structure Break (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK) (Ggen : G)
+    (H : Oracles AK NK RIVK ASK QK SK)
+    (w₁ w₂ : Witness G IVK AK NK RIVK QK SK) : Prop where
   kb₁ : KB Extract S hfn Ggen H w₁
   kb₂ : KB Extract S hfn Ggen H w₂
   ivk_eq : w₁.ivk = w₂.ivk
@@ -238,9 +241,9 @@ structure Break (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (
 /-- `nk`-pinning (Balance's import): two valid witnesses with the same `ivk` that do **not** form a
 key-binding break must share the same nullifier key `nk`. (The probability that a break *does* occur
 is the birthday bound.) -/
-theorem nk_pinned (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
-    (H : Oracles F AK NK SK QK)
-    {w₁ w₂ : Witness G F IVK AK NK SK QK}
+theorem nk_pinned (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK) (Ggen : G)
+    (H : Oracles AK NK RIVK ASK QK SK)
+    {w₁ w₂ : Witness G IVK AK NK RIVK QK SK}
     (h₁ : KB Extract S hfn Ggen H w₁)
     (h₂ : KB Extract S hfn Ggen H w₂)
     (hivk : w₁.ivk = w₂.ivk)
@@ -254,9 +257,9 @@ theorem nk_pinned (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F)
 /-- `ak`-pinning up to y-sign (Spend Authorization's import): two valid witnesses with the same `ivk`
 that do *not* form a key-binding break share the same `ak = Extract.toAK ak^ℙ` — i.e. `ak^ℙ` is pinned up
 to its y-sign, matching the protocol's choice to consume `ak` as a single x-coordinate. -/
-theorem ak_pinned (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
-    (H : Oracles F AK NK SK QK)
-    {w₁ w₂ : Witness G F IVK AK NK SK QK}
+theorem ak_pinned (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK) (Ggen : G)
+    (H : Oracles AK NK RIVK ASK QK SK)
+    {w₁ w₂ : Witness G IVK AK NK RIVK QK SK}
     (h₁ : KB Extract S hfn Ggen H w₁)
     (h₂ : KB Extract S hfn Ggen H w₂)
     (hivk : w₁.ivk = w₂.ivk)
@@ -271,9 +274,9 @@ theorem ak_pinned (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F)
 *not* form a key-binding break share the same branch — the same `qk` or the same `sk`, including
 *which* of the two backs the witness. This is stronger than ZIP 2005's former "`qk` determined by
 `ivk` when `qk ≠ ⊥`". -/
-theorem qk_or_sk_pinned (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
-    (H : Oracles F AK NK SK QK)
-    {w₁ w₂ : Witness G F IVK AK NK SK QK}
+theorem qk_or_sk_pinned (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK) (Ggen : G)
+    (H : Oracles AK NK RIVK ASK QK SK)
+    {w₁ w₂ : Witness G IVK AK NK RIVK QK SK}
     (h₁ : KB Extract S hfn Ggen H w₁)
     (h₂ : KB Extract S hfn Ggen H w₂)
     (hivk : w₁.ivk = w₂.ivk)
@@ -287,11 +290,11 @@ theorem qk_or_sk_pinned (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK 
 end Full
 
 section Onward
-variable [AddCommGroup G] [Field F] [Field IVK] [Module F G] [DecidableEq F]
+variable [AddCommGroup G] [Field RIVK] [Field IVK] [Module RIVK G] [SMul ASK G] [DecidableEq RIVK]
 
 /-- The `rivk_ext`-derivation query of a witness: the query at which the combined final oracle
 produces its `rivk_ext`, selected by the branch. Never `.int` (`extQueryOf_ne_int`). -/
-def extQueryOf (Extract : Extractor G IVK AK) (w : Witness G F IVK AK NK SK QK) : FinalQuery QK SK AK NK F :=
+def extQueryOf (Extract : Extractor G IVK AK) (w : Witness G IVK AK NK RIVK QK SK) : FinalQuery AK NK RIVK QK SK :=
   match w.qk_or_sk with
   | .qk qk => .ext qk (Extract.toAK w.akP) w.nk
   | .sk sk => .legacy sk
@@ -303,11 +306,11 @@ fixpoint `Hrivk_int rivk_ext ak nk = rivk_ext`, an internally-derived witness de
 external — harmless for `rivk_eq_finalOracle` (which holds either way), but the birthday
 accounting must partition query pairs by this decode, not by how the witnesses were
 derived. -/
-def finalQueryOf (Extract : Extractor G IVK AK) (w : Witness G F IVK AK NK SK QK) : FinalQuery QK SK AK NK F :=
+def finalQueryOf (Extract : Extractor G IVK AK) (w : Witness G IVK AK NK RIVK QK SK) : FinalQuery AK NK RIVK QK SK :=
   if w.rivk = w.rivk_ext then extQueryOf Extract w
   else .int w.rivk_ext (Extract.toAK w.akP) w.nk
 
-omit [Field IVK] in
+omit [Field IVK] [Field RIVK] [Module RIVK G] in
 /-- **Final-random-oracle representation** (ZIP 2005 key-binding proof, "Final-random-oracle
 structure"): under the derivation constraints, `rivk` is the output of the combined final oracle at
 the witness's `finalQueryOf`. It bridges the Pedersen-scalar collision
@@ -315,8 +318,8 @@ the witness's `finalQueryOf`. It bridges the Pedersen-scalar collision
 probabilistic is only the birthday bound over the final-query space. -/
 theorem rivk_eq_finalOracle
     (Extract : Extractor G IVK AK) (Ggen : G)
-    (H : Oracles F AK NK SK QK)
-    {w : Witness G F IVK AK NK SK QK}
+    (H : Oracles AK NK RIVK ASK QK SK)
+    {w : Witness G IVK AK NK RIVK QK SK}
     (hd : KBDerivation Extract Ggen H w) :
     w.rivk = (finalQueryOf Extract w).eval H.rivk_legacy H.rivk_ext H.rivk_int := by
   obtain ⟨hbc, hrivk⟩ := hd
@@ -332,8 +335,8 @@ theorem rivk_eq_finalOracle
 
 /-- The non-querying shift: `hfn` at the query's key data (for `.legacy sk`, `ak`/`nk` are
 recovered via `Hask`/`Hnk`, so the shift is a function of the query alone). -/
-def shiftOf (Extract : Extractor G IVK AK) (Ggen : G) (hfn : AK → NK → F) (Hask : SK → F) (Hnk : SK → NK) :
-    FinalQuery QK SK AK NK F → F
+def shiftOf (Extract : Extractor G IVK AK) (Ggen : G) (hfn : AK → NK → RIVK) (Hask : SK → ASK) (Hnk : SK → NK) :
+    FinalQuery AK NK RIVK QK SK → RIVK
   | .ext _ ak nk => hfn ak nk
   | .legacy sk => hfn (Extract.toAK ((Hask sk) • Ggen)) (Hnk sk)
   | .int _ ak nk => hfn ak nk
@@ -341,18 +344,18 @@ def shiftOf (Extract : Extractor G IVK AK) (Ggen : G) (hfn : AK → NK → F) (H
 /-- The *shifted* combined final oracle: the `H^*` output offset by the non-querying shift.
 The ±-collision a `Break` computes (`CollisionUpToSign.ofBreak`) is of this map — the event
 the birthday layer bounds. -/
-def shiftedFinalOracle (Extract : Extractor G IVK AK) (Ggen : G) (hfn : AK → NK → F)
-    (H : Oracles F AK NK SK QK)
-    (q : FinalQuery QK SK AK NK F) : F :=
+def shiftedFinalOracle (Extract : Extractor G IVK AK) (Ggen : G) (hfn : AK → NK → RIVK)
+    (H : Oracles AK NK RIVK ASK QK SK)
+    (q : FinalQuery AK NK RIVK QK SK) : RIVK :=
   shiftOf Extract Ggen hfn H.ask H.nk q + q.eval H.rivk_legacy H.rivk_ext H.rivk_int
 
-omit [Field IVK] in
+omit [Field IVK] [Module RIVK G] in
 /-- On a witness's `finalQueryOf`, the shifted oracle is the shift plus the `H^*` output — the form
 `sameIvk_finalOracle_pm`'s equation is stated in. -/
 theorem shiftedFinalOracle_finalQueryOf
-    (Extract : Extractor G IVK AK) (Ggen : G) (hfn : AK → NK → F)
-    (H : Oracles F AK NK SK QK)
-    {w : Witness G F IVK AK NK SK QK}
+    (Extract : Extractor G IVK AK) (Ggen : G) (hfn : AK → NK → RIVK)
+    (H : Oracles AK NK RIVK ASK QK SK)
+    {w : Witness G IVK AK NK RIVK QK SK}
     (hd : KBDerivation Extract Ggen H w) :
     shiftedFinalOracle Extract Ggen hfn H
         (finalQueryOf Extract w)
@@ -372,7 +375,8 @@ theorem shiftedFinalOracle_finalQueryOf
 end Onward
 
 section OnwardCollision
-variable [AddCommGroup G] [Field F] [Field IVK] [Module F G] [NoZeroSMulDivisors F G] [DecidableEq F]
+variable [AddCommGroup G] [Field RIVK] [Field IVK] [Module RIVK G] [SMul ASK G]
+variable [NoZeroSMulDivisors RIVK G] [DecidableEq RIVK]
 
 /-- **Same-`ivk` ±-equation over `H^*`.** Two witnesses opening the same `ivk` (`KBOpening`), both
 satisfying the derivation constraints, give the ZIP 2005 break equation with the final-oracle
@@ -384,9 +388,9 @@ notions (`OpeningBreak`, `Break`) carry a distinctness witness. That is why this
 equation rather than a full `CollisionUpToSign`; the `ne` field arrives with
 `CollisionUpToSign.ofBreak`'s case split. -/
 theorem sameIvk_finalOracle_pm
-    (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (Ggen : G) (hS : S ≠ 0)
-    (H : Oracles F AK NK SK QK)
-    {w₁ w₂ : Witness G F IVK AK NK SK QK}
+    (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK) (Ggen : G) (hS : S ≠ 0)
+    (H : Oracles AK NK RIVK ASK QK SK)
+    {w₁ w₂ : Witness G IVK AK NK RIVK QK SK}
     (hop₁ : KBOpening Extract S hfn w₁) (hop₂ : KBOpening Extract S hfn w₂)
     (hivk : w₁.ivk = w₂.ivk)
     (hd₁ : KBDerivation Extract Ggen H w₁)
@@ -404,9 +408,9 @@ theorem sameIvk_finalOracle_pm
 /-- The `H^*` ±-equation from an `OpeningBreak` (the object the games produce): the same-`ivk`
 core `sameIvk_finalOracle_pm` applied to the break's two openings. -/
 theorem openingBreak_finalOracle_pm
-    (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (Ggen : G) (hS : S ≠ 0)
-    (H : Oracles F AK NK SK QK)
-    {w₁ w₂ : Witness G F IVK AK NK SK QK}
+    (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK) (Ggen : G) (hS : S ≠ 0)
+    (H : Oracles AK NK RIVK ASK QK SK)
+    {w₁ w₂ : Witness G IVK AK NK RIVK QK SK}
     (hbrk : OpeningBreak Extract S hfn w₁ w₂)
     (hd₁ : KBDerivation Extract Ggen H w₁)
     (hd₂ : KBDerivation Extract Ggen H w₂) :
@@ -420,9 +424,9 @@ derivation constraints are already inside the `Break` (via `KB`), and *no* `Brea
 upgrade is needed: the equation depends only on the openings and `ivk`-equality, never on how the
 projections differ. `CollisionUpToSign.ofBreak` builds its case split on this. -/
 theorem break_finalOracle_pm
-    (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (Ggen : G) (hS : S ≠ 0)
-    (H : Oracles F AK NK SK QK)
-    {w₁ w₂ : Witness G F IVK AK NK SK QK}
+    (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK) (Ggen : G) (hS : S ≠ 0)
+    (H : Oracles AK NK RIVK ASK QK SK)
+    {w₁ w₂ : Witness G IVK AK NK RIVK QK SK}
     (hbrk : Break Extract S hfn Ggen H w₁ w₂) :
     hfn (Extract.toAK w₁.akP) w₁.nk + (finalQueryOf Extract w₁).eval H.rivk_legacy H.rivk_ext H.rivk_int
       =± hfn (Extract.toAK w₂.akP) w₂.nk + (finalQueryOf Extract w₂).eval H.rivk_legacy H.rivk_ext H.rivk_int :=
@@ -431,38 +435,38 @@ theorem break_finalOracle_pm
 
 /-- The break projection an *externally-decoded* witness must have, read off its
 `rivk_ext`-derivation query (`proj_eq_projOfQuery`); `.int` is not in `extQueryOf`'s image. -/
-def projOfQuery (Extract : Extractor G IVK AK) (Ggen : G) (H : Oracles F AK NK SK QK) :
-    FinalQuery QK SK AK NK F → Option (BreakProj QK SK AK NK F)
-  | .ext qk ak nk => some ⟨.qk qk, ak, nk, H.rivk_ext qk ak nk⟩
-  | .legacy sk => some ⟨.sk sk, Extract.toAK ((H.ask sk) • Ggen), H.nk sk, H.rivk_legacy sk⟩
+def projOfQuery (Extract : Extractor G IVK AK) (Ggen : G) (H : Oracles AK NK RIVK ASK QK SK) :
+    FinalQuery AK NK RIVK QK SK → Option (BreakProj AK NK RIVK QK SK)
+  | .ext qk ak nk => some ⟨ak, nk, H.rivk_ext qk ak nk, .qk qk⟩
+  | .legacy sk => some ⟨Extract.toAK ((H.ask sk) • Ggen), H.nk sk, H.rivk_legacy sk, .sk sk⟩
   | .int _ _ _ => none
 
 /-- The Branch data of a witness, read off its `rivk_ext`-derivation query
 (`branch_eq_branchOfQuery`); `.int` is not in `extQueryOf`'s image. -/
-def branchOfQuery : FinalQuery QK SK AK NK F → Option (Branch QK SK)
+def branchOfQuery : FinalQuery AK NK RIVK QK SK → Option (Branch QK SK)
   | .ext qk _ _ => some (.qk qk)
   | .legacy sk => some (.sk sk)
   | .int _ _ _ => none
 
-omit [Field F] [Field IVK] [NoZeroSMulDivisors F G] [DecidableEq F] in
+omit [Field RIVK] [Field IVK] [NoZeroSMulDivisors RIVK G] [DecidableEq RIVK] in
 /-- A witness's Branch data is recoverable from its `rivk_ext`-derivation query. -/
-theorem branch_eq_branchOfQuery {w : Witness G F IVK AK NK SK QK} (Extract : Extractor G IVK AK) :
+theorem branch_eq_branchOfQuery {w : Witness G IVK AK NK RIVK QK SK} (Extract : Extractor G IVK AK) :
     some w.qk_or_sk = branchOfQuery (extQueryOf Extract w) := by
   rcases hb : w.qk_or_sk with qk | sk <;> simp [extQueryOf, branchOfQuery, hb]
 
-omit [Field F] [Field IVK] [NoZeroSMulDivisors F G] [DecidableEq F] in
+omit [Field RIVK] [Field IVK] [NoZeroSMulDivisors RIVK G] [DecidableEq RIVK] in
 /-- A witness's `rivk_ext`-derivation query is never `.int`. -/
-theorem extQueryOf_ne_int {w : Witness G F IVK AK NK SK QK} (Extract : Extractor G IVK AK) (rivk_ext : F) (ak : AK) (nk : NK) :
+theorem extQueryOf_ne_int {w : Witness G IVK AK NK RIVK QK SK} (Extract : Extractor G IVK AK) (rivk_ext : RIVK) (ak : AK) (nk : NK) :
     extQueryOf Extract w ≠ .int rivk_ext ak nk := by
   rcases hb : w.qk_or_sk with qk | sk <;> simp [extQueryOf, hb]
 
-omit [Field IVK] [NoZeroSMulDivisors F G] [DecidableEq F] in
+omit [Field IVK] [NoZeroSMulDivisors RIVK G] [DecidableEq RIVK] [Field RIVK] [Module RIVK G] in
 /-- An externally-decoded witness's break projection is recoverable from its `rivk_ext`-derivation
 query: the derivation constraints determine every component from the query. -/
 theorem proj_eq_projOfQuery
     (Extract : Extractor G IVK AK) (Ggen : G)
-    (H : Oracles F AK NK SK QK)
-    {w : Witness G F IVK AK NK SK QK}
+    (H : Oracles AK NK RIVK ASK QK SK)
+    {w : Witness G IVK AK NK RIVK QK SK}
     (hd : KBDerivation Extract Ggen H w)
     (hext : w.rivk = w.rivk_ext) :
     some (w.breakProj Extract)
@@ -474,14 +478,14 @@ theorem proj_eq_projOfQuery
   · obtain ⟨hakP, hnk, hre⟩ := hbc
     rw [hakP, hnk, hext.trans hre]
 
-omit [Field IVK] [NoZeroSMulDivisors F G] [DecidableEq F] in
+omit [Field IVK] [NoZeroSMulDivisors RIVK G] [DecidableEq RIVK] [Module RIVK G] in
 /-- A witness's shifted-oracle output at its `rivk_ext`-derivation query is
 `hfn (ak, nk) + rivk_ext`: the derivation constraints collapse the per-branch shift to the
 witness's own key data. -/
 theorem shiftedFinalOracle_extQueryOf
-    (Extract : Extractor G IVK AK) (Ggen : G) (hfn : AK → NK → F)
-    (H : Oracles F AK NK SK QK)
-    {w : Witness G F IVK AK NK SK QK}
+    (Extract : Extractor G IVK AK) (Ggen : G) (hfn : AK → NK → RIVK)
+    (H : Oracles AK NK RIVK ASK QK SK)
+    {w : Witness G IVK AK NK RIVK QK SK}
     (hd : KBDerivation Extract Ggen H w) :
     shiftedFinalOracle Extract Ggen hfn H
         (extQueryOf Extract w)
@@ -493,15 +497,15 @@ theorem shiftedFinalOracle_extQueryOf
   · obtain ⟨hakP, hnk, hre⟩ := hbc
     rw [← hakP, ← hnk, ← hre]
 
-omit [NoZeroSMulDivisors F G] in
+omit [NoZeroSMulDivisors RIVK G] in
 /-- **The residual case is deterministic**: if a `Break`'s two final queries coincide, then both
 witnesses are internally derived, sharing `(ak, nk, rivk_ext, rivk)` and differing in `qk_or_sk`.
 The collision then relocates to the `rivk_ext`-derivation queries, at which the shifted oracle's
 outputs are *equal* and the queries are *distinct*. -/
 theorem residual_of_finalQuery_eq
-    (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
-    (H : Oracles F AK NK SK QK)
-    {w₁ w₂ : Witness G F IVK AK NK SK QK}
+    (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK) (Ggen : G)
+    (H : Oracles AK NK RIVK ASK QK SK)
+    {w₁ w₂ : Witness G IVK AK NK RIVK QK SK}
     (hbrk : Break Extract S hfn Ggen H w₁ w₂)
     (hq : finalQueryOf Extract w₁ = finalQueryOf Extract w₂) :
     extQueryOf Extract w₁ ≠ extQueryOf Extract w₂ ∧
@@ -555,9 +559,9 @@ non-querying, so a fixed shift cannot be steered to manufacture collisions, and 
 shifted oracle at distinct queries has probability at most `q(q-1)/r` (`Birthday.lean`). -/
 def _root_.Zcash.Security.RandomOracle.CollisionUpToSign.ofBreak
     [DecidableEq QK] [DecidableEq SK] [DecidableEq AK] [DecidableEq NK]
-    (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (Ggen : G) (hS : S ≠ 0)
-    (H : Oracles F AK NK SK QK)
-    {w₁ w₂ : Witness G F IVK AK NK SK QK}
+    (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK) (Ggen : G) (hS : S ≠ 0)
+    (H : Oracles AK NK RIVK ASK QK SK)
+    {w₁ w₂ : Witness G IVK AK NK RIVK QK SK}
     (hbrk : Break Extract S hfn Ggen H w₁ w₂) :
     RandomOracle.CollisionUpToSign
       (shiftedFinalOracle Extract Ggen hfn H
@@ -576,20 +580,20 @@ def _root_.Zcash.Security.RandomOracle.CollisionUpToSign.ofBreak
             shiftedFinalOracle_finalQueryOf Extract Ggen hfn H hbrk.kb₂.derivation]
         exact break_finalOracle_pm Extract S hfn Ggen hS H hbrk }
 
-omit [Field IVK] [NoZeroSMulDivisors F G] in
+omit [Field IVK] [NoZeroSMulDivisors RIVK G] [Module RIVK G] in
 /-- **The bridge to the birthday counting**: the pair of `H^*` outputs at a shifted-oracle
 ±-collision's queries lies in the shifted ±-collision set that
 `Birthday.card_shifted_pm_collision_le` counts, with the shifts read off the queries. Combined
 with the collision's `ne` field (distinct queries) this is the per-pair event whose fraction the
 birthday layer bounds by `2/|F|`. -/
-theorem collision_mem_shifted_pm [Fintype F]
-    (Extract : Extractor G IVK AK) (Ggen : G) (hfn : AK → NK → F)
-    (H : Oracles F AK NK SK QK)
+theorem collision_mem_shifted_pm [Fintype RIVK]
+    (Extract : Extractor G IVK AK) (Ggen : G) (hfn : AK → NK → RIVK)
+    (H : Oracles AK NK RIVK ASK QK SK)
     (c : RandomOracle.CollisionUpToSign
       (shiftedFinalOracle Extract Ggen hfn H
         (QK := QK) (SK := SK))) :
     (c.q₁.eval H.rivk_legacy H.rivk_ext H.rivk_int, c.q₂.eval H.rivk_legacy H.rivk_ext H.rivk_int)
-      ∈ Finset.univ.filter (fun p : F × F =>
+      ∈ Finset.univ.filter (fun p : RIVK × RIVK =>
           shiftOf Extract Ggen hfn H.ask H.nk c.q₁ + p.1
             =± shiftOf Extract Ggen hfn H.ask H.nk c.q₂ + p.2) := by
   simpa [shiftedFinalOracle] using c.pm

--- a/Zcash/Security/KeyBinding/Basic.lean
+++ b/Zcash/Security/KeyBinding/Basic.lean
@@ -24,10 +24,11 @@ The probabilistic side — producing the computed collision is hard — is the b
 `ε_kb ≤ q(q-1)/r` (`Birthday.lean`). `PRF^nf`-pinning, Spendability's import, is not here yet.
 
 Abstract setting: a prime-order group `G` as an `F`-vector space (`F = ZMod r` the scalar field),
-base-field types `AK` and `NK` (both `= ZMod q` concretely: `AK` for `Extract` outputs — `ak`,
-and `ivk`, which shares the type since `Commit^ivk` can return 0 in circuit contexts (§4.1.8);
-nonzeroness is the `KBOpening.nonzero` hypothesis — and `NK` for `nk`), with `Extract : G → AK`
-having the ±-property (`hExt`).
+base-field types `IVK`, `AK`, and `NK` (all `= ZMod q` concretely), and an `Extract` structure
+bundling the two extract maps — `toIVK : G → IVK` carrying the ±-property (`hExt`), and
+`toAK : G → AK` for the derivation side; both instantiate to `Extract_P`. `ivk`'s nonzeroness
+is the `KBOpening.nonzero` hypothesis, not a type refinement (`Commit^ivk` can return 0 in
+circuit contexts, §4.1.8).
 `Commitivk` is required to have the Pedersen structure (not opaque), which is what makes the break
 reduction provable; no Pallas instantiation is included (the intended concrete route is via
 CompElliptic).
@@ -49,15 +50,15 @@ inductive Branch (QK SK : Type*) where
 /-- A Recovery-Statement / Orchard key witness (ZIP 2005 §"key binding"). `use_qsk` is encoded by
 the `qk_or_sk` constructor. The internal-vs-external `ivk` choice is encoded by `rivk`'s value,
 not a tag (see `finalQueryOf`). -/
-structure Witness (G F AK NK SK QK : Type*) where
-  ivk      : AK
+structure Witness (G F IVK AK NK SK QK : Type*) where
+  ivk      : IVK
   qk_or_sk : Branch QK SK
   akP      : G
   nk       : NK
   rivk_ext : F
   rivk     : F
 
-variable {G F AK NK SK QK : Type*}
+variable {G F IVK AK NK SK QK : Type*}
 
 /-- The Pedersen-scalar map a `Commitivk` opening reduces to: `(ak, nk, rivk) ↦ h ak nk + rivk`.
 An `OpeningBreak` is exhibited as a `CollisionUpToSign` of this map by
@@ -85,23 +86,30 @@ def FinalQuery.eval (Hrivk_legacy : SK → F) (Hrivk_ext : QK → AK → NK → 
   | .legacy sk => Hrivk_legacy sk
   | .int rivk_ext ak nk => Hrivk_int rivk_ext ak nk
 
+/-- The two extract maps of the key-binding model; both instantiate to `Extract_P`
+concretely. `toIVK` carries the ±-property (`hExt`); `toAK` serves the derivation and
+projection side. -/
+structure Extractor (G IVK AK : Type*) where
+  toIVK : G → IVK
+  toAK : G → AK
+
 section Algebra
-variable [AddCommGroup G] [Field F] [Field AK] [Module F G] [NoZeroSMulDivisors F G]
+variable [AddCommGroup G] [Field F] [Field IVK] [Module F G] [NoZeroSMulDivisors F G]
 
 /-- The `ivk` commitment as a Pedersen lift:
-`Commitivk rivk ak nk = Extract ((h ak nk + rivk) • S)`, with `h` abstract-but-non-querying and `S`
+`Commitivk rivk ak nk = Extract.toIVK ((h ak nk + rivk) • S)`, with `h` abstract-but-non-querying and `S`
 a fixed base. Mirrors the `NoteCommit` repair `(H^rcm + f) • R`. -/
-def Commitivk (Extract : G → AK) (S : G) (hfn : AK → NK → F) (rivk : F) (ak : AK) (nk : NK) : AK :=
-  Extract ((hfn ak nk + rivk) • S)
+def Commitivk (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (rivk : F) (ak : AK) (nk : NK) : IVK :=
+  Extract.toIVK ((hfn ak nk + rivk) • S)
 
-omit [Field AK] in
+omit [Field IVK] in
 /-- Algebraic core: two openings of the same `Commitivk` value force their Pedersen scalars to be
 equal or negatives — the deterministic content the whole key-binding reduction rests on. Proved
-from the `Extract` ±-property and injectivity of `· • S` for `S ≠ 0` (`smul_left_injective`;
+from the `toIVK` ±-property and injectivity of `· • S` for `S ≠ 0` (`smul_left_injective`;
 `G` is an `F`-vector space). -/
 theorem commit_scalar_pm
-    (Extract : G → AK) (S : G) (hfn : AK → NK → F)
-    (hExt : ∀ P Q : G, Extract P = Extract Q ↔ P =± Q) (hS : S ≠ 0)
+    (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F)
+    (hExt : ∀ P Q : G, Extract.toIVK P = Extract.toIVK Q ↔ P =± Q) (hS : S ≠ 0)
     {rivk₁ rivk₂ : F} {ak₁ ak₂ : AK} {nk₁ nk₂ : NK}
     (hcm : Commitivk Extract S hfn rivk₁ ak₁ nk₁ = Commitivk Extract S hfn rivk₂ ak₂ nk₂) :
     hfn ak₁ nk₁ + rivk₁ =± hfn ak₂ nk₂ + rivk₂ := by
@@ -116,22 +124,22 @@ theorem commit_scalar_pm
 
 /-- `KBOpening` — the commitment-opening core of the key-binding condition (what statement-validity
 yields). -/
-structure KBOpening (Extract : G → AK) (S : G) (hfn : AK → NK → F)
-    (w : Witness G F AK NK SK QK) : Prop where
+structure KBOpening (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F)
+    (w : Witness G F IVK AK NK SK QK) : Prop where
   /-- `ivk` opens as `Commitivk` at `(rivk, ak, nk)`. -/
-  commit : w.ivk = Commitivk Extract S hfn w.rivk (Extract w.akP) w.nk
+  commit : w.ivk = Commitivk Extract S hfn w.rivk (Extract.toAK w.akP) w.nk
   /-- `ivk ≠ 0`. -/
   nonzero : w.ivk ≠ 0
 
 /-- `OpeningBreak` — a `Commitivk`-opening collision (produced by the games layer): two valid
 `KBOpening` witnesses with the same `ivk` but differing `(ak, nk, rivk)`. -/
-structure OpeningBreak (Extract : G → AK) (S : G) (hfn : AK → NK → F)
-    (w₁ w₂ : Witness G F AK NK SK QK) : Prop where
+structure OpeningBreak (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F)
+    (w₁ w₂ : Witness G F IVK AK NK SK QK) : Prop where
   opening₁ : KBOpening Extract S hfn w₁
   opening₂ : KBOpening Extract S hfn w₂
   ivk_eq : w₁.ivk = w₂.ivk
   /-- The witnesses differ in the opening data. -/
-  proj_ne : (Extract w₁.akP, w₁.nk, w₁.rivk) ≠ (Extract w₂.akP, w₂.nk, w₂.rivk)
+  proj_ne : (Extract.toAK w₁.akP, w₁.nk, w₁.rivk) ≠ (Extract.toAK w₂.akP, w₂.nk, w₂.rivk)
 
 /-- The deterministic reduction (composable core), as computed data: an `OpeningBreak` exhibits a
 ±-collision of the Pedersen-scalar map `pedersenScalar hfn`. The colliding queries are the two
@@ -143,12 +151,12 @@ standalone inhabitant is computable outright. The security content is conditiona
 `OpeningBreak` hypothesis; hardness enters per-instantiation, where `rivk` is an `H^*` output
 (`KBDerivation`) and the birthday bound applies. -/
 def _root_.Zcash.Security.RandomOracle.CollisionUpToSign.ofOpeningBreak
-    (Extract : G → AK) (S : G) (hfn : AK → NK → F)
-    (hExt : ∀ P Q : G, Extract P = Extract Q ↔ P =± Q) (hS : S ≠ 0)
-    {w₁ w₂ : Witness G F AK NK SK QK} (hbrk : OpeningBreak Extract S hfn w₁ w₂) :
+    (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F)
+    (hExt : ∀ P Q : G, Extract.toIVK P = Extract.toIVK Q ↔ P =± Q) (hS : S ≠ 0)
+    {w₁ w₂ : Witness G F IVK AK NK SK QK} (hbrk : OpeningBreak Extract S hfn w₁ w₂) :
     RandomOracle.CollisionUpToSign (pedersenScalar hfn) where
-  q₁ := (Extract w₁.akP, w₁.nk, w₁.rivk)
-  q₂ := (Extract w₂.akP, w₂.nk, w₂.rivk)
+  q₁ := (Extract.toAK w₁.akP, w₁.nk, w₁.rivk)
+  q₂ := (Extract.toAK w₂.akP, w₂.nk, w₂.rivk)
   ne := hbrk.proj_ne
   pm := by
     -- Commitivk(w₁) = w₁.ivk = w₂.ivk = Commitivk(w₂)
@@ -171,7 +179,7 @@ structure Oracles (F AK NK SK QK : Type*) where
   rivk_int : F → AK → NK → F
 
 section Derivation
-variable [AddCommGroup G] [Field F] [Field AK] [Module F G]
+variable [AddCommGroup G] [Field F] [Field IVK] [Module F G]
 
 /-- `BindKeys^sk` (ZIP 2005): the `sk`-branch derivation constraints. -/
 structure BindKeysSk (Ggen : G) (H : Oracles F AK NK SK QK)
@@ -182,30 +190,30 @@ structure BindKeysSk (Ggen : G) (H : Oracles F AK NK SK QK)
 
 /-- `KBDerivation` — the ZIP 2005 derivation constraints (the `qk_or_sk` branch structure is
 enforced by the `Branch` type). -/
-structure KBDerivation (Extract : G → AK) (Ggen : G)
+structure KBDerivation (Extract : Extractor G IVK AK) (Ggen : G)
     (H : Oracles F AK NK SK QK)
-    (w : Witness G F AK NK SK QK) : Prop where
+    (w : Witness G F IVK AK NK SK QK) : Prop where
   /-- The per-branch constraint: `Hrivk_ext` on the qk-branch, `BindKeys^sk` on the sk-branch. -/
   branch : match w.qk_or_sk with
-    | .qk qk => w.rivk_ext = H.rivk_ext qk (Extract w.akP) w.nk
+    | .qk qk => w.rivk_ext = H.rivk_ext qk (Extract.toAK w.akP) w.nk
     | .sk sk => BindKeysSk Ggen H sk w.akP w.nk w.rivk_ext
   /-- `rivk ∈ {rivk_ext, Hrivk_int ...}`. -/
-  rivk_choice : w.rivk = w.rivk_ext ∨ w.rivk = H.rivk_int w.rivk_ext (Extract w.akP) w.nk
+  rivk_choice : w.rivk = w.rivk_ext ∨ w.rivk = H.rivk_int w.rivk_ext (Extract.toAK w.akP) w.nk
 
 end Derivation
 
 section Full
-variable [AddCommGroup G] [Field F] [Field AK] [Module F G]
+variable [AddCommGroup G] [Field F] [Field IVK] [Module F G]
 
 /-- The full key-binding condition: commitment opening and key derivation constraints. -/
-structure KB (Extract : G → AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
+structure KB (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
     (H : Oracles F AK NK SK QK)
-    (w : Witness G F AK NK SK QK) : Prop where
+    (w : Witness G F IVK AK NK SK QK) : Prop where
   opening : KBOpening Extract S hfn w
   derivation : KBDerivation Extract Ggen H w
 
 /-- The break projection of a witness: the components a key-binding break must differ in. Using
-`ak = Extract ak^ℙ` quotients the y-sign of `ak^ℙ`. -/
+`ak = Extract.toAK ak^ℙ` quotients the y-sign of `ak^ℙ`. -/
 structure BreakProj (QK SK AK NK F : Type*) where
   qk_or_sk : Branch QK SK
   ak : AK
@@ -213,14 +221,14 @@ structure BreakProj (QK SK AK NK F : Type*) where
   rivk : F
 
 /-- The break projection, read off a witness. -/
-def Witness.breakProj (Extract : G → AK) (w : Witness G F AK NK SK QK) : BreakProj QK SK AK NK F :=
-  ⟨w.qk_or_sk, Extract w.akP, w.nk, w.rivk⟩
+def Witness.breakProj (Extract : Extractor G IVK AK) (w : Witness G F IVK AK NK SK QK) : BreakProj QK SK AK NK F :=
+  ⟨w.qk_or_sk, Extract.toAK w.akP, w.nk, w.rivk⟩
 
 /-- A full key-binding break (ZIP 2005): two valid witnesses with equal `ivk` and differing
 break projections. -/
-structure Break (Extract : G → AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
+structure Break (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
     (H : Oracles F AK NK SK QK)
-    (w₁ w₂ : Witness G F AK NK SK QK) : Prop where
+    (w₁ w₂ : Witness G F IVK AK NK SK QK) : Prop where
   kb₁ : KB Extract S hfn Ggen H w₁
   kb₂ : KB Extract S hfn Ggen H w₂
   ivk_eq : w₁.ivk = w₂.ivk
@@ -230,9 +238,9 @@ structure Break (Extract : G → AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
 /-- `nk`-pinning (Balance's import): two valid witnesses with the same `ivk` that do **not** form a
 key-binding break must share the same nullifier key `nk`. (The probability that a break *does* occur
 is the birthday bound.) -/
-theorem nk_pinned (Extract : G → AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
+theorem nk_pinned (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
     (H : Oracles F AK NK SK QK)
-    {w₁ w₂ : Witness G F AK NK SK QK}
+    {w₁ w₂ : Witness G F IVK AK NK SK QK}
     (h₁ : KB Extract S hfn Ggen H w₁)
     (h₂ : KB Extract S hfn Ggen H w₂)
     (hivk : w₁.ivk = w₂.ivk)
@@ -244,16 +252,16 @@ theorem nk_pinned (Extract : G → AK) (S : G) (hfn : AK → NK → F) (Ggen : G
   exact congrArg BreakProj.nk heq
 
 /-- `ak`-pinning up to y-sign (Spend Authorization's import): two valid witnesses with the same `ivk`
-that do *not* form a key-binding break share the same `ak = Extract ak^ℙ` — i.e. `ak^ℙ` is pinned up
+that do *not* form a key-binding break share the same `ak = Extract.toAK ak^ℙ` — i.e. `ak^ℙ` is pinned up
 to its y-sign, matching the protocol's choice to consume `ak` as a single x-coordinate. -/
-theorem ak_pinned (Extract : G → AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
+theorem ak_pinned (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
     (H : Oracles F AK NK SK QK)
-    {w₁ w₂ : Witness G F AK NK SK QK}
+    {w₁ w₂ : Witness G F IVK AK NK SK QK}
     (h₁ : KB Extract S hfn Ggen H w₁)
     (h₂ : KB Extract S hfn Ggen H w₂)
     (hivk : w₁.ivk = w₂.ivk)
     (hnb : ¬ Break Extract S hfn Ggen H w₁ w₂) :
-    Extract w₁.akP = Extract w₂.akP := by
+    Extract.toAK w₁.akP = Extract.toAK w₂.akP := by
   by_contra hne
   apply hnb
   refine ⟨h₁, h₂, hivk, fun heq => hne ?_⟩
@@ -263,9 +271,9 @@ theorem ak_pinned (Extract : G → AK) (S : G) (hfn : AK → NK → F) (Ggen : G
 *not* form a key-binding break share the same branch — the same `qk` or the same `sk`, including
 *which* of the two backs the witness. This is stronger than ZIP 2005's former "`qk` determined by
 `ivk` when `qk ≠ ⊥`". -/
-theorem qk_or_sk_pinned (Extract : G → AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
+theorem qk_or_sk_pinned (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
     (H : Oracles F AK NK SK QK)
-    {w₁ w₂ : Witness G F AK NK SK QK}
+    {w₁ w₂ : Witness G F IVK AK NK SK QK}
     (h₁ : KB Extract S hfn Ggen H w₁)
     (h₂ : KB Extract S hfn Ggen H w₂)
     (hivk : w₁.ivk = w₂.ivk)
@@ -279,13 +287,13 @@ theorem qk_or_sk_pinned (Extract : G → AK) (S : G) (hfn : AK → NK → F) (Gg
 end Full
 
 section Onward
-variable [AddCommGroup G] [Field F] [Field AK] [Module F G] [DecidableEq F]
+variable [AddCommGroup G] [Field F] [Field IVK] [Module F G] [DecidableEq F]
 
 /-- The `rivk_ext`-derivation query of a witness: the query at which the combined final oracle
 produces its `rivk_ext`, selected by the branch. Never `.int` (`extQueryOf_ne_int`). -/
-def extQueryOf (Extract : G → AK) (w : Witness G F AK NK SK QK) : FinalQuery QK SK AK NK F :=
+def extQueryOf (Extract : Extractor G IVK AK) (w : Witness G F IVK AK NK SK QK) : FinalQuery QK SK AK NK F :=
   match w.qk_or_sk with
-  | .qk qk => .ext qk (Extract w.akP) w.nk
+  | .qk qk => .ext qk (Extract.toAK w.akP) w.nk
   | .sk sk => .legacy sk
 
 /-- The final query of a witness: which final oracle produces its `rivk`, and at what input.
@@ -295,20 +303,20 @@ fixpoint `Hrivk_int rivk_ext ak nk = rivk_ext`, an internally-derived witness de
 external — harmless for `rivk_eq_finalOracle` (which holds either way), but the birthday
 accounting must partition query pairs by this decode, not by how the witnesses were
 derived. -/
-def finalQueryOf (Extract : G → AK) (w : Witness G F AK NK SK QK) : FinalQuery QK SK AK NK F :=
+def finalQueryOf (Extract : Extractor G IVK AK) (w : Witness G F IVK AK NK SK QK) : FinalQuery QK SK AK NK F :=
   if w.rivk = w.rivk_ext then extQueryOf Extract w
-  else .int w.rivk_ext (Extract w.akP) w.nk
+  else .int w.rivk_ext (Extract.toAK w.akP) w.nk
 
-omit [Field AK] in
+omit [Field IVK] in
 /-- **Final-random-oracle representation** (ZIP 2005 key-binding proof, "Final-random-oracle
 structure"): under the derivation constraints, `rivk` is the output of the combined final oracle at
 the witness's `finalQueryOf`. It bridges the Pedersen-scalar collision
 (`CollisionUpToSign.ofOpeningBreak`) to a collision of the actual `H^*` oracles. What remains
 probabilistic is only the birthday bound over the final-query space. -/
 theorem rivk_eq_finalOracle
-    (Extract : G → AK) (Ggen : G)
+    (Extract : Extractor G IVK AK) (Ggen : G)
     (H : Oracles F AK NK SK QK)
-    {w : Witness G F AK NK SK QK}
+    {w : Witness G F IVK AK NK SK QK}
     (hd : KBDerivation Extract Ggen H w) :
     w.rivk = (finalQueryOf Extract w).eval H.rivk_legacy H.rivk_ext H.rivk_int := by
   obtain ⟨hbc, hrivk⟩ := hd
@@ -324,31 +332,31 @@ theorem rivk_eq_finalOracle
 
 /-- The non-querying shift: `hfn` at the query's key data (for `.legacy sk`, `ak`/`nk` are
 recovered via `Hask`/`Hnk`, so the shift is a function of the query alone). -/
-def shiftOf (Extract : G → AK) (Ggen : G) (hfn : AK → NK → F) (Hask : SK → F) (Hnk : SK → NK) :
+def shiftOf (Extract : Extractor G IVK AK) (Ggen : G) (hfn : AK → NK → F) (Hask : SK → F) (Hnk : SK → NK) :
     FinalQuery QK SK AK NK F → F
   | .ext _ ak nk => hfn ak nk
-  | .legacy sk => hfn (Extract ((Hask sk) • Ggen)) (Hnk sk)
+  | .legacy sk => hfn (Extract.toAK ((Hask sk) • Ggen)) (Hnk sk)
   | .int _ ak nk => hfn ak nk
 
 /-- The *shifted* combined final oracle: the `H^*` output offset by the non-querying shift.
 The ±-collision a `Break` computes (`CollisionUpToSign.ofBreak`) is of this map — the event
 the birthday layer bounds. -/
-def shiftedFinalOracle (Extract : G → AK) (Ggen : G) (hfn : AK → NK → F)
+def shiftedFinalOracle (Extract : Extractor G IVK AK) (Ggen : G) (hfn : AK → NK → F)
     (H : Oracles F AK NK SK QK)
     (q : FinalQuery QK SK AK NK F) : F :=
   shiftOf Extract Ggen hfn H.ask H.nk q + q.eval H.rivk_legacy H.rivk_ext H.rivk_int
 
-omit [Field AK] in
+omit [Field IVK] in
 /-- On a witness's `finalQueryOf`, the shifted oracle is the shift plus the `H^*` output — the form
 `sameIvk_finalOracle_pm`'s equation is stated in. -/
 theorem shiftedFinalOracle_finalQueryOf
-    (Extract : G → AK) (Ggen : G) (hfn : AK → NK → F)
+    (Extract : Extractor G IVK AK) (Ggen : G) (hfn : AK → NK → F)
     (H : Oracles F AK NK SK QK)
-    {w : Witness G F AK NK SK QK}
+    {w : Witness G F IVK AK NK SK QK}
     (hd : KBDerivation Extract Ggen H w) :
     shiftedFinalOracle Extract Ggen hfn H
         (finalQueryOf Extract w)
-      = hfn (Extract w.akP) w.nk
+      = hfn (Extract.toAK w.akP) w.nk
           + (finalQueryOf Extract w).eval H.rivk_legacy H.rivk_ext H.rivk_int := by
   obtain ⟨hbc, hrivk⟩ := hd
   unfold finalQueryOf extQueryOf
@@ -364,7 +372,7 @@ theorem shiftedFinalOracle_finalQueryOf
 end Onward
 
 section OnwardCollision
-variable [AddCommGroup G] [Field F] [Field AK] [Module F G] [NoZeroSMulDivisors F G] [DecidableEq F]
+variable [AddCommGroup G] [Field F] [Field IVK] [Module F G] [NoZeroSMulDivisors F G] [DecidableEq F]
 
 /-- **Same-`ivk` ±-equation over `H^*`.** Two witnesses opening the same `ivk` (`KBOpening`), both
 satisfying the derivation constraints, give the ZIP 2005 break equation with the final-oracle
@@ -376,18 +384,18 @@ notions (`OpeningBreak`, `Break`) carry a distinctness witness. That is why this
 equation rather than a full `CollisionUpToSign`; the `ne` field arrives with
 `CollisionUpToSign.ofBreak`'s case split. -/
 theorem sameIvk_finalOracle_pm
-    (Extract : G → AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
-    (hExt : ∀ P Q : G, Extract P = Extract Q ↔ P =± Q) (hS : S ≠ 0)
+    (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
+    (hExt : ∀ P Q : G, Extract.toIVK P = Extract.toIVK Q ↔ P =± Q) (hS : S ≠ 0)
     (H : Oracles F AK NK SK QK)
-    {w₁ w₂ : Witness G F AK NK SK QK}
+    {w₁ w₂ : Witness G F IVK AK NK SK QK}
     (hop₁ : KBOpening Extract S hfn w₁) (hop₂ : KBOpening Extract S hfn w₂)
     (hivk : w₁.ivk = w₂.ivk)
     (hd₁ : KBDerivation Extract Ggen H w₁)
     (hd₂ : KBDerivation Extract Ggen H w₂) :
-    hfn (Extract w₁.akP) w₁.nk + (finalQueryOf Extract w₁).eval H.rivk_legacy H.rivk_ext H.rivk_int
-      =± hfn (Extract w₂.akP) w₂.nk + (finalQueryOf Extract w₂).eval H.rivk_legacy H.rivk_ext H.rivk_int := by
-  have hcm : Commitivk Extract S hfn w₁.rivk (Extract w₁.akP) w₁.nk
-      = Commitivk Extract S hfn w₂.rivk (Extract w₂.akP) w₂.nk :=
+    hfn (Extract.toAK w₁.akP) w₁.nk + (finalQueryOf Extract w₁).eval H.rivk_legacy H.rivk_ext H.rivk_int
+      =± hfn (Extract.toAK w₂.akP) w₂.nk + (finalQueryOf Extract w₂).eval H.rivk_legacy H.rivk_ext H.rivk_int := by
+  have hcm : Commitivk Extract S hfn w₁.rivk (Extract.toAK w₁.akP) w₁.nk
+      = Commitivk Extract S hfn w₂.rivk (Extract.toAK w₂.akP) w₂.nk :=
     hop₁.commit.symm.trans (hivk.trans hop₂.commit)
   have hpm := commit_scalar_pm Extract S hfn hExt hS hcm
   rw [rivk_eq_finalOracle Extract Ggen H hd₁,
@@ -397,15 +405,15 @@ theorem sameIvk_finalOracle_pm
 /-- The `H^*` ±-equation from an `OpeningBreak` (the object the games produce): the same-`ivk`
 core `sameIvk_finalOracle_pm` applied to the break's two openings. -/
 theorem openingBreak_finalOracle_pm
-    (Extract : G → AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
-    (hExt : ∀ P Q : G, Extract P = Extract Q ↔ P =± Q) (hS : S ≠ 0)
+    (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
+    (hExt : ∀ P Q : G, Extract.toIVK P = Extract.toIVK Q ↔ P =± Q) (hS : S ≠ 0)
     (H : Oracles F AK NK SK QK)
-    {w₁ w₂ : Witness G F AK NK SK QK}
+    {w₁ w₂ : Witness G F IVK AK NK SK QK}
     (hbrk : OpeningBreak Extract S hfn w₁ w₂)
     (hd₁ : KBDerivation Extract Ggen H w₁)
     (hd₂ : KBDerivation Extract Ggen H w₂) :
-    hfn (Extract w₁.akP) w₁.nk + (finalQueryOf Extract w₁).eval H.rivk_legacy H.rivk_ext H.rivk_int
-      =± hfn (Extract w₂.akP) w₂.nk + (finalQueryOf Extract w₂).eval H.rivk_legacy H.rivk_ext H.rivk_int :=
+    hfn (Extract.toAK w₁.akP) w₁.nk + (finalQueryOf Extract w₁).eval H.rivk_legacy H.rivk_ext H.rivk_int
+      =± hfn (Extract.toAK w₂.akP) w₂.nk + (finalQueryOf Extract w₂).eval H.rivk_legacy H.rivk_ext H.rivk_int :=
   sameIvk_finalOracle_pm Extract S hfn Ggen hExt hS H
     hbrk.opening₁ hbrk.opening₂ hbrk.ivk_eq hd₁ hd₂
 
@@ -414,22 +422,22 @@ derivation constraints are already inside the `Break` (via `KB`), and *no* `Brea
 upgrade is needed: the equation depends only on the openings and `ivk`-equality, never on how the
 projections differ. `CollisionUpToSign.ofBreak` builds its case split on this. -/
 theorem break_finalOracle_pm
-    (Extract : G → AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
-    (hExt : ∀ P Q : G, Extract P = Extract Q ↔ P =± Q) (hS : S ≠ 0)
+    (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
+    (hExt : ∀ P Q : G, Extract.toIVK P = Extract.toIVK Q ↔ P =± Q) (hS : S ≠ 0)
     (H : Oracles F AK NK SK QK)
-    {w₁ w₂ : Witness G F AK NK SK QK}
+    {w₁ w₂ : Witness G F IVK AK NK SK QK}
     (hbrk : Break Extract S hfn Ggen H w₁ w₂) :
-    hfn (Extract w₁.akP) w₁.nk + (finalQueryOf Extract w₁).eval H.rivk_legacy H.rivk_ext H.rivk_int
-      =± hfn (Extract w₂.akP) w₂.nk + (finalQueryOf Extract w₂).eval H.rivk_legacy H.rivk_ext H.rivk_int :=
+    hfn (Extract.toAK w₁.akP) w₁.nk + (finalQueryOf Extract w₁).eval H.rivk_legacy H.rivk_ext H.rivk_int
+      =± hfn (Extract.toAK w₂.akP) w₂.nk + (finalQueryOf Extract w₂).eval H.rivk_legacy H.rivk_ext H.rivk_int :=
   sameIvk_finalOracle_pm Extract S hfn Ggen hExt hS H
     hbrk.kb₁.opening hbrk.kb₂.opening hbrk.ivk_eq hbrk.kb₁.derivation hbrk.kb₂.derivation
 
 /-- The break projection an *externally-decoded* witness must have, read off its
 `rivk_ext`-derivation query (`proj_eq_projOfQuery`); `.int` is not in `extQueryOf`'s image. -/
-def projOfQuery (Extract : G → AK) (Ggen : G) (H : Oracles F AK NK SK QK) :
+def projOfQuery (Extract : Extractor G IVK AK) (Ggen : G) (H : Oracles F AK NK SK QK) :
     FinalQuery QK SK AK NK F → Option (BreakProj QK SK AK NK F)
   | .ext qk ak nk => some ⟨.qk qk, ak, nk, H.rivk_ext qk ak nk⟩
-  | .legacy sk => some ⟨.sk sk, Extract ((H.ask sk) • Ggen), H.nk sk, H.rivk_legacy sk⟩
+  | .legacy sk => some ⟨.sk sk, Extract.toAK ((H.ask sk) • Ggen), H.nk sk, H.rivk_legacy sk⟩
   | .int _ _ _ => none
 
 /-- The Branch data of a witness, read off its `rivk_ext`-derivation query
@@ -439,25 +447,25 @@ def branchOfQuery : FinalQuery QK SK AK NK F → Option (Branch QK SK)
   | .legacy sk => some (.sk sk)
   | .int _ _ _ => none
 
-omit [AddCommGroup G] [Field F] [Field AK] [NoZeroSMulDivisors F G] [DecidableEq F] in
+omit [AddCommGroup G] [Field F] [Field IVK] [NoZeroSMulDivisors F G] [DecidableEq F] in
 /-- A witness's Branch data is recoverable from its `rivk_ext`-derivation query. -/
-theorem branch_eq_branchOfQuery {w : Witness G F AK NK SK QK} (Extract : G → AK) :
+theorem branch_eq_branchOfQuery {w : Witness G F IVK AK NK SK QK} (Extract : Extractor G IVK AK) :
     some w.qk_or_sk = branchOfQuery (extQueryOf Extract w) := by
   rcases hb : w.qk_or_sk with qk | sk <;> simp [extQueryOf, branchOfQuery, hb]
 
-omit [AddCommGroup G] [Field F] [Field AK] [NoZeroSMulDivisors F G] [DecidableEq F] in
+omit [AddCommGroup G] [Field F] [Field IVK] [NoZeroSMulDivisors F G] [DecidableEq F] in
 /-- A witness's `rivk_ext`-derivation query is never `.int`. -/
-theorem extQueryOf_ne_int {w : Witness G F AK NK SK QK} (Extract : G → AK) (rivk_ext : F) (ak : AK) (nk : NK) :
+theorem extQueryOf_ne_int {w : Witness G F IVK AK NK SK QK} (Extract : Extractor G IVK AK) (rivk_ext : F) (ak : AK) (nk : NK) :
     extQueryOf Extract w ≠ .int rivk_ext ak nk := by
   rcases hb : w.qk_or_sk with qk | sk <;> simp [extQueryOf, hb]
 
-omit [Field AK] [NoZeroSMulDivisors F G] [DecidableEq F] in
+omit [Field IVK] [NoZeroSMulDivisors F G] [DecidableEq F] in
 /-- An externally-decoded witness's break projection is recoverable from its `rivk_ext`-derivation
 query: the derivation constraints determine every component from the query. -/
 theorem proj_eq_projOfQuery
-    (Extract : G → AK) (Ggen : G)
+    (Extract : Extractor G IVK AK) (Ggen : G)
     (H : Oracles F AK NK SK QK)
-    {w : Witness G F AK NK SK QK}
+    {w : Witness G F IVK AK NK SK QK}
     (hd : KBDerivation Extract Ggen H w)
     (hext : w.rivk = w.rivk_ext) :
     some (w.breakProj Extract)
@@ -469,18 +477,18 @@ theorem proj_eq_projOfQuery
   · obtain ⟨hakP, hnk, hre⟩ := hbc
     rw [hakP, hnk, hext.trans hre]
 
-omit [Field AK] [NoZeroSMulDivisors F G] [DecidableEq F] in
+omit [Field IVK] [NoZeroSMulDivisors F G] [DecidableEq F] in
 /-- A witness's shifted-oracle output at its `rivk_ext`-derivation query is
 `hfn (ak, nk) + rivk_ext`: the derivation constraints collapse the per-branch shift to the
 witness's own key data. -/
 theorem shiftedFinalOracle_extQueryOf
-    (Extract : G → AK) (Ggen : G) (hfn : AK → NK → F)
+    (Extract : Extractor G IVK AK) (Ggen : G) (hfn : AK → NK → F)
     (H : Oracles F AK NK SK QK)
-    {w : Witness G F AK NK SK QK}
+    {w : Witness G F IVK AK NK SK QK}
     (hd : KBDerivation Extract Ggen H w) :
     shiftedFinalOracle Extract Ggen hfn H
         (extQueryOf Extract w)
-      = hfn (Extract w.akP) w.nk + w.rivk_ext := by
+      = hfn (Extract.toAK w.akP) w.nk + w.rivk_ext := by
   obtain ⟨hbc, _⟩ := hd
   rcases hb : w.qk_or_sk with qk | sk <;> simp only [hb] at hbc <;>
     simp only [extQueryOf, hb, shiftedFinalOracle, shiftOf, FinalQuery.eval]
@@ -494,9 +502,9 @@ witnesses are internally derived, sharing `(ak, nk, rivk_ext, rivk)` and differi
 The collision then relocates to the `rivk_ext`-derivation queries, at which the shifted oracle's
 outputs are *equal* and the queries are *distinct*. -/
 theorem residual_of_finalQuery_eq
-    (Extract : G → AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
+    (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
     (H : Oracles F AK NK SK QK)
-    {w₁ w₂ : Witness G F AK NK SK QK}
+    {w₁ w₂ : Witness G F IVK AK NK SK QK}
     (hbrk : Break Extract S hfn Ggen H w₁ w₂)
     (hq : finalQueryOf Extract w₁ = finalQueryOf Extract w₂) :
     extQueryOf Extract w₁ ≠ extQueryOf Extract w₂ ∧
@@ -550,10 +558,10 @@ non-querying, so a fixed shift cannot be steered to manufacture collisions, and 
 shifted oracle at distinct queries has probability at most `q(q-1)/r` (`Birthday.lean`). -/
 def _root_.Zcash.Security.RandomOracle.CollisionUpToSign.ofBreak
     [DecidableEq QK] [DecidableEq SK] [DecidableEq AK] [DecidableEq NK]
-    (Extract : G → AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
-    (hExt : ∀ P Q : G, Extract P = Extract Q ↔ P =± Q) (hS : S ≠ 0)
+    (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
+    (hExt : ∀ P Q : G, Extract.toIVK P = Extract.toIVK Q ↔ P =± Q) (hS : S ≠ 0)
     (H : Oracles F AK NK SK QK)
-    {w₁ w₂ : Witness G F AK NK SK QK}
+    {w₁ w₂ : Witness G F IVK AK NK SK QK}
     (hbrk : Break Extract S hfn Ggen H w₁ w₂) :
     RandomOracle.CollisionUpToSign
       (shiftedFinalOracle Extract Ggen hfn H
@@ -572,14 +580,14 @@ def _root_.Zcash.Security.RandomOracle.CollisionUpToSign.ofBreak
             shiftedFinalOracle_finalQueryOf Extract Ggen hfn H hbrk.kb₂.derivation]
         exact break_finalOracle_pm Extract S hfn Ggen hExt hS H hbrk }
 
-omit [Field AK] [NoZeroSMulDivisors F G] in
+omit [Field IVK] [NoZeroSMulDivisors F G] in
 /-- **The bridge to the birthday counting**: the pair of `H^*` outputs at a shifted-oracle
 ±-collision's queries lies in the shifted ±-collision set that
 `Birthday.card_shifted_pm_collision_le` counts, with the shifts read off the queries. Combined
 with the collision's `ne` field (distinct queries) this is the per-pair event whose fraction the
 birthday layer bounds by `2/|F|`. -/
 theorem collision_mem_shifted_pm [Fintype F]
-    (Extract : G → AK) (Ggen : G) (hfn : AK → NK → F)
+    (Extract : Extractor G IVK AK) (Ggen : G) (hfn : AK → NK → F)
     (H : Oracles F AK NK SK QK)
     (c : RandomOracle.CollisionUpToSign
       (shiftedFinalOracle Extract Ggen hfn H

--- a/Zcash/Security/KeyBinding/Basic.lean
+++ b/Zcash/Security/KeyBinding/Basic.lean
@@ -21,7 +21,8 @@ The route, each step proven here:
    (Balance's and Spend Authorization's imports).
 
 The probabilistic side — producing the computed collision is hard — is the birthday bound
-`ε_kb ≤ q(q-1)/r` (`Birthday.lean`). `PRF^nf`-pinning, Spendability's import, is not here yet.
+`ε_kb ≤ q(q-1)/r` (`Birthday.lean`), ZIP 2005's `ε_kb` as sharpened in zcash/zips#1338.
+`PRF^nf`-pinning, Spendability's import, is not here yet.
 
 Abstract setting: a prime-order group `G` as an `RIVK`-vector space. The scalar types are
 `RIVK` (rivk values and the rivk-derivation oracle outputs) and `ASK` (`H^ask` outputs, acting
@@ -95,7 +96,9 @@ projection side. -/
 structure Extractor (G IVK AK : Type*) [Neg G] where
   toIVK : G → IVK
   toAK : G → AK
-  /-- `toIVK` identifies exactly the ±-pairs (the x-coordinate property). -/
+  /-- `toIVK` identifies exactly the ±-pairs (the x-coordinate property). At the identity
+  point the concrete x-coordinate instantiation needs "no Pallas point has x = 0"
+  (x = 0 forces y² = 5, a non-square). -/
   toIVK_pm : ∀ P Q : G, toIVK P = toIVK Q ↔ P =± Q
 
 /-- `toIVK` is at most 2-to-1 (`toIVK_pm`), so the `IVK` domain is at least half the group:
@@ -155,7 +158,8 @@ structure KBOpening (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → 
     (w : Witness G IVK AK NK RIVK QK SK) : Prop where
   /-- `ivk` opens as `Commitivk` at `(rivk, ak, nk)`. -/
   commit : w.ivk = Commitivk Extract S hfn w.rivk (Extract.toAK w.akP) w.nk
-  /-- `ivk ≠ 0`. -/
+  /-- `ivk ≠ 0` (ZIP 2005 requires `ivk ∉ {0, ⊥}`). No proof in this development consumes
+  it; its discharge belongs to the statement instantiation. -/
   nonzero : w.ivk ≠ 0
 
 /-- `OpeningBreak` — a `Commitivk`-opening collision (produced by the games layer): two valid

--- a/Zcash/Security/KeyBinding/Basic.lean
+++ b/Zcash/Security/KeyBinding/Basic.lean
@@ -98,6 +98,29 @@ structure Extractor (G IVK AK : Type*) [Neg G] where
   /-- `toIVK` identifies exactly the ±-pairs (the x-coordinate property). -/
   toIVK_pm : ∀ P Q : G, toIVK P = toIVK Q ↔ P =± Q
 
+/-- `toIVK` is at most 2-to-1 (`toIVK_pm`), so the `IVK` domain is at least half the group:
+`|G| ≤ 2·|IVK|`. An `IVK` small enough to find collisions in admits no `Extractor` at all —
+undersized instantiations make the key-binding theorems vacuous rather than falsely secure.
+This is why the birthday bounds involve only `|RIVK|`: `ivk`-derivation collisions are
+excluded exactly, which the deployed x-coordinate extraction satisfies (exactly 2-to-1 on
+±-pairs). A hash-derived `ivk` (Sapling's `CRH^ivk`) does not satisfy `toIVK_pm` and would
+need a collision-resistance term in the bound instead. -/
+theorem Extractor.card_ivk_ge [Neg G] [Fintype G] [Fintype IVK] [DecidableEq G]
+    [DecidableEq IVK] (Extract : Extractor G IVK AK) :
+    Fintype.card G ≤ 2 * Fintype.card IVK := by
+  refine Finset.card_le_mul_card_image_of_maps_to
+    (f := Extract.toIVK) (fun a _ => Finset.mem_univ _) 2 fun b _ => ?_
+  by_cases hb : ∃ P, Extract.toIVK P = b
+  · obtain ⟨P, hP⟩ := hb
+    calc ((Finset.univ : Finset G).filter fun x => Extract.toIVK x = b).card
+        ≤ ({P, -P} : Finset G).card := Finset.card_le_card fun x hx => by
+            rw [Finset.mem_filter] at hx
+            rcases (Extract.toIVK_pm x P).mp (hx.2.trans hP.symm) with h | h <;>
+              simp [Finset.mem_insert, h]
+      _ ≤ 2 := le_trans (Finset.card_insert_le _ _) (by simp)
+  · rw [Finset.filter_eq_empty_iff.mpr fun {x} _ => fun hx => hb ⟨x, hx⟩]
+    simp
+
 section Algebra
 variable [AddCommGroup G] [Field IVK] [Field RIVK] [Module RIVK G] [NoZeroSMulDivisors RIVK G]
 

--- a/Zcash/Security/KeyBinding/Basic.lean
+++ b/Zcash/Security/KeyBinding/Basic.lean
@@ -84,8 +84,8 @@ inductive FinalQuery (AK NK RIVK QK SK : Type*) where
   deriving DecidableEq
 
 /-- The combined final `rivk`-derivation random oracle: dispatch each final query to its oracle. -/
-def FinalQuery.eval (Hrivk_legacy : SK → RIVK) (Hrivk_ext : QK → AK → NK → RIVK) (Hrivk_int : RIVK → AK → NK → RIVK) :
-    FinalQuery AK NK RIVK QK SK → RIVK
+def FinalQuery.eval (Hrivk_legacy : SK → RIVK) (Hrivk_ext : QK → AK → NK → RIVK)
+    (Hrivk_int : RIVK → AK → NK → RIVK) : FinalQuery AK NK RIVK QK SK → RIVK
   | .ext qk ak nk => Hrivk_ext qk ak nk
   | .legacy sk => Hrivk_legacy sk
   | .int rivk_ext ak nk => Hrivk_int rivk_ext ak nk
@@ -130,7 +130,8 @@ variable [AddCommGroup G] [Field IVK] [Field RIVK] [Module RIVK G] [NoZeroSMulDi
 /-- The `ivk` commitment as a Pedersen lift:
 `Commitivk rivk ak nk = Extract.toIVK ((h ak nk + rivk) • S)`, with `h` abstract-but-non-querying and `S`
 a fixed base. Mirrors the `NoteCommit` repair `(H^rcm + f) • R`. -/
-def Commitivk (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK) (rivk : RIVK) (ak : AK) (nk : NK) : IVK :=
+def Commitivk (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK) (rivk : RIVK)
+    (ak : AK) (nk : NK) : IVK :=
   Extract.toIVK ((hfn ak nk + rivk) • S)
 
 omit [Field IVK] in
@@ -251,7 +252,8 @@ structure BreakProj (AK NK RIVK QK SK : Type*) where
   qk_or_sk : Branch QK SK
 
 /-- The break projection, read off a witness. -/
-def Witness.breakProj (Extract : Extractor G IVK AK) (w : Witness G IVK AK NK RIVK QK SK) : BreakProj AK NK RIVK QK SK :=
+def Witness.breakProj (Extract : Extractor G IVK AK) (w : Witness G IVK AK NK RIVK QK SK) :
+    BreakProj AK NK RIVK QK SK :=
   ⟨Extract.toAK w.akP, w.nk, w.rivk, w.qk_or_sk⟩
 
 /-- A full key-binding break (ZIP 2005): two valid witnesses with equal `ivk` and differing
@@ -362,8 +364,8 @@ theorem rivk_eq_finalOracle
 
 /-- The non-querying shift: `hfn` at the query's key data (for `.legacy sk`, `ak`/`nk` are
 recovered via `Hask`/`Hnk`, so the shift is a function of the query alone). -/
-def shiftOf (Extract : Extractor G IVK AK) (Ggen : G) (hfn : AK → NK → RIVK) (Hask : SK → ASK) (Hnk : SK → NK) :
-    FinalQuery AK NK RIVK QK SK → RIVK
+def shiftOf (Extract : Extractor G IVK AK) (Ggen : G) (hfn : AK → NK → RIVK)
+    (Hask : SK → ASK) (Hnk : SK → NK) : FinalQuery AK NK RIVK QK SK → RIVK
   | .ext _ ak nk => hfn ak nk
   | .legacy sk => hfn (Extract.toAK ((Hask sk) • Ggen)) (Hnk sk)
   | .int _ ak nk => hfn ak nk
@@ -483,7 +485,8 @@ theorem branch_eq_branchOfQuery {w : Witness G IVK AK NK RIVK QK SK} (Extract : 
 
 omit [Field IVK] [Field RIVK] [NoZeroSMulDivisors RIVK G] [DecidableEq RIVK] in
 /-- A witness's `rivk_ext`-derivation query is never `.int`. -/
-theorem extQueryOf_ne_int {w : Witness G IVK AK NK RIVK QK SK} (Extract : Extractor G IVK AK) (rivk_ext : RIVK) (ak : AK) (nk : NK) :
+theorem extQueryOf_ne_int {w : Witness G IVK AK NK RIVK QK SK} (Extract : Extractor G IVK AK)
+    (rivk_ext : RIVK) (ak : AK) (nk : NK) :
     extQueryOf Extract w ≠ .int rivk_ext ak nk := by
   rcases hb : w.qk_or_sk with qk | sk <;> simp [extQueryOf, hb]
 

--- a/Zcash/Security/KeyBinding/Basic.lean
+++ b/Zcash/Security/KeyBinding/Basic.lean
@@ -24,7 +24,10 @@ The probabilistic side — producing the computed collision is hard — is the b
 `ε_kb ≤ q(q-1)/r` (`Birthday.lean`). `PRF^nf`-pinning, Spendability's import, is not here yet.
 
 Abstract setting: a prime-order group `G` as an `F`-vector space (`F = ZMod r` the scalar field),
-a base field `B` (x-coordinates, `= ZMod q`), and `Extract : G → B` with the ±-property (`hExt`).
+base-field types `AK` and `NK` (both `= ZMod q` concretely: `AK` for `Extract` outputs — `ak`,
+and `ivk`, which shares the type since `Commit^ivk` can return 0 in circuit contexts (§4.1.8);
+nonzeroness is the `KBOpening.nonzero` hypothesis — and `NK` for `nk`), with `Extract : G → AK`
+having the ±-property (`hExt`).
 `Commitivk` is required to have the Pedersen structure (not opaque), which is what makes the break
 reduction provable; no Pallas instantiation is included (the intended concrete route is via
 CompElliptic).
@@ -46,60 +49,60 @@ inductive Branch (QK SK : Type*) where
 /-- A Recovery-Statement / Orchard key witness (ZIP 2005 §"key binding"). `use_qsk` is encoded by
 the `qk_or_sk` constructor. The internal-vs-external `ivk` choice is encoded by `rivk`'s value,
 not a tag (see `finalQueryOf`). -/
-structure Witness (G F B SK QK : Type*) where
-  ivk      : B
+structure Witness (G F AK NK SK QK : Type*) where
+  ivk      : AK
   qk_or_sk : Branch QK SK
   akP      : G
-  nk       : B
+  nk       : NK
   rivk_ext : F
   rivk     : F
 
-variable {G F B SK QK : Type*}
+variable {G F AK NK SK QK : Type*}
 
 /-- The Pedersen-scalar map a `Commitivk` opening reduces to: `(ak, nk, rivk) ↦ h ak nk + rivk`.
 An `OpeningBreak` is exhibited as a `CollisionUpToSign` of this map by
 `CollisionUpToSign.ofOpeningBreak`. -/
-def pedersenScalar [Add F] (hfn : B → B → F) (t : B × B × F) : F :=
+def pedersenScalar [Add F] (hfn : AK → NK → F) (t : AK × NK × F) : F :=
   let (ak, nk, rivk) := t
   hfn ak nk + rivk
 
 /-- The "final input" to the final `rivk`-derivation random oracle (ZIP 2005 key-binding proof):
 the query at which `rivk` is that oracle's output, selected by the `qk`/`sk` branch and the
 external/internal ivk choice. -/
-inductive FinalQuery (QK SK B F : Type*) where
+inductive FinalQuery (QK SK AK NK F : Type*) where
   /-- qk-branch, external ivk: `rivk = Hrivk_ext qk ak nk`. -/
-  | ext : QK → B → B → FinalQuery QK SK B F
+  | ext : QK → AK → NK → FinalQuery QK SK AK NK F
   /-- sk-branch, external ivk: `rivk = Hrivk_legacy sk`. -/
-  | legacy : SK → FinalQuery QK SK B F
+  | legacy : SK → FinalQuery QK SK AK NK F
   /-- internal ivk: `rivk = Hrivk_int rivk_ext ak nk`. -/
-  | int : F → B → B → FinalQuery QK SK B F
+  | int : F → AK → NK → FinalQuery QK SK AK NK F
   deriving DecidableEq
 
 /-- The combined final `rivk`-derivation random oracle: dispatch each final query to its oracle. -/
-def FinalQuery.eval (Hrivk_legacy : SK → F) (Hrivk_ext : QK → B → B → F) (Hrivk_int : F → B → B → F) :
-    FinalQuery QK SK B F → F
+def FinalQuery.eval (Hrivk_legacy : SK → F) (Hrivk_ext : QK → AK → NK → F) (Hrivk_int : F → AK → NK → F) :
+    FinalQuery QK SK AK NK F → F
   | .ext qk ak nk => Hrivk_ext qk ak nk
   | .legacy sk => Hrivk_legacy sk
   | .int rivk_ext ak nk => Hrivk_int rivk_ext ak nk
 
 section Algebra
-variable [AddCommGroup G] [Field F] [Field B] [Module F G] [NoZeroSMulDivisors F G]
+variable [AddCommGroup G] [Field F] [Field AK] [Module F G] [NoZeroSMulDivisors F G]
 
 /-- The `ivk` commitment as a Pedersen lift:
 `Commitivk rivk ak nk = Extract ((h ak nk + rivk) • S)`, with `h` abstract-but-non-querying and `S`
 a fixed base. Mirrors the `NoteCommit` repair `(H^rcm + f) • R`. -/
-def Commitivk (Extract : G → B) (S : G) (hfn : B → B → F) (rivk : F) (ak nk : B) : B :=
+def Commitivk (Extract : G → AK) (S : G) (hfn : AK → NK → F) (rivk : F) (ak : AK) (nk : NK) : AK :=
   Extract ((hfn ak nk + rivk) • S)
 
-omit [Field B] in
+omit [Field AK] in
 /-- Algebraic core: two openings of the same `Commitivk` value force their Pedersen scalars to be
 equal or negatives — the deterministic content the whole key-binding reduction rests on. Proved
 from the `Extract` ±-property and injectivity of `· • S` for `S ≠ 0` (`smul_left_injective`;
 `G` is an `F`-vector space). -/
 theorem commit_scalar_pm
-    (Extract : G → B) (S : G) (hfn : B → B → F)
+    (Extract : G → AK) (S : G) (hfn : AK → NK → F)
     (hExt : ∀ P Q : G, Extract P = Extract Q ↔ P =± Q) (hS : S ≠ 0)
-    {rivk₁ rivk₂ : F} {ak₁ nk₁ ak₂ nk₂ : B}
+    {rivk₁ rivk₂ : F} {ak₁ ak₂ : AK} {nk₁ nk₂ : NK}
     (hcm : Commitivk Extract S hfn rivk₁ ak₁ nk₁ = Commitivk Extract S hfn rivk₂ ak₂ nk₂) :
     hfn ak₁ nk₁ + rivk₁ =± hfn ak₂ nk₂ + rivk₂ := by
   unfold Commitivk at hcm
@@ -113,8 +116,8 @@ theorem commit_scalar_pm
 
 /-- `KBOpening` — the commitment-opening core of the key-binding condition (what statement-validity
 yields). -/
-structure KBOpening (Extract : G → B) (S : G) (hfn : B → B → F)
-    (w : Witness G F B SK QK) : Prop where
+structure KBOpening (Extract : G → AK) (S : G) (hfn : AK → NK → F)
+    (w : Witness G F AK NK SK QK) : Prop where
   /-- `ivk` opens as `Commitivk` at `(rivk, ak, nk)`. -/
   commit : w.ivk = Commitivk Extract S hfn w.rivk (Extract w.akP) w.nk
   /-- `ivk ≠ 0`. -/
@@ -122,8 +125,8 @@ structure KBOpening (Extract : G → B) (S : G) (hfn : B → B → F)
 
 /-- `OpeningBreak` — a `Commitivk`-opening collision (produced by the games layer): two valid
 `KBOpening` witnesses with the same `ivk` but differing `(ak, nk, rivk)`. -/
-structure OpeningBreak (Extract : G → B) (S : G) (hfn : B → B → F)
-    (w₁ w₂ : Witness G F B SK QK) : Prop where
+structure OpeningBreak (Extract : G → AK) (S : G) (hfn : AK → NK → F)
+    (w₁ w₂ : Witness G F AK NK SK QK) : Prop where
   opening₁ : KBOpening Extract S hfn w₁
   opening₂ : KBOpening Extract S hfn w₂
   ivk_eq : w₁.ivk = w₂.ivk
@@ -140,9 +143,9 @@ standalone inhabitant is computable outright. The security content is conditiona
 `OpeningBreak` hypothesis; hardness enters per-instantiation, where `rivk` is an `H^*` output
 (`KBDerivation`) and the birthday bound applies. -/
 def _root_.Zcash.Security.RandomOracle.CollisionUpToSign.ofOpeningBreak
-    (Extract : G → B) (S : G) (hfn : B → B → F)
+    (Extract : G → AK) (S : G) (hfn : AK → NK → F)
     (hExt : ∀ P Q : G, Extract P = Extract Q ↔ P =± Q) (hS : S ≠ 0)
-    {w₁ w₂ : Witness G F B SK QK} (hbrk : OpeningBreak Extract S hfn w₁ w₂) :
+    {w₁ w₂ : Witness G F AK NK SK QK} (hbrk : OpeningBreak Extract S hfn w₁ w₂) :
     RandomOracle.CollisionUpToSign (pedersenScalar hfn) where
   q₁ := (Extract w₁.akP, w₁.nk, w₁.rivk)
   q₂ := (Extract w₂.akP, w₂.nk, w₂.rivk)
@@ -156,21 +159,21 @@ def _root_.Zcash.Security.RandomOracle.CollisionUpToSign.ofOpeningBreak
 end Algebra
 
 section Derivation
-variable [AddCommGroup G] [Field F] [Field B] [Module F G]
+variable [AddCommGroup G] [Field F] [Field AK] [Module F G]
 
 /-- `BindKeys^sk` (ZIP 2005): the `sk`-branch derivation constraints. -/
-structure BindKeysSk (Ggen : G) (Hask : SK → F) (Hnk : SK → B) (Hrivk_legacy : SK → F)
-    (sk : SK) (akP : G) (nk : B) (rivk_ext : F) : Prop where
+structure BindKeysSk (Ggen : G) (Hask : SK → F) (Hnk : SK → NK) (Hrivk_legacy : SK → F)
+    (sk : SK) (akP : G) (nk : NK) (rivk_ext : F) : Prop where
   akP_eq : akP = (Hask sk) • Ggen
   nk_eq : nk = Hnk sk
   rivk_ext_eq : rivk_ext = Hrivk_legacy sk
 
 /-- `KBDerivation` — the ZIP 2005 derivation constraints (the `qk_or_sk` branch structure is
 enforced by the `Branch` type). -/
-structure KBDerivation (Extract : G → B) (Ggen : G)
-    (Hask : SK → F) (Hnk : SK → B) (Hrivk_legacy : SK → F)
-    (Hrivk_ext : QK → B → B → F) (Hrivk_int : F → B → B → F)
-    (w : Witness G F B SK QK) : Prop where
+structure KBDerivation (Extract : G → AK) (Ggen : G)
+    (Hask : SK → F) (Hnk : SK → NK) (Hrivk_legacy : SK → F)
+    (Hrivk_ext : QK → AK → NK → F) (Hrivk_int : F → AK → NK → F)
+    (w : Witness G F AK NK SK QK) : Prop where
   /-- The per-branch constraint: `Hrivk_ext` on the qk-branch, `BindKeys^sk` on the sk-branch. -/
   branch : match w.qk_or_sk with
     | .qk qk => w.rivk_ext = Hrivk_ext qk (Extract w.akP) w.nk
@@ -181,34 +184,34 @@ structure KBDerivation (Extract : G → B) (Ggen : G)
 end Derivation
 
 section Full
-variable [AddCommGroup G] [Field F] [Field B] [Module F G]
+variable [AddCommGroup G] [Field F] [Field AK] [Module F G]
 
 /-- The full key-binding condition: commitment opening and key derivation constraints. -/
-structure KB (Extract : G → B) (S : G) (hfn : B → B → F) (Ggen : G)
-    (Hask : SK → F) (Hnk : SK → B) (Hrivk_legacy : SK → F)
-    (Hrivk_ext : QK → B → B → F) (Hrivk_int : F → B → B → F)
-    (w : Witness G F B SK QK) : Prop where
+structure KB (Extract : G → AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
+    (Hask : SK → F) (Hnk : SK → NK) (Hrivk_legacy : SK → F)
+    (Hrivk_ext : QK → AK → NK → F) (Hrivk_int : F → AK → NK → F)
+    (w : Witness G F AK NK SK QK) : Prop where
   opening : KBOpening Extract S hfn w
   derivation : KBDerivation Extract Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int w
 
 /-- The break projection of a witness: the components a key-binding break must differ in. Using
 `ak = Extract ak^ℙ` quotients the y-sign of `ak^ℙ`. -/
-structure BreakProj (QK SK B F : Type*) where
+structure BreakProj (QK SK AK NK F : Type*) where
   qk_or_sk : Branch QK SK
-  ak : B
-  nk : B
+  ak : AK
+  nk : NK
   rivk : F
 
 /-- The break projection, read off a witness. -/
-def Witness.breakProj (Extract : G → B) (w : Witness G F B SK QK) : BreakProj QK SK B F :=
+def Witness.breakProj (Extract : G → AK) (w : Witness G F AK NK SK QK) : BreakProj QK SK AK NK F :=
   ⟨w.qk_or_sk, Extract w.akP, w.nk, w.rivk⟩
 
 /-- A full key-binding break (ZIP 2005): two valid witnesses with equal `ivk` and differing
 break projections. -/
-structure Break (Extract : G → B) (S : G) (hfn : B → B → F) (Ggen : G)
-    (Hask : SK → F) (Hnk : SK → B) (Hrivk_legacy : SK → F)
-    (Hrivk_ext : QK → B → B → F) (Hrivk_int : F → B → B → F)
-    (w₁ w₂ : Witness G F B SK QK) : Prop where
+structure Break (Extract : G → AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
+    (Hask : SK → F) (Hnk : SK → NK) (Hrivk_legacy : SK → F)
+    (Hrivk_ext : QK → AK → NK → F) (Hrivk_int : F → AK → NK → F)
+    (w₁ w₂ : Witness G F AK NK SK QK) : Prop where
   kb₁ : KB Extract S hfn Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int w₁
   kb₂ : KB Extract S hfn Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int w₂
   ivk_eq : w₁.ivk = w₂.ivk
@@ -218,10 +221,10 @@ structure Break (Extract : G → B) (S : G) (hfn : B → B → F) (Ggen : G)
 /-- `nk`-pinning (Balance's import): two valid witnesses with the same `ivk` that do **not** form a
 key-binding break must share the same nullifier key `nk`. (The probability that a break *does* occur
 is the birthday bound.) -/
-theorem nk_pinned (Extract : G → B) (S : G) (hfn : B → B → F) (Ggen : G)
-    (Hask : SK → F) (Hnk : SK → B) (Hrivk_legacy : SK → F)
-    (Hrivk_ext : QK → B → B → F) (Hrivk_int : F → B → B → F)
-    {w₁ w₂ : Witness G F B SK QK}
+theorem nk_pinned (Extract : G → AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
+    (Hask : SK → F) (Hnk : SK → NK) (Hrivk_legacy : SK → F)
+    (Hrivk_ext : QK → AK → NK → F) (Hrivk_int : F → AK → NK → F)
+    {w₁ w₂ : Witness G F AK NK SK QK}
     (h₁ : KB Extract S hfn Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int w₁)
     (h₂ : KB Extract S hfn Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int w₂)
     (hivk : w₁.ivk = w₂.ivk)
@@ -235,10 +238,10 @@ theorem nk_pinned (Extract : G → B) (S : G) (hfn : B → B → F) (Ggen : G)
 /-- `ak`-pinning up to y-sign (Spend Authorization's import): two valid witnesses with the same `ivk`
 that do *not* form a key-binding break share the same `ak = Extract ak^ℙ` — i.e. `ak^ℙ` is pinned up
 to its y-sign, matching the protocol's choice to consume `ak` as a single x-coordinate. -/
-theorem ak_pinned (Extract : G → B) (S : G) (hfn : B → B → F) (Ggen : G)
-    (Hask : SK → F) (Hnk : SK → B) (Hrivk_legacy : SK → F)
-    (Hrivk_ext : QK → B → B → F) (Hrivk_int : F → B → B → F)
-    {w₁ w₂ : Witness G F B SK QK}
+theorem ak_pinned (Extract : G → AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
+    (Hask : SK → F) (Hnk : SK → NK) (Hrivk_legacy : SK → F)
+    (Hrivk_ext : QK → AK → NK → F) (Hrivk_int : F → AK → NK → F)
+    {w₁ w₂ : Witness G F AK NK SK QK}
     (h₁ : KB Extract S hfn Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int w₁)
     (h₂ : KB Extract S hfn Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int w₂)
     (hivk : w₁.ivk = w₂.ivk)
@@ -253,10 +256,10 @@ theorem ak_pinned (Extract : G → B) (S : G) (hfn : B → B → F) (Ggen : G)
 *not* form a key-binding break share the same branch — the same `qk` or the same `sk`, including
 *which* of the two backs the witness. This is stronger than ZIP 2005's former "`qk` determined by
 `ivk` when `qk ≠ ⊥`". -/
-theorem qk_or_sk_pinned (Extract : G → B) (S : G) (hfn : B → B → F) (Ggen : G)
-    (Hask : SK → F) (Hnk : SK → B) (Hrivk_legacy : SK → F)
-    (Hrivk_ext : QK → B → B → F) (Hrivk_int : F → B → B → F)
-    {w₁ w₂ : Witness G F B SK QK}
+theorem qk_or_sk_pinned (Extract : G → AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
+    (Hask : SK → F) (Hnk : SK → NK) (Hrivk_legacy : SK → F)
+    (Hrivk_ext : QK → AK → NK → F) (Hrivk_int : F → AK → NK → F)
+    {w₁ w₂ : Witness G F AK NK SK QK}
     (h₁ : KB Extract S hfn Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int w₁)
     (h₂ : KB Extract S hfn Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int w₂)
     (hivk : w₁.ivk = w₂.ivk)
@@ -270,11 +273,11 @@ theorem qk_or_sk_pinned (Extract : G → B) (S : G) (hfn : B → B → F) (Ggen 
 end Full
 
 section Onward
-variable [AddCommGroup G] [Field F] [Field B] [Module F G] [DecidableEq F]
+variable [AddCommGroup G] [Field F] [Field AK] [Module F G] [DecidableEq F]
 
 /-- The `rivk_ext`-derivation query of a witness: the query at which the combined final oracle
 produces its `rivk_ext`, selected by the branch. Never `.int` (`extQueryOf_ne_int`). -/
-def extQueryOf (Extract : G → B) (w : Witness G F B SK QK) : FinalQuery QK SK B F :=
+def extQueryOf (Extract : G → AK) (w : Witness G F AK NK SK QK) : FinalQuery QK SK AK NK F :=
   match w.qk_or_sk with
   | .qk qk => .ext qk (Extract w.akP) w.nk
   | .sk sk => .legacy sk
@@ -286,21 +289,21 @@ fixpoint `Hrivk_int rivk_ext ak nk = rivk_ext`, an internally-derived witness de
 external — harmless for `rivk_eq_finalOracle` (which holds either way), but the birthday
 accounting must partition query pairs by this decode, not by how the witnesses were
 derived. -/
-def finalQueryOf (Extract : G → B) (w : Witness G F B SK QK) : FinalQuery QK SK B F :=
+def finalQueryOf (Extract : G → AK) (w : Witness G F AK NK SK QK) : FinalQuery QK SK AK NK F :=
   if w.rivk = w.rivk_ext then extQueryOf Extract w
   else .int w.rivk_ext (Extract w.akP) w.nk
 
-omit [Field B] in
+omit [Field AK] in
 /-- **Final-random-oracle representation** (ZIP 2005 key-binding proof, "Final-random-oracle
 structure"): under the derivation constraints, `rivk` is the output of the combined final oracle at
 the witness's `finalQueryOf`. It bridges the Pedersen-scalar collision
 (`CollisionUpToSign.ofOpeningBreak`) to a collision of the actual `H^*` oracles. What remains
 probabilistic is only the birthday bound over the final-query space. -/
 theorem rivk_eq_finalOracle
-    (Extract : G → B) (Ggen : G)
-    (Hask : SK → F) (Hnk : SK → B) (Hrivk_legacy : SK → F)
-    (Hrivk_ext : QK → B → B → F) (Hrivk_int : F → B → B → F)
-    {w : Witness G F B SK QK}
+    (Extract : G → AK) (Ggen : G)
+    (Hask : SK → F) (Hnk : SK → NK) (Hrivk_legacy : SK → F)
+    (Hrivk_ext : QK → AK → NK → F) (Hrivk_int : F → AK → NK → F)
+    {w : Witness G F AK NK SK QK}
     (hd : KBDerivation Extract Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int w) :
     w.rivk = (finalQueryOf Extract w).eval Hrivk_legacy Hrivk_ext Hrivk_int := by
   obtain ⟨hbc, hrivk⟩ := hd
@@ -316,8 +319,8 @@ theorem rivk_eq_finalOracle
 
 /-- The non-querying shift: `hfn` at the query's key data (for `.legacy sk`, `ak`/`nk` are
 recovered via `Hask`/`Hnk`, so the shift is a function of the query alone). -/
-def shiftOf (Extract : G → B) (Ggen : G) (hfn : B → B → F) (Hask : SK → F) (Hnk : SK → B) :
-    FinalQuery QK SK B F → F
+def shiftOf (Extract : G → AK) (Ggen : G) (hfn : AK → NK → F) (Hask : SK → F) (Hnk : SK → NK) :
+    FinalQuery QK SK AK NK F → F
   | .ext _ ak nk => hfn ak nk
   | .legacy sk => hfn (Extract ((Hask sk) • Ggen)) (Hnk sk)
   | .int _ ak nk => hfn ak nk
@@ -325,20 +328,20 @@ def shiftOf (Extract : G → B) (Ggen : G) (hfn : B → B → F) (Hask : SK → 
 /-- The *shifted* combined final oracle: the `H^*` output offset by the non-querying shift.
 The ±-collision a `Break` computes (`CollisionUpToSign.ofBreak`) is of this map — the event
 the birthday layer bounds. -/
-def shiftedFinalOracle (Extract : G → B) (Ggen : G) (hfn : B → B → F)
-    (Hask : SK → F) (Hnk : SK → B) (Hrivk_legacy : SK → F)
-    (Hrivk_ext : QK → B → B → F) (Hrivk_int : F → B → B → F)
-    (q : FinalQuery QK SK B F) : F :=
+def shiftedFinalOracle (Extract : G → AK) (Ggen : G) (hfn : AK → NK → F)
+    (Hask : SK → F) (Hnk : SK → NK) (Hrivk_legacy : SK → F)
+    (Hrivk_ext : QK → AK → NK → F) (Hrivk_int : F → AK → NK → F)
+    (q : FinalQuery QK SK AK NK F) : F :=
   shiftOf Extract Ggen hfn Hask Hnk q + q.eval Hrivk_legacy Hrivk_ext Hrivk_int
 
-omit [Field B] in
+omit [Field AK] in
 /-- On a witness's `finalQueryOf`, the shifted oracle is the shift plus the `H^*` output — the form
 `sameIvk_finalOracle_pm`'s equation is stated in. -/
 theorem shiftedFinalOracle_finalQueryOf
-    (Extract : G → B) (Ggen : G) (hfn : B → B → F)
-    (Hask : SK → F) (Hnk : SK → B) (Hrivk_legacy : SK → F)
-    (Hrivk_ext : QK → B → B → F) (Hrivk_int : F → B → B → F)
-    {w : Witness G F B SK QK}
+    (Extract : G → AK) (Ggen : G) (hfn : AK → NK → F)
+    (Hask : SK → F) (Hnk : SK → NK) (Hrivk_legacy : SK → F)
+    (Hrivk_ext : QK → AK → NK → F) (Hrivk_int : F → AK → NK → F)
+    {w : Witness G F AK NK SK QK}
     (hd : KBDerivation Extract Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int w) :
     shiftedFinalOracle Extract Ggen hfn Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int
         (finalQueryOf Extract w)
@@ -358,7 +361,7 @@ theorem shiftedFinalOracle_finalQueryOf
 end Onward
 
 section OnwardCollision
-variable [AddCommGroup G] [Field F] [Field B] [Module F G] [NoZeroSMulDivisors F G] [DecidableEq F]
+variable [AddCommGroup G] [Field F] [Field AK] [Module F G] [NoZeroSMulDivisors F G] [DecidableEq F]
 
 /-- **Same-`ivk` ±-equation over `H^*`.** Two witnesses opening the same `ivk` (`KBOpening`), both
 satisfying the derivation constraints, give the ZIP 2005 break equation with the final-oracle
@@ -370,11 +373,11 @@ notions (`OpeningBreak`, `Break`) carry a distinctness witness. That is why this
 equation rather than a full `CollisionUpToSign`; the `ne` field arrives with
 `CollisionUpToSign.ofBreak`'s case split. -/
 theorem sameIvk_finalOracle_pm
-    (Extract : G → B) (S : G) (hfn : B → B → F) (Ggen : G)
+    (Extract : G → AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
     (hExt : ∀ P Q : G, Extract P = Extract Q ↔ P =± Q) (hS : S ≠ 0)
-    (Hask : SK → F) (Hnk : SK → B) (Hrivk_legacy : SK → F)
-    (Hrivk_ext : QK → B → B → F) (Hrivk_int : F → B → B → F)
-    {w₁ w₂ : Witness G F B SK QK}
+    (Hask : SK → F) (Hnk : SK → NK) (Hrivk_legacy : SK → F)
+    (Hrivk_ext : QK → AK → NK → F) (Hrivk_int : F → AK → NK → F)
+    {w₁ w₂ : Witness G F AK NK SK QK}
     (hop₁ : KBOpening Extract S hfn w₁) (hop₂ : KBOpening Extract S hfn w₂)
     (hivk : w₁.ivk = w₂.ivk)
     (hd₁ : KBDerivation Extract Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int w₁)
@@ -392,11 +395,11 @@ theorem sameIvk_finalOracle_pm
 /-- The `H^*` ±-equation from an `OpeningBreak` (the object the games produce): the same-`ivk`
 core `sameIvk_finalOracle_pm` applied to the break's two openings. -/
 theorem openingBreak_finalOracle_pm
-    (Extract : G → B) (S : G) (hfn : B → B → F) (Ggen : G)
+    (Extract : G → AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
     (hExt : ∀ P Q : G, Extract P = Extract Q ↔ P =± Q) (hS : S ≠ 0)
-    (Hask : SK → F) (Hnk : SK → B) (Hrivk_legacy : SK → F)
-    (Hrivk_ext : QK → B → B → F) (Hrivk_int : F → B → B → F)
-    {w₁ w₂ : Witness G F B SK QK}
+    (Hask : SK → F) (Hnk : SK → NK) (Hrivk_legacy : SK → F)
+    (Hrivk_ext : QK → AK → NK → F) (Hrivk_int : F → AK → NK → F)
+    {w₁ w₂ : Witness G F AK NK SK QK}
     (hbrk : OpeningBreak Extract S hfn w₁ w₂)
     (hd₁ : KBDerivation Extract Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int w₁)
     (hd₂ : KBDerivation Extract Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int w₂) :
@@ -410,11 +413,11 @@ derivation constraints are already inside the `Break` (via `KB`), and *no* `Brea
 upgrade is needed: the equation depends only on the openings and `ivk`-equality, never on how the
 projections differ. `CollisionUpToSign.ofBreak` builds its case split on this. -/
 theorem break_finalOracle_pm
-    (Extract : G → B) (S : G) (hfn : B → B → F) (Ggen : G)
+    (Extract : G → AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
     (hExt : ∀ P Q : G, Extract P = Extract Q ↔ P =± Q) (hS : S ≠ 0)
-    (Hask : SK → F) (Hnk : SK → B) (Hrivk_legacy : SK → F)
-    (Hrivk_ext : QK → B → B → F) (Hrivk_int : F → B → B → F)
-    {w₁ w₂ : Witness G F B SK QK}
+    (Hask : SK → F) (Hnk : SK → NK) (Hrivk_legacy : SK → F)
+    (Hrivk_ext : QK → AK → NK → F) (Hrivk_int : F → AK → NK → F)
+    {w₁ w₂ : Witness G F AK NK SK QK}
     (hbrk : Break Extract S hfn Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int w₁ w₂) :
     hfn (Extract w₁.akP) w₁.nk + (finalQueryOf Extract w₁).eval Hrivk_legacy Hrivk_ext Hrivk_int
       =± hfn (Extract w₂.akP) w₂.nk + (finalQueryOf Extract w₂).eval Hrivk_legacy Hrivk_ext Hrivk_int :=
@@ -423,40 +426,40 @@ theorem break_finalOracle_pm
 
 /-- The break projection an *externally-decoded* witness must have, read off its
 `rivk_ext`-derivation query (`proj_eq_projOfQuery`); `.int` is not in `extQueryOf`'s image. -/
-def projOfQuery (Extract : G → B) (Ggen : G) (Hask : SK → F) (Hnk : SK → B)
-    (Hrivk_legacy : SK → F) (Hrivk_ext : QK → B → B → F) :
-    FinalQuery QK SK B F → Option (BreakProj QK SK B F)
+def projOfQuery (Extract : G → AK) (Ggen : G) (Hask : SK → F) (Hnk : SK → NK)
+    (Hrivk_legacy : SK → F) (Hrivk_ext : QK → AK → NK → F) :
+    FinalQuery QK SK AK NK F → Option (BreakProj QK SK AK NK F)
   | .ext qk ak nk => some ⟨.qk qk, ak, nk, Hrivk_ext qk ak nk⟩
   | .legacy sk => some ⟨.sk sk, Extract ((Hask sk) • Ggen), Hnk sk, Hrivk_legacy sk⟩
   | .int _ _ _ => none
 
 /-- The Branch data of a witness, read off its `rivk_ext`-derivation query
 (`branch_eq_branchOfQuery`); `.int` is not in `extQueryOf`'s image. -/
-def branchOfQuery : FinalQuery QK SK B F → Option (Branch QK SK)
+def branchOfQuery : FinalQuery QK SK AK NK F → Option (Branch QK SK)
   | .ext qk _ _ => some (.qk qk)
   | .legacy sk => some (.sk sk)
   | .int _ _ _ => none
 
-omit [AddCommGroup G] [Field F] [Field B] [NoZeroSMulDivisors F G] [DecidableEq F] in
+omit [AddCommGroup G] [Field F] [Field AK] [NoZeroSMulDivisors F G] [DecidableEq F] in
 /-- A witness's Branch data is recoverable from its `rivk_ext`-derivation query. -/
-theorem branch_eq_branchOfQuery {w : Witness G F B SK QK} (Extract : G → B) :
+theorem branch_eq_branchOfQuery {w : Witness G F AK NK SK QK} (Extract : G → AK) :
     some w.qk_or_sk = branchOfQuery (extQueryOf Extract w) := by
   rcases hb : w.qk_or_sk with qk | sk <;> simp [extQueryOf, branchOfQuery, hb]
 
-omit [AddCommGroup G] [Field F] [Field B] [NoZeroSMulDivisors F G] [DecidableEq F] in
+omit [AddCommGroup G] [Field F] [Field AK] [NoZeroSMulDivisors F G] [DecidableEq F] in
 /-- A witness's `rivk_ext`-derivation query is never `.int`. -/
-theorem extQueryOf_ne_int {w : Witness G F B SK QK} (Extract : G → B) (rivk_ext : F) (ak nk : B) :
+theorem extQueryOf_ne_int {w : Witness G F AK NK SK QK} (Extract : G → AK) (rivk_ext : F) (ak : AK) (nk : NK) :
     extQueryOf Extract w ≠ .int rivk_ext ak nk := by
   rcases hb : w.qk_or_sk with qk | sk <;> simp [extQueryOf, hb]
 
-omit [Field B] [NoZeroSMulDivisors F G] [DecidableEq F] in
+omit [Field AK] [NoZeroSMulDivisors F G] [DecidableEq F] in
 /-- An externally-decoded witness's break projection is recoverable from its `rivk_ext`-derivation
 query: the derivation constraints determine every component from the query. -/
 theorem proj_eq_projOfQuery
-    (Extract : G → B) (Ggen : G)
-    (Hask : SK → F) (Hnk : SK → B) (Hrivk_legacy : SK → F)
-    (Hrivk_ext : QK → B → B → F) (Hrivk_int : F → B → B → F)
-    {w : Witness G F B SK QK}
+    (Extract : G → AK) (Ggen : G)
+    (Hask : SK → F) (Hnk : SK → NK) (Hrivk_legacy : SK → F)
+    (Hrivk_ext : QK → AK → NK → F) (Hrivk_int : F → AK → NK → F)
+    {w : Witness G F AK NK SK QK}
     (hd : KBDerivation Extract Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int w)
     (hext : w.rivk = w.rivk_ext) :
     some (w.breakProj Extract)
@@ -468,15 +471,15 @@ theorem proj_eq_projOfQuery
   · obtain ⟨hakP, hnk, hre⟩ := hbc
     rw [hakP, hnk, hext.trans hre]
 
-omit [Field B] [NoZeroSMulDivisors F G] [DecidableEq F] in
+omit [Field AK] [NoZeroSMulDivisors F G] [DecidableEq F] in
 /-- A witness's shifted-oracle output at its `rivk_ext`-derivation query is
 `hfn (ak, nk) + rivk_ext`: the derivation constraints collapse the per-branch shift to the
 witness's own key data. -/
 theorem shiftedFinalOracle_extQueryOf
-    (Extract : G → B) (Ggen : G) (hfn : B → B → F)
-    (Hask : SK → F) (Hnk : SK → B) (Hrivk_legacy : SK → F)
-    (Hrivk_ext : QK → B → B → F) (Hrivk_int : F → B → B → F)
-    {w : Witness G F B SK QK}
+    (Extract : G → AK) (Ggen : G) (hfn : AK → NK → F)
+    (Hask : SK → F) (Hnk : SK → NK) (Hrivk_legacy : SK → F)
+    (Hrivk_ext : QK → AK → NK → F) (Hrivk_int : F → AK → NK → F)
+    {w : Witness G F AK NK SK QK}
     (hd : KBDerivation Extract Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int w) :
     shiftedFinalOracle Extract Ggen hfn Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int
         (extQueryOf Extract w)
@@ -494,10 +497,10 @@ witnesses are internally derived, sharing `(ak, nk, rivk_ext, rivk)` and differi
 The collision then relocates to the `rivk_ext`-derivation queries, at which the shifted oracle's
 outputs are *equal* and the queries are *distinct*. -/
 theorem residual_of_finalQuery_eq
-    (Extract : G → B) (S : G) (hfn : B → B → F) (Ggen : G)
-    (Hask : SK → F) (Hnk : SK → B) (Hrivk_legacy : SK → F)
-    (Hrivk_ext : QK → B → B → F) (Hrivk_int : F → B → B → F)
-    {w₁ w₂ : Witness G F B SK QK}
+    (Extract : G → AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
+    (Hask : SK → F) (Hnk : SK → NK) (Hrivk_legacy : SK → F)
+    (Hrivk_ext : QK → AK → NK → F) (Hrivk_int : F → AK → NK → F)
+    {w₁ w₂ : Witness G F AK NK SK QK}
     (hbrk : Break Extract S hfn Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int w₁ w₂)
     (hq : finalQueryOf Extract w₁ = finalQueryOf Extract w₂) :
     extQueryOf Extract w₁ ≠ extQueryOf Extract w₂ ∧
@@ -552,12 +555,12 @@ coincide. What the birthday bound then adds is that inhabiting this event is har
 non-querying, so a fixed shift cannot be steered to manufacture collisions, and ±-colliding the
 shifted oracle at distinct queries has probability at most `q(q-1)/r` (`Birthday.lean`). -/
 def _root_.Zcash.Security.RandomOracle.CollisionUpToSign.ofBreak
-    [DecidableEq QK] [DecidableEq SK] [DecidableEq B]
-    (Extract : G → B) (S : G) (hfn : B → B → F) (Ggen : G)
+    [DecidableEq QK] [DecidableEq SK] [DecidableEq AK] [DecidableEq NK]
+    (Extract : G → AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
     (hExt : ∀ P Q : G, Extract P = Extract Q ↔ P =± Q) (hS : S ≠ 0)
-    (Hask : SK → F) (Hnk : SK → B) (Hrivk_legacy : SK → F)
-    (Hrivk_ext : QK → B → B → F) (Hrivk_int : F → B → B → F)
-    {w₁ w₂ : Witness G F B SK QK}
+    (Hask : SK → F) (Hnk : SK → NK) (Hrivk_legacy : SK → F)
+    (Hrivk_ext : QK → AK → NK → F) (Hrivk_int : F → AK → NK → F)
+    {w₁ w₂ : Witness G F AK NK SK QK}
     (hbrk : Break Extract S hfn Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int w₁ w₂) :
     RandomOracle.CollisionUpToSign
       (shiftedFinalOracle Extract Ggen hfn Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int
@@ -581,16 +584,16 @@ def _root_.Zcash.Security.RandomOracle.CollisionUpToSign.ofBreak
         exact break_finalOracle_pm Extract S hfn Ggen hExt hS Hask Hnk Hrivk_legacy Hrivk_ext
           Hrivk_int hbrk }
 
-omit [Field B] [NoZeroSMulDivisors F G] in
+omit [Field AK] [NoZeroSMulDivisors F G] in
 /-- **The bridge to the birthday counting**: the pair of `H^*` outputs at a shifted-oracle
 ±-collision's queries lies in the shifted ±-collision set that
 `Birthday.card_shifted_pm_collision_le` counts, with the shifts read off the queries. Combined
 with the collision's `ne` field (distinct queries) this is the per-pair event whose fraction the
 birthday layer bounds by `2/|F|`. -/
 theorem collision_mem_shifted_pm [Fintype F]
-    (Extract : G → B) (Ggen : G) (hfn : B → B → F)
-    (Hask : SK → F) (Hnk : SK → B) (Hrivk_legacy : SK → F)
-    (Hrivk_ext : QK → B → B → F) (Hrivk_int : F → B → B → F)
+    (Extract : G → AK) (Ggen : G) (hfn : AK → NK → F)
+    (Hask : SK → F) (Hnk : SK → NK) (Hrivk_legacy : SK → F)
+    (Hrivk_ext : QK → AK → NK → F) (Hrivk_int : F → AK → NK → F)
     (c : RandomOracle.CollisionUpToSign
       (shiftedFinalOracle Extract Ggen hfn Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int
         (QK := QK) (SK := SK))) :

--- a/Zcash/Security/KeyBinding/Instance.lean
+++ b/Zcash/Security/KeyBinding/Instance.lean
@@ -20,7 +20,7 @@ variable {G IVK AK NK RIVK ASK QK SK : Type*}
 
 /-- The concrete key-binding witness, viewed through the games' `KeyBindingInterface`. -/
 def KeyBinding.toInterface
-    [AddCommGroup G] [Field RIVK] [Field IVK] [Module RIVK G] [SMul ASK G]
+    [AddCommGroup G] [Field IVK] [Field RIVK] [Module RIVK G] [SMul ASK G]
     (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK) (Ggen : G)
     (H : Oracles AK NK RIVK ASK QK SK) :
     KeyBindingInterface (KeyBinding.Witness G IVK AK NK RIVK QK SK) G IVK NK where
@@ -41,10 +41,10 @@ probability at most `(n+4)·(n+3)/|F|`. `toInterface` interprets `Break` as
 `KeyBinding.Break` definitionally, so the games' `∨ kv.Break` branches inherit the bound
 directly. -/
 theorem toInterface_break_measure_le {ι : Type*}
-    [AddCommGroup G] [Field RIVK] [Field IVK] [Module RIVK G] [NoZeroSMulDivisors RIVK G]
-    [SMul ASK G] [Fintype QK] [Fintype SK] [Fintype AK] [Fintype NK] [Fintype RIVK]
-    [Fintype ASK] [Nonempty ASK] [Nonempty NK]
-    [DecidableEq QK] [DecidableEq SK] [DecidableEq AK] [DecidableEq NK] [DecidableEq RIVK]
+    [AddCommGroup G] [Field IVK] [Field RIVK] [Module RIVK G] [NoZeroSMulDivisors RIVK G]
+    [SMul ASK G] [Fintype AK] [Fintype NK] [Fintype RIVK] [Fintype ASK] [Fintype QK]
+    [Fintype SK] [Nonempty NK] [Nonempty ASK]
+    [DecidableEq AK] [DecidableEq NK] [DecidableEq RIVK] [DecidableEq QK] [DecidableEq SK]
     (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK) (Ggen : G) (hS : S ≠ 0) (p : PMF ι)
     {A : ι → OracleComp (FinalQuery AK NK RIVK QK SK) RIVK
       (KeyBinding.Witness G IVK AK NK RIVK QK SK × KeyBinding.Witness G IVK AK NK RIVK QK SK)}

--- a/Zcash/Security/KeyBinding/Instance.lean
+++ b/Zcash/Security/KeyBinding/Instance.lean
@@ -21,17 +21,15 @@ variable {G F AK NK SK QK : Type*}
 def KeyBinding.toInterface
     [AddCommGroup G] [Field F] [Field AK] [Module F G]
     (Extract : G → AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
-    (Hask : SK → F) (Hnk : SK → NK) (Hrivk_legacy : SK → F)
-    (Hrivk_ext : QK → AK → NK → F) (Hrivk_int : F → AK → NK → F) :
+    (H : Oracles F AK NK SK QK) :
     KeyBindingInterface (KeyBinding.Witness G F AK NK SK QK) G AK NK where
   ivk w := w.ivk
   nk w := w.nk
   akP w := w.akP
-  KB := KeyBinding.KB Extract S hfn Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int
-  Break := KeyBinding.Break Extract S hfn Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int
+  KB := KeyBinding.KB Extract S hfn Ggen H
+  Break := KeyBinding.Break Extract S hfn Ggen H
   break_of_nk_ne {_w₁ _w₂} h₁ h₂ hivk hne := by
     by_contra hnb
-    exact hne (KeyBinding.nk_pinned Extract S hfn Ggen Hask Hnk Hrivk_legacy
-      Hrivk_ext Hrivk_int h₁ h₂ hivk hnb)
+    exact hne (KeyBinding.nk_pinned Extract S hfn Ggen H h₁ h₂ hivk hnb)
 
 end Zcash.Security

--- a/Zcash/Security/KeyBinding/Instance.lean
+++ b/Zcash/Security/KeyBinding/Instance.lean
@@ -15,14 +15,14 @@ namespace Zcash.Security
 
 open Zcash.Security.KeyBinding Zcash.Security.Ledger
 
-variable {G F AK NK SK QK : Type*}
+variable {G F IVK AK NK SK QK : Type*}
 
 /-- The concrete key-binding witness, viewed through the games' `KeyBindingInterface`. -/
 def KeyBinding.toInterface
-    [AddCommGroup G] [Field F] [Field AK] [Module F G]
-    (Extract : G → AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
+    [AddCommGroup G] [Field F] [Field IVK] [Module F G]
+    (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
     (H : Oracles F AK NK SK QK) :
-    KeyBindingInterface (KeyBinding.Witness G F AK NK SK QK) G AK NK where
+    KeyBindingInterface (KeyBinding.Witness G F IVK AK NK SK QK) G IVK NK where
   ivk w := w.ivk
   nk w := w.nk
   akP w := w.akP

--- a/Zcash/Security/KeyBinding/Instance.lean
+++ b/Zcash/Security/KeyBinding/Instance.lean
@@ -29,9 +29,8 @@ def KeyBinding.toInterface
   akP w := w.akP
   KB := KeyBinding.KB Extract S hfn Ggen H
   Break := KeyBinding.Break Extract S hfn Ggen H
-  break_of_nk_ne {_w₁ _w₂} h₁ h₂ hivk hne := by
-    by_contra hnb
-    exact hne (KeyBinding.nk_pinned Extract S hfn Ggen H h₁ h₂ hivk hnb)
+  break_of_nk_ne {_w₁ _w₂} h₁ h₂ hivk hne :=
+    ⟨h₁, h₂, hivk, fun heq => hne (congrArg BreakProj.nk heq)⟩
 
 
 /-- The probabilistic key-binding bound, delivered at the games' interface: over the

--- a/Zcash/Security/KeyBinding/Instance.lean
+++ b/Zcash/Security/KeyBinding/Instance.lean
@@ -16,14 +16,14 @@ namespace Zcash.Security
 
 open Zcash.Security.KeyBinding Zcash.Security.Ledger Zcash.Security.RandomOracle Zcash.Snark
 
-variable {G F IVK AK NK SK QK : Type*}
+variable {G IVK AK NK RIVK ASK QK SK : Type*}
 
 /-- The concrete key-binding witness, viewed through the games' `KeyBindingInterface`. -/
 def KeyBinding.toInterface
-    [AddCommGroup G] [Field F] [Field IVK] [Module F G]
-    (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
-    (H : Oracles F AK NK SK QK) :
-    KeyBindingInterface (KeyBinding.Witness G F IVK AK NK SK QK) G IVK NK where
+    [AddCommGroup G] [Field RIVK] [Field IVK] [Module RIVK G] [SMul ASK G]
+    (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK) (Ggen : G)
+    (H : Oracles AK NK RIVK ASK QK SK) :
+    KeyBindingInterface (KeyBinding.Witness G IVK AK NK RIVK QK SK) G IVK NK where
   ivk w := w.ivk
   nk w := w.nk
   akP w := w.akP
@@ -41,26 +41,27 @@ probability at most `(n+4)·(n+3)/|F|`. `toInterface` interprets `Break` as
 `KeyBinding.Break` definitionally, so the games' `∨ kv.Break` branches inherit the bound
 directly. -/
 theorem toInterface_break_measure_le {ι : Type*}
-    [AddCommGroup G] [Field F] [Field IVK] [Module F G] [NoZeroSMulDivisors F G]
-    [Fintype QK] [Fintype SK] [Fintype AK] [Fintype NK] [Fintype F] [Nonempty NK]
-    [DecidableEq QK] [DecidableEq SK] [DecidableEq AK] [DecidableEq NK] [DecidableEq F]
-    (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (Ggen : G) (hS : S ≠ 0) (p : PMF ι)
-    {A : ι → OracleComp (FinalQuery QK SK AK NK F) F
-      (KeyBinding.Witness G F IVK AK NK SK QK × KeyBinding.Witness G F IVK AK NK SK QK)}
+    [AddCommGroup G] [Field RIVK] [Field IVK] [Module RIVK G] [NoZeroSMulDivisors RIVK G]
+    [SMul ASK G] [Fintype QK] [Fintype SK] [Fintype AK] [Fintype NK] [Fintype RIVK]
+    [Fintype ASK] [Nonempty ASK] [Nonempty NK]
+    [DecidableEq QK] [DecidableEq SK] [DecidableEq AK] [DecidableEq NK] [DecidableEq RIVK]
+    (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK) (Ggen : G) (hS : S ≠ 0) (p : PMF ι)
+    {A : ι → OracleComp (FinalQuery AK NK RIVK QK SK) RIVK
+      (KeyBinding.Witness G IVK AK NK RIVK QK SK × KeyBinding.Witness G IVK AK NK RIVK QK SK)}
     {n : ℕ} (hQ : ∀ i, (A i).QueryBound n) :
-    ((p.bind fun i => (PMF.uniformOfFintype (SK → F)).bind fun Hask =>
+    ((p.bind fun i => (PMF.uniformOfFintype (SK → ASK)).bind fun Hask =>
         (PMF.uniformOfFintype (SK → NK)).bind fun Hnk =>
-          (PMF.uniformOfFintype (SK → F)).bind fun Hleg =>
-            (PMF.uniformOfFintype (QK → AK → NK → F)).bind fun Hext =>
-              (PMF.uniformOfFintype (F → AK → NK → F)).map fun Hint =>
+          (PMF.uniformOfFintype (SK → RIVK)).bind fun Hleg =>
+            (PMF.uniformOfFintype (QK → AK → NK → RIVK)).bind fun Hext =>
+              (PMF.uniformOfFintype (RIVK → AK → NK → RIVK)).map fun Hint =>
                 (i, Hask, Hnk, FinalQuery.eval Hleg Hext Hint))).toOuterMeasure
-        {x : ι × (SK → F) × (SK → NK) × (FinalQuery QK SK AK NK F → F) |
+        {x : ι × (SK → ASK) × (SK → NK) × (FinalQuery AK NK RIVK QK SK → RIVK) |
           (KeyBinding.toInterface Extract S hfn Ggen
               ⟨x.2.1, x.2.2.1, fun sk => x.2.2.2 (.legacy sk),
                 fun qk ak nk => x.2.2.2 (.ext qk ak nk),
                 fun rivk_ext ak nk => x.2.2.2 (.int rivk_ext ak nk)⟩).Break
             ((A x.1).run x.2.2.2).1 ((A x.1).run x.2.2.2).2}
-      ≤ ((n + 4) * (n + 3) : ℕ) / Fintype.card F :=
+      ≤ ((n + 4) * (n + 3) : ℕ) / Fintype.card RIVK :=
   KeyBinding.break_measure_le_product Extract S hfn Ggen hS p hQ
 
 

--- a/Zcash/Security/KeyBinding/Instance.lean
+++ b/Zcash/Security/KeyBinding/Instance.lean
@@ -36,7 +36,8 @@ def KeyBinding.toInterface
 
 /-- The probabilistic key-binding bound, delivered at the games' interface: over the
 adversary's private randomness (any distribution `p`) and the five independent oracle
-tables, a bounded-query machine's output witnesses exhibit the interface's `Break` with
+tables, a bounded-query machine — receiving the sampled `H^ask`/`H^nk` tables and querying
+the combined rivk table — has output witnesses exhibiting the interface's `Break` with
 probability at most `(n+4)·(n+3)/|F|`. `toInterface` interprets `Break` as
 `KeyBinding.Break` definitionally, so the games' `∨ kv.Break` branches inherit the bound
 directly. -/
@@ -46,21 +47,21 @@ theorem toInterface_break_measure_le {ι : Type*}
     [Fintype SK] [Nonempty NK] [Nonempty ASK]
     [DecidableEq AK] [DecidableEq NK] [DecidableEq RIVK] [DecidableEq QK] [DecidableEq SK]
     (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK) (Ggen : G) (hS : S ≠ 0) (p : PMF ι)
-    {A : ι → OracleComp (FinalQuery AK NK RIVK QK SK) RIVK
+    {A : ι → (SK → ASK) → (SK → NK) → OracleComp (FinalQuery AK NK RIVK QK SK) RIVK
       (KeyBinding.Witness G IVK AK NK RIVK QK SK × KeyBinding.Witness G IVK AK NK RIVK QK SK)}
-    {n : ℕ} (hQ : ∀ i, (A i).QueryBound n) :
+    {n : ℕ} (hQ : ∀ i Hask Hnk, (A i Hask Hnk).QueryBound n) :
     ((p.bind fun i => (PMF.uniformOfFintype (SK → ASK)).bind fun Hask =>
         (PMF.uniformOfFintype (SK → NK)).bind fun Hnk =>
           (PMF.uniformOfFintype (SK → RIVK)).bind fun Hleg =>
             (PMF.uniformOfFintype (QK → AK → NK → RIVK)).bind fun Hext =>
               (PMF.uniformOfFintype (RIVK → AK → NK → RIVK)).map fun Hint =>
                 (i, Hask, Hnk, FinalQuery.eval Hleg Hext Hint))).toOuterMeasure
-        {x : ι × (SK → ASK) × (SK → NK) × (FinalQuery AK NK RIVK QK SK → RIVK) |
+        (setOf fun (i, Hask, Hnk, O) =>
           (KeyBinding.toInterface Extract S hfn Ggen
-              ⟨x.2.1, x.2.2.1, fun sk => x.2.2.2 (.legacy sk),
-                fun qk ak nk => x.2.2.2 (.ext qk ak nk),
-                fun rivk_ext ak nk => x.2.2.2 (.int rivk_ext ak nk)⟩).Break
-            ((A x.1).run x.2.2.2).1 ((A x.1).run x.2.2.2).2}
+              ⟨Hask, Hnk, fun sk => O (.legacy sk),
+                fun qk ak nk => O (.ext qk ak nk),
+                fun rivk_ext ak nk => O (.int rivk_ext ak nk)⟩).Break
+            ((A i Hask Hnk).run O).1 ((A i Hask Hnk).run O).2)
       ≤ ((n + 4) * (n + 3) : ℕ) / Fintype.card RIVK :=
   KeyBinding.break_measure_le_product Extract S hfn Ggen hS p hQ
 

--- a/Zcash/Security/KeyBinding/Instance.lean
+++ b/Zcash/Security/KeyBinding/Instance.lean
@@ -44,8 +44,7 @@ theorem toInterface_break_measure_le {ι : Type*}
     [AddCommGroup G] [Field F] [Field IVK] [Module F G] [NoZeroSMulDivisors F G]
     [Fintype QK] [Fintype SK] [Fintype AK] [Fintype NK] [Fintype F] [Nonempty NK]
     [DecidableEq QK] [DecidableEq SK] [DecidableEq AK] [DecidableEq NK] [DecidableEq F]
-    (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
-    (hExt : ∀ P R : G, Extract.toIVK P = Extract.toIVK R ↔ P =± R) (hS : S ≠ 0) (p : PMF ι)
+    (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (Ggen : G) (hS : S ≠ 0) (p : PMF ι)
     {A : ι → OracleComp (FinalQuery QK SK AK NK F) F
       (KeyBinding.Witness G F IVK AK NK SK QK × KeyBinding.Witness G F IVK AK NK SK QK)}
     {n : ℕ} (hQ : ∀ i, (A i).QueryBound n) :
@@ -62,7 +61,7 @@ theorem toInterface_break_measure_le {ι : Type*}
                 fun rivk_ext ak nk => x.2.2.2 (.int rivk_ext ak nk)⟩).Break
             ((A x.1).run x.2.2.2).1 ((A x.1).run x.2.2.2).2}
       ≤ ((n + 4) * (n + 3) : ℕ) / Fintype.card F :=
-  KeyBinding.break_measure_le_product Extract S hfn Ggen hExt hS p hQ
+  KeyBinding.break_measure_le_product Extract S hfn Ggen hS p hQ
 
 
 end Zcash.Security

--- a/Zcash/Security/KeyBinding/Instance.lean
+++ b/Zcash/Security/KeyBinding/Instance.lean
@@ -15,15 +15,15 @@ namespace Zcash.Security
 
 open Zcash.Security.KeyBinding Zcash.Security.Ledger
 
-variable {G F B SK QK : Type*}
+variable {G F AK NK SK QK : Type*}
 
 /-- The concrete key-binding witness, viewed through the games' `KeyBindingInterface`. -/
 def KeyBinding.toInterface
-    [AddCommGroup G] [Field F] [Field B] [Module F G]
-    (Extract : G → B) (S : G) (hfn : B → B → F) (Ggen : G)
-    (Hask : SK → F) (Hnk : SK → B) (Hrivk_legacy : SK → F)
-    (Hrivk_ext : QK → B → B → F) (Hrivk_int : F → B → B → F) :
-    KeyBindingInterface (KeyBinding.Witness G F B SK QK) G B where
+    [AddCommGroup G] [Field F] [Field AK] [Module F G]
+    (Extract : G → AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
+    (Hask : SK → F) (Hnk : SK → NK) (Hrivk_legacy : SK → F)
+    (Hrivk_ext : QK → AK → NK → F) (Hrivk_int : F → AK → NK → F) :
+    KeyBindingInterface (KeyBinding.Witness G F AK NK SK QK) G AK NK where
   ivk w := w.ivk
   nk w := w.nk
   akP w := w.akP

--- a/Zcash/Security/KeyBinding/Instance.lean
+++ b/Zcash/Security/KeyBinding/Instance.lean
@@ -1,4 +1,5 @@
 import Zcash.Security.KeyBinding.Basic
+import Zcash.Security.KeyBinding.Probability
 import Zcash.Security.Ledger.Statement
 
 /-!
@@ -13,7 +14,7 @@ only the projections and the `break_of_nk_ne` guarantee; here we discharge that 
 
 namespace Zcash.Security
 
-open Zcash.Security.KeyBinding Zcash.Security.Ledger
+open Zcash.Security.KeyBinding Zcash.Security.Ledger Zcash.Security.RandomOracle Zcash.Snark
 
 variable {G F IVK AK NK SK QK : Type*}
 
@@ -31,5 +32,37 @@ def KeyBinding.toInterface
   break_of_nk_ne {_w₁ _w₂} h₁ h₂ hivk hne := by
     by_contra hnb
     exact hne (KeyBinding.nk_pinned Extract S hfn Ggen H h₁ h₂ hivk hnb)
+
+
+/-- The probabilistic key-binding bound, delivered at the games' interface: over the
+adversary's private randomness (any distribution `p`) and the five independent oracle
+tables, a bounded-query machine's output witnesses exhibit the interface's `Break` with
+probability at most `(n+4)·(n+3)/|F|`. `toInterface` interprets `Break` as
+`KeyBinding.Break` definitionally, so the games' `∨ kv.Break` branches inherit the bound
+directly. -/
+theorem toInterface_break_measure_le {ι : Type*}
+    [AddCommGroup G] [Field F] [Field IVK] [Module F G] [NoZeroSMulDivisors F G]
+    [Fintype QK] [Fintype SK] [Fintype AK] [Fintype NK] [Fintype F] [Nonempty NK]
+    [DecidableEq QK] [DecidableEq SK] [DecidableEq AK] [DecidableEq NK] [DecidableEq F]
+    (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
+    (hExt : ∀ P R : G, Extract.toIVK P = Extract.toIVK R ↔ P =± R) (hS : S ≠ 0) (p : PMF ι)
+    {A : ι → OracleComp (FinalQuery QK SK AK NK F) F
+      (KeyBinding.Witness G F IVK AK NK SK QK × KeyBinding.Witness G F IVK AK NK SK QK)}
+    {n : ℕ} (hQ : ∀ i, (A i).QueryBound n) :
+    ((p.bind fun i => (PMF.uniformOfFintype (SK → F)).bind fun Hask =>
+        (PMF.uniformOfFintype (SK → NK)).bind fun Hnk =>
+          (PMF.uniformOfFintype (SK → F)).bind fun Hleg =>
+            (PMF.uniformOfFintype (QK → AK → NK → F)).bind fun Hext =>
+              (PMF.uniformOfFintype (F → AK → NK → F)).map fun Hint =>
+                (i, Hask, Hnk, FinalQuery.eval Hleg Hext Hint))).toOuterMeasure
+        {x : ι × (SK → F) × (SK → NK) × (FinalQuery QK SK AK NK F → F) |
+          (KeyBinding.toInterface Extract S hfn Ggen
+              ⟨x.2.1, x.2.2.1, fun sk => x.2.2.2 (.legacy sk),
+                fun qk ak nk => x.2.2.2 (.ext qk ak nk),
+                fun rivk_ext ak nk => x.2.2.2 (.int rivk_ext ak nk)⟩).Break
+            ((A x.1).run x.2.2.2).1 ((A x.1).run x.2.2.2).2}
+      ≤ ((n + 4) * (n + 3) : ℕ) / Fintype.card F :=
+  KeyBinding.break_measure_le_product Extract S hfn Ggen hExt hS p hQ
+
 
 end Zcash.Security

--- a/Zcash/Security/KeyBinding/Probability.lean
+++ b/Zcash/Security/KeyBinding/Probability.lean
@@ -13,7 +13,7 @@ This module adds the probabilistic model that turns those counting facts into a 
 bound.
 
 The model samples the combined final `rivk`-derivation oracle `H^*` as one uniform table
-`O : FinalQuery QK SK B F → F`. A uniform table is the same as independent uniform outputs at
+`O : FinalQuery QK SK AK NK F → F`. A uniform table is the same as independent uniform outputs at
 every query — the product structure of the uniform measure. (In Markov-category terms `PMF` is a
 commutative monad, so samples reorder freely; see Fritz [eprint arXiv:1908.07021] and
 `Mathlib.CategoryTheory.MarkovCategory` for the abstract setting.) The three constituent oracles
@@ -59,12 +59,12 @@ namespace Zcash.Security.KeyBinding
 open Finset Zcash.Security.RandomOracle Zcash.Security.Birthday Zcash.Snark
 open scoped ENNReal
 
-variable {G F B SK QK : Type*}
+variable {G F AK NK SK QK : Type*}
 
 /-! ## Finiteness of the query space -/
 
 /-- `FinalQuery` as the sum of its constructors' data. -/
-def finalQueryEquiv : FinalQuery QK SK B F ≃ (QK × B × B) ⊕ SK ⊕ (F × B × B) where
+def finalQueryEquiv : FinalQuery QK SK AK NK F ≃ (QK × AK × NK) ⊕ SK ⊕ (F × AK × NK) where
   toFun
     | .ext qk ak nk => .inl (qk, ak, nk)
     | .legacy sk => .inr (.inl sk)
@@ -76,13 +76,13 @@ def finalQueryEquiv : FinalQuery QK SK B F ≃ (QK × B × B) ⊕ SK ⊕ (F × B
   left_inv q := by cases q <;> rfl
   right_inv x := by rcases x with ⟨qk, ak, nk⟩ | sk | ⟨rivk_ext, ak, nk⟩ <;> rfl
 
-instance [Fintype QK] [Fintype SK] [Fintype B] [Fintype F] :
-    Fintype (FinalQuery QK SK B F) :=
+instance [Fintype QK] [Fintype SK] [Fintype AK] [Fintype NK] [Fintype F] :
+    Fintype (FinalQuery QK SK AK NK F) :=
   Fintype.ofEquiv _ finalQueryEquiv.symm
 
 /-- Assembling the combined final oracle from a table's constructor restrictions gives back the
 table. -/
-theorem eval_restrict (O : FinalQuery QK SK B F → F) :
+theorem eval_restrict (O : FinalQuery QK SK AK NK F → F) :
     FinalQuery.eval (fun sk => O (.legacy sk)) (fun qk ak nk => O (.ext qk ak nk))
       (fun rivk_ext ak nk => O (.int rivk_ext ak nk)) = O := by
   funext q; cases q <;> rfl
@@ -502,20 +502,20 @@ theorem toOuterMeasure_bind_le {α β : Type*} (p : PMF α) (f : α → PMF β) 
 
 section Capstone
 
-variable [AddCommGroup G] [Field F] [Field B] [Module F G] [NoZeroSMulDivisors F G]
-variable [Fintype QK] [Fintype SK] [Fintype B] [Fintype F]
-variable [DecidableEq QK] [DecidableEq SK] [DecidableEq B] [DecidableEq F]
+variable [AddCommGroup G] [Field F] [Field AK] [Module F G] [NoZeroSMulDivisors F G]
+variable [Fintype QK] [Fintype SK] [Fintype AK] [Fintype NK] [Fintype F]
+variable [DecidableEq QK] [DecidableEq SK] [DecidableEq AK] [DecidableEq NK] [DecidableEq F]
 
-omit [Fintype QK] [Fintype SK] [Fintype B] [Fintype F] in
+omit [Fintype QK] [Fintype SK] [Fintype AK] [Fintype NK] [Fintype F] in
 /-- The queries at which `CollisionUpToSign.ofBreak` exhibits its collision are the witnesses'
 derivation queries: the `rivk_ext`-derivation pair in the residual case, the final-query pair
 otherwise. Stated over any `c` equal to the computed collision (`hc`), so that a consumer's
 `set c := CollisionUpToSign.ofBreak ... with hc` supplies `hc` directly. -/
-theorem ofBreak_queries {Extract : G → B} {S : G} {hfn : B → B → F} {Ggen : G}
+theorem ofBreak_queries {Extract : G → AK} {S : G} {hfn : AK → NK → F} {Ggen : G}
     {hExt : ∀ P R : G, Extract P = Extract R ↔ P =± R} {hS : S ≠ 0}
-    {Hask : SK → F} {Hnk : SK → B} {Hrivk_legacy : SK → F}
-    {Hrivk_ext : QK → B → B → F} {Hrivk_int : F → B → B → F}
-    {w₁ w₂ : Witness G F B SK QK}
+    {Hask : SK → F} {Hnk : SK → NK} {Hrivk_legacy : SK → F}
+    {Hrivk_ext : QK → AK → NK → F} {Hrivk_int : F → AK → NK → F}
+    {w₁ w₂ : Witness G F AK NK SK QK}
     {hbrk : Break Extract S hfn Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int w₁ w₂}
     {c : RandomOracle.CollisionUpToSign
       (shiftedFinalOracle Extract Ggen hfn Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int
@@ -535,15 +535,15 @@ table. An adversary —here, any pair of witness choices depending on the whole 
 witnesses' derivation queries lie in a set `Qs` of at most `q` queries *fixed in advance*,
 produces a key-binding `Break` with probability at most `q·(q−1)/|F|`. This is ZIP 2005's
 `ε_kb` at `|F| = r`. -/
-theorem break_measure_le (Extract : G → B) (S : G) (hfn : B → B → F) (Ggen : G)
+theorem break_measure_le (Extract : G → AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
     (hExt : ∀ P R : G, Extract P = Extract R ↔ P =± R) (hS : S ≠ 0)
-    (Hask : SK → F) (Hnk : SK → B)
-    (w₁ w₂ : (FinalQuery QK SK B F → F) → Witness G F B SK QK)
-    (Qs : Finset (FinalQuery QK SK B F)) {q : ℕ} (hq : Qs.card ≤ q)
+    (Hask : SK → F) (Hnk : SK → NK)
+    (w₁ w₂ : (FinalQuery QK SK AK NK F → F) → Witness G F AK NK SK QK)
+    (Qs : Finset (FinalQuery QK SK AK NK F)) {q : ℕ} (hq : Qs.card ≤ q)
     (hqueries : ∀ O, finalQueryOf Extract (w₁ O) ∈ Qs ∧ finalQueryOf Extract (w₂ O) ∈ Qs ∧
       extQueryOf Extract (w₁ O) ∈ Qs ∧ extQueryOf Extract (w₂ O) ∈ Qs) :
-    (PMF.uniformOfFintype (FinalQuery QK SK B F → F)).toOuterMeasure
-        {O : FinalQuery QK SK B F → F |
+    (PMF.uniformOfFintype (FinalQuery QK SK AK NK F → F)).toOuterMeasure
+        {O : FinalQuery QK SK AK NK F → F |
           Break Extract S hfn Ggen Hask Hnk
             (fun sk => O (.legacy sk)) (fun qk ak nk => O (.ext qk ak nk))
             (fun rivk_ext ak nk => O (.int rivk_ext ak nk)) (w₁ O) (w₂ O)}
@@ -567,23 +567,23 @@ theorem break_measure_le (Extract : G → B) (S : G) (hfn : B → B → F) (Ggen
 /-- The derivation queries of an output witness pair: the final and `rivk_ext`-derivation
 queries of both witnesses — the four points at which `CollisionUpToSign.ofBreak` can exhibit
 its collision. -/
-def derivQueries (Extract : G → B)
-    (w : Witness G F B SK QK × Witness G F B SK QK) : Fin 4 → FinalQuery QK SK B F :=
+def derivQueries (Extract : G → AK)
+    (w : Witness G F AK NK SK QK × Witness G F AK NK SK QK) : Fin 4 → FinalQuery QK SK AK NK F :=
   ![finalQueryOf Extract w.1, finalQueryOf Extract w.2,
     extQueryOf Extract w.1, extQueryOf Extract w.2]
 
 /-- **Adaptive key-binding bound (ZIP 2005 accounting).** An `n`-query machine that queries its
 output witnesses' derivation inputs produces a key-binding `Break` with probability at most
 `n·(n−1)/|F|` — ZIP 2005's `ε_kb` at `|F| = r`, with the adversary's queries chosen adaptively. -/
-theorem break_measure_le_adaptive (Extract : G → B) (S : G) (hfn : B → B → F) (Ggen : G)
+theorem break_measure_le_adaptive (Extract : G → AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
     (hExt : ∀ P R : G, Extract P = Extract R ↔ P =± R) (hS : S ≠ 0)
-    (Hask : SK → F) (Hnk : SK → B)
-    {A : OracleComp (FinalQuery QK SK B F) F (Witness G F B SK QK × Witness G F B SK QK)}
+    (Hask : SK → F) (Hnk : SK → NK)
+    {A : OracleComp (FinalQuery QK SK AK NK F) F (Witness G F AK NK SK QK × Witness G F AK NK SK QK)}
     {n : ℕ} (hQ : A.QueryBound n)
-    (hqueries : ∀ (O : FinalQuery QK SK B F → F) (i : Fin 4),
+    (hqueries : ∀ (O : FinalQuery QK SK AK NK F → F) (i : Fin 4),
       derivQueries Extract (A.run O) i ∈ A.queries O) :
-    (PMF.uniformOfFintype (FinalQuery QK SK B F → F)).toOuterMeasure
-        {O : FinalQuery QK SK B F → F |
+    (PMF.uniformOfFintype (FinalQuery QK SK AK NK F → F)).toOuterMeasure
+        {O : FinalQuery QK SK AK NK F → F |
           Break Extract S hfn Ggen Hask Hnk
             (fun sk => O (.legacy sk)) (fun qk ak nk => O (.ext qk ak nk))
             (fun rivk_ext ak nk => O (.int rivk_ext ak nk)) (A.run O).1 (A.run O).2}
@@ -609,18 +609,18 @@ theorem break_measure_le_adaptive (Extract : G → B) (S : G) (hfn : B → B →
 key-binding `Break` with probability at most `(n+4)·(n+3)/|F|`: complete the machine with its
 output witnesses' four derivation queries (`OracleComp.completing`) and apply the adaptive
 bound at budget `n + 4`. -/
-theorem break_measure_le_of_queryBound (Extract : G → B) (S : G) (hfn : B → B → F) (Ggen : G)
+theorem break_measure_le_of_queryBound (Extract : G → AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
     (hExt : ∀ P R : G, Extract P = Extract R ↔ P =± R) (hS : S ≠ 0)
-    (Hask : SK → F) (Hnk : SK → B)
-    {A : OracleComp (FinalQuery QK SK B F) F (Witness G F B SK QK × Witness G F B SK QK)}
+    (Hask : SK → F) (Hnk : SK → NK)
+    {A : OracleComp (FinalQuery QK SK AK NK F) F (Witness G F AK NK SK QK × Witness G F AK NK SK QK)}
     {n : ℕ} (hQ : A.QueryBound n) :
-    (PMF.uniformOfFintype (FinalQuery QK SK B F → F)).toOuterMeasure
-        {O : FinalQuery QK SK B F → F |
+    (PMF.uniformOfFintype (FinalQuery QK SK AK NK F → F)).toOuterMeasure
+        {O : FinalQuery QK SK AK NK F → F |
           Break Extract S hfn Ggen Hask Hnk
             (fun sk => O (.legacy sk)) (fun qk ak nk => O (.ext qk ak nk))
             (fun rivk_ext ak nk => O (.int rivk_ext ak nk)) (A.run O).1 (A.run O).2}
       ≤ ((n + 4) * (n + 3) : ℕ) / Fintype.card F := by
-  have hqueries : ∀ (O : FinalQuery QK SK B F → F) (i : Fin 4),
+  have hqueries : ∀ (O : FinalQuery QK SK AK NK F → F) (i : Fin 4),
       derivQueries Extract ((A.completing (derivQueries Extract)).run O) i
         ∈ (A.completing (derivQueries Extract)).queries O := by
     intro O i
@@ -638,14 +638,14 @@ pointwise capstone conditions on the adversary's private randomness and the `H^a
 tables; this lifts it to the mixture. The index `ι` bundles everything the pointwise bound
 fixes — private coins and both outer tables, under any joint distribution `p` — and the
 bound is uniform in the slice, so averaging preserves it. -/
-theorem break_measure_le_mixture {ι : Type*} (Extract : G → B) (S : G) (hfn : B → B → F)
+theorem break_measure_le_mixture {ι : Type*} (Extract : G → AK) (S : G) (hfn : AK → NK → F)
     (Ggen : G) (hExt : ∀ P R : G, Extract P = Extract R ↔ P =± R) (hS : S ≠ 0)
-    (p : PMF ι) (Hask : ι → SK → F) (Hnk : ι → SK → B)
-    {A : ι → OracleComp (FinalQuery QK SK B F) F (Witness G F B SK QK × Witness G F B SK QK)}
+    (p : PMF ι) (Hask : ι → SK → F) (Hnk : ι → SK → NK)
+    {A : ι → OracleComp (FinalQuery QK SK AK NK F) F (Witness G F AK NK SK QK × Witness G F AK NK SK QK)}
     {n : ℕ} (hQ : ∀ i, (A i).QueryBound n) :
-    ((p.bind fun i => (PMF.uniformOfFintype (FinalQuery QK SK B F → F)).map
+    ((p.bind fun i => (PMF.uniformOfFintype (FinalQuery QK SK AK NK F → F)).map
         (Prod.mk i))).toOuterMeasure
-        {x : ι × (FinalQuery QK SK B F → F) |
+        {x : ι × (FinalQuery QK SK AK NK F → F) |
           Break Extract S hfn Ggen (Hask x.1) (Hnk x.1)
             (fun sk => x.2 (.legacy sk)) (fun qk ak nk => x.2 (.ext qk ak nk))
             (fun rivk_ext ak nk => x.2 (.int rivk_ext ak nk))

--- a/Zcash/Security/KeyBinding/Probability.lean
+++ b/Zcash/Security/KeyBinding/Probability.lean
@@ -216,8 +216,9 @@ whole table. -/
 
 /-- The answers at `t` that would ±-collide with a recorded `(query, answer)` pair: two
 candidate values per pair, one per sign. A list representing the step's *bad set* (only
-membership matters, but it is more convenient to use the list length `2·|σ|` to bound the
-set's cardinality; coinciding candidates only slacken the bound). -/
+membership matters, but the list length `2·|σ|` is a convenient bound on the set's
+cardinality; coinciding candidates merely leave the inequality slack, they do not
+invalidate it). -/
 def badList (s : Q → F) (σ : List (Q × F)) (t : Q) : List F :=
   σ.map (fun p => s p.1 + p.2 - s t) ++ σ.map (fun p => -(s p.1 + p.2) - s t)
 

--- a/Zcash/Security/KeyBinding/Probability.lean
+++ b/Zcash/Security/KeyBinding/Probability.lean
@@ -82,7 +82,7 @@ def finalQueryEquiv : FinalQuery AK NK RIVK QK SK ≃ (QK × AK × NK) ⊕ SK �
   left_inv q := by cases q <;> rfl
   right_inv x := by rcases x with ⟨qk, ak, nk⟩ | sk | ⟨rivk_ext, ak, nk⟩ <;> rfl
 
-instance [Fintype QK] [Fintype SK] [Fintype AK] [Fintype NK] [Fintype RIVK] :
+instance [Fintype AK] [Fintype NK] [Fintype RIVK] [Fintype QK] [Fintype SK] :
     Fintype (FinalQuery AK NK RIVK QK SK) :=
   Fintype.ofEquiv _ finalQueryEquiv.symm
 
@@ -509,8 +509,8 @@ theorem toOuterMeasure_bind_le {α β : Type*} (p : PMF α) (f : α → PMF β) 
 
 section Transport
 
-variable [Field RIVK] [Fintype QK] [Fintype SK] [Fintype AK] [Fintype NK] [Fintype RIVK]
-variable [DecidableEq QK] [DecidableEq SK] [DecidableEq AK] [DecidableEq NK] [DecidableEq RIVK]
+variable [Field RIVK] [Fintype AK] [Fintype NK] [Fintype RIVK] [Fintype QK] [Fintype SK]
+variable [DecidableEq AK] [DecidableEq NK] [DecidableEq RIVK] [DecidableEq QK] [DecidableEq SK]
 
 /-- Drawing the coordinates independently and uniformly is the uniform draw on the product. -/
 theorem uniformOfFintype_prod {α β : Type*} [Fintype α] [Nonempty α] [Fintype β] [Nonempty β] :
@@ -557,12 +557,12 @@ end Transport
 
 section Capstone
 
-variable [AddCommGroup G] [Field RIVK] [Field IVK] [Module RIVK G] [NoZeroSMulDivisors RIVK G]
+variable [AddCommGroup G] [Field IVK] [Field RIVK] [Module RIVK G] [NoZeroSMulDivisors RIVK G]
 variable [SMul ASK G]
-variable [Fintype QK] [Fintype SK] [Fintype AK] [Fintype NK] [Fintype RIVK]
-variable [DecidableEq QK] [DecidableEq SK] [DecidableEq AK] [DecidableEq NK] [DecidableEq RIVK]
+variable [Fintype AK] [Fintype NK] [Fintype RIVK] [Fintype QK] [Fintype SK]
+variable [DecidableEq AK] [DecidableEq NK] [DecidableEq RIVK] [DecidableEq QK] [DecidableEq SK]
 
-omit [Fintype QK] [Fintype SK] [Fintype AK] [Fintype NK] [Fintype RIVK] in
+omit [Fintype AK] [Fintype NK] [Fintype RIVK] [Fintype QK] [Fintype SK] in
 /-- The queries at which `CollisionUpToSign.ofBreak` exhibits its collision are the witnesses'
 derivation queries: the `rivk_ext`-derivation pair in the residual case, the final-query pair
 otherwise. Stated over any `c` equal to the computed collision (`hc`), so that a consumer's
@@ -715,7 +715,7 @@ probability space in full: the adversary's private randomness (any distribution 
 the five oracle tables — `H^ask`, `H^nk`, and the three final `rivk`-derivation oracles —
 drawn independently, the tables uniformly. The machine runs on the combined table, and the
 bound is the hypothesis-free `(n+4)·(n+3)/|F|`. -/
-theorem break_measure_le_product {ι : Type*} [Fintype ASK] [Nonempty ASK] [Nonempty NK]
+theorem break_measure_le_product {ι : Type*} [Fintype ASK] [Nonempty NK] [Nonempty ASK]
     (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK)
     (Ggen : G) (hS : S ≠ 0)
     (p : PMF ι)

--- a/Zcash/Security/KeyBinding/Probability.lean
+++ b/Zcash/Security/KeyBinding/Probability.lean
@@ -530,7 +530,8 @@ theorem uniformOfFintype_prod {α β : Type*} [Fintype α] [Nonempty α] [Fintyp
 /-- The three final `rivk`-derivation oracles assemble bijectively into whole tables
 (`FinalQuery.eval`); the inverse is restriction along the constructors. -/
 def evalEquiv :
-    ((SK → RIVK) × (QK → AK → NK → RIVK) × (RIVK → AK → NK → RIVK)) ≃ (FinalQuery AK NK RIVK QK SK → RIVK) where
+    ((SK → RIVK) × (QK → AK → NK → RIVK) × (RIVK → AK → NK → RIVK))
+      ≃ (FinalQuery AK NK RIVK QK SK → RIVK) where
   toFun H := FinalQuery.eval H.1 H.2.1 H.2.2
   invFun O := (fun sk => O (.legacy sk), fun qk ak nk => O (.ext qk ak nk),
     fun rivk_ext ak nk => O (.int rivk_ext ak nk))
@@ -633,7 +634,8 @@ the adversary's queries chosen adaptively. -/
 theorem break_measure_le_adaptive (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK)
     (Ggen : G) (hS : S ≠ 0)
     (Hask : SK → ASK) (Hnk : SK → NK)
-    {A : OracleComp (FinalQuery AK NK RIVK QK SK) RIVK (Witness G IVK AK NK RIVK QK SK × Witness G IVK AK NK RIVK QK SK)}
+    {A : OracleComp (FinalQuery AK NK RIVK QK SK) RIVK
+      (Witness G IVK AK NK RIVK QK SK × Witness G IVK AK NK RIVK QK SK)}
     {n : ℕ} (hQ : A.QueryBound n)
     (hqueries : ∀ (O : FinalQuery AK NK RIVK QK SK → RIVK) (i : Fin 4),
       derivQueries Extract (A.run O) i ∈ A.queries O) :
@@ -667,7 +669,8 @@ bound at budget `n + 4`. -/
 theorem break_measure_le_of_queryBound (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK)
     (Ggen : G) (hS : S ≠ 0)
     (Hask : SK → ASK) (Hnk : SK → NK)
-    {A : OracleComp (FinalQuery AK NK RIVK QK SK) RIVK (Witness G IVK AK NK RIVK QK SK × Witness G IVK AK NK RIVK QK SK)}
+    {A : OracleComp (FinalQuery AK NK RIVK QK SK) RIVK
+      (Witness G IVK AK NK RIVK QK SK × Witness G IVK AK NK RIVK QK SK)}
     {n : ℕ} (hQ : A.QueryBound n) :
     (PMF.uniformOfFintype (FinalQuery AK NK RIVK QK SK → RIVK)).toOuterMeasure
         {O : FinalQuery AK NK RIVK QK SK → RIVK |
@@ -696,7 +699,8 @@ bound is uniform in the slice, so averaging preserves it. -/
 theorem break_measure_le_mixture {ι : Type*} (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK)
     (Ggen : G) (hS : S ≠ 0)
     (p : PMF ι) (Hask : ι → SK → ASK) (Hnk : ι → SK → NK)
-    {A : ι → OracleComp (FinalQuery AK NK RIVK QK SK) RIVK (Witness G IVK AK NK RIVK QK SK × Witness G IVK AK NK RIVK QK SK)}
+    {A : ι → OracleComp (FinalQuery AK NK RIVK QK SK) RIVK
+      (Witness G IVK AK NK RIVK QK SK × Witness G IVK AK NK RIVK QK SK)}
     {n : ℕ} (hQ : ∀ i, (A i).QueryBound n) :
     ((p.bind fun i => (PMF.uniformOfFintype (FinalQuery AK NK RIVK QK SK → RIVK)).map
         (Prod.mk i))).toOuterMeasure

--- a/Zcash/Security/KeyBinding/Probability.lean
+++ b/Zcash/Security/KeyBinding/Probability.lean
@@ -52,6 +52,9 @@ an `OracleComp` from the Fiat–Shamir layer):
 * `uniform_triple_eval` — the triple↔table transport: the three derivation oracles drawn
   independently and uniformly assemble (`FinalQuery.eval`) into exactly the uniform whole
   table.
+* `break_measure_le_mixture` / `break_measure_le_product` — the bound over the full
+  probability space: adversary private randomness (any distribution) and the five oracle
+  tables drawn independently, the tables uniformly; same `(Q+4)·(Q+3)/|F|` bound.
 
 The remaining modelling steps toward the full ZIP 2005 key-binding theorem are tracked in
 issue #68.
@@ -707,6 +710,45 @@ theorem break_measure_le_mixture {ι : Type*} (Extract : G → AK) (S : G) (hfn 
   rw [PMF.toOuterMeasure_map_apply]
   exact break_measure_le_of_queryBound Extract S hfn Ggen hExt hS (Hask i) (Hnk i) (hQ i)
 
+
+/-- **Adaptive key-binding bound over five independent oracle tables** — ZIP 2005's
+probability space in full: the adversary's private randomness (any distribution `p`) and
+the five oracle tables — `H^ask`, `H^nk`, and the three final `rivk`-derivation oracles —
+drawn independently, the tables uniformly. The machine runs on the combined table, and the
+bound is the hypothesis-free `(n+4)·(n+3)/|F|`. -/
+theorem break_measure_le_product {ι : Type*} [Nonempty NK]
+    (Extract : G → AK) (S : G) (hfn : AK → NK → F)
+    (Ggen : G) (hExt : ∀ P R : G, Extract P = Extract R ↔ P =± R) (hS : S ≠ 0)
+    (p : PMF ι)
+    {A : ι → OracleComp (FinalQuery QK SK AK NK F) F
+      (Witness G F AK NK SK QK × Witness G F AK NK SK QK)}
+    {n : ℕ} (hQ : ∀ i, (A i).QueryBound n) :
+    ((p.bind fun i => (PMF.uniformOfFintype (SK → F)).bind fun Hask =>
+        (PMF.uniformOfFintype (SK → NK)).bind fun Hnk =>
+          (PMF.uniformOfFintype (SK → F)).bind fun Hleg =>
+            (PMF.uniformOfFintype (QK → AK → NK → F)).bind fun Hext =>
+              (PMF.uniformOfFintype (F → AK → NK → F)).map fun Hint =>
+                (i, Hask, Hnk, FinalQuery.eval Hleg Hext Hint))).toOuterMeasure
+        {x : ι × (SK → F) × (SK → NK) × (FinalQuery QK SK AK NK F → F) |
+          Break Extract S hfn Ggen x.2.1 x.2.2.1
+            (fun sk => x.2.2.2 (.legacy sk)) (fun qk ak nk => x.2.2.2 (.ext qk ak nk))
+            (fun rivk_ext ak nk => x.2.2.2 (.int rivk_ext ak nk))
+            ((A x.1).run x.2.2.2).1 ((A x.1).run x.2.2.2).2}
+      ≤ ((n + 4) * (n + 3) : ℕ) / Fintype.card F := by
+  refine toOuterMeasure_bind_le _ _ _ fun i => ?_
+  refine toOuterMeasure_bind_le _ _ _ fun Hask => ?_
+  refine toOuterMeasure_bind_le _ _ _ fun Hnk => ?_
+  have htr : ((PMF.uniformOfFintype (SK → F)).bind fun Hleg =>
+        (PMF.uniformOfFintype (QK → AK → NK → F)).bind fun Hext =>
+          (PMF.uniformOfFintype (F → AK → NK → F)).map fun Hint =>
+            (i, Hask, Hnk, FinalQuery.eval Hleg Hext Hint))
+      = (PMF.uniformOfFintype (FinalQuery QK SK AK NK F → F)).map fun O =>
+          (i, Hask, Hnk, O) := by
+    rw [← uniform_triple_eval]
+    simp only [PMF.map_bind, PMF.map_comp]
+    rfl
+  rw [htr, PMF.toOuterMeasure_map_apply]
+  exact break_measure_le_of_queryBound Extract S hfn Ggen hExt hS Hask Hnk (hQ i)
 
 end Capstone
 

--- a/Zcash/Security/KeyBinding/Probability.lean
+++ b/Zcash/Security/KeyBinding/Probability.lean
@@ -13,7 +13,7 @@ This module adds the probabilistic model that turns those counting facts into a 
 bound.
 
 The model samples the combined final `rivk`-derivation oracle `H^*` as one uniform table
-`O : FinalQuery QK SK AK NK F → F`. A uniform table is the same as independent uniform outputs at
+`O : FinalQuery AK NK RIVK QK SK → RIVK`. A uniform table is the same as independent uniform outputs at
 every query — the product structure of the uniform measure. (In Markov-category terms `PMF` is a
 commutative monad, so samples reorder freely; see Fritz [eprint arXiv:1908.07021] and
 `Mathlib.CategoryTheory.MarkovCategory` for the abstract setting.) The three constituent oracles
@@ -33,8 +33,8 @@ Results (static model — the query set is fixed before the table is sampled):
 * `finset_shifted_collision_measure_le` — union bound over the `C(q,2)` unordered pairs of a
   query set of size at most `q`: probability at most `q·(q−1)/|F|`.
 * `break_measure_le` — the key-binding capstone: an adversary whose witnesses' derivation
-  queries land in the static set produces a `Break` with probability at most `q·(q−1)/|F|`
-  (ZIP 2005's `ε_kb` at `|F| = r`).
+  queries land in the static set produces a `Break` with probability at most `q·(q−1)/|RIVK|`
+  (ZIP 2005's `ε_kb`; `|RIVK| = r`).
 
 Results (adaptive — a bounded-query machine choosing queries after seeing earlier answers, as
 an `OracleComp` from the Fiat–Shamir layer):
@@ -46,15 +46,15 @@ an `OracleComp` from the Fiat–Shamir layer):
 * `queries_pair_collision_measure_le` — a `Q`-query machine's trace contains a shifted
   ±-colliding pair with probability at most `Q·(Q−1)/|F|`.
 * `break_measure_le_adaptive` — the adaptive capstone, for a machine that queries its output
-  witnesses' derivation inputs: `Q·(Q−1)/|F|` (ZIP 2005's accounting).
+  witnesses' derivation inputs: `Q·(Q−1)/|RIVK|` (ZIP 2005's accounting).
 * `break_measure_le_of_queryBound` — hypothesis-free: any `Q`-query machine, via
-  `OracleComp.completing` appending the four derivation queries: `(Q+4)·(Q+3)/|F|`.
+  `OracleComp.completing` appending the four derivation queries: `(Q+4)·(Q+3)/|RIVK|`.
 * `uniform_triple_eval` — the triple↔table transport: the three derivation oracles drawn
   independently and uniformly assemble (`FinalQuery.eval`) into exactly the uniform whole
   table.
 * `break_measure_le_mixture` / `break_measure_le_product` — the bound over the full
   probability space: adversary private randomness (any distribution) and the five oracle
-  tables drawn independently, the tables uniformly; same `(Q+4)·(Q+3)/|F|` bound.
+  tables drawn independently, the tables uniformly; same `(Q+4)·(Q+3)/|RIVK|` bound.
 
 The remaining modelling steps toward the full ZIP 2005 key-binding theorem are tracked in
 issue #68.
@@ -65,12 +65,12 @@ namespace Zcash.Security.KeyBinding
 open Finset Zcash.Security.RandomOracle Zcash.Security.Birthday Zcash.Snark
 open scoped ENNReal
 
-variable {G F IVK AK NK SK QK : Type*}
+variable {G F IVK AK NK RIVK ASK QK SK : Type*}
 
 /-! ## Finiteness of the query space -/
 
 /-- `FinalQuery` as the sum of its constructors' data. -/
-def finalQueryEquiv : FinalQuery QK SK AK NK F ≃ (QK × AK × NK) ⊕ SK ⊕ (F × AK × NK) where
+def finalQueryEquiv : FinalQuery AK NK RIVK QK SK ≃ (QK × AK × NK) ⊕ SK ⊕ (RIVK × AK × NK) where
   toFun
     | .ext qk ak nk => .inl (qk, ak, nk)
     | .legacy sk => .inr (.inl sk)
@@ -82,13 +82,13 @@ def finalQueryEquiv : FinalQuery QK SK AK NK F ≃ (QK × AK × NK) ⊕ SK ⊕ (
   left_inv q := by cases q <;> rfl
   right_inv x := by rcases x with ⟨qk, ak, nk⟩ | sk | ⟨rivk_ext, ak, nk⟩ <;> rfl
 
-instance [Fintype QK] [Fintype SK] [Fintype AK] [Fintype NK] [Fintype F] :
-    Fintype (FinalQuery QK SK AK NK F) :=
+instance [Fintype QK] [Fintype SK] [Fintype AK] [Fintype NK] [Fintype RIVK] :
+    Fintype (FinalQuery AK NK RIVK QK SK) :=
   Fintype.ofEquiv _ finalQueryEquiv.symm
 
 /-- Assembling the combined final oracle from a table's constructor restrictions gives back the
 table. -/
-theorem eval_restrict (O : FinalQuery QK SK AK NK F → F) :
+theorem eval_restrict (O : FinalQuery AK NK RIVK QK SK → RIVK) :
     FinalQuery.eval (fun sk => O (.legacy sk)) (fun qk ak nk => O (.ext qk ak nk))
       (fun rivk_ext ak nk => O (.int rivk_ext ak nk)) = O := by
   funext q; cases q <;> rfl
@@ -509,8 +509,8 @@ theorem toOuterMeasure_bind_le {α β : Type*} (p : PMF α) (f : α → PMF β) 
 
 section Transport
 
-variable [Field F] [Fintype QK] [Fintype SK] [Fintype AK] [Fintype NK] [Fintype F]
-variable [DecidableEq QK] [DecidableEq SK] [DecidableEq AK] [DecidableEq NK] [DecidableEq F]
+variable [Field RIVK] [Fintype QK] [Fintype SK] [Fintype AK] [Fintype NK] [Fintype RIVK]
+variable [DecidableEq QK] [DecidableEq SK] [DecidableEq AK] [DecidableEq NK] [DecidableEq RIVK]
 
 /-- Drawing the coordinates independently and uniformly is the uniform draw on the product. -/
 theorem uniformOfFintype_prod {α β : Type*} [Fintype α] [Nonempty α] [Fintype β] [Nonempty β] :
@@ -530,7 +530,7 @@ theorem uniformOfFintype_prod {α β : Type*} [Fintype α] [Nonempty α] [Fintyp
 /-- The three final `rivk`-derivation oracles assemble bijectively into whole tables
 (`FinalQuery.eval`); the inverse is restriction along the constructors. -/
 def evalEquiv :
-    ((SK → F) × (QK → AK → NK → F) × (F → AK → NK → F)) ≃ (FinalQuery QK SK AK NK F → F) where
+    ((SK → RIVK) × (QK → AK → NK → RIVK) × (RIVK → AK → NK → RIVK)) ≃ (FinalQuery AK NK RIVK QK SK → RIVK) where
   toFun H := FinalQuery.eval H.1 H.2.1 H.2.2
   invFun O := (fun sk => O (.legacy sk), fun qk ak nk => O (.ext qk ak nk),
     fun rivk_ext ak nk => O (.int rivk_ext ak nk))
@@ -541,13 +541,13 @@ def evalEquiv :
 `rivk`-derivation oracles independently and uniformly and combining them with
 `FinalQuery.eval` is the uniform whole-table draw. -/
 theorem uniform_triple_eval :
-    ((PMF.uniformOfFintype (SK → F)).bind fun Hleg =>
-        (PMF.uniformOfFintype (QK → AK → NK → F)).bind fun Hext =>
-          (PMF.uniformOfFintype (F → AK → NK → F)).map fun Hint =>
+    ((PMF.uniformOfFintype (SK → RIVK)).bind fun Hleg =>
+        (PMF.uniformOfFintype (QK → AK → NK → RIVK)).bind fun Hext =>
+          (PMF.uniformOfFintype (RIVK → AK → NK → RIVK)).map fun Hint =>
             FinalQuery.eval Hleg Hext Hint)
-      = PMF.uniformOfFintype (FinalQuery QK SK AK NK F → F) := by
+      = PMF.uniformOfFintype (FinalQuery AK NK RIVK QK SK → RIVK) := by
   rw [← map_uniformOfFintype_equiv (evalEquiv (QK := QK) (SK := SK) (AK := AK) (NK := NK)
-    (F := F))]
+    (RIVK := RIVK))]
   simp only [uniformOfFintype_prod, PMF.map_bind, PMF.map_comp]
   rfl
 
@@ -557,19 +557,20 @@ end Transport
 
 section Capstone
 
-variable [AddCommGroup G] [Field F] [Field IVK] [Module F G] [NoZeroSMulDivisors F G]
-variable [Fintype QK] [Fintype SK] [Fintype AK] [Fintype NK] [Fintype F]
-variable [DecidableEq QK] [DecidableEq SK] [DecidableEq AK] [DecidableEq NK] [DecidableEq F]
+variable [AddCommGroup G] [Field RIVK] [Field IVK] [Module RIVK G] [NoZeroSMulDivisors RIVK G]
+variable [SMul ASK G]
+variable [Fintype QK] [Fintype SK] [Fintype AK] [Fintype NK] [Fintype RIVK]
+variable [DecidableEq QK] [DecidableEq SK] [DecidableEq AK] [DecidableEq NK] [DecidableEq RIVK]
 
-omit [Fintype QK] [Fintype SK] [Fintype AK] [Fintype NK] [Fintype F] in
+omit [Fintype QK] [Fintype SK] [Fintype AK] [Fintype NK] [Fintype RIVK] in
 /-- The queries at which `CollisionUpToSign.ofBreak` exhibits its collision are the witnesses'
 derivation queries: the `rivk_ext`-derivation pair in the residual case, the final-query pair
 otherwise. Stated over any `c` equal to the computed collision (`hc`), so that a consumer's
 `set c := CollisionUpToSign.ofBreak ... with hc` supplies `hc` directly. -/
-theorem ofBreak_queries {Extract : Extractor G IVK AK} {S : G} {hfn : AK → NK → F}
+theorem ofBreak_queries {Extract : Extractor G IVK AK} {S : G} {hfn : AK → NK → RIVK}
     {Ggen : G} {hS : S ≠ 0}
-    {H : Oracles F AK NK SK QK}
-    {w₁ w₂ : Witness G F IVK AK NK SK QK}
+    {H : Oracles AK NK RIVK ASK QK SK}
+    {w₁ w₂ : Witness G IVK AK NK RIVK QK SK}
     {hbrk : Break Extract S hfn Ggen H w₁ w₂}
     {c : RandomOracle.CollisionUpToSign
       (shiftedFinalOracle Extract Ggen hfn H
@@ -588,19 +589,19 @@ table. An adversary —here, any pair of witness choices depending on the whole 
 witnesses' derivation queries lie in a set `Qs` of at most `q` queries *fixed in advance*,
 produces a key-binding `Break` with probability at most `q·(q−1)/|F|`. This is ZIP 2005's
 `ε_kb` at `|F| = r`. -/
-theorem break_measure_le (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F)
+theorem break_measure_le (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK)
     (Ggen : G) (hS : S ≠ 0)
-    (Hask : SK → F) (Hnk : SK → NK)
-    (w₁ w₂ : (FinalQuery QK SK AK NK F → F) → Witness G F IVK AK NK SK QK)
-    (Qs : Finset (FinalQuery QK SK AK NK F)) {q : ℕ} (hq : Qs.card ≤ q)
+    (Hask : SK → ASK) (Hnk : SK → NK)
+    (w₁ w₂ : (FinalQuery AK NK RIVK QK SK → RIVK) → Witness G IVK AK NK RIVK QK SK)
+    (Qs : Finset (FinalQuery AK NK RIVK QK SK)) {q : ℕ} (hq : Qs.card ≤ q)
     (hqueries : ∀ O, finalQueryOf Extract (w₁ O) ∈ Qs ∧ finalQueryOf Extract (w₂ O) ∈ Qs ∧
       extQueryOf Extract (w₁ O) ∈ Qs ∧ extQueryOf Extract (w₂ O) ∈ Qs) :
-    (PMF.uniformOfFintype (FinalQuery QK SK AK NK F → F)).toOuterMeasure
-        {O : FinalQuery QK SK AK NK F → F |
+    (PMF.uniformOfFintype (FinalQuery AK NK RIVK QK SK → RIVK)).toOuterMeasure
+        {O : FinalQuery AK NK RIVK QK SK → RIVK |
           Break Extract S hfn Ggen
             ⟨Hask, Hnk, fun sk => O (.legacy sk), fun qk ak nk => O (.ext qk ak nk),
               fun rivk_ext ak nk => O (.int rivk_ext ak nk)⟩ (w₁ O) (w₂ O)}
-      ≤ (q * (q - 1) : ℕ) / Fintype.card F := by
+      ≤ (q * (q - 1) : ℕ) / Fintype.card RIVK := by
   refine le_trans (MeasureTheory.measure_mono ?_)
     (finset_shifted_collision_measure_le (shiftOf Extract Ggen hfn Hask Hnk) Qs hq)
   intro O hO
@@ -621,26 +622,26 @@ theorem break_measure_le (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK
 queries of both witnesses — the four points at which `CollisionUpToSign.ofBreak` can exhibit
 its collision. -/
 def derivQueries (Extract : Extractor G IVK AK)
-    (w : Witness G F IVK AK NK SK QK × Witness G F IVK AK NK SK QK) : Fin 4 → FinalQuery QK SK AK NK F :=
+    (w : Witness G IVK AK NK RIVK QK SK × Witness G IVK AK NK RIVK QK SK) : Fin 4 → FinalQuery AK NK RIVK QK SK :=
   ![finalQueryOf Extract w.1, finalQueryOf Extract w.2,
     extQueryOf Extract w.1, extQueryOf Extract w.2]
 
 /-- **Adaptive key-binding bound (ZIP 2005 accounting).** An `n`-query machine that queries its
 output witnesses' derivation inputs produces a key-binding `Break` with probability at most
 `n·(n−1)/|F|` — ZIP 2005's `ε_kb` at `|F| = r`, with the adversary's queries chosen adaptively. -/
-theorem break_measure_le_adaptive (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F)
+theorem break_measure_le_adaptive (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK)
     (Ggen : G) (hS : S ≠ 0)
-    (Hask : SK → F) (Hnk : SK → NK)
-    {A : OracleComp (FinalQuery QK SK AK NK F) F (Witness G F IVK AK NK SK QK × Witness G F IVK AK NK SK QK)}
+    (Hask : SK → ASK) (Hnk : SK → NK)
+    {A : OracleComp (FinalQuery AK NK RIVK QK SK) RIVK (Witness G IVK AK NK RIVK QK SK × Witness G IVK AK NK RIVK QK SK)}
     {n : ℕ} (hQ : A.QueryBound n)
-    (hqueries : ∀ (O : FinalQuery QK SK AK NK F → F) (i : Fin 4),
+    (hqueries : ∀ (O : FinalQuery AK NK RIVK QK SK → RIVK) (i : Fin 4),
       derivQueries Extract (A.run O) i ∈ A.queries O) :
-    (PMF.uniformOfFintype (FinalQuery QK SK AK NK F → F)).toOuterMeasure
-        {O : FinalQuery QK SK AK NK F → F |
+    (PMF.uniformOfFintype (FinalQuery AK NK RIVK QK SK → RIVK)).toOuterMeasure
+        {O : FinalQuery AK NK RIVK QK SK → RIVK |
           Break Extract S hfn Ggen
             ⟨Hask, Hnk, fun sk => O (.legacy sk), fun qk ak nk => O (.ext qk ak nk),
               fun rivk_ext ak nk => O (.int rivk_ext ak nk)⟩ (A.run O).1 (A.run O).2}
-      ≤ (n * (n - 1) : ℕ) / Fintype.card F := by
+      ≤ (n * (n - 1) : ℕ) / Fintype.card RIVK := by
   refine le_trans (MeasureTheory.measure_mono ?_)
     (queries_pair_collision_measure_le (shiftOf Extract Ggen hfn Hask Hnk) hQ)
   intro O hO
@@ -662,18 +663,18 @@ theorem break_measure_le_adaptive (Extract : Extractor G IVK AK) (S : G) (hfn : 
 key-binding `Break` with probability at most `(n+4)·(n+3)/|F|`: complete the machine with its
 output witnesses' four derivation queries (`OracleComp.completing`) and apply the adaptive
 bound at budget `n + 4`. -/
-theorem break_measure_le_of_queryBound (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F)
+theorem break_measure_le_of_queryBound (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK)
     (Ggen : G) (hS : S ≠ 0)
-    (Hask : SK → F) (Hnk : SK → NK)
-    {A : OracleComp (FinalQuery QK SK AK NK F) F (Witness G F IVK AK NK SK QK × Witness G F IVK AK NK SK QK)}
+    (Hask : SK → ASK) (Hnk : SK → NK)
+    {A : OracleComp (FinalQuery AK NK RIVK QK SK) RIVK (Witness G IVK AK NK RIVK QK SK × Witness G IVK AK NK RIVK QK SK)}
     {n : ℕ} (hQ : A.QueryBound n) :
-    (PMF.uniformOfFintype (FinalQuery QK SK AK NK F → F)).toOuterMeasure
-        {O : FinalQuery QK SK AK NK F → F |
+    (PMF.uniformOfFintype (FinalQuery AK NK RIVK QK SK → RIVK)).toOuterMeasure
+        {O : FinalQuery AK NK RIVK QK SK → RIVK |
           Break Extract S hfn Ggen
             ⟨Hask, Hnk, fun sk => O (.legacy sk), fun qk ak nk => O (.ext qk ak nk),
               fun rivk_ext ak nk => O (.int rivk_ext ak nk)⟩ (A.run O).1 (A.run O).2}
-      ≤ ((n + 4) * (n + 3) : ℕ) / Fintype.card F := by
-  have hqueries : ∀ (O : FinalQuery QK SK AK NK F → F) (i : Fin 4),
+      ≤ ((n + 4) * (n + 3) : ℕ) / Fintype.card RIVK := by
+  have hqueries : ∀ (O : FinalQuery AK NK RIVK QK SK → RIVK) (i : Fin 4),
       derivQueries Extract ((A.completing (derivQueries Extract)).run O) i
         ∈ (A.completing (derivQueries Extract)).queries O := by
     intro O i
@@ -691,19 +692,19 @@ pointwise capstone conditions on the adversary's private randomness and the `H^a
 tables; this lifts it to the mixture. The index `ι` bundles everything the pointwise bound
 fixes — private coins and both outer tables, under any joint distribution `p` — and the
 bound is uniform in the slice, so averaging preserves it. -/
-theorem break_measure_le_mixture {ι : Type*} (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F)
+theorem break_measure_le_mixture {ι : Type*} (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK)
     (Ggen : G) (hS : S ≠ 0)
-    (p : PMF ι) (Hask : ι → SK → F) (Hnk : ι → SK → NK)
-    {A : ι → OracleComp (FinalQuery QK SK AK NK F) F (Witness G F IVK AK NK SK QK × Witness G F IVK AK NK SK QK)}
+    (p : PMF ι) (Hask : ι → SK → ASK) (Hnk : ι → SK → NK)
+    {A : ι → OracleComp (FinalQuery AK NK RIVK QK SK) RIVK (Witness G IVK AK NK RIVK QK SK × Witness G IVK AK NK RIVK QK SK)}
     {n : ℕ} (hQ : ∀ i, (A i).QueryBound n) :
-    ((p.bind fun i => (PMF.uniformOfFintype (FinalQuery QK SK AK NK F → F)).map
+    ((p.bind fun i => (PMF.uniformOfFintype (FinalQuery AK NK RIVK QK SK → RIVK)).map
         (Prod.mk i))).toOuterMeasure
-        {x : ι × (FinalQuery QK SK AK NK F → F) |
+        {x : ι × (FinalQuery AK NK RIVK QK SK → RIVK) |
           Break Extract S hfn Ggen
             ⟨(Hask x.1), (Hnk x.1), fun sk => x.2 (.legacy sk), fun qk ak nk => x.2 (.ext qk ak nk),
               fun rivk_ext ak nk => x.2 (.int rivk_ext ak nk)⟩
             ((A x.1).run x.2).1 ((A x.1).run x.2).2}
-      ≤ ((n + 4) * (n + 3) : ℕ) / Fintype.card F := by
+      ≤ ((n + 4) * (n + 3) : ℕ) / Fintype.card RIVK := by
   refine toOuterMeasure_bind_le _ _ _ fun i => ?_
   rw [PMF.toOuterMeasure_map_apply]
   exact break_measure_le_of_queryBound Extract S hfn Ggen hS (Hask i) (Hnk i) (hQ i)
@@ -714,33 +715,33 @@ probability space in full: the adversary's private randomness (any distribution 
 the five oracle tables — `H^ask`, `H^nk`, and the three final `rivk`-derivation oracles —
 drawn independently, the tables uniformly. The machine runs on the combined table, and the
 bound is the hypothesis-free `(n+4)·(n+3)/|F|`. -/
-theorem break_measure_le_product {ι : Type*} [Nonempty NK]
-    (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F)
+theorem break_measure_le_product {ι : Type*} [Fintype ASK] [Nonempty ASK] [Nonempty NK]
+    (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK)
     (Ggen : G) (hS : S ≠ 0)
     (p : PMF ι)
-    {A : ι → OracleComp (FinalQuery QK SK AK NK F) F
-      (Witness G F IVK AK NK SK QK × Witness G F IVK AK NK SK QK)}
+    {A : ι → OracleComp (FinalQuery AK NK RIVK QK SK) RIVK
+      (Witness G IVK AK NK RIVK QK SK × Witness G IVK AK NK RIVK QK SK)}
     {n : ℕ} (hQ : ∀ i, (A i).QueryBound n) :
-    ((p.bind fun i => (PMF.uniformOfFintype (SK → F)).bind fun Hask =>
+    ((p.bind fun i => (PMF.uniformOfFintype (SK → ASK)).bind fun Hask =>
         (PMF.uniformOfFintype (SK → NK)).bind fun Hnk =>
-          (PMF.uniformOfFintype (SK → F)).bind fun Hleg =>
-            (PMF.uniformOfFintype (QK → AK → NK → F)).bind fun Hext =>
-              (PMF.uniformOfFintype (F → AK → NK → F)).map fun Hint =>
+          (PMF.uniformOfFintype (SK → RIVK)).bind fun Hleg =>
+            (PMF.uniformOfFintype (QK → AK → NK → RIVK)).bind fun Hext =>
+              (PMF.uniformOfFintype (RIVK → AK → NK → RIVK)).map fun Hint =>
                 (i, Hask, Hnk, FinalQuery.eval Hleg Hext Hint))).toOuterMeasure
-        {x : ι × (SK → F) × (SK → NK) × (FinalQuery QK SK AK NK F → F) |
+        {x : ι × (SK → ASK) × (SK → NK) × (FinalQuery AK NK RIVK QK SK → RIVK) |
           Break Extract S hfn Ggen
             ⟨x.2.1, x.2.2.1, fun sk => x.2.2.2 (.legacy sk), fun qk ak nk => x.2.2.2 (.ext qk ak nk),
               fun rivk_ext ak nk => x.2.2.2 (.int rivk_ext ak nk)⟩
             ((A x.1).run x.2.2.2).1 ((A x.1).run x.2.2.2).2}
-      ≤ ((n + 4) * (n + 3) : ℕ) / Fintype.card F := by
+      ≤ ((n + 4) * (n + 3) : ℕ) / Fintype.card RIVK := by
   refine toOuterMeasure_bind_le _ _ _ fun i => ?_
   refine toOuterMeasure_bind_le _ _ _ fun Hask => ?_
   refine toOuterMeasure_bind_le _ _ _ fun Hnk => ?_
-  have htr : ((PMF.uniformOfFintype (SK → F)).bind fun Hleg =>
-        (PMF.uniformOfFintype (QK → AK → NK → F)).bind fun Hext =>
-          (PMF.uniformOfFintype (F → AK → NK → F)).map fun Hint =>
+  have htr : ((PMF.uniformOfFintype (SK → RIVK)).bind fun Hleg =>
+        (PMF.uniformOfFintype (QK → AK → NK → RIVK)).bind fun Hext =>
+          (PMF.uniformOfFintype (RIVK → AK → NK → RIVK)).map fun Hint =>
             (i, Hask, Hnk, FinalQuery.eval Hleg Hext Hint))
-      = (PMF.uniformOfFintype (FinalQuery QK SK AK NK F → F)).map fun O =>
+      = (PMF.uniformOfFintype (FinalQuery AK NK RIVK QK SK → RIVK)).map fun O =>
           (i, Hask, Hnk, O) := by
     rw [← uniform_triple_eval]
     simp only [PMF.map_bind, PMF.map_comp]

--- a/Zcash/Security/KeyBinding/Probability.lean
+++ b/Zcash/Security/KeyBinding/Probability.lean
@@ -49,6 +49,9 @@ an `OracleComp` from the Fiat–Shamir layer):
   witnesses' derivation inputs: `Q·(Q−1)/|F|` (ZIP 2005's accounting).
 * `break_measure_le_of_queryBound` — hypothesis-free: any `Q`-query machine, via
   `OracleComp.completing` appending the four derivation queries: `(Q+4)·(Q+3)/|F|`.
+* `uniform_triple_eval` — the triple↔table transport: the three derivation oracles drawn
+  independently and uniformly assemble (`FinalQuery.eval`) into exactly the uniform whole
+  table.
 
 The remaining modelling steps toward the full ZIP 2005 key-binding theorem are tracked in
 issue #68.
@@ -498,6 +501,55 @@ theorem toOuterMeasure_bind_le {α β : Type*} (p : PMF α) (f : α → PMF β) 
       ≤ ∑' a, p a * ε := ENNReal.tsum_le_tsum fun a => mul_le_mul_right (h a) _
     _ = ε := by rw [ENNReal.tsum_mul_right, PMF.tsum_coe, one_mul]
 
+
+/-! ## The derivation oracles as independent draws -/
+
+section Transport
+
+variable [Field F] [Fintype QK] [Fintype SK] [Fintype AK] [Fintype NK] [Fintype F]
+variable [DecidableEq QK] [DecidableEq SK] [DecidableEq AK] [DecidableEq NK] [DecidableEq F]
+
+/-- Drawing the coordinates independently and uniformly is the uniform draw on the product. -/
+theorem uniformOfFintype_prod {α β : Type*} [Fintype α] [Nonempty α] [Fintype β] [Nonempty β] :
+    PMF.uniformOfFintype (α × β)
+      = (PMF.uniformOfFintype α).bind fun a => (PMF.uniformOfFintype β).map (Prod.mk a) := by
+  refine PMF.ext fun x => ?_
+  rw [PMF.bind_apply, tsum_eq_single x.1 fun a ha => ?_]
+  · rw [PMF.map_apply, tsum_eq_single x.2 fun b hb => ?_]
+    · simp only [Prod.mk.eta, if_pos, PMF.uniformOfFintype_apply, Fintype.card_prod,
+        Nat.cast_mul]
+      rw [ENNReal.mul_inv (Or.inr (ENNReal.natCast_ne_top _))
+        (Or.inl (ENNReal.natCast_ne_top _))]
+    · exact if_neg fun h => hb (congrArg Prod.snd h).symm
+  · rw [PMF.map_apply, ENNReal.tsum_eq_zero.mpr fun b => if_neg fun h =>
+      ha (congrArg Prod.fst h).symm, mul_zero]
+
+/-- The three final `rivk`-derivation oracles assemble bijectively into whole tables
+(`FinalQuery.eval`); the inverse is restriction along the constructors. -/
+def evalEquiv :
+    ((SK → F) × (QK → AK → NK → F) × (F → AK → NK → F)) ≃ (FinalQuery QK SK AK NK F → F) where
+  toFun H := FinalQuery.eval H.1 H.2.1 H.2.2
+  invFun O := (fun sk => O (.legacy sk), fun qk ak nk => O (.ext qk ak nk),
+    fun rivk_ext ak nk => O (.int rivk_ext ak nk))
+  left_inv _H := rfl
+  right_inv O := eval_restrict O
+
+/-- **Triple↔table uniformity transport**, as a stated PMF equality: drawing the three final
+`rivk`-derivation oracles independently and uniformly and combining them with
+`FinalQuery.eval` is the uniform whole-table draw. -/
+theorem uniform_triple_eval :
+    ((PMF.uniformOfFintype (SK → F)).bind fun Hleg =>
+        (PMF.uniformOfFintype (QK → AK → NK → F)).bind fun Hext =>
+          (PMF.uniformOfFintype (F → AK → NK → F)).map fun Hint =>
+            FinalQuery.eval Hleg Hext Hint)
+      = PMF.uniformOfFintype (FinalQuery QK SK AK NK F → F) := by
+  rw [← map_uniformOfFintype_equiv (evalEquiv (QK := QK) (SK := SK) (AK := AK) (NK := NK)
+    (F := F))]
+  simp only [uniformOfFintype_prod, PMF.map_bind, PMF.map_comp]
+  rfl
+
+end Transport
+
 /-! ## The key-binding capstone -/
 
 section Capstone
@@ -654,6 +706,7 @@ theorem break_measure_le_mixture {ι : Type*} (Extract : G → AK) (S : G) (hfn 
   refine toOuterMeasure_bind_le _ _ _ fun i => ?_
   rw [PMF.toOuterMeasure_map_apply]
   exact break_measure_le_of_queryBound Extract S hfn Ggen hExt hS (Hask i) (Hnk i) (hQ i)
+
 
 end Capstone
 

--- a/Zcash/Security/KeyBinding/Probability.lean
+++ b/Zcash/Security/KeyBinding/Probability.lean
@@ -19,7 +19,7 @@ commutative monad, so samples reorder freely; see Fritz [eprint arXiv:1908.07021
 `Mathlib.CategoryTheory.MarkovCategory` for the abstract setting.) The three constituent oracles
 are the table's restrictions along the `FinalQuery` constructors (`FinalQuery.eval_restrict`).
 
-The remaining data (`Extract`, the bases, `hfn`, `Hask`, `Hnk`) are fixed parameters. The shift
+The remaining data (the extract maps, the bases, `hfn`, `Hask`, `Hnk`) are fixed parameters. The shift
 `shiftOf` reads only the query and these parameters, never the sampled table — so a shifted read
 of the table at distinct queries is still a uniform pair. (The shift is a deterministic, a.k.a.
 copy-preserving, map in the Markov-category sense.) The pair and union lemmas below are stated
@@ -65,7 +65,7 @@ namespace Zcash.Security.KeyBinding
 open Finset Zcash.Security.RandomOracle Zcash.Security.Birthday Zcash.Snark
 open scoped ENNReal
 
-variable {G F AK NK SK QK : Type*}
+variable {G F IVK AK NK SK QK : Type*}
 
 /-! ## Finiteness of the query space -/
 
@@ -557,7 +557,7 @@ end Transport
 
 section Capstone
 
-variable [AddCommGroup G] [Field F] [Field AK] [Module F G] [NoZeroSMulDivisors F G]
+variable [AddCommGroup G] [Field F] [Field IVK] [Module F G] [NoZeroSMulDivisors F G]
 variable [Fintype QK] [Fintype SK] [Fintype AK] [Fintype NK] [Fintype F]
 variable [DecidableEq QK] [DecidableEq SK] [DecidableEq AK] [DecidableEq NK] [DecidableEq F]
 
@@ -566,10 +566,10 @@ omit [Fintype QK] [Fintype SK] [Fintype AK] [Fintype NK] [Fintype F] in
 derivation queries: the `rivk_ext`-derivation pair in the residual case, the final-query pair
 otherwise. Stated over any `c` equal to the computed collision (`hc`), so that a consumer's
 `set c := CollisionUpToSign.ofBreak ... with hc` supplies `hc` directly. -/
-theorem ofBreak_queries {Extract : G → AK} {S : G} {hfn : AK → NK → F} {Ggen : G}
-    {hExt : ∀ P R : G, Extract P = Extract R ↔ P =± R} {hS : S ≠ 0}
+theorem ofBreak_queries {Extract : Extractor G IVK AK} {S : G} {hfn : AK → NK → F} {Ggen : G}
+    {hExt : ∀ P R : G, Extract.toIVK P = Extract.toIVK R ↔ P =± R} {hS : S ≠ 0}
     {H : Oracles F AK NK SK QK}
-    {w₁ w₂ : Witness G F AK NK SK QK}
+    {w₁ w₂ : Witness G F IVK AK NK SK QK}
     {hbrk : Break Extract S hfn Ggen H w₁ w₂}
     {c : RandomOracle.CollisionUpToSign
       (shiftedFinalOracle Extract Ggen hfn H
@@ -588,10 +588,10 @@ table. An adversary —here, any pair of witness choices depending on the whole 
 witnesses' derivation queries lie in a set `Qs` of at most `q` queries *fixed in advance*,
 produces a key-binding `Break` with probability at most `q·(q−1)/|F|`. This is ZIP 2005's
 `ε_kb` at `|F| = r`. -/
-theorem break_measure_le (Extract : G → AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
-    (hExt : ∀ P R : G, Extract P = Extract R ↔ P =± R) (hS : S ≠ 0)
+theorem break_measure_le (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
+    (hExt : ∀ P R : G, Extract.toIVK P = Extract.toIVK R ↔ P =± R) (hS : S ≠ 0)
     (Hask : SK → F) (Hnk : SK → NK)
-    (w₁ w₂ : (FinalQuery QK SK AK NK F → F) → Witness G F AK NK SK QK)
+    (w₁ w₂ : (FinalQuery QK SK AK NK F → F) → Witness G F IVK AK NK SK QK)
     (Qs : Finset (FinalQuery QK SK AK NK F)) {q : ℕ} (hq : Qs.card ≤ q)
     (hqueries : ∀ O, finalQueryOf Extract (w₁ O) ∈ Qs ∧ finalQueryOf Extract (w₂ O) ∈ Qs ∧
       extQueryOf Extract (w₁ O) ∈ Qs ∧ extQueryOf Extract (w₂ O) ∈ Qs) :
@@ -620,18 +620,18 @@ theorem break_measure_le (Extract : G → AK) (S : G) (hfn : AK → NK → F) (G
 /-- The derivation queries of an output witness pair: the final and `rivk_ext`-derivation
 queries of both witnesses — the four points at which `CollisionUpToSign.ofBreak` can exhibit
 its collision. -/
-def derivQueries (Extract : G → AK)
-    (w : Witness G F AK NK SK QK × Witness G F AK NK SK QK) : Fin 4 → FinalQuery QK SK AK NK F :=
+def derivQueries (Extract : Extractor G IVK AK)
+    (w : Witness G F IVK AK NK SK QK × Witness G F IVK AK NK SK QK) : Fin 4 → FinalQuery QK SK AK NK F :=
   ![finalQueryOf Extract w.1, finalQueryOf Extract w.2,
     extQueryOf Extract w.1, extQueryOf Extract w.2]
 
 /-- **Adaptive key-binding bound (ZIP 2005 accounting).** An `n`-query machine that queries its
 output witnesses' derivation inputs produces a key-binding `Break` with probability at most
 `n·(n−1)/|F|` — ZIP 2005's `ε_kb` at `|F| = r`, with the adversary's queries chosen adaptively. -/
-theorem break_measure_le_adaptive (Extract : G → AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
-    (hExt : ∀ P R : G, Extract P = Extract R ↔ P =± R) (hS : S ≠ 0)
+theorem break_measure_le_adaptive (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
+    (hExt : ∀ P R : G, Extract.toIVK P = Extract.toIVK R ↔ P =± R) (hS : S ≠ 0)
     (Hask : SK → F) (Hnk : SK → NK)
-    {A : OracleComp (FinalQuery QK SK AK NK F) F (Witness G F AK NK SK QK × Witness G F AK NK SK QK)}
+    {A : OracleComp (FinalQuery QK SK AK NK F) F (Witness G F IVK AK NK SK QK × Witness G F IVK AK NK SK QK)}
     {n : ℕ} (hQ : A.QueryBound n)
     (hqueries : ∀ (O : FinalQuery QK SK AK NK F → F) (i : Fin 4),
       derivQueries Extract (A.run O) i ∈ A.queries O) :
@@ -662,10 +662,10 @@ theorem break_measure_le_adaptive (Extract : G → AK) (S : G) (hfn : AK → NK 
 key-binding `Break` with probability at most `(n+4)·(n+3)/|F|`: complete the machine with its
 output witnesses' four derivation queries (`OracleComp.completing`) and apply the adaptive
 bound at budget `n + 4`. -/
-theorem break_measure_le_of_queryBound (Extract : G → AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
-    (hExt : ∀ P R : G, Extract P = Extract R ↔ P =± R) (hS : S ≠ 0)
+theorem break_measure_le_of_queryBound (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
+    (hExt : ∀ P R : G, Extract.toIVK P = Extract.toIVK R ↔ P =± R) (hS : S ≠ 0)
     (Hask : SK → F) (Hnk : SK → NK)
-    {A : OracleComp (FinalQuery QK SK AK NK F) F (Witness G F AK NK SK QK × Witness G F AK NK SK QK)}
+    {A : OracleComp (FinalQuery QK SK AK NK F) F (Witness G F IVK AK NK SK QK × Witness G F IVK AK NK SK QK)}
     {n : ℕ} (hQ : A.QueryBound n) :
     (PMF.uniformOfFintype (FinalQuery QK SK AK NK F → F)).toOuterMeasure
         {O : FinalQuery QK SK AK NK F → F |
@@ -691,10 +691,10 @@ pointwise capstone conditions on the adversary's private randomness and the `H^a
 tables; this lifts it to the mixture. The index `ι` bundles everything the pointwise bound
 fixes — private coins and both outer tables, under any joint distribution `p` — and the
 bound is uniform in the slice, so averaging preserves it. -/
-theorem break_measure_le_mixture {ι : Type*} (Extract : G → AK) (S : G) (hfn : AK → NK → F)
-    (Ggen : G) (hExt : ∀ P R : G, Extract P = Extract R ↔ P =± R) (hS : S ≠ 0)
+theorem break_measure_le_mixture {ι : Type*} (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F)
+    (Ggen : G) (hExt : ∀ P R : G, Extract.toIVK P = Extract.toIVK R ↔ P =± R) (hS : S ≠ 0)
     (p : PMF ι) (Hask : ι → SK → F) (Hnk : ι → SK → NK)
-    {A : ι → OracleComp (FinalQuery QK SK AK NK F) F (Witness G F AK NK SK QK × Witness G F AK NK SK QK)}
+    {A : ι → OracleComp (FinalQuery QK SK AK NK F) F (Witness G F IVK AK NK SK QK × Witness G F IVK AK NK SK QK)}
     {n : ℕ} (hQ : ∀ i, (A i).QueryBound n) :
     ((p.bind fun i => (PMF.uniformOfFintype (FinalQuery QK SK AK NK F → F)).map
         (Prod.mk i))).toOuterMeasure
@@ -715,11 +715,11 @@ the five oracle tables — `H^ask`, `H^nk`, and the three final `rivk`-derivatio
 drawn independently, the tables uniformly. The machine runs on the combined table, and the
 bound is the hypothesis-free `(n+4)·(n+3)/|F|`. -/
 theorem break_measure_le_product {ι : Type*} [Nonempty NK]
-    (Extract : G → AK) (S : G) (hfn : AK → NK → F)
-    (Ggen : G) (hExt : ∀ P R : G, Extract P = Extract R ↔ P =± R) (hS : S ≠ 0)
+    (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F)
+    (Ggen : G) (hExt : ∀ P R : G, Extract.toIVK P = Extract.toIVK R ↔ P =± R) (hS : S ≠ 0)
     (p : PMF ι)
     {A : ι → OracleComp (FinalQuery QK SK AK NK F) F
-      (Witness G F AK NK SK QK × Witness G F AK NK SK QK)}
+      (Witness G F IVK AK NK SK QK × Witness G F IVK AK NK SK QK)}
     {n : ℕ} (hQ : ∀ i, (A i).QueryBound n) :
     ((p.bind fun i => (PMF.uniformOfFintype (SK → F)).bind fun Hask =>
         (PMF.uniformOfFintype (SK → NK)).bind fun Hnk =>

--- a/Zcash/Security/KeyBinding/Probability.lean
+++ b/Zcash/Security/KeyBinding/Probability.lean
@@ -713,26 +713,28 @@ theorem break_measure_le_mixture {ι : Type*} (Extract : Extractor G IVK AK) (S 
 /-- **Adaptive key-binding bound over five independent oracle tables** — ZIP 2005's
 probability space in full: the adversary's private randomness (any distribution `p`) and
 the five oracle tables — `H^ask`, `H^nk`, and the three final `rivk`-derivation oracles —
-drawn independently, the tables uniformly. The machine runs on the combined table, and the
-bound is the hypothesis-free `(n+4)·(n+3)/|F|`. -/
+drawn independently, the tables uniformly. The machine receives the sampled `H^ask`/`H^nk`
+tables — dominating any query strategy against those oracles, with the query budget counting
+only rivk-oracle queries — and runs on the combined table; the bound is the hypothesis-free
+`(n+4)·(n+3)/|F|`. -/
 theorem break_measure_le_product {ι : Type*} [Fintype ASK] [Nonempty NK] [Nonempty ASK]
     (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK)
     (Ggen : G) (hS : S ≠ 0)
     (p : PMF ι)
-    {A : ι → OracleComp (FinalQuery AK NK RIVK QK SK) RIVK
+    {A : ι → (SK → ASK) → (SK → NK) → OracleComp (FinalQuery AK NK RIVK QK SK) RIVK
       (Witness G IVK AK NK RIVK QK SK × Witness G IVK AK NK RIVK QK SK)}
-    {n : ℕ} (hQ : ∀ i, (A i).QueryBound n) :
+    {n : ℕ} (hQ : ∀ i Hask Hnk, (A i Hask Hnk).QueryBound n) :
     ((p.bind fun i => (PMF.uniformOfFintype (SK → ASK)).bind fun Hask =>
         (PMF.uniformOfFintype (SK → NK)).bind fun Hnk =>
           (PMF.uniformOfFintype (SK → RIVK)).bind fun Hleg =>
             (PMF.uniformOfFintype (QK → AK → NK → RIVK)).bind fun Hext =>
               (PMF.uniformOfFintype (RIVK → AK → NK → RIVK)).map fun Hint =>
                 (i, Hask, Hnk, FinalQuery.eval Hleg Hext Hint))).toOuterMeasure
-        {x : ι × (SK → ASK) × (SK → NK) × (FinalQuery AK NK RIVK QK SK → RIVK) |
+        (setOf fun (i, Hask, Hnk, O) =>
           Break Extract S hfn Ggen
-            ⟨x.2.1, x.2.2.1, fun sk => x.2.2.2 (.legacy sk), fun qk ak nk => x.2.2.2 (.ext qk ak nk),
-              fun rivk_ext ak nk => x.2.2.2 (.int rivk_ext ak nk)⟩
-            ((A x.1).run x.2.2.2).1 ((A x.1).run x.2.2.2).2}
+            ⟨Hask, Hnk, fun sk => O (.legacy sk), fun qk ak nk => O (.ext qk ak nk),
+              fun rivk_ext ak nk => O (.int rivk_ext ak nk)⟩
+            ((A i Hask Hnk).run O).1 ((A i Hask Hnk).run O).2)
       ≤ ((n + 4) * (n + 3) : ℕ) / Fintype.card RIVK := by
   refine toOuterMeasure_bind_le _ _ _ fun i => ?_
   refine toOuterMeasure_bind_le _ _ _ fun Hask => ?_
@@ -747,7 +749,7 @@ theorem break_measure_le_product {ι : Type*} [Fintype ASK] [Nonempty NK] [Nonem
     simp only [PMF.map_bind, PMF.map_comp]
     rfl
   rw [htr, PMF.toOuterMeasure_map_apply]
-  exact break_measure_le_of_queryBound Extract S hfn Ggen hS Hask Hnk (hQ i)
+  exact break_measure_le_of_queryBound Extract S hfn Ggen hS Hask Hnk (hQ i Hask Hnk)
 
 end Capstone
 

--- a/Zcash/Security/KeyBinding/Probability.lean
+++ b/Zcash/Security/KeyBinding/Probability.lean
@@ -566,15 +566,15 @@ omit [Fintype QK] [Fintype SK] [Fintype AK] [Fintype NK] [Fintype F] in
 derivation queries: the `rivk_ext`-derivation pair in the residual case, the final-query pair
 otherwise. Stated over any `c` equal to the computed collision (`hc`), so that a consumer's
 `set c := CollisionUpToSign.ofBreak ... with hc` supplies `hc` directly. -/
-theorem ofBreak_queries {Extract : Extractor G IVK AK} {S : G} {hfn : AK → NK → F} {Ggen : G}
-    {hExt : ∀ P R : G, Extract.toIVK P = Extract.toIVK R ↔ P =± R} {hS : S ≠ 0}
+theorem ofBreak_queries {Extract : Extractor G IVK AK} {S : G} {hfn : AK → NK → F}
+    {Ggen : G} {hS : S ≠ 0}
     {H : Oracles F AK NK SK QK}
     {w₁ w₂ : Witness G F IVK AK NK SK QK}
     {hbrk : Break Extract S hfn Ggen H w₁ w₂}
     {c : RandomOracle.CollisionUpToSign
       (shiftedFinalOracle Extract Ggen hfn H
         (QK := QK) (SK := SK))}
-    (hc : c = CollisionUpToSign.ofBreak Extract S hfn Ggen hExt hS H hbrk) :
+    (hc : c = CollisionUpToSign.ofBreak Extract S hfn Ggen hS H hbrk) :
     (c.q₁ = extQueryOf Extract w₁ ∧ c.q₂ = extQueryOf Extract w₂) ∨
       (c.q₁ = finalQueryOf Extract w₁ ∧ c.q₂ = finalQueryOf Extract w₂) := by
   subst hc
@@ -588,8 +588,8 @@ table. An adversary —here, any pair of witness choices depending on the whole 
 witnesses' derivation queries lie in a set `Qs` of at most `q` queries *fixed in advance*,
 produces a key-binding `Break` with probability at most `q·(q−1)/|F|`. This is ZIP 2005's
 `ε_kb` at `|F| = r`. -/
-theorem break_measure_le (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
-    (hExt : ∀ P R : G, Extract.toIVK P = Extract.toIVK R ↔ P =± R) (hS : S ≠ 0)
+theorem break_measure_le (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F)
+    (Ggen : G) (hS : S ≠ 0)
     (Hask : SK → F) (Hnk : SK → NK)
     (w₁ w₂ : (FinalQuery QK SK AK NK F → F) → Witness G F IVK AK NK SK QK)
     (Qs : Finset (FinalQuery QK SK AK NK F)) {q : ℕ} (hq : Qs.card ≤ q)
@@ -605,7 +605,7 @@ theorem break_measure_le (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK
     (finset_shifted_collision_measure_le (shiftOf Extract Ggen hfn Hask Hnk) Qs hq)
   intro O hO
   obtain ⟨hf₁, hf₂, he₁, he₂⟩ := hqueries O
-  set c := CollisionUpToSign.ofBreak Extract S hfn Ggen hExt hS _ hO with hc
+  set c := CollisionUpToSign.ofBreak Extract S hfn Ggen hS _ hO with hc
   have hq12 := ofBreak_queries hc
   have hpm : shiftOf Extract Ggen hfn Hask Hnk c.q₁ + O c.q₁
       =± shiftOf Extract Ggen hfn Hask Hnk c.q₂ + O c.q₂ := by
@@ -628,8 +628,8 @@ def derivQueries (Extract : Extractor G IVK AK)
 /-- **Adaptive key-binding bound (ZIP 2005 accounting).** An `n`-query machine that queries its
 output witnesses' derivation inputs produces a key-binding `Break` with probability at most
 `n·(n−1)/|F|` — ZIP 2005's `ε_kb` at `|F| = r`, with the adversary's queries chosen adaptively. -/
-theorem break_measure_le_adaptive (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
-    (hExt : ∀ P R : G, Extract.toIVK P = Extract.toIVK R ↔ P =± R) (hS : S ≠ 0)
+theorem break_measure_le_adaptive (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F)
+    (Ggen : G) (hS : S ≠ 0)
     (Hask : SK → F) (Hnk : SK → NK)
     {A : OracleComp (FinalQuery QK SK AK NK F) F (Witness G F IVK AK NK SK QK × Witness G F IVK AK NK SK QK)}
     {n : ℕ} (hQ : A.QueryBound n)
@@ -644,7 +644,7 @@ theorem break_measure_le_adaptive (Extract : Extractor G IVK AK) (S : G) (hfn : 
   refine le_trans (MeasureTheory.measure_mono ?_)
     (queries_pair_collision_measure_le (shiftOf Extract Ggen hfn Hask Hnk) hQ)
   intro O hO
-  set c := CollisionUpToSign.ofBreak Extract S hfn Ggen hExt hS _ hO with hc
+  set c := CollisionUpToSign.ofBreak Extract S hfn Ggen hS _ hO with hc
   have hq12 := ofBreak_queries hc
   have hpm : shiftOf Extract Ggen hfn Hask Hnk c.q₁ + O c.q₁
       =± shiftOf Extract Ggen hfn Hask Hnk c.q₂ + O c.q₂ := by
@@ -662,8 +662,8 @@ theorem break_measure_le_adaptive (Extract : Extractor G IVK AK) (S : G) (hfn : 
 key-binding `Break` with probability at most `(n+4)·(n+3)/|F|`: complete the machine with its
 output witnesses' four derivation queries (`OracleComp.completing`) and apply the adaptive
 bound at budget `n + 4`. -/
-theorem break_measure_le_of_queryBound (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F) (Ggen : G)
-    (hExt : ∀ P R : G, Extract.toIVK P = Extract.toIVK R ↔ P =± R) (hS : S ≠ 0)
+theorem break_measure_le_of_queryBound (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F)
+    (Ggen : G) (hS : S ≠ 0)
     (Hask : SK → F) (Hnk : SK → NK)
     {A : OracleComp (FinalQuery QK SK AK NK F) F (Witness G F IVK AK NK SK QK × Witness G F IVK AK NK SK QK)}
     {n : ℕ} (hQ : A.QueryBound n) :
@@ -680,7 +680,7 @@ theorem break_measure_le_of_queryBound (Extract : Extractor G IVK AK) (S : G) (h
     rw [OracleComp.run_completing, OracleComp.completing, OracleComp.queries_bind,
       OracleComp.queries_queryList]
     exact List.mem_append.2 (Or.inr (List.mem_ofFn.2 ⟨i, rfl⟩))
-  have hbound := break_measure_le_adaptive Extract S hfn Ggen hExt hS Hask Hnk
+  have hbound := break_measure_le_adaptive Extract S hfn Ggen hS Hask Hnk
     (OracleComp.queryBound_completing (derivQueries Extract) hQ) hqueries
   have h43 : n + 4 - 1 = n + 3 := by omega
   simpa [OracleComp.run_completing, h43] using hbound
@@ -692,7 +692,7 @@ tables; this lifts it to the mixture. The index `ι` bundles everything the poin
 fixes — private coins and both outer tables, under any joint distribution `p` — and the
 bound is uniform in the slice, so averaging preserves it. -/
 theorem break_measure_le_mixture {ι : Type*} (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F)
-    (Ggen : G) (hExt : ∀ P R : G, Extract.toIVK P = Extract.toIVK R ↔ P =± R) (hS : S ≠ 0)
+    (Ggen : G) (hS : S ≠ 0)
     (p : PMF ι) (Hask : ι → SK → F) (Hnk : ι → SK → NK)
     {A : ι → OracleComp (FinalQuery QK SK AK NK F) F (Witness G F IVK AK NK SK QK × Witness G F IVK AK NK SK QK)}
     {n : ℕ} (hQ : ∀ i, (A i).QueryBound n) :
@@ -706,7 +706,7 @@ theorem break_measure_le_mixture {ι : Type*} (Extract : Extractor G IVK AK) (S 
       ≤ ((n + 4) * (n + 3) : ℕ) / Fintype.card F := by
   refine toOuterMeasure_bind_le _ _ _ fun i => ?_
   rw [PMF.toOuterMeasure_map_apply]
-  exact break_measure_le_of_queryBound Extract S hfn Ggen hExt hS (Hask i) (Hnk i) (hQ i)
+  exact break_measure_le_of_queryBound Extract S hfn Ggen hS (Hask i) (Hnk i) (hQ i)
 
 
 /-- **Adaptive key-binding bound over five independent oracle tables** — ZIP 2005's
@@ -716,7 +716,7 @@ drawn independently, the tables uniformly. The machine runs on the combined tabl
 bound is the hypothesis-free `(n+4)·(n+3)/|F|`. -/
 theorem break_measure_le_product {ι : Type*} [Nonempty NK]
     (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → F)
-    (Ggen : G) (hExt : ∀ P R : G, Extract.toIVK P = Extract.toIVK R ↔ P =± R) (hS : S ≠ 0)
+    (Ggen : G) (hS : S ≠ 0)
     (p : PMF ι)
     {A : ι → OracleComp (FinalQuery QK SK AK NK F) F
       (Witness G F IVK AK NK SK QK × Witness G F IVK AK NK SK QK)}
@@ -746,7 +746,7 @@ theorem break_measure_le_product {ι : Type*} [Nonempty NK]
     simp only [PMF.map_bind, PMF.map_comp]
     rfl
   rw [htr, PMF.toOuterMeasure_map_apply]
-  exact break_measure_le_of_queryBound Extract S hfn Ggen hExt hS Hask Hnk (hQ i)
+  exact break_measure_le_of_queryBound Extract S hfn Ggen hS Hask Hnk (hQ i)
 
 end Capstone
 

--- a/Zcash/Security/KeyBinding/Probability.lean
+++ b/Zcash/Security/KeyBinding/Probability.lean
@@ -568,15 +568,13 @@ otherwise. Stated over any `c` equal to the computed collision (`hc`), so that a
 `set c := CollisionUpToSign.ofBreak ... with hc` supplies `hc` directly. -/
 theorem ofBreak_queries {Extract : G → AK} {S : G} {hfn : AK → NK → F} {Ggen : G}
     {hExt : ∀ P R : G, Extract P = Extract R ↔ P =± R} {hS : S ≠ 0}
-    {Hask : SK → F} {Hnk : SK → NK} {Hrivk_legacy : SK → F}
-    {Hrivk_ext : QK → AK → NK → F} {Hrivk_int : F → AK → NK → F}
+    {H : Oracles F AK NK SK QK}
     {w₁ w₂ : Witness G F AK NK SK QK}
-    {hbrk : Break Extract S hfn Ggen Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int w₁ w₂}
+    {hbrk : Break Extract S hfn Ggen H w₁ w₂}
     {c : RandomOracle.CollisionUpToSign
-      (shiftedFinalOracle Extract Ggen hfn Hask Hnk Hrivk_legacy Hrivk_ext Hrivk_int
+      (shiftedFinalOracle Extract Ggen hfn H
         (QK := QK) (SK := SK))}
-    (hc : c = CollisionUpToSign.ofBreak Extract S hfn Ggen hExt hS Hask Hnk Hrivk_legacy
-      Hrivk_ext Hrivk_int hbrk) :
+    (hc : c = CollisionUpToSign.ofBreak Extract S hfn Ggen hExt hS H hbrk) :
     (c.q₁ = extQueryOf Extract w₁ ∧ c.q₂ = extQueryOf Extract w₂) ∨
       (c.q₁ = finalQueryOf Extract w₁ ∧ c.q₂ = finalQueryOf Extract w₂) := by
   subst hc
@@ -599,15 +597,15 @@ theorem break_measure_le (Extract : G → AK) (S : G) (hfn : AK → NK → F) (G
       extQueryOf Extract (w₁ O) ∈ Qs ∧ extQueryOf Extract (w₂ O) ∈ Qs) :
     (PMF.uniformOfFintype (FinalQuery QK SK AK NK F → F)).toOuterMeasure
         {O : FinalQuery QK SK AK NK F → F |
-          Break Extract S hfn Ggen Hask Hnk
-            (fun sk => O (.legacy sk)) (fun qk ak nk => O (.ext qk ak nk))
-            (fun rivk_ext ak nk => O (.int rivk_ext ak nk)) (w₁ O) (w₂ O)}
+          Break Extract S hfn Ggen
+            ⟨Hask, Hnk, fun sk => O (.legacy sk), fun qk ak nk => O (.ext qk ak nk),
+              fun rivk_ext ak nk => O (.int rivk_ext ak nk)⟩ (w₁ O) (w₂ O)}
       ≤ (q * (q - 1) : ℕ) / Fintype.card F := by
   refine le_trans (MeasureTheory.measure_mono ?_)
     (finset_shifted_collision_measure_le (shiftOf Extract Ggen hfn Hask Hnk) Qs hq)
   intro O hO
   obtain ⟨hf₁, hf₂, he₁, he₂⟩ := hqueries O
-  set c := CollisionUpToSign.ofBreak Extract S hfn Ggen hExt hS Hask Hnk _ _ _ hO with hc
+  set c := CollisionUpToSign.ofBreak Extract S hfn Ggen hExt hS _ hO with hc
   have hq12 := ofBreak_queries hc
   have hpm : shiftOf Extract Ggen hfn Hask Hnk c.q₁ + O c.q₁
       =± shiftOf Extract Ggen hfn Hask Hnk c.q₂ + O c.q₂ := by
@@ -639,14 +637,14 @@ theorem break_measure_le_adaptive (Extract : G → AK) (S : G) (hfn : AK → NK 
       derivQueries Extract (A.run O) i ∈ A.queries O) :
     (PMF.uniformOfFintype (FinalQuery QK SK AK NK F → F)).toOuterMeasure
         {O : FinalQuery QK SK AK NK F → F |
-          Break Extract S hfn Ggen Hask Hnk
-            (fun sk => O (.legacy sk)) (fun qk ak nk => O (.ext qk ak nk))
-            (fun rivk_ext ak nk => O (.int rivk_ext ak nk)) (A.run O).1 (A.run O).2}
+          Break Extract S hfn Ggen
+            ⟨Hask, Hnk, fun sk => O (.legacy sk), fun qk ak nk => O (.ext qk ak nk),
+              fun rivk_ext ak nk => O (.int rivk_ext ak nk)⟩ (A.run O).1 (A.run O).2}
       ≤ (n * (n - 1) : ℕ) / Fintype.card F := by
   refine le_trans (MeasureTheory.measure_mono ?_)
     (queries_pair_collision_measure_le (shiftOf Extract Ggen hfn Hask Hnk) hQ)
   intro O hO
-  set c := CollisionUpToSign.ofBreak Extract S hfn Ggen hExt hS Hask Hnk _ _ _ hO with hc
+  set c := CollisionUpToSign.ofBreak Extract S hfn Ggen hExt hS _ hO with hc
   have hq12 := ofBreak_queries hc
   have hpm : shiftOf Extract Ggen hfn Hask Hnk c.q₁ + O c.q₁
       =± shiftOf Extract Ggen hfn Hask Hnk c.q₂ + O c.q₂ := by
@@ -671,9 +669,9 @@ theorem break_measure_le_of_queryBound (Extract : G → AK) (S : G) (hfn : AK �
     {n : ℕ} (hQ : A.QueryBound n) :
     (PMF.uniformOfFintype (FinalQuery QK SK AK NK F → F)).toOuterMeasure
         {O : FinalQuery QK SK AK NK F → F |
-          Break Extract S hfn Ggen Hask Hnk
-            (fun sk => O (.legacy sk)) (fun qk ak nk => O (.ext qk ak nk))
-            (fun rivk_ext ak nk => O (.int rivk_ext ak nk)) (A.run O).1 (A.run O).2}
+          Break Extract S hfn Ggen
+            ⟨Hask, Hnk, fun sk => O (.legacy sk), fun qk ak nk => O (.ext qk ak nk),
+              fun rivk_ext ak nk => O (.int rivk_ext ak nk)⟩ (A.run O).1 (A.run O).2}
       ≤ ((n + 4) * (n + 3) : ℕ) / Fintype.card F := by
   have hqueries : ∀ (O : FinalQuery QK SK AK NK F → F) (i : Fin 4),
       derivQueries Extract ((A.completing (derivQueries Extract)).run O) i
@@ -701,9 +699,9 @@ theorem break_measure_le_mixture {ι : Type*} (Extract : G → AK) (S : G) (hfn 
     ((p.bind fun i => (PMF.uniformOfFintype (FinalQuery QK SK AK NK F → F)).map
         (Prod.mk i))).toOuterMeasure
         {x : ι × (FinalQuery QK SK AK NK F → F) |
-          Break Extract S hfn Ggen (Hask x.1) (Hnk x.1)
-            (fun sk => x.2 (.legacy sk)) (fun qk ak nk => x.2 (.ext qk ak nk))
-            (fun rivk_ext ak nk => x.2 (.int rivk_ext ak nk))
+          Break Extract S hfn Ggen
+            ⟨(Hask x.1), (Hnk x.1), fun sk => x.2 (.legacy sk), fun qk ak nk => x.2 (.ext qk ak nk),
+              fun rivk_ext ak nk => x.2 (.int rivk_ext ak nk)⟩
             ((A x.1).run x.2).1 ((A x.1).run x.2).2}
       ≤ ((n + 4) * (n + 3) : ℕ) / Fintype.card F := by
   refine toOuterMeasure_bind_le _ _ _ fun i => ?_
@@ -730,9 +728,9 @@ theorem break_measure_le_product {ι : Type*} [Nonempty NK]
               (PMF.uniformOfFintype (F → AK → NK → F)).map fun Hint =>
                 (i, Hask, Hnk, FinalQuery.eval Hleg Hext Hint))).toOuterMeasure
         {x : ι × (SK → F) × (SK → NK) × (FinalQuery QK SK AK NK F → F) |
-          Break Extract S hfn Ggen x.2.1 x.2.2.1
-            (fun sk => x.2.2.2 (.legacy sk)) (fun qk ak nk => x.2.2.2 (.ext qk ak nk))
-            (fun rivk_ext ak nk => x.2.2.2 (.int rivk_ext ak nk))
+          Break Extract S hfn Ggen
+            ⟨x.2.1, x.2.2.1, fun sk => x.2.2.2 (.legacy sk), fun qk ak nk => x.2.2.2 (.ext qk ak nk),
+              fun rivk_ext ak nk => x.2.2.2 (.int rivk_ext ak nk)⟩
             ((A x.1).run x.2.2.2).1 ((A x.1).run x.2.2.2).2}
       ≤ ((n + 4) * (n + 3) : ℕ) / Fintype.card F := by
   refine toOuterMeasure_bind_le _ _ _ fun i => ?_

--- a/Zcash/Security/KeyBinding/Probability.lean
+++ b/Zcash/Security/KeyBinding/Probability.lean
@@ -34,7 +34,7 @@ Results (static model — the query set is fixed before the table is sampled):
   query set of size at most `q`: probability at most `q·(q−1)/|F|`.
 * `break_measure_le` — the key-binding capstone: an adversary whose witnesses' derivation
   queries land in the static set produces a `Break` with probability at most `q·(q−1)/|RIVK|`
-  (ZIP 2005's `ε_kb`; `|RIVK| = r`).
+  (ZIP 2005's `ε_kb` as sharpened in zcash/zips#1338; `|RIVK| = r`).
 
 Results (adaptive — a bounded-query machine choosing queries after seeing earlier answers, as
 an `OracleComp` from the Fiat–Shamir layer):
@@ -587,8 +587,8 @@ theorem ofBreak_queries {Extract : Extractor G IVK AK} {S : G} {hfn : AK → NK 
 /-- **Non-adaptive key-binding birthday bound.** Sample the combined final oracle as a uniform
 table. An adversary —here, any pair of witness choices depending on the whole table— whose
 witnesses' derivation queries lie in a set `Qs` of at most `q` queries *fixed in advance*,
-produces a key-binding `Break` with probability at most `q·(q−1)/|F|`. This is ZIP 2005's
-`ε_kb` at `|F| = r`. -/
+produces a key-binding `Break` with probability at most `q·(q−1)/|RIVK|`. This is ZIP 2005's
+`ε_kb` as sharpened in zcash/zips#1338, at `|RIVK| = r`. -/
 theorem break_measure_le (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK)
     (Ggen : G) (hS : S ≠ 0)
     (Hask : SK → ASK) (Hnk : SK → NK)
@@ -628,7 +628,8 @@ def derivQueries (Extract : Extractor G IVK AK)
 
 /-- **Adaptive key-binding bound (ZIP 2005 accounting).** An `n`-query machine that queries its
 output witnesses' derivation inputs produces a key-binding `Break` with probability at most
-`n·(n−1)/|F|` — ZIP 2005's `ε_kb` at `|F| = r`, with the adversary's queries chosen adaptively. -/
+`n·(n−1)/|RIVK|` — ZIP 2005's `ε_kb` (as sharpened in zcash/zips#1338) at `|RIVK| = r`, with
+the adversary's queries chosen adaptively. -/
 theorem break_measure_le_adaptive (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK)
     (Ggen : G) (hS : S ≠ 0)
     (Hask : SK → ASK) (Hnk : SK → NK)
@@ -716,7 +717,7 @@ the five oracle tables — `H^ask`, `H^nk`, and the three final `rivk`-derivatio
 drawn independently, the tables uniformly. The machine receives the sampled `H^ask`/`H^nk`
 tables — dominating any query strategy against those oracles, with the query budget counting
 only rivk-oracle queries — and runs on the combined table; the bound is the hypothesis-free
-`(n+4)·(n+3)/|F|`. -/
+`(n+4)·(n+3)/|RIVK|`. -/
 theorem break_measure_le_product {ι : Type*} [Fintype ASK] [Nonempty NK] [Nonempty ASK]
     (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK)
     (Ggen : G) (hS : S ≠ 0)

--- a/Zcash/Security/Ledger/Statement.lean
+++ b/Zcash/Security/Ledger/Statement.lean
@@ -37,42 +37,44 @@ namespace Zcash.Security.Ledger
 
 variable {F : Type*} [Field F]
 variable {G : Type*} [AddCommGroup G] [Module F G]
-variable {B : Type*} {KW : Type*}
+variable {IVK NK RHO PSI CMX RT : Type*} {KW : Type*}
 
 /-- An Orchard-shaped note. Point encodings and type conversions are abstracted away:
 `gd` and `pkd` are group elements, `ρ` and `ψ` base-field values, `v` a natural number
 (range-bounded by the statement). -/
-structure Note (G B : Type*) where
+structure Note (G RHO PSI : Type*) where
   gd : G
   pkd : G
   v : ℕ
-  ρ : B
-  ψ : B
+  ρ : RHO
+  ψ : PSI
 
 /-- The public inputs of an Action that the games consume: the anchor, the revealed
 nullifier, the randomized verification key, the net value commitment, and the new note
 commitment's extracted coordinate. -/
-structure ActionInstance (G B : Type*) where
-  rt : B
-  nf_old : B
+structure ActionInstance (G RT RHO CMX : Type*) where
+  rt : RT
+  /-- `⦂ RHO`: nullifiers share ρ's type, forced by ρ-uniqueness (`ρ_new = nf_old`). -/
+  nf_old : RHO
   rk : G
   cv_net : G
-  cmx_new : B
+  cmx_new : CMX
 
 /-- The abstract primitives of an Orchard-shaped shielded protocol. No algebraic structure
 is required of the fields themselves; the group algebra enters only through the statement
 and lemmas. `emb` is the embedding of base-field values used as scalars
 (`[0, q) ⊆ [0, r)` concretely). -/
-structure Primitives (F G B : Type*) where
+structure Primitives (F G IVK NK RHO PSI CMX RT : Type*) where
   depth : ℕ
   valueBound : ℕ
-  emb : B → F
+  emb : IVK → F
   emb_injective : Function.Injective emb
-  extract : G → B
-  noteCommit : F → Note G B → Option G
-  deriveNullifier : B → B → B → G → B
-  merkleCRH : B × B → B
-  leafOf : B → B → B
+  extract : G → CMX
+  noteCommit : F → Note G RHO PSI → Option G
+  /-- Nullifiers share ρ's type (`RHO`), forced by ρ-uniqueness (`ρ_new = nf_old`). -/
+  deriveNullifier : NK → RHO → PSI → G → RHO
+  merkleCRH : RT × RT → RT
+  leafOf : CMX → RHO → RT
   randomizePublic : F → G → G
   valueCommit : ℤ → F → G
 
@@ -80,9 +82,9 @@ structure Primitives (F G B : Type*) where
 condition `KB` enforced by the statement, and a `Break` predicate. `break_of_nk_ne` is the
 guarantee the games consume; the key-binding layer instantiates `Break` and discharges it
 (reducing breaks onward to random-oracle collisions or DLR relations). -/
-structure KeyBindingInterface (KW G B : Type*) where
-  ivk : KW → B
-  nk : KW → B
+structure KeyBindingInterface (KW G IVK NK : Type*) where
+  ivk : KW → IVK
+  nk : KW → NK
   akP : KW → G
   KB : KW → Prop
   Break : KW → KW → Prop
@@ -91,11 +93,11 @@ structure KeyBindingInterface (KW G B : Type*) where
 
 /-- The auxiliary inputs of an Action. `cm_old`/`cm_new` are carried explicitly so that the
 statement's commitment checks pin them; `kw` is the key-binding witness. -/
-structure ActionWitness (KW F G B : Type*) (d : ℕ) where
+structure ActionWitness (KW F G RHO PSI RT : Type*) (d : ℕ) where
   pos : Fin d → Bool
-  path : Fin d → B
-  note_old : Note G B
-  note_new : Note G B
+  path : Fin d → RT
+  note_old : Note G RHO PSI
+  note_new : Note G RHO PSI
   cm_old : G
   cm_new : G
   kw : KW
@@ -111,8 +113,9 @@ satisfy this interface (the latter enforces strictly more).
 TODO: It's unclear how well this will compose with Gregor's approach to the circuit proof.
 In particular, should this be `Prop`-only or will we need to apply the break-as-computed-data
 pattern here? -/
-structure ActionSatisfied (P : Primitives F G B) (kv : KeyBindingInterface KW G B)
-    (inst : ActionInstance G B) (w : ActionWitness KW F G B P.depth) : Prop where
+structure ActionSatisfied (P : Primitives F G IVK NK RHO PSI CMX RT)
+    (kv : KeyBindingInterface KW G IVK NK) (inst : ActionInstance G RT RHO CMX)
+    (w : ActionWitness KW F G RHO PSI RT P.depth) : Prop where
   /-- Spend-side commitment integrity: `cm_old` opens `note_old` with `rcm_old`. -/
   commit_old : P.noteCommit w.rcm_old w.note_old = some w.cm_old
   /-- Merkle path validity for nonzero-valued spends. -/
@@ -148,11 +151,11 @@ convention in `Zcash.Security.RandomOracle`): two distinct `(rcm, note)` tuples 
 equal extracted coordinates. Computed by the games' reductions; each instantiation reduces
 it onward (a Sinsemilla/DLR relation pre-quantum; an `H^rcm` ±-collision for the Recovery
 Statement via the Pedersen lift and the `extract` ±-property). -/
-structure NoteCommitBreak (P : Primitives F G B) where
+structure NoteCommitBreak (P : Primitives F G IVK NK RHO PSI CMX RT) where
   rcm₁ : F
-  n₁ : Note G B
+  n₁ : Note G RHO PSI
   rcm₂ : F
-  n₂ : Note G B
+  n₂ : Note G RHO PSI
   cm₁ : G
   cm₂ : G
   ne : (rcm₁, n₁) ≠ (rcm₂, n₂)
@@ -162,9 +165,9 @@ structure NoteCommitBreak (P : Primitives F G B) where
 
 section Pinning
 
-variable {P : Primitives F G B} {kv : KeyBindingInterface KW G B}
-variable {inst₁ inst₂ : ActionInstance G B}
-variable {w₁ w₂ : ActionWitness KW F G B P.depth}
+variable {P : Primitives F G IVK NK RHO PSI CMX RT} {kv : KeyBindingInterface KW G IVK NK}
+variable {inst₁ inst₂ : ActionInstance G RT RHO CMX}
+variable {w₁ w₂ : ActionWitness KW F G RHO PSI RT P.depth}
 
 /-- **`ivk`-pinning** (ZIP 2005 `lemma-ivk-pinning`): the address `(g_d, pk_d)` of the
 spent note determines `ivk`. Pure module algebra: needs only `g_d ≠ 0`, injectivity of the

--- a/Zcash/Security/Ledger/Statement.lean
+++ b/Zcash/Security/Ledger/Statement.lean
@@ -81,7 +81,10 @@ structure Primitives (F G IVK NK RHO PSI CMX RT : Type*) where
 /-- The games-facing view of a key-binding witness type `KW`: projections, the key-binding
 condition `KB` enforced by the statement, and a `Break` predicate. `break_of_nk_ne` is the
 guarantee the games consume; the key-binding layer instantiates `Break` and discharges it
-(reducing breaks onward to random-oracle collisions or DLR relations). -/
+(reducing breaks onward to random-oracle collisions or DLR relations). This interface is
+provisional: its shape is to be revisited against what the Balance and Spendability games
+actually consume once they are formalized — in particular `Break` being an opaque `Prop`
+limits the games to certificate-level break exhibition. -/
 structure KeyBindingInterface (KW G IVK NK : Type*) where
   ivk : KW → IVK
   nk : KW → NK
@@ -208,23 +211,29 @@ def noteCommitBreakOfNe
     NoteCommitBreak P :=
   ⟨_, _, _, _, _, _, hne, h₁.commit_old, h₂.commit_old, hx⟩
 
-/-- **Nullifier determinism up to a break**: two satisfied spends of the same note tuple
-reveal the same nullifier, or their key witnesses exhibit a key-binding break. Together
-with `tuple_eq_or_noteCommitBreak` this is what turns a repeated spend of a positioned note
-into a repeated nullifier in the Balance argument. -/
-theorem nf_old_eq_or_break [NoZeroSMulDivisors F G]
+/-- **Nullifier determinism up to a break** — **nf-pinning** (ZIP 2005 `lemma-nf-pinning`,
+consumed by the Spendability argument), as computed data per the breaks-as-computed-data
+convention: two satisfied spends of the same note tuple either reveal the same nullifier or
+their key witnesses exhibit a key-binding break, with the branch decided on the
+nullifier-key comparison. Together with `tuple_eq_or_noteCommitBreak` this is what turns a
+repeated spend of a positioned note into a repeated nullifier in the Balance argument. The
+nullifier here is a function by definition; the circuit-soundness layer must separately
+ensure the deployed circuit computes `DeriveNullifier` deterministically as a function of
+`(nk, ρ, ψ, cm)`. -/
+def nfOldEqOrBreak [DecidableEq NK] [NoZeroSMulDivisors F G]
     (h₁ : ActionSatisfied P kv inst₁ w₁) (h₂ : ActionSatisfied P kv inst₂ w₂)
     (hrcm : w₁.rcm_old = w₂.rcm_old) (hnote : w₁.note_old = w₂.note_old) :
-    inst₁.nf_old = inst₂.nf_old ∨ kv.Break w₁.kw w₂.kw := by
-  have hcm : w₁.cm_old = w₂.cm_old := by
-    have h := h₁.commit_old
-    rw [hrcm, hnote, h₂.commit_old] at h
-    exact (Option.some.inj h).symm
-  rcases nk_eq_or_break h₁ h₂ (congrArg Note.gd hnote) (congrArg Note.pkd hnote) with
-    hnk | hbr
-  · left
-    rw [h₁.nf_old_eq, h₂.nf_old_eq, hnk, hcm, hnote]
-  · exact Or.inr hbr
+    (inst₁.nf_old = inst₂.nf_old) ⊕' kv.Break w₁.kw w₂.kw :=
+  if hnk : kv.nk w₁.kw = kv.nk w₂.kw then
+    .inl (by
+      have hcm : w₁.cm_old = w₂.cm_old := by
+        have h := h₁.commit_old
+        rw [hrcm, hnote, h₂.commit_old] at h
+        exact (Option.some.inj h).symm
+      rw [h₁.nf_old_eq, h₂.nf_old_eq, hnk, hcm, hnote])
+  else
+    .inr (kv.break_of_nk_ne h₁.key_binding h₂.key_binding
+      (ivk_pinned h₁ h₂ (congrArg Note.gd hnote) (congrArg Note.pkd hnote)) hnk)
 
 end Pinning
 

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -80,6 +80,7 @@ assert_axioms Zcash.Security.KeyBinding.uniformOfFintype_prod
 assert_computable Zcash.Security.KeyBinding.evalEquiv
 assert_axioms Zcash.Security.KeyBinding.uniform_triple_eval
 assert_axioms Zcash.Security.KeyBinding.break_measure_le_product
+assert_axioms Zcash.Security.toInterface_break_measure_le
 
 /-! ## Ledger-layer break reductions
 

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -79,6 +79,7 @@ assert_axioms Zcash.Security.KeyBinding.break_measure_le_mixture
 assert_axioms Zcash.Security.KeyBinding.uniformOfFintype_prod
 assert_computable Zcash.Security.KeyBinding.evalEquiv
 assert_axioms Zcash.Security.KeyBinding.uniform_triple_eval
+assert_axioms Zcash.Security.KeyBinding.break_measure_le_product
 
 /-! ## Ledger-layer break reductions
 

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -76,6 +76,9 @@ assert_axioms Zcash.Security.KeyBinding.break_measure_le_adaptive
 assert_axioms Zcash.Security.KeyBinding.break_measure_le_of_queryBound
 assert_axioms Zcash.Security.KeyBinding.toOuterMeasure_bind_le
 assert_axioms Zcash.Security.KeyBinding.break_measure_le_mixture
+assert_axioms Zcash.Security.KeyBinding.uniformOfFintype_prod
+assert_computable Zcash.Security.KeyBinding.evalEquiv
+assert_axioms Zcash.Security.KeyBinding.uniform_triple_eval
 
 /-! ## Ledger-layer break reductions
 

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -91,6 +91,7 @@ even in erased positions, which is the strict (flagless) `assert_computable` tie
 assert_computable Collision.upToSign
 assert_computable Merkle.collisionOfWrongLeaf
 assert_computable noteCommitBreakOfNe
+assert_computable Zcash.Security.Ledger.nfOldEqOrBreak +choice
 
 /-! ## Binding-signature relation reductions
 

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -35,6 +35,7 @@ assert_computable Zcash.Security.RandomOracle.CollisionUpToSign.ofBreak +choice
 
 /-! ## Key binding — theorems -/
 
+assert_axioms Zcash.Security.KeyBinding.Extractor.card_ivk_ge
 assert_axioms Zcash.Security.KeyBinding.commit_scalar_pm
 assert_axioms Zcash.Security.KeyBinding.rivk_eq_finalOracle
 assert_axioms Zcash.Security.KeyBinding.sameIvk_finalOracle_pm


### PR DESCRIPTION
Fixes #68 — the four remaining items of the key-binding ROM model.

* **Triple↔table transport, as a stated PMF equality.** `uniformOfFintype_prod`, `evalEquiv`, and `uniform_triple_eval`: independent uniform draws of the three rivk-derivation oracles, combined with `FinalQuery.eval`, are exactly the uniform whole-table draw.

* **Five independent oracle tables.** `break_measure_le_product` states ZIP 2005's probability space in full — adversary private randomness under an arbitrary distribution, and the five oracle tables drawn independently, the tables uniformly — keeping the hypothesis-free `(n+4)·(n+3)/|F|` bound.

* **Interface delivery.** `toInterface_break_measure_le` phrases the break event through the games' `KeyBindingInterface`, so the games' `∨ kv.Break` branches inherit the bound directly.

* **Role-typed variables.** The shared base-field variable splits by role, following the spec typing of each quantity: the key-binding layer gets `IVK`/`AK`/`NK`, and the games layer's `Primitives` / `Note` / `ActionInstance` / `ActionWitness` split over `IVK`, `NK`, `RHO`, `PSI`, `CMX`, and `RT` (nullifiers share `RHO`, forced by ρ-uniqueness). All concretely `ZMod q` for Orchard; the roles are documentary and Sapling-ready.

* **Scalar role types.** `RIVK` (rivk values and the rivk-derivation oracle outputs; `G` is an `RIVK`-module and the capstone denominators read `|RIVK| = r`) splits from `ASK` (`H^ask` outputs, acting on `G` via `SMul` only); the generic birthday layer keeps its own field `F`, instantiated at `RIVK` by the capstones. Type-parameter order is canonical across the layer — `G, IVK, AK, NK, RIVK, ASK, QK, SK`, with `QK` before `SK` matching the ZIP's tagged-union order — and the `Witness`/`BreakProj` fields and the instance arguments follow it; ZIP 2005's witness and break-projection presentations are to adopt the same order.

* **`IVK` sizing, checked.** `Extractor.card_ivk_ge`: `toIVK_pm` makes `toIVK` at most 2-to-1, so `|G| ≤ 2·|IVK|` — an `IVK` small enough to find collisions in admits no `Extractor`, making undersized instantiations vacuous rather than falsely secure. This records why the birthday bounds involve only `|RIVK|`; a hash-derived `ivk` (Sapling's `CRH^ivk`) does not satisfy `toIVK_pm` and would need a collision-resistance term in the bound instead.

Two signature refactors ride along: the five oracles bundle as an `Oracles` structure, and the two extract maps as an `Extractor` structure (`toIVK`, carrying the ±-property as the `toIVK_pm` field, and `toAK`; both instantiate to `Extract_P` concretely). A wording clarification in the `badList` docstring leads the branch.

Verification: full build green at the tip, and every commit in the range builds green individually; census entries added for all new declarations, with `evalEquiv` at the flagless `assert_computable` tier.

🤖 Claude Fable 5





