### PR TITLE
feat(fv): the deterministic layer of the Balance, Spendability, and Spend Authority games

### DIFF
--- a/Zcash/Security.lean
+++ b/Zcash/Security.lean
@@ -7,6 +7,7 @@ import Zcash.Security.BindingSignature.Sapling
 import Zcash.Security.Ledger.Merkle
 import Zcash.Security.Ledger.Statement
 import Zcash.Security.Ledger.Model
+import Zcash.Security.Ledger.Effects
 import Zcash.Security.Common.RandomOracle
 import Zcash.Security.Common.Birthday
 import Zcash.Security.KeyBinding.Basic

--- a/Zcash/Security.lean
+++ b/Zcash/Security.lean
@@ -10,6 +10,7 @@ import Zcash.Security.Ledger.Model
 import Zcash.Security.Ledger.Effects
 import Zcash.Security.Ledger.Balance
 import Zcash.Security.Ledger.Spendability
+import Zcash.Security.Ledger.SpendAuthority
 import Zcash.Security.Common.RandomOracle
 import Zcash.Security.Common.Birthday
 import Zcash.Security.KeyBinding.Basic

--- a/Zcash/Security.lean
+++ b/Zcash/Security.lean
@@ -9,6 +9,7 @@ import Zcash.Security.Ledger.Statement
 import Zcash.Security.Ledger.Model
 import Zcash.Security.Ledger.Effects
 import Zcash.Security.Ledger.Balance
+import Zcash.Security.Ledger.Spendability
 import Zcash.Security.Common.RandomOracle
 import Zcash.Security.Common.Birthday
 import Zcash.Security.KeyBinding.Basic

--- a/Zcash/Security.lean
+++ b/Zcash/Security.lean
@@ -6,6 +6,7 @@ import Zcash.Security.BindingSignature.Orchard
 import Zcash.Security.BindingSignature.Sapling
 import Zcash.Security.Ledger.Merkle
 import Zcash.Security.Ledger.Statement
+import Zcash.Security.Ledger.Model
 import Zcash.Security.Common.RandomOracle
 import Zcash.Security.Common.Birthday
 import Zcash.Security.KeyBinding.Basic

--- a/Zcash/Security.lean
+++ b/Zcash/Security.lean
@@ -8,6 +8,7 @@ import Zcash.Security.Ledger.Merkle
 import Zcash.Security.Ledger.Statement
 import Zcash.Security.Ledger.Model
 import Zcash.Security.Ledger.Effects
+import Zcash.Security.Ledger.Balance
 import Zcash.Security.Common.RandomOracle
 import Zcash.Security.Common.Birthday
 import Zcash.Security.KeyBinding.Basic

--- a/Zcash/Security/Common/RandomOracle.lean
+++ b/Zcash/Security/Common/RandomOracle.lean
@@ -64,4 +64,16 @@ structure CollisionUpToSign [Neg F] (O : Q → F) where
 def Collision.upToSign [Neg F] {O : Q → F} (c : Collision O) : CollisionUpToSign O :=
   ⟨c.q₁, c.q₂, c.ne, Or.inl c.eq⟩
 
+/-- A collision of a partial oracle `O`, as data: two distinct queries on which `O` is
+defined, with equal outputs.  For a totalized partial function, plain `Collision` would
+also accept two undefined queries mapped to the same sentinel; requiring the successful
+evaluations keeps the event a genuine collision. -/
+structure DefinedCollision (O : Q → Option F) where
+  q₁ : Q
+  q₂ : Q
+  ne : q₁ ≠ q₂
+  output : F
+  eval₁ : O q₁ = some output
+  eval₂ : O q₂ = some output
+
 end Zcash.Security.RandomOracle

--- a/Zcash/Security/KeyBinding/Basic.lean
+++ b/Zcash/Security/KeyBinding/Basic.lean
@@ -92,8 +92,8 @@ def FinalQuery.eval (Hrivk_legacy : SK → RIVK) (Hrivk_ext : QK → AK → NK �
   | .int rivk_ext ak nk => Hrivk_int rivk_ext ak nk
 
 /-- The two extract maps of the key-binding model; both instantiate to `Extract_P`
-concretely. `toIVK` carries the ±-property (`toIVK_pm`); `toAK` serves the derivation and
-projection side. -/
+concretely, and both carry the ±-property. `toIVK` serves the commitment opening; `toAK`
+serves the derivation and projection side. -/
 structure Extractor (G IVK AK : Type*) [Neg G] where
   toIVK : G → IVK
   toAK : G → AK
@@ -101,6 +101,11 @@ structure Extractor (G IVK AK : Type*) [Neg G] where
   point the concrete x-coordinate instantiation needs "no Pallas point has x = 0"
   (x = 0 forces y² = 5, a non-square). -/
   toIVK_pm : ∀ P Q : G, toIVK P = toIVK Q ↔ P =± Q
+  /-- `toAK` identifies exactly the ±-pairs, like `toIVK`. The forward direction is what
+  discharges the games' `break_of_akP_ne`: `ak` is consumed as a single extracted
+  coordinate, so two witnesses whose `ak^ℙ` differ by more than y-sign have different
+  break projections. -/
+  toAK_pm : ∀ P Q : G, toAK P = toAK Q ↔ P =± Q
 
 /-- `toIVK` is at most 2-to-1 (`toIVK_pm`), so the `IVK` domain is at least half the group:
 `|G| ≤ 2·|IVK|`. An `IVK` small enough to find collisions in admits no `Extractor` at all —

--- a/Zcash/Security/KeyBinding/Instance.lean
+++ b/Zcash/Security/KeyBinding/Instance.lean
@@ -8,8 +8,9 @@ import Zcash.Security.Ledger.Statement
 The deliberate contact point between the concrete key-binding development
 (`Zcash.Security.KeyBinding`: the `Witness`, the factored condition `KB = KBOpening ∧ KBDerivation`,
 and `Break`) and the games-facing view (`Zcash.Security.Ledger.KeyBindingInterface`). The games see
-only the projections and the `break_of_nk_ne` guarantee; here we discharge that guarantee from
-`nk_pinned`.
+only the projections and the `break_of_nk_ne` / `break_of_akP_ne` guarantees; here we discharge
+them from the break projection (`nk` differing directly; `akP` via `toAK_pm`, since the projection
+quotients the y-sign).
 -/
 
 namespace Zcash.Security
@@ -31,6 +32,8 @@ def KeyBinding.toInterface
   Break := KeyBinding.Break Extract S hfn Ggen H
   break_of_nk_ne {_w₁ _w₂} h₁ h₂ hivk hne :=
     ⟨h₁, h₂, hivk, fun heq => hne (congrArg BreakProj.nk heq)⟩
+  break_of_akP_ne {_w₁ _w₂} h₁ h₂ hivk hne :=
+    ⟨h₁, h₂, hivk, fun heq => hne ((Extract.toAK_pm _ _).mp (congrArg BreakProj.ak heq))⟩
 
 
 /-- The probabilistic key-binding bound, delivered at the games' interface: over the

--- a/Zcash/Security/Ledger/Balance.lean
+++ b/Zcash/Security/Ledger/Balance.lean
@@ -19,10 +19,10 @@ opening is spent twice — or the ledger's own data computes a `BalanceBreak`:
 
 The shape of the argument (design doc, "The theorems"): the anchor pins each spend's
 path to a prefix tree; position binding pins the leaf; `uncommitted_ne` rules out the
-padding; the opening comparison pins the output or computes the note-commitment break;
-and duplicate spends of one positioned opening are found by `findPair`, whose result is
-certified as a two-element *sublist* — carrying "two distinct occurrences" with no index
-arithmetic — so `nfOldEqOrBreak` and nullifier uniqueness finish.
+padding; and the opening comparison pins the output or computes the note-commitment
+break. Duplicate spends of one positioned opening are found by `findPair`. Its result
+is certified as a two-element *sublist*, which carries "two distinct occurrences" with
+no index arithmetic, so `nfOldEqOrBreak` and nullifier uniqueness finish.
 
 Everything is a plain computable `def` per breaks-as-computed-data; the anchor index and
 the duplicate pair are found by decidable search, so no data is conjured from the
@@ -48,6 +48,8 @@ def findPair {α β : Type*} [DecidableEq β] (f : α → β) : List α → Opti
     | some b => some (a, b)
     | none => findPair f t
 
+/-- A successful scan certifies its pair: equal images under `f`, and the two entries
+form a two-element sublist of the input — distinct occurrences, in list order. -/
 theorem findPair_spec {α β : Type*} [DecidableEq β] (f : α → β) :
     ∀ {l : List α} {a₁ a₂ : α}, findPair f l = some (a₁, a₂) →
       f a₁ = f a₂ ∧ List.Sublist [a₁, a₂] l
@@ -67,6 +69,7 @@ theorem findPair_spec {α β : Type*} [DecidableEq β] (f : α → β) :
         obtain ⟨hfa, hsub⟩ := findPair_spec f h
         exact ⟨hfa, hsub.trans (List.sublist_cons_self a t)⟩
 
+/-- A failed scan certifies that all images under `f` are pairwise distinct. -/
 theorem findPair_none {α β : Type*} [DecidableEq β] (f : α → β) :
     ∀ {l : List α}, findPair f l = none → (l.map f).Nodup
   | [], _ => by simp
@@ -96,11 +99,13 @@ theorem flatMap_sublist {α β : Type*} {l : List α} {g g' : α → List β}
       simp only [List.flatMap_cons]
       exact (h a (by simp)).append (ih fun x hx => h x (by simp [hx]))
 
+/-- A ledger prefix contributes a prefix of the flattened action list. -/
 theorem outputActions_prefix {l₁ l₂ : Ledger KW F G RHO PSI MHASH MENC MSG SIG d}
     (h : l₁ <+: l₂) : outputActions l₁ <+: outputActions l₂ := by
   obtain ⟨r, rfl⟩ := h
   exact ⟨outputActions r, by simp [outputActions, List.flatMap_append]⟩
 
+/-- A ledger prefix contributes a prefix of the revealed-nullifier list. -/
 theorem nullifiers_prefix {l₁ l₂ : Ledger KW F G RHO PSI MHASH MENC MSG SIG d}
     (h : l₁ <+: l₂) : nullifiers l₁ <+: nullifiers l₂ := by
   obtain ⟨r, rfl⟩ := h
@@ -346,18 +351,21 @@ def issuanceTotal (issuance : ℕ → ℕ)
 
 section SumToolbox
 
+/-- Summing over a flat map is summing the per-chunk sums. -/
 private theorem sum_flatMap {α β : Type*} (g : α → List β) (f : β → ℤ) (l : List α) :
     ((l.flatMap g).map f).sum = (l.map fun x => ((g x).map f).sum).sum := by
   induction l with
   | nil => simp
   | cons a t ih => simp [List.flatMap_cons, ih]
 
+/-- The sum of pointwise differences is the difference of sums. -/
 private theorem sum_map_sub {α : Type*} (f g : α → ℤ) (l : List α) :
     (l.map fun x => f x - g x).sum = (l.map f).sum - (l.map g).sum := by
   induction l with
   | nil => simp
   | cons a t ih => simp only [List.map_cons, List.sum_cons, ih]; ring
 
+/-- Mapping a function of the entry over an index-zipped list ignores the indices. -/
 private theorem map_zipIdx_fst {α β : Type*} {f : α → β} :
     ∀ (l : List α) (n : ℕ), ((l.zipIdx n).map fun p => f p.1) = l.map f
   | [], _ => rfl

--- a/Zcash/Security/Ledger/Balance.lean
+++ b/Zcash/Security/Ledger/Balance.lean
@@ -5,9 +5,12 @@ import Zcash.Security.Ledger.Effects
 # Balance-subset: every nonzero spend is a committed output
 
 The first Balance theorem, as a computed reduction. For a valid ledger, the nonzero
-spends form a sub-multiset of the positioned outputs — each spend is the opening of the
-output that created its commitment, at that output's leaf position, and no positioned
-opening is spent twice — or the ledger's own data computes a `BalanceBreak`:
+spends of the first `i + 1` transactions form a sub-multiset of the positioned outputs
+of the first `i` — outputs of *strictly earlier* transactions, since an anchor
+references the tree at a transaction boundary, so a spend can never match an output of
+its own transaction. Each spend is the opening of the output that created its
+commitment, at that output's leaf position, and no positioned opening is spent twice —
+or the ledger's own data computes a `BalanceBreak`:
 
 * a Merkle `Collision` — one height's compression collided, with both evaluations
   successful — when a spend's authentication path validates a leaf that is not the
@@ -196,7 +199,7 @@ theorem satisfied_of_spendMem
 theorem anchor_of_spendMem
     (hval : ValidLedger P kv issuance maxActions ledger) {i : ℕ}
     {a : Action KW F G RHO PSI MHASH MENC SIG P.depth} (ha : a ∈ spendActions ledger i) :
-    ∃ j, j ≤ i ∧ rootAfter P ledger j = some a.inst.rt := by
+    ∃ j, j < i ∧ rootAfter P ledger j = some a.inst.rt := by
   obtain ⟨tx, htx, hafil⟩ := List.mem_flatMap.mp ha
   obtain ⟨k, hk, hgetk⟩ := List.mem_iff_getElem.mp htx
   have hki : k < i := lt_of_lt_of_le hk (by simp [List.length_take])
@@ -206,7 +209,7 @@ theorem anchor_of_spendMem
     exact hgetk
   obtain ⟨j, hjk, hrt⟩ := hval.anchor_valid ⟨k, hkl⟩ a
     (by rw [hget]; exact List.mem_of_mem_filter hafil)
-  exact ⟨j, le_of_lt (lt_of_le_of_lt hjk hki), hrt⟩
+  exact ⟨j, lt_of_le_of_lt hjk hki, hrt⟩
 
 /-- **Per-spend pinning.** A nonzero spend of a valid ledger is the positioned opening
 of the output that created its commitment — or the ledger data computes a break. The
@@ -215,11 +218,13 @@ computable. -/
 def spendPinnedOrBreak [DecidableEq F] [DecidableEq G] [DecidableEq RHO]
     [DecidableEq PSI] [DecidableEq MHASH] [DecidableEq MENC]
     (hval : ValidLedger P kv issuance maxActions ledger) {i : ℕ}
-    {a : Action KW F G RHO PSI MHASH MENC SIG P.depth} (ha : a ∈ spendActions ledger i) :
+    {a : Action KW F G RHO PSI MHASH MENC SIG P.depth}
+    (ha : a ∈ spendActions ledger (i + 1)) :
     (spendRecord a ∈ positionedOutputs ledger i) ⊕' BalanceBreak P kv :=
-  have hex : ∃ j, j ≤ i ∧ rootAfter P ledger j = some a.inst.rt := anchor_of_spendMem hval ha
+  have hex : ∃ j, j < i + 1 ∧ rootAfter P ledger j = some a.inst.rt :=
+    anchor_of_spendMem hval ha
   let j := Nat.find hex
-  have hji : j ≤ i := (Nat.find_spec hex).1
+  have hji : j ≤ i := Nat.lt_succ_iff.mp (Nat.find_spec hex).1
   have hpath : Merkle.Path P.merkle (P.extract a.w.cm_old) a.inst.rt a.w.path a.w.side :=
     (satisfied_of_spendMem hval ha).1.merkle_path (satisfied_of_spendMem hval ha).2
   have hroot : Merkle.root P.merkle (leafFun P (leafList (ledger.take j)))
@@ -264,7 +269,7 @@ def allPinnedOrBreak [DecidableEq F] [DecidableEq G] [DecidableEq RHO]
     [DecidableEq PSI] [DecidableEq MHASH] [DecidableEq MENC]
     (hval : ValidLedger P kv issuance maxActions ledger) {i : ℕ} :
     (L : List (Action KW F G RHO PSI MHASH MENC SIG P.depth)) →
-    (∀ a ∈ L, a ∈ spendActions ledger i) →
+    (∀ a ∈ L, a ∈ spendActions ledger (i + 1)) →
     ((∀ a ∈ L, spendRecord a ∈ positionedOutputs ledger i) ⊕' BalanceBreak P kv)
   | [], _ => .inl (by simp)
   | a :: t, hL =>
@@ -279,20 +284,23 @@ def allPinnedOrBreak [DecidableEq F] [DecidableEq G] [DecidableEq RHO]
           exacts [hmem, hall x hx'])
 
 /-- **Balance-subset, as a computed reduction.** For a valid ledger, the nonzero spends
-are a sub-multiset of the positioned outputs — or the ledger data computes a
-`BalanceBreak`. Duplicate spends are located by `findPair`; sharing a positioned opening
+of the first `i + 1` transactions are a sub-multiset of the positioned outputs of the
+first `i` — or the ledger data computes a `BalanceBreak`. The one-transaction lag is the
+strictly-earlier constraint: an anchor references a transaction boundary, so a spend
+never matches an output of its own transaction. Duplicate spends are located by
+`findPair`; sharing a positioned opening
 forces sharing a revealed nullifier (`nfOldEqOrBreak`), which nullifier uniqueness
 forbids, so the surviving branch is a key-binding break. -/
 def balanceSubsetOrBreak [DecidableEq F] [DecidableEq G] [DecidableEq RHO]
     [DecidableEq PSI] [DecidableEq MHASH] [DecidableEq MENC] [DecidableEq NK]
     [NoZeroSMulDivisors F G]
     (hval : ValidLedger P kv issuance maxActions ledger) (i : ℕ) :
-    (nonZeroSpends ledger i ≤ ↑(positionedOutputs ledger i)) ⊕' BalanceBreak P kv :=
-  match hfp : findPair spendRecord (spendActions ledger i) with
+    (nonZeroSpends ledger (i + 1) ≤ ↑(positionedOutputs ledger i)) ⊕' BalanceBreak P kv :=
+  match hfp : findPair spendRecord (spendActions ledger (i + 1)) with
   | some (a₁, a₂) =>
       have hspec := findPair_spec spendRecord hfp
-      have h₁ : a₁ ∈ spendActions ledger i := hspec.2.subset (by simp)
-      have h₂ : a₂ ∈ spendActions ledger i := hspec.2.subset (by simp)
+      have h₁ : a₁ ∈ spendActions ledger (i + 1) := hspec.2.subset (by simp)
+      have h₂ : a₂ ∈ spendActions ledger (i + 1) := hspec.2.subset (by simp)
       have hrcm : a₁.w.rcm_old = a₂.w.rcm_old := by
         have := congrArg (fun r => r.opening.rcm) hspec.1
         simpa [spendRecord] using this
@@ -306,15 +314,15 @@ def balanceSubsetOrBreak [DecidableEq F] [DecidableEq G] [DecidableEq RHO]
           -- one nullifier at two distinct occurrences — impossible in a valid ledger
           have hsubnf : List.Sublist [a₁.inst.nf_old, a₂.inst.nf_old] (nullifiers ledger) := by
             have h := (hspec.2.map fun a => a.inst.nf_old).trans
-              (spendActions_map_nf_sublist ledger i)
+              (spendActions_map_nf_sublist ledger (i + 1))
             simpa using h
           have hnd : [a₁.inst.nf_old, a₂.inst.nf_old].Nodup :=
             hval.nf_nodup.sublist hsubnf
           absurd hnf (by simpa using hnd)
   | none =>
-      have hnodup : ((spendActions ledger i).map spendRecord).Nodup :=
+      have hnodup : ((spendActions ledger (i + 1)).map spendRecord).Nodup :=
         findPair_none spendRecord hfp
-      match allPinnedOrBreak hval (spendActions ledger i) (fun _ h => h) with
+      match allPinnedOrBreak hval (spendActions ledger (i + 1)) (fun _ h => h) with
       | .inr b => .inr b
       | .inl hall =>
           .inl (by

--- a/Zcash/Security/Ledger/Balance.lean
+++ b/Zcash/Security/Ledger/Balance.lean
@@ -321,4 +321,185 @@ def balanceSubsetOrBreak [DecidableEq F] [DecidableEq G] [DecidableEq RHO]
 
 end Validity
 
+/-! ## Balance-value, in conservation form
+
+The value ledger balances: what the shielded pool holds plus what the transparent pool
+holds is exactly what issuance has minted — up to a per-transaction value premiss. The
+premiss says each transaction's witnessed net value matches its declared `vBalance`, or
+a value break of the caller's type is exhibited. The intended deployed discharge is the
+binding-signature machinery (`NontrivialRelation.ofBundleIntImbalance` with the
+statement's value ranges and the action-count bound), with a nontrivial discrete-log
+relation as the break; that glue is not yet formalized, and validity does not yet carry
+binding-signature verification. Balance is then the corollary: given the transparent
+pool never goes negative (`ValidLedger.transparent_nonneg`), the shielded pool holds at
+most what was minted. -/
+
+/-- A transaction's net value, read off its witnesses: spent minus created, over all
+actions (zero-valued dummies contribute zero). -/
+def txNetValue (tx : Tx KW F G RHO PSI MHASH MENC MSG SIG d) : ℤ :=
+  (tx.actions.map fun a => (a.w.note_old.v : ℤ) - a.w.note_new.v).sum
+
+/-- The issuance minted alongside the first `i` transactions. -/
+def issuanceTotal (issuance : ℕ → ℕ)
+    (ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG d) (i : ℕ) : ℤ :=
+  ((ledger.take i).zipIdx.map fun p => (issuance p.2 : ℤ)).sum
+
+section SumToolbox
+
+private theorem sum_flatMap {α β : Type*} (g : α → List β) (f : β → ℤ) (l : List α) :
+    ((l.flatMap g).map f).sum = (l.map fun x => ((g x).map f).sum).sum := by
+  induction l with
+  | nil => simp
+  | cons a t ih => simp [List.flatMap_cons, ih]
+
+private theorem sum_map_sub {α : Type*} (f g : α → ℤ) (l : List α) :
+    (l.map fun x => f x - g x).sum = (l.map f).sum - (l.map g).sum := by
+  induction l with
+  | nil => simp
+  | cons a t ih => simp only [List.map_cons, List.sum_cons, ih]; ring
+
+private theorem map_zipIdx_fst {α β : Type*} {f : α → β} :
+    ∀ (l : List α) (n : ℕ), ((l.zipIdx n).map fun p => f p.1) = l.map f
+  | [], _ => rfl
+  | a :: t, n => by
+    simp only [List.zipIdx_cons, List.map_cons]
+    rw [map_zipIdx_fst t (n + 1)]
+
+end SumToolbox
+
+/-- The transparent pool balance splits into minted issuance plus declared balances. -/
+theorem transparentPoolBalance_eq (issuance : ℕ → ℕ)
+    (ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG d) (i : ℕ) :
+    transparentPoolBalance issuance ledger i
+      = issuanceTotal issuance ledger i
+        + ((ledger.take i).map fun tx => tx.vBalance).sum := by
+  rw [transparentPoolBalance, issuanceTotal, List.sum_map_add, map_zipIdx_fst]
+
+/-- The outputs' value total, transaction by transaction. -/
+theorem positionedOutputs_value_sum
+    (ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG d) (i : ℕ) :
+    ((positionedOutputs ledger i).map fun p => (p.opening.note.v : ℤ)).sum
+      = ((ledger.take i).map fun tx =>
+          (tx.actions.map fun a => (a.w.note_new.v : ℤ)).sum).sum := by
+  rw [positionedOutputs, List.map_map]
+  rw [show ((fun p : PositionedOpening F G RHO PSI => (p.opening.note.v : ℤ))
+        ∘ fun p : Opening F G RHO PSI × ℕ => (⟨p.2, p.1⟩ : PositionedOpening F G RHO PSI))
+      = fun p : Opening F G RHO PSI × ℕ => (p.1.note.v : ℤ) from rfl]
+  rw [show ((outputOpenings (ledger.take i)).zipIdx.map fun p => (p.1.note.v : ℤ))
+      = (outputOpenings (ledger.take i)).map fun o => (o.note.v : ℤ) from
+    map_zipIdx_fst (f := fun o : Opening F G RHO PSI => (o.note.v : ℤ)) _ 0]
+  rw [outputOpenings, List.map_map]
+  rw [show ((fun o : Opening F G RHO PSI => (o.note.v : ℤ)) ∘ outputOpening)
+      = fun a : Action KW F G RHO PSI MHASH MENC SIG d => (a.w.note_new.v : ℤ) from rfl]
+  rw [outputActions, sum_flatMap]
+
+/-- The nonzero spends' value total is every spend's value total: the filtered-out
+spends have value zero. -/
+theorem nonZeroSpends_value_sum
+    (ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG d) (i : ℕ) :
+    ((nonZeroSpends ledger i).map fun p => (p.opening.note.v : ℤ)).sum
+      = ((ledger.take i).map fun tx =>
+          (tx.actions.map fun a => (a.w.note_old.v : ℤ)).sum).sum := by
+  have hfil : ∀ acts : List (Action KW F G RHO PSI MHASH MENC SIG d),
+      (((acts.filter fun a => a.w.note_old.v ≠ 0).map fun a =>
+          (a.w.note_old.v : ℤ))).sum
+        = (acts.map fun a => (a.w.note_old.v : ℤ)).sum := by
+    intro acts
+    induction acts with
+    | nil => rfl
+    | cons a t ih =>
+        rw [List.filter_cons]
+        by_cases h : a.w.note_old.v ≠ 0
+        · rw [if_pos (by simpa using h), List.map_cons, List.sum_cons, ih,
+            List.map_cons, List.sum_cons]
+        · rw [if_neg (by simpa using h), ih, List.map_cons, List.sum_cons]
+          have h0 : a.w.note_old.v = 0 := by omega
+          rw [h0]
+          simp
+  rw [nonZeroSpends]
+  rw [show ((↑((spendActions ledger i).map spendRecord) :
+        Multiset (PositionedOpening F G RHO PSI)).map
+          fun p => (p.opening.note.v : ℤ)).sum
+      = (((spendActions ledger i).map spendRecord).map
+          fun p => (p.opening.note.v : ℤ)).sum by simp]
+  rw [List.map_map]
+  rw [show ((fun p : PositionedOpening F G RHO PSI => (p.opening.note.v : ℤ))
+        ∘ spendRecord)
+      = fun a : Action KW F G RHO PSI MHASH MENC SIG d => (a.w.note_old.v : ℤ) from rfl]
+  rw [spendActions, sum_flatMap]
+  exact congrArg List.sum (List.map_congr_left fun tx _ => hfil tx.actions)
+
+/-- The shielded pool balance is the negated sum of the transactions' net values. -/
+theorem poolValueBalance_eq_neg
+    (ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG d) (i : ℕ) :
+    poolValueBalance ledger i = -((ledger.take i).map txNetValue).sum := by
+  rw [poolValueBalance, positionedOutputs_value_sum, nonZeroSpends_value_sum]
+  rw [show ((ledger.take i).map txNetValue).sum
+      = ((ledger.take i).map fun tx =>
+            (tx.actions.map fun a => (a.w.note_old.v : ℤ)).sum).sum
+        - ((ledger.take i).map fun tx =>
+            (tx.actions.map fun a => (a.w.note_new.v : ℤ)).sum).sum by
+    rw [← sum_map_sub]
+    exact congrArg List.sum (List.map_congr_left fun tx _ => by
+      rw [txNetValue, sum_map_sub])]
+  ring
+
+section Conservation
+
+variable [Field F] [AddCommGroup G] [Module F G]
+variable {P : Primitives F G IVK NK RHO PSI MHASH MENC MSG SIG}
+variable {kv : KeyBindingInterface KW G IVK NK}
+variable {ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG P.depth}
+variable {issuance : ℕ → ℕ} {maxActions : ℕ}
+
+/-- Run the per-transaction value premiss over a list, stopping at the first break. -/
+def allValueOrBreak {VB : Type*}
+    (perTx : (tx : Tx KW F G RHO PSI MHASH MENC MSG SIG P.depth) → tx ∈ ledger →
+      (txNetValue tx = tx.vBalance) ⊕' VB) :
+    (L : List (Tx KW F G RHO PSI MHASH MENC MSG SIG P.depth)) → (∀ tx ∈ L, tx ∈ ledger) →
+    ((∀ tx ∈ L, txNetValue tx = tx.vBalance) ⊕' VB)
+  | [], _ => .inl (by simp)
+  | tx :: t, hL =>
+    match perTx tx (hL tx (by simp)) with
+    | .inr b => .inr b
+    | .inl heq =>
+      match allValueOrBreak perTx t (fun x hx => hL x (by simp [hx])) with
+      | .inr b => .inr b
+      | .inl hall => .inl (by
+          intro x hx
+          rcases List.mem_cons.mp hx with rfl | hx'
+          exacts [heq, hall x hx'])
+
+/-- **Value conservation.** Up to the value premiss's break, the shielded pool plus the
+transparent pool is exactly the minted issuance. -/
+def valueConservationOrBreak {VB : Type*}
+    (perTx : (tx : Tx KW F G RHO PSI MHASH MENC MSG SIG P.depth) → tx ∈ ledger →
+      (txNetValue tx = tx.vBalance) ⊕' VB) (i : ℕ) :
+    (poolValueBalance ledger i + transparentPoolBalance issuance ledger i
+        = issuanceTotal issuance ledger i) ⊕' VB :=
+  match allValueOrBreak perTx (ledger.take i)
+      (fun _ h => (List.take_sublist i ledger).subset h) with
+  | .inr b => .inr b
+  | .inl hall => .inl (by
+      have hsum : ((ledger.take i).map txNetValue).sum
+          = ((ledger.take i).map fun tx => tx.vBalance).sum :=
+        congrArg List.sum (List.map_congr_left fun tx htx => hall tx htx)
+      rw [poolValueBalance_eq_neg, transparentPoolBalance_eq, hsum]
+      ring)
+
+/-- **Balance-value.** Given the transparent pool never goes negative, the shielded pool
+holds at most what issuance has minted — up to the value premiss's break. -/
+def balanceValueOrBreak {VB : Type*}
+    (hval : ValidLedger P kv issuance maxActions ledger)
+    (perTx : (tx : Tx KW F G RHO PSI MHASH MENC MSG SIG P.depth) → tx ∈ ledger →
+      (txNetValue tx = tx.vBalance) ⊕' VB) (i : ℕ) :
+    (poolValueBalance ledger i ≤ issuanceTotal issuance ledger i) ⊕' VB :=
+  match valueConservationOrBreak (issuance := issuance) perTx i with
+  | .inr b => .inr b
+  | .inl h => .inl (by
+      have hnn := hval.transparent_nonneg i
+      omega)
+
+end Conservation
+
 end Zcash.Security.Ledger.Model

--- a/Zcash/Security/Ledger/Balance.lean
+++ b/Zcash/Security/Ledger/Balance.lean
@@ -1,0 +1,324 @@
+import Mathlib
+import Zcash.Security.Ledger.Effects
+
+/-!
+# Balance-subset: every nonzero spend is a committed output
+
+The first Balance theorem, as a computed reduction. For a valid ledger, the nonzero
+spends form a sub-multiset of the positioned outputs — each spend is the opening of the
+output that created its commitment, at that output's leaf position, and no positioned
+opening is spent twice — or the ledger's own data computes a `BalanceBreak`:
+
+* a Merkle `Collision` — one height's compression collided, with both evaluations
+  successful — when a spend's authentication path validates a leaf that is not the
+  committed one;
+* a `NoteCommitBreak`, when a spend's commitment matches an output's but their openings
+  differ;
+* a key-binding break, when two spends of one note tuple would otherwise have to reveal
+  the same nullifier twice.
+
+The shape of the argument (design doc, "The theorems"): the anchor pins each spend's
+path to a prefix tree; position binding pins the leaf; `uncommitted_ne` rules out the
+padding; the opening comparison pins the output or computes the note-commitment break;
+and duplicate spends of one positioned opening are found by `findPair`, whose result is
+certified as a two-element *sublist* — carrying "two distinct occurrences" with no index
+arithmetic — so `nfOldEqOrBreak` and nullifier uniqueness finish.
+
+Everything is a plain computable `def` per breaks-as-computed-data; the anchor index and
+the duplicate pair are found by decidable search, so no data is conjured from the
+validity hypothesis's existentials.
+-/
+
+namespace Zcash.Security.Ledger.Model
+
+variable {F : Type*}
+variable {G : Type*}
+variable {IVK NK RHO PSI MHASH MENC MSG SIG : Type*} {KW : Type*} {d : ℕ}
+
+/-! ## Finding a duplicate, certified as a sublist -/
+
+/-- Scan for the first two entries with equal images under `f`, returned in list order.
+`findPair_spec` certifies them as a two-element sublist — which is what carries "two
+distinct occurrences" without any index arithmetic — and `findPair_none` certifies that
+a failed scan means the images are pairwise distinct. -/
+def findPair {α β : Type*} [DecidableEq β] (f : α → β) : List α → Option (α × α)
+  | [] => none
+  | a :: t =>
+    match t.find? fun b => f b = f a with
+    | some b => some (a, b)
+    | none => findPair f t
+
+theorem findPair_spec {α β : Type*} [DecidableEq β] (f : α → β) :
+    ∀ {l : List α} {a₁ a₂ : α}, findPair f l = some (a₁, a₂) →
+      f a₁ = f a₂ ∧ List.Sublist [a₁, a₂] l
+  | [], _, _, h => by simp [findPair] at h
+  | a :: t, a₁, a₂, h => by
+    rw [findPair] at h
+    cases hf : t.find? fun b => f b = f a with
+    | some b =>
+        rw [hf] at h
+        obtain ⟨rfl, rfl⟩ : a = a₁ ∧ b = a₂ := by simpa [eq_comm] using h
+        refine ⟨?_, ?_⟩
+        · have := List.find?_some hf
+          simpa [eq_comm] using this
+        · exact (List.singleton_sublist.mpr (List.mem_of_find?_eq_some hf)).cons_cons a
+    | none =>
+        rw [hf] at h
+        obtain ⟨hfa, hsub⟩ := findPair_spec f h
+        exact ⟨hfa, hsub.trans (List.sublist_cons_self a t)⟩
+
+theorem findPair_none {α β : Type*} [DecidableEq β] (f : α → β) :
+    ∀ {l : List α}, findPair f l = none → (l.map f).Nodup
+  | [], _ => by simp
+  | a :: t, h => by
+    rw [findPair] at h
+    cases hf : t.find? fun b => f b = f a with
+    | some b => rw [hf] at h; exact absurd h (by simp)
+    | none =>
+        rw [hf] at h
+        have hnot : ∀ b ∈ t, ¬ f b = f a := by
+          have := List.find?_eq_none.mp hf
+          simpa using this
+        simp only [List.map_cons, List.nodup_cons]
+        refine ⟨fun hmem => ?_, findPair_none f h⟩
+        obtain ⟨b, hb, hfb⟩ := List.mem_map.mp hmem
+        exact hnot b hb hfb
+
+/-! ## List plumbing: sublists and prefixes through the ledger's flat maps -/
+
+/-- A pointwise sublist of chunks is a sublist of the flat maps. -/
+theorem flatMap_sublist {α β : Type*} {l : List α} {g g' : α → List β}
+    (h : ∀ x ∈ l, List.Sublist (g x) (g' x)) :
+    List.Sublist (l.flatMap g) (l.flatMap g') := by
+  induction l with
+  | nil => simp
+  | cons a t ih =>
+      simp only [List.flatMap_cons]
+      exact (h a (by simp)).append (ih fun x hx => h x (by simp [hx]))
+
+theorem outputActions_prefix {l₁ l₂ : Ledger KW F G RHO PSI MHASH MENC MSG SIG d}
+    (h : l₁ <+: l₂) : outputActions l₁ <+: outputActions l₂ := by
+  obtain ⟨r, rfl⟩ := h
+  exact ⟨outputActions r, by simp [outputActions, List.flatMap_append]⟩
+
+theorem nullifiers_prefix {l₁ l₂ : Ledger KW F G RHO PSI MHASH MENC MSG SIG d}
+    (h : l₁ <+: l₂) : nullifiers l₁ <+: nullifiers l₂ := by
+  obtain ⟨r, rfl⟩ := h
+  exact ⟨nullifiers r, by simp [nullifiers, List.flatMap_append]⟩
+
+/-- Earlier prefixes of a ledger are prefixes of later ones. -/
+theorem take_prefix_take {l : Ledger KW F G RHO PSI MHASH MENC MSG SIG d} {j i : ℕ}
+    (h : j ≤ i) : l.take j <+: l.take i := by
+  have : l.take j = (l.take i).take j := by
+    rw [List.take_take, Nat.min_eq_left h]
+  rw [this]
+  exact List.take_prefix j (l.take i)
+
+/-- The spends' nullifiers sit inside the ledger's nullifier list, occurrence for
+occurrence. -/
+theorem spendActions_map_nf_sublist
+    (ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG d) (i : ℕ) :
+    List.Sublist ((spendActions ledger i).map fun a => a.inst.nf_old)
+      (nullifiers ledger) := by
+  have h1 : List.Sublist ((spendActions ledger i).map fun a => a.inst.nf_old)
+      (nullifiers (ledger.take i)) := by
+    rw [spendActions, nullifiers, List.map_flatMap]
+    exact flatMap_sublist fun tx _ => tx.actions.filter_sublist.map _
+  exact h1.trans (nullifiers_prefix (List.take_prefix i ledger)).sublist
+
+/-- Leaves and output actions correspond index for index. -/
+theorem length_leafList (ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG d) :
+    (leafList ledger).length = (outputActions ledger).length := by
+  rw [leafList_eq_map, List.length_map]
+
+/-- A prefix agrees with the longer list at every index it has. -/
+private theorem getElem_of_prefix {α : Type*} {l₁ l₂ : List α} (h : l₁ <+: l₂) {p : ℕ}
+    (hp : p < l₁.length) : l₂[p]'(lt_of_lt_of_le hp h.length_le) = l₁[p] := by
+  obtain ⟨r, rfl⟩ := h
+  exact List.getElem_append_left hp
+
+@[simp] theorem length_positionedOutputs
+    (ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG d) (i : ℕ) :
+    (positionedOutputs ledger i).length = (outputActions (ledger.take i)).length := by
+  simp [positionedOutputs, outputOpenings]
+
+/-- The `p`-th positioned output is the `p`-th output action's opening at position `p`. -/
+theorem positionedOutputs_getElem
+    {ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG d} {i p : ℕ}
+    (hp : p < (outputActions (ledger.take i)).length) :
+    (positionedOutputs ledger i)[p]'(by simpa using hp)
+      = ⟨p, outputOpening ((outputActions (ledger.take i))[p])⟩ := by
+  simp [positionedOutputs, outputOpenings]
+
+section Validity
+
+variable [Field F] [AddCommGroup G] [Module F G]
+variable {P : Primitives F G IVK NK RHO PSI MHASH MENC MSG SIG}
+variable {kv : KeyBindingInterface KW G IVK NK}
+variable {ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG P.depth}
+variable {issuance : ℕ → ℕ} {maxActions : ℕ}
+
+/-- The break data a Balance violation computes: a tree-hash collision at one height, a
+note-commitment opening collision, or a key-binding break on the two spends' key
+witnesses. -/
+inductive BalanceBreak (P : Primitives F G IVK NK RHO PSI MHASH MENC MSG SIG)
+    (kv : KeyBindingInterface KW G IVK NK) where
+  | merkle (c : Merkle.Collision P.merkle)
+  | noteCommit (b : NoteCommitBreak P)
+  | keyBinding (w₁ w₂ : KW) (h : kv.Break w₁ w₂)
+
+/-- A spend whose commitment `extract`-matches an output's, with a different opening,
+computes a note-commitment break — `noteCommitBreakOfNe`'s spend-versus-output twin. -/
+def noteCommitBreakOfOutputNe {inst₁ inst₂ : ActionInstance G MHASH RHO}
+    {w₁ w₂ : ActionWitness KW F G RHO PSI MHASH MENC P.depth}
+    (h₁ : ActionSatisfied P kv inst₁ w₁) (h₂ : ActionSatisfied P kv inst₂ w₂)
+    (hx : P.extract w₁.cm_old = P.extract w₂.cm_new)
+    (hne : (w₁.rcm_old, w₁.note_old) ≠ (w₂.rcm_new, w₂.note_new)) :
+    NoteCommitBreak P :=
+  ⟨_, _, _, _, _, _, hne, h₁.commit_old, h₂.commit_new, hx⟩
+
+/-- Membership in the spends carries statement satisfaction and nonzero value. -/
+theorem satisfied_of_spendMem
+    (hval : ValidLedger P kv issuance maxActions ledger) {i : ℕ}
+    {a : Action KW F G RHO PSI MHASH MENC SIG P.depth} (ha : a ∈ spendActions ledger i) :
+    ActionSatisfied P kv a.inst a.w ∧ a.w.note_old.v ≠ 0 := by
+  obtain ⟨tx, htx, hafil⟩ := List.mem_flatMap.mp ha
+  have htx' : tx ∈ ledger := (List.take_sublist i ledger).subset htx
+  refine ⟨hval.satisfied tx htx' a (List.mem_of_mem_filter hafil), ?_⟩
+  simpa using (List.mem_filter.mp hafil).2
+
+/-- A spend's anchor is the root after some prefix within range. -/
+theorem anchor_of_spendMem
+    (hval : ValidLedger P kv issuance maxActions ledger) {i : ℕ}
+    {a : Action KW F G RHO PSI MHASH MENC SIG P.depth} (ha : a ∈ spendActions ledger i) :
+    ∃ j, j ≤ i ∧ rootAfter P ledger j = some a.inst.rt := by
+  obtain ⟨tx, htx, hafil⟩ := List.mem_flatMap.mp ha
+  obtain ⟨k, hk, hgetk⟩ := List.mem_iff_getElem.mp htx
+  have hki : k < i := lt_of_lt_of_le hk (by simp [List.length_take])
+  have hkl : k < ledger.length := lt_of_lt_of_le hk (by simp [List.length_take])
+  have hget : ledger.get ⟨k, hkl⟩ = tx := by
+    rw [List.get_eq_getElem, ← List.getElem_take (h := hk)]
+    exact hgetk
+  obtain ⟨j, hjk, hrt⟩ := hval.anchor_valid ⟨k, hkl⟩ a
+    (by rw [hget]; exact List.mem_of_mem_filter hafil)
+  exact ⟨j, le_of_lt (lt_of_le_of_lt hjk hki), hrt⟩
+
+/-- **Per-spend pinning.** A nonzero spend of a valid ledger is the positioned opening
+of the output that created its commitment — or the ledger data computes a break. The
+anchor prefix is recovered by decidable search (`Nat.find`), so the branches stay
+computable. -/
+def spendPinnedOrBreak [DecidableEq F] [DecidableEq G] [DecidableEq RHO]
+    [DecidableEq PSI] [DecidableEq MHASH] [DecidableEq MENC]
+    (hval : ValidLedger P kv issuance maxActions ledger) {i : ℕ}
+    {a : Action KW F G RHO PSI MHASH MENC SIG P.depth} (ha : a ∈ spendActions ledger i) :
+    (spendRecord a ∈ positionedOutputs ledger i) ⊕' BalanceBreak P kv :=
+  have hex : ∃ j, j ≤ i ∧ rootAfter P ledger j = some a.inst.rt := anchor_of_spendMem hval ha
+  let j := Nat.find hex
+  have hji : j ≤ i := (Nat.find_spec hex).1
+  have hpath : Merkle.Path P.merkle (P.extract a.w.cm_old) a.inst.rt a.w.path a.w.side :=
+    (satisfied_of_spendMem hval ha).1.merkle_path (satisfied_of_spendMem hval ha).2
+  have hroot : Merkle.root P.merkle (leafFun P (leafList (ledger.take j)))
+      = some a.inst.rt := (Nat.find_spec hex).2
+  if hleaf : P.extract a.w.cm_old = leafFun P (leafList (ledger.take j)) a.w.side then
+    if hp : posVal a.w.side < (leafList (ledger.take j)).length then
+      have hpa : posVal a.w.side < (outputActions (ledger.take j)).length := by
+        rwa [← length_leafList]
+      let out := (outputActions (ledger.take j))[posVal a.w.side]
+      have hcx : P.extract a.w.cm_old = out.inst.cmx_new := by
+        rw [hleaf, leafFun, List.getD_eq_getElem _ _ hp]
+        have := leafList_eq_map (ledger.take j)
+        simp only [out, this, List.getElem_map]
+      have hout_sat : ActionSatisfied P kv out.inst out.w := by
+        have hmem : out ∈ outputActions (ledger.take j) := List.getElem_mem hpa
+        obtain ⟨tx, htx, hout⟩ := List.mem_flatMap.mp hmem
+        exact hval.satisfied tx ((List.take_sublist j ledger).subset htx) out hout
+      if hop : (⟨a.w.rcm_old, a.w.note_old⟩ : Opening F G RHO PSI) = outputOpening out then
+        .inl (by
+          have hpre : outputActions (ledger.take j) <+: outputActions (ledger.take i) :=
+            outputActions_prefix (take_prefix_take hji)
+          have hpi : posVal a.w.side < (outputActions (ledger.take i)).length :=
+            lt_of_lt_of_le hpa hpre.length_le
+          refine List.mem_iff_getElem.mpr ⟨posVal a.w.side, by simpa using hpi, ?_⟩
+          rw [positionedOutputs_getElem hpi, getElem_of_prefix hpre hpa]
+          rw [spendRecord, ← hop])
+      else
+        .inr (.noteCommit (noteCommitBreakOfOutputNe (satisfied_of_spendMem hval ha).1
+          hout_sat (hcx.trans hout_sat.cmx_new_eq)
+          (fun hpair => hop (by
+            simp only [Prod.mk.injEq] at hpair
+            simp [outputOpening, hpair.1, hpair.2]))))
+    else
+      absurd (by
+          rw [hleaf, leafFun, List.getD_eq_default]
+          omega) (P.uncommitted_ne a.w.cm_old)
+  else
+    .inr (.merkle (Merkle.collisionOfWrongLeaf P.merkle hpath hroot hleaf))
+
+/-- Run the per-spend pinning over a list of spends, stopping at the first break. -/
+def allPinnedOrBreak [DecidableEq F] [DecidableEq G] [DecidableEq RHO]
+    [DecidableEq PSI] [DecidableEq MHASH] [DecidableEq MENC]
+    (hval : ValidLedger P kv issuance maxActions ledger) {i : ℕ} :
+    (L : List (Action KW F G RHO PSI MHASH MENC SIG P.depth)) →
+    (∀ a ∈ L, a ∈ spendActions ledger i) →
+    ((∀ a ∈ L, spendRecord a ∈ positionedOutputs ledger i) ⊕' BalanceBreak P kv)
+  | [], _ => .inl (by simp)
+  | a :: t, hL =>
+    match spendPinnedOrBreak hval (hL a (by simp)) with
+    | .inr b => .inr b
+    | .inl hmem =>
+      match allPinnedOrBreak hval t (fun x hx => hL x (by simp [hx])) with
+      | .inr b => .inr b
+      | .inl hall => .inl (by
+          intro x hx
+          rcases List.mem_cons.mp hx with rfl | hx'
+          exacts [hmem, hall x hx'])
+
+/-- **Balance-subset, as a computed reduction.** For a valid ledger, the nonzero spends
+are a sub-multiset of the positioned outputs — or the ledger data computes a
+`BalanceBreak`. Duplicate spends are located by `findPair`; sharing a positioned opening
+forces sharing a revealed nullifier (`nfOldEqOrBreak`), which nullifier uniqueness
+forbids, so the surviving branch is a key-binding break. -/
+def balanceSubsetOrBreak [DecidableEq F] [DecidableEq G] [DecidableEq RHO]
+    [DecidableEq PSI] [DecidableEq MHASH] [DecidableEq MENC] [DecidableEq NK]
+    [NoZeroSMulDivisors F G]
+    (hval : ValidLedger P kv issuance maxActions ledger) (i : ℕ) :
+    (nonZeroSpends ledger i ≤ ↑(positionedOutputs ledger i)) ⊕' BalanceBreak P kv :=
+  match hfp : findPair spendRecord (spendActions ledger i) with
+  | some (a₁, a₂) =>
+      have hspec := findPair_spec spendRecord hfp
+      have h₁ : a₁ ∈ spendActions ledger i := hspec.2.subset (by simp)
+      have h₂ : a₂ ∈ spendActions ledger i := hspec.2.subset (by simp)
+      have hrcm : a₁.w.rcm_old = a₂.w.rcm_old := by
+        have := congrArg (fun r => r.opening.rcm) hspec.1
+        simpa [spendRecord] using this
+      have hnote : a₁.w.note_old = a₂.w.note_old := by
+        have := congrArg (fun r => r.opening.note) hspec.1
+        simpa [spendRecord] using this
+      match nfOldEqOrBreak (satisfied_of_spendMem hval h₁).1
+          (satisfied_of_spendMem hval h₂).1 hrcm hnote with
+      | .inr hbr => .inr (.keyBinding a₁.w.kw a₂.w.kw hbr)
+      | .inl hnf =>
+          -- one nullifier at two distinct occurrences — impossible in a valid ledger
+          have hsubnf : List.Sublist [a₁.inst.nf_old, a₂.inst.nf_old] (nullifiers ledger) := by
+            have h := (hspec.2.map fun a => a.inst.nf_old).trans
+              (spendActions_map_nf_sublist ledger i)
+            simpa using h
+          have hnd : [a₁.inst.nf_old, a₂.inst.nf_old].Nodup :=
+            hval.nf_nodup.sublist hsubnf
+          absurd hnf (by simpa using hnd)
+  | none =>
+      have hnodup : ((spendActions ledger i).map spendRecord).Nodup :=
+        findPair_none spendRecord hfp
+      match allPinnedOrBreak hval (spendActions ledger i) (fun _ h => h) with
+      | .inr b => .inr b
+      | .inl hall =>
+          .inl (by
+            rw [nonZeroSpends]
+            refine (Multiset.le_iff_subset (by simpa using hnodup)).mpr ?_
+            intro x hx
+            obtain ⟨a, haL, rfl⟩ := List.mem_map.mp (by simpa using hx)
+            simpa using hall a haL)
+
+end Validity
+
+end Zcash.Security.Ledger.Model

--- a/Zcash/Security/Ledger/Effects.lean
+++ b/Zcash/Security/Ledger/Effects.lean
@@ -1,0 +1,92 @@
+import Mathlib
+import Zcash.Security.Ledger.Model
+
+/-!
+# Effects: outputs, spends, and the shielded pool balance
+
+The effects of a valid ledger are read off its witnesses (Zcon3 slides 20-21). An
+output is the `(rcm, note)` opening carried by an action's output side, positioned by
+its leaf index; a spend is the opening carried by an action's spend side, positioned by
+its witnessed path position. Zero-valued spends are excluded — the statement's Merkle
+condition is vacuous for them, so they are dummies by construction and do not need to
+correspond to any output.
+
+`Opening` is exactly the pair that `noteCommitBreakOfNe` pins: once Balance-subset pins
+a spend's commitment to an output's leaf, the two openings agree or a note-commitment
+break is exhibited. The shielded pool balance is the output value total minus the
+nonzero-spend value total.
+-/
+
+namespace Zcash.Security.Ledger.Model
+
+variable {F : Type*}
+variable {G : Type*}
+variable {IVK NK RHO PSI MHASH MENC MSG SIG : Type*} {KW : Type*} {d : ℕ}
+
+/-- A note-commitment opening: the randomness and the note. This is the tuple a
+commitment pins (up to `NoteCommitBreak`), and the unit of account for effects. -/
+structure Opening (F G RHO PSI : Type*) where
+  rcm : F
+  note : Note G RHO PSI
+
+/-- An opening at a tree position: the leaf index for outputs, the witnessed path
+position for spends. -/
+structure PositionedOpening (F G RHO PSI : Type*) where
+  pos : ℕ
+  opening : Opening F G RHO PSI
+
+/-- All actions of a ledger, in order. Outputs, spends, and leaves are all per-action,
+so their index correspondences reduce to `List.map` facts over this list. -/
+def outputActions (ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG d) :
+    List (Action KW F G RHO PSI MHASH MENC SIG d) :=
+  ledger.flatMap fun tx => tx.actions
+
+/-- The output-side opening of an action. -/
+def outputOpening (a : Action KW F G RHO PSI MHASH MENC SIG d) : Opening F G RHO PSI :=
+  ⟨a.w.rcm_new, a.w.note_new⟩
+
+/-- The spend-side opening of an action, at its witnessed path position. -/
+def spendRecord (a : Action KW F G RHO PSI MHASH MENC SIG d) :
+    PositionedOpening F G RHO PSI :=
+  ⟨posVal a.w.side, ⟨a.w.rcm_old, a.w.note_old⟩⟩
+
+/-- The output openings of a ledger, in leaf order. -/
+def outputOpenings (ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG d) :
+    List (Opening F G RHO PSI) :=
+  (outputActions ledger).map outputOpening
+
+/-- The leaf list is the per-action map of the commitment over the flattened actions. -/
+theorem leafList_eq_map (ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG d) :
+    leafList ledger = (outputActions ledger).map fun a => a.inst.cmx_new := by
+  rw [leafList, outputActions, List.map_flatMap]
+
+/-- Outputs and leaves correspond one to one. -/
+theorem outputOpenings_length (ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG d) :
+    (outputOpenings ledger).length = (leafList ledger).length := by
+  rw [outputOpenings, leafList_eq_map, List.length_map, List.length_map]
+
+/-- The positioned outputs of the first `i` transactions: each output opening at its
+leaf index. -/
+def positionedOutputs (ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG d) (i : ℕ) :
+    List (PositionedOpening F G RHO PSI) :=
+  (outputOpenings (ledger.take i)).zipIdx.map fun p => ⟨p.2, p.1⟩
+
+/-- The nonzero-valued spend actions of the first `i` transactions. -/
+def spendActions (ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG d) (i : ℕ) :
+    List (Action KW F G RHO PSI MHASH MENC SIG d) :=
+  (ledger.take i).flatMap fun tx => tx.actions.filter fun a => a.w.note_old.v ≠ 0
+
+/-- The nonzero-valued spends of the first `i` transactions, as a multiset of positioned
+openings: the spend-side opening at the witnessed path position. A multiset because a
+double spend must be countable; Balance-subset proves it is in fact a set. -/
+def nonZeroSpends (ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG d) (i : ℕ) :
+    Multiset (PositionedOpening F G RHO PSI) :=
+  ↑((spendActions ledger i).map spendRecord)
+
+/-- The shielded pool balance after the first `i` transactions: output value total minus
+nonzero-spend value total, both read off the witnesses. -/
+def poolValueBalance (ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG d) (i : ℕ) : ℤ :=
+  (((positionedOutputs ledger i).map fun p => (p.opening.note.v : ℤ)).sum : ℤ)
+    - ((nonZeroSpends ledger i).map fun p => (p.opening.note.v : ℤ)).sum
+
+end Zcash.Security.Ledger.Model

--- a/Zcash/Security/Ledger/Effects.lean
+++ b/Zcash/Security/Ledger/Effects.lean
@@ -4,12 +4,12 @@ import Zcash.Security.Ledger.Model
 /-!
 # Effects: outputs, spends, and the shielded pool balance
 
-The effects of a valid ledger are read off its witnesses (Zcon3 slides 20-21). An
-output is the `(rcm, note)` opening carried by an action's output side, positioned by
-its leaf index; a spend is the opening carried by an action's spend side, positioned by
-its witnessed path position. Zero-valued spends are excluded — the statement's Merkle
-condition is vacuous for them, so they are dummies by construction and do not need to
-correspond to any output.
+The effects of a valid ledger are read off its witnesses (Zcon3 "Understanding the
+Security of Zcash" slides 20-21). An output is the `(rcm, note)` opening carried by an
+action's output side, positioned by its leaf index; a spend is the opening carried by
+an action's spend side, positioned by its witnessed path position. Zero-valued spends
+are excluded — the statement's Merkle condition is vacuous for them, so they are
+dummies by construction and do not need to correspond to any output.
 
 `Opening` is exactly the pair that `noteCommitBreakOfNe` pins: once Balance-subset pins
 a spend's commitment to an output's leaf, the two openings agree or a note-commitment

--- a/Zcash/Security/Ledger/Effects.lean
+++ b/Zcash/Security/Ledger/Effects.lean
@@ -28,12 +28,14 @@ commitment pins (up to `NoteCommitBreak`), and the unit of account for effects. 
 structure Opening (F G RHO PSI : Type*) where
   rcm : F
   note : Note G RHO PSI
+  deriving DecidableEq
 
 /-- An opening at a tree position: the leaf index for outputs, the witnessed path
 position for spends. -/
 structure PositionedOpening (F G RHO PSI : Type*) where
   pos : ℕ
   opening : Opening F G RHO PSI
+  deriving DecidableEq
 
 /-- All actions of a ledger, in order. Outputs, spends, and leaves are all per-action,
 so their index correspondences reduce to `List.map` facts over this list. -/

--- a/Zcash/Security/Ledger/Merkle.lean
+++ b/Zcash/Security/Ledger/Merkle.lean
@@ -2,133 +2,406 @@ import Mathlib
 import Zcash.Security.Common.RandomOracle
 
 /-!
-# Fixed-depth Merkle trees are position-binding, up to an exhibited hash collision
+# Fixed-depth Merkle trees over a partial tree hash
 
-This module proves the Merkle lemma of the ledger-model layer: from a validating
-authentication path for a leaf that is *not* the committed one at its position,
-`Merkle.collisionOfWrongLeaf` **computes** a collision of the tree hash — a
-`RandomOracle.Collision`, so the shared collision vocabulary applies directly. This is the
-position-binding vector commitment property that the Balance and Spendability arguments
-require of the note commitment tree.
+This module holds the ledger layer's Merkle machinery, over the raw-encoding partial
+compression interface (`MerklePrimitives`, adopted from the circuit-bridge work in #98 so
+that the two layers share one model). The interface is faithful to the deployed hash in
+two ways that the concrete collision bound needs:
 
-The tree hash takes its two children as a pair (`H : B × B → B`), so a collision's data is
-directly the two input pairs. Leaves are indexed by root-to-leaf paths `Fin d → Bool`
-(`false` = left, `true` = right), so the tree is the full binary tree of depth `d` and no
-arithmetic on positions is needed.
+* **Inputs are raw encodings.** The compression consumes child *encodings* of type `E`,
+  and an Orchard field element can have more than one accepted 255-bit encoding — the
+  circuit does not pay for a canonicity check, a conscious trade-off from Sapling onward.
+  Collisions are therefore counted over the encoding domain. `canon` is the canonical
+  encoding — a section of `decode` — used by honest tree construction.
+* **Compression is partial.** `none` is an escaped compression (for Orchard, a Sinsemilla
+  exceptional branch). Escapes are not totalized away: `Path` records per-height success,
+  and a `Collision` demands *successful* evaluations on both queries
+  (`RandomOracle.DefinedCollision`), so an escaped query can never constitute a
+  collision. A totalized model would let two escapes masquerade as a collision that the
+  concrete reduction to a hardness assumption could not consume.
 
-Per the breaks-as-computed-data convention (documented in `Zcash.Security.RandomOracle`):
-collisions of a compressing hash always exist propositionally, so the reduction is a
-computable function producing the collision as data, not a theorem with a `∨ ∃-collision`
-conclusion. No hardness assumption appears here; prequantumly, collision-resistance of
-Sinsemilla reduces to a DLR break (Zcash protocol specification Theorems 5.4.3 and 5.4.4).
-For the ZIP 2005 Recovery Protocol, the Merkle tree will be rehashed using a hash function
-that is assumed to be collapsing.
+Compression indices count from the leaves, with the leafmost hashes at height `0`:
+`compress 0` combines two leaves, and in general `compress i` combines two height-`i`
+children into their height-`(i + 1)` parent. Each height's compression is
+personalized, so an adversary's queries count against one height's compression at a
+time. The protocol spec's *layers* count from the root instead (§4.9, layer 0 at the
+root). The index here equals `MerkleDepth − 1 − layer`, which is exactly the value
+§5.4.1.3 encodes into the Sinsemilla input. So the index is faithful to the circuit,
+and the spec's layer is recoverable by that subtraction. Positions are leaf-to-root
+bit vectors: bit `i` selects the child at height `i`, so position bits align with
+binary leaf indices.
+
+Adversarial freedom differs by an input's role. A path's *sibling* encodings are
+unconstrained; its *on-path* encodings are constrained only up to the decode fibre —
+any accepted representative of the pinned running node, because the deployed circuit
+constrains the decomposition to the field element, not to a canonical encoding. Only
+the honest tree's inputs (`subRoot`) are canonical, by construction. Distinct encodings
+of equal values are distinct queries, so a collision between them is a genuine
+collision of the deployed hash.
+
+`Path` (with `node`, `selectedChild`, and `Path.compress_isSome`) is the witness-side
+path fact: both raw child encodings at every height plus the selected side, with the
+selected encoding decoding to the running node and every compression succeeding. On top
+of it this module proves the two lemmas the games consume:
+
+* **Position binding** (`collisionOfWrongLeaf`): a valid path for a leaf that is *not*
+  the committed one at its position, against a defined tree, computes a collision of one
+  height's compression — as a computable `def` per the breaks-as-computed-data convention
+  (documented in `Zcash.Security.RandomOracle`).
+* **Completeness** (`path_of_root`): if the tree is defined, the honest authentication
+  data (`authChildren`) exists and forms a valid `Path` for the committed leaf.
+
+No hardness assumption appears here; prequantumly, collision-resistance of Sinsemilla
+reduces to a DLR break (Zcash protocol specification Theorems 5.4.3 and 5.4.4). For the
+ZIP 2005 Recovery Protocol, the Merkle tree will be rehashed using a hash function that
+is assumed to be collapsing.
 -/
 
 namespace Zcash.Security.Ledger.Merkle
 
-variable {B : Type*}
+variable {B E : Type*}
 
-/-- The root of the depth-`d` full binary Merkle tree over leaves `f`, indexed by
-root-to-leaf paths. -/
-def root (H : B × B → B) : (d : ℕ) → ((Fin d → Bool) → B) → B
-  | 0, f => f Fin.elim0
-  | d+1, f =>
-    H (root H d fun p => f (Fin.cons false p), root H d fun p => f (Fin.cons true p))
+/-- The Merkle-specific part of the ledger primitive interface.  `E` is the raw
+encoding consumed by the compression function; it is deliberately separate from the
+node type `B`, since an Orchard field element can have more than one accepted 255-bit
+encoding. `canon` is the canonical encoding used by honest tree construction; it is a
+section of `decode` (hence injective). -/
+structure MerklePrimitives (B E : Type*) where
+  depth : ℕ
+  decode : E → B
+  /-- Height-indexed, personalized compression of a raw child pair (heights count from
+  the leaves; the spec's root-counted layer is `MerkleDepth − 1` minus this index).
+  `none` is an escaped compression; for Orchard, a Sinsemilla exceptional branch.
+  Definedness is not totalized away — it is recorded in `Path` and recoverable from a
+  path fact. -/
+  compress : Fin depth → E × E → Option B
+  /-- The canonical encoding of a node value. -/
+  canon : B → E
+  /-- `canon` encodes faithfully: decoding a canonical encoding returns the node. -/
+  decode_canon : ∀ b, decode (canon b) = b
 
-/-- Recompute the root from a claimed `leaf` at position `pos`, given the sibling subtree
-values `sibs`, both indexed from the top level down. -/
-def pathRoot (H : B × B → B) : (d : ℕ) → (Fin d → Bool) → (Fin d → B) → B → B
-  | 0, _, _, leaf => leaf
-  | d+1, pos, sibs, leaf =>
-    let child := pathRoot H d (Fin.tail pos) (Fin.tail sibs) leaf
-    H (cond (pos 0) (sibs 0) child, cond (pos 0) child (sibs 0))
+/-- Select the raw child on the path.  `false` selects the left child and `true`
+selects the right child. -/
+def selectedChild (side : Bool) (children : E × E) : E :=
+  if side then children.2 else children.1
 
-/-- The honest authentication path for position `pos`: the sibling subtree root at each
-level, from the top level down. -/
-def authPath (H : B × B → B) : (d : ℕ) → ((Fin d → Bool) → B) → (Fin d → Bool) → Fin d → B
-  | 0, _, _ => Fin.elim0
-  | d+1, f, pos =>
-    Fin.cons (root H d fun p => f (Fin.cons (!pos 0) p))
-      (authPath H d (fun p => f (Fin.cons (pos 0) p)) (Fin.tail pos))
+/-- The running node after the first `i` leaf-to-root path cells.  In particular,
+`node ... 0` is `some leaf` and `node ... (i + 1)` is the compression at height `i`,
+which is `none` on an escaped compression.  The selected-child equations in `Path`
+tie these otherwise raw inputs together. -/
+def node (P : MerklePrimitives B E) (leaf : B) (children : Fin P.depth → E × E) :
+    Fin (P.depth + 1) → Option B :=
+  Fin.cases (some leaf) (fun i => P.compress i (children i))
 
-/-- The two candidate colliding input pairs located by descending a wrong-leaf opening: the
-recomputed (path-side) pair and the tree-side pair, at the first level where the child
-components differ. Pure data — the executable half of the reduction;
-`collisionInputsOfWrongLeaf_spec` certifies the collision under the wrong-leaf hypotheses.
-At depth `0` there is no pair, and the spec's hypotheses are contradictory, so any value
-serves. -/
-private def collisionInputsOfWrongLeaf [DecidableEq B] (H : B × B → B) :
-    (d : ℕ) → ((Fin d → Bool) → B) → (Fin d → Bool) → (Fin d → B) → B → (B × B) × (B × B)
-  | 0, _, _, _, leaf => ((leaf, leaf), (leaf, leaf))
-  | d+1, f, pos, sibs, leaf =>
-    let child := pathRoot H d (Fin.tail pos) (Fin.tail sibs) leaf
-    let sub : Bool → B := fun i => root H d fun p => f (Fin.cons i p)
-    if child = sub (pos 0) then
-      collisionInputsOfWrongLeaf H d (fun p => f (Fin.cons (pos 0) p)) (Fin.tail pos)
-        (Fin.tail sibs) leaf
-    else
-      ((cond (pos 0) (sibs 0) child, cond (pos 0) child (sibs 0)), (sub false, sub true))
+/-- A raw Orchard-style authentication path, ordered from the leaf towards the root.
+Every path cell carries both *raw* child encodings and its selected side.  The selected
+encoding must decode to the current node, and compression at height `i` produces the
+next node — each equation *also* asserts that the previous compression succeeded, so
+definedness at every height is part of path validity and is recoverable from the `Path`
+fact itself (see `Path.compress_isSome`). -/
+def Path (P : MerklePrimitives B E) (leaf root : B)
+    (children : Fin P.depth → E × E) (side : Fin P.depth → Bool) : Prop :=
+  (∀ i, node P leaf children (Fin.castSucc i) =
+      some (P.decode (selectedChild (side i) (children i)))) ∧
+    node P leaf children (Fin.last P.depth) = some root
 
-/-- The located input pairs are distinct and hash equally: the certification half of the
-reduction, by the same recursion as `collisionInputsOfWrongLeaf`. -/
-private theorem collisionInputsOfWrongLeaf_spec [DecidableEq B] (H : B × B → B) :
-    ∀ (d : ℕ) (f : (Fin d → Bool) → B) (pos : Fin d → Bool) (sibs : Fin d → B) (leaf : B),
-      pathRoot H d pos sibs leaf = root H d f → leaf ≠ f pos →
-      (collisionInputsOfWrongLeaf H d f pos sibs leaf).1
-          ≠ (collisionInputsOfWrongLeaf H d f pos sibs leaf).2
-        ∧ H (collisionInputsOfWrongLeaf H d f pos sibs leaf).1
-            = H (collisionInputsOfWrongLeaf H d f pos sibs leaf).2
-  | 0, f, _, _, _, h, hne =>
-    absurd (h.trans (congrArg f (funext fun i => i.elim0))) hne
-  | d+1, f, pos, sibs, leaf, h, hne => by
-    have h' : H (cond (pos 0) (sibs 0) (pathRoot H d (Fin.tail pos) (Fin.tail sibs) leaf),
-          cond (pos 0) (pathRoot H d (Fin.tail pos) (Fin.tail sibs) leaf) (sibs 0))
-        = H (root H d fun p => f (Fin.cons false p),
-             root H d fun p => f (Fin.cons true p)) := by
-      simpa only [pathRoot, root] using h
-    rw [collisionInputsOfWrongLeaf]
-    split
-    · exact collisionInputsOfWrongLeaf_spec H d _ (Fin.tail pos) (Fin.tail sibs) leaf
-        (by assumption)
-        (fun heq => hne (heq.trans (congrArg f (Fin.cons_self_tail pos))))
-    · next hchild =>
-      refine ⟨fun hp => hchild ?_, h'⟩
-      have h1 := congrArg Prod.fst hp
-      have h2 := congrArg Prod.snd hp
-      cases hb : pos 0 <;>
-        simp only [hb, Bool.cond_false, Bool.cond_true] at h1 h2 <;>
-        first | exact h1 | exact h2
+/-- Every height of a valid path has a defined compression: definedness is recorded
+in the `Path` fact rather than carried as a separate bridge invariant.  This is the
+property motivating the partial (`Option`-valued) compressor — the fact each `Path`
+equation asserts `some _` on the running node lets a consumer recover a successful
+evaluation at every height. -/
+theorem Path.compress_isSome {P : MerklePrimitives B E} {leaf root : B}
+    {children : Fin P.depth → E × E} {side : Fin P.depth → Bool}
+    (h : Path P leaf root children side) (i : Fin P.depth) :
+    ∃ b, P.compress i (children i) = some b := by
+  have hnode : node P leaf children i.succ = P.compress i (children i) := by
+    simp [node, Fin.cases_succ]
+  rcases Nat.lt_or_ge (i.1 + 1) P.depth with hlt | hge
+  · have hcast : Fin.castSucc (⟨i.1 + 1, hlt⟩ : Fin P.depth) = i.succ := by
+      apply Fin.ext
+      simp [Fin.val_succ]
+    have hstep := h.1 ⟨i.1 + 1, hlt⟩
+    rw [hcast, hnode] at hstep
+    exact ⟨_, hstep⟩
+  · have heq : i.1 + 1 = P.depth := by have := i.isLt; omega
+    have hlast : i.succ = Fin.last P.depth := by
+      apply Fin.ext
+      simp [Fin.val_succ, Fin.val_last, heq]
+    have hroot := h.2
+    rw [← hlast, hnode] at hroot
+    exact ⟨_, hroot⟩
 
-/-- **Position binding, as an explicit reduction.** From a path that validates `leaf` at
-position `pos` against the root of the tree over `f`, together with `leaf ≠ f pos`, compute
-a collision of the tree hash: the standard fixed-depth Merkle argument, as a computable
-`def` per the breaks-as-computed-data convention. The recursive search is
-`collisionInputsOfWrongLeaf` (pure data), its certification is
-`collisionInputsOfWrongLeaf_spec`, and this definition packages the two. -/
-def collisionOfWrongLeaf [DecidableEq B] (H : B × B → B) (d : ℕ) (f : (Fin d → Bool) → B)
-    (pos : Fin d → Bool) (sibs : Fin d → B) (leaf : B)
-    (h : pathRoot H d pos sibs leaf = root H d f) (hne : leaf ≠ f pos) :
-    RandomOracle.Collision H :=
-  { q₁ := (collisionInputsOfWrongLeaf H d f pos sibs leaf).1
-    q₂ := (collisionInputsOfWrongLeaf H d f pos sibs leaf).2
-    ne := (collisionInputsOfWrongLeaf_spec H d f pos sibs leaf h hne).1
-    eq := (collisionInputsOfWrongLeaf_spec H d f pos sibs leaf h hne).2 }
+/-- A Merkle collision records the height whose personalized compression was collided,
+and demands *successful* evaluations on both queries (a `DefinedCollision`): an escaped
+compression, being `none`, can therefore never constitute a collision. -/
+abbrev Collision (P : MerklePrimitives B E) :=
+  Σ i : Fin P.depth, RandomOracle.DefinedCollision (P.compress i)
 
-/-- Completeness: the honest authentication path for position `pos` validates the leaf
-`f pos` against the tree root. -/
-theorem pathRoot_authPath (H : B × B → B) (d : ℕ) (f : (Fin d → Bool) → B)
-    (pos : Fin d → Bool) :
-    pathRoot H d pos (authPath H d f pos) (f pos) = root H d f := by
-  induction d with
-  | zero =>
-    simp only [pathRoot, root]
-    exact congrArg f (funext fun i => i.elim0)
-  | succ d ih =>
-    induction pos using Fin.consCases with
-    | cons b q =>
-    cases b <;>
-      simp only [pathRoot, root, authPath, Fin.cons_zero, Fin.tail_cons, Bool.cond_false,
-        Bool.cond_true, Bool.not_false, Bool.not_true, ih]
+/-! ## The honest tree
+
+The honest tree over a leaf assignment, built with canonical child encodings. A
+height-`h` subtree compresses its two height-`(h - 1)` children with
+`compress (h - 1)`, so a subtree's compression indices depend only on its height, not
+its location. The construction is partial because the compression is. -/
+
+/-- The root of the height-`h` subtree over leaves `f`, or `none` if any compression
+along the way escapes. Positions are leaf-to-root: the last bit selects between the two
+height-`(h-1)` halves. -/
+def subRoot (P : MerklePrimitives B E) :
+    (h : ℕ) → h ≤ P.depth → ((Fin h → Bool) → B) → Option B
+  | 0, _, f => some (f (fun i => i.elim0))
+  | h + 1, hle, f =>
+    match subRoot P h (Nat.le_of_succ_le hle) (fun p => f (Fin.snoc p false)),
+          subRoot P h (Nat.le_of_succ_le hle) (fun p => f (Fin.snoc p true)) with
+    | some bl, some br => P.compress ⟨h, hle⟩ (P.canon bl, P.canon br)
+    | _, _ => none
+
+/-- The root of the full tree over leaves `f`, or `none` if any compression escapes. -/
+def root (P : MerklePrimitives B E) (f : (Fin P.depth → Bool) → B) : Option B :=
+  subRoot P P.depth le_rfl f
+
+/-! ## Machinery over subtree heights
+
+The recursions below work on subtrees of height `h ≤ depth`; `nodeAux` is the running
+node chain of a height-`h` path, using the same absolute compression indices as the
+full tree. At `h = P.depth` it is definitionally `node`, and `PathAux` is
+definitionally `Path`. -/
+
+/-- The running node chain of a height-`h` path (the height-`h` analogue of `node`). -/
+def nodeAux (P : MerklePrimitives B E) (h : ℕ) (hle : h ≤ P.depth) (leaf : B)
+    (children : Fin h → E × E) : Fin (h + 1) → Option B :=
+  Fin.cases (some leaf) (fun i => P.compress (Fin.castLE hle i) (children i))
+
+/-- The height-`h` analogue of `Path`, over the same absolute compression indices. -/
+def PathAux (P : MerklePrimitives B E) (h : ℕ) (hle : h ≤ P.depth) (leaf root : B)
+    (children : Fin h → E × E) (side : Fin h → Bool) : Prop :=
+  (∀ i, nodeAux P h hle leaf children (Fin.castSucc i) =
+      some (P.decode (selectedChild (side i) (children i)))) ∧
+    nodeAux P h hle leaf children (Fin.last h) = some root
+
+/-- At full height the auxiliary path fact is the path fact. -/
+theorem pathAux_depth_iff (P : MerklePrimitives B E) {leaf root : B}
+    {children : Fin P.depth → E × E} {side : Fin P.depth → Bool} :
+    PathAux P P.depth le_rfl leaf root children side ↔ Path P leaf root children side :=
+  Iff.rfl
+
+/-- Dropping the topmost compression of a height-`(h+1)` chain gives the height-`h` chain of the
+initial segments. -/
+theorem nodeAux_init (P : MerklePrimitives B E) {h : ℕ} (hle : h + 1 ≤ P.depth)
+    (leaf : B) (children : Fin (h + 1) → E × E) (i : Fin (h + 1)) :
+    nodeAux P h (Nat.le_of_succ_le hle) leaf (Fin.init children) i
+      = nodeAux P (h + 1) hle leaf children (Fin.castSucc i) := by
+  induction i using Fin.cases with
+  | zero => rfl
+  | succ j =>
+      rw [← Fin.succ_castSucc]
+      simp only [nodeAux, Fin.cases_succ]
+      rfl
+
+/-! ## Completeness: the honest authentication data -/
+
+/-- Inversion for a defined height-`(h+1)` subtree: both halves are defined and the top
+compression succeeds on their canonical encodings. -/
+theorem subRoot_succ (P : MerklePrimitives B E) {h : ℕ} (hle : h + 1 ≤ P.depth)
+    (f : (Fin (h + 1) → Bool) → B) {rt : B} :
+    subRoot P (h + 1) hle f = some rt ↔
+      ∃ bl br, subRoot P h (Nat.le_of_succ_le hle) (fun p => f (Fin.snoc p false)) = some bl ∧
+        subRoot P h (Nat.le_of_succ_le hle) (fun p => f (Fin.snoc p true)) = some br ∧
+        P.compress ⟨h, hle⟩ (P.canon bl, P.canon br) = some rt := by
+  cases hbl : subRoot P h (Nat.le_of_succ_le hle) (fun p => f (Fin.snoc p false)) <;>
+    cases hbr : subRoot P h (Nat.le_of_succ_le hle) (fun p => f (Fin.snoc p true)) <;>
+    simp [subRoot, hbl, hbr]
+
+/-- The honest authentication data for position `pos` in the height-`h` subtree over
+`f`: at each height, the canonical encodings of the two child subroots along the path.
+`none` when the tree is not defined there. -/
+def authChildren (P : MerklePrimitives B E) :
+    (h : ℕ) → h ≤ P.depth → ((Fin h → Bool) → B) → (Fin h → Bool) → Option (Fin h → E × E)
+  | 0, _, _, _ => some (fun i => i.elim0)
+  | h + 1, hle, f, pos =>
+    match subRoot P h (Nat.le_of_succ_le hle) (fun p => f (Fin.snoc p false)),
+          subRoot P h (Nat.le_of_succ_le hle) (fun p => f (Fin.snoc p true)),
+          authChildren P h (Nat.le_of_succ_le hle)
+            (fun p => f (Fin.snoc p (pos (Fin.last h)))) (Fin.init pos) with
+    | some bl, some br, some rest => some (Fin.snoc rest (P.canon bl, P.canon br))
+    | _, _, _ => none
+
+/-- Inversion for defined honest authentication data at height `h + 1`. -/
+theorem authChildren_succ (P : MerklePrimitives B E) {h : ℕ} (hle : h + 1 ≤ P.depth)
+    (f : (Fin (h + 1) → Bool) → B) (pos : Fin (h + 1) → Bool)
+    {children : Fin (h + 1) → E × E} :
+    authChildren P (h + 1) hle f pos = some children ↔
+      ∃ bl br rest,
+        subRoot P h (Nat.le_of_succ_le hle) (fun p => f (Fin.snoc p false)) = some bl ∧
+        subRoot P h (Nat.le_of_succ_le hle) (fun p => f (Fin.snoc p true)) = some br ∧
+        authChildren P h (Nat.le_of_succ_le hle)
+          (fun p => f (Fin.snoc p (pos (Fin.last h)))) (Fin.init pos) = some rest ∧
+        children = Fin.snoc rest (P.canon bl, P.canon br) := by
+  cases hbl : subRoot P h (Nat.le_of_succ_le hle) (fun p => f (Fin.snoc p false)) <;>
+    cases hbr : subRoot P h (Nat.le_of_succ_le hle) (fun p => f (Fin.snoc p true)) <;>
+    cases hrest : authChildren P h (Nat.le_of_succ_le hle)
+      (fun p => f (Fin.snoc p (pos (Fin.last h)))) (Fin.init pos) <;>
+    simp [authChildren, hbl, hbr, hrest, eq_comm]
+
+/-- A defined subtree has defined honest authentication data at every position. -/
+theorem authChildren_isSome (P : MerklePrimitives B E) :
+    ∀ (h : ℕ) (hle : h ≤ P.depth) (f : (Fin h → Bool) → B) (pos : Fin h → Bool) {rt : B},
+      subRoot P h hle f = some rt → (authChildren P h hle f pos).isSome
+  | 0, _, _, _, _, _ => by simp [authChildren]
+  | h + 1, hle, f, pos, rt, hroot => by
+    obtain ⟨bl, br, hbl, hbr, -⟩ := (subRoot_succ P hle f).mp hroot
+    have hchosen : subRoot P h (Nat.le_of_succ_le hle)
+        (fun p => f (Fin.snoc p (pos (Fin.last h)))) = some (cond (pos (Fin.last h)) br bl) := by
+      rcases Bool.eq_false_or_eq_true (pos (Fin.last h)) with hbv | hbv <;> rw [hbv] <;>
+        first
+        | exact hbl
+        | exact hbr
+    have hrec := authChildren_isSome P h (Nat.le_of_succ_le hle)
+      (fun p => f (Fin.snoc p (pos (Fin.last h)))) (Fin.init pos) hchosen
+    obtain ⟨rest, hrest⟩ := Option.isSome_iff_exists.mp hrec
+    simp [authChildren, hbl, hbr, hrest]
+
+/-- **Completeness at subtree height.** If the subtree is defined, the honest
+authentication data forms a valid height-`h` path for the committed leaf, with the
+position bits as the side selectors. -/
+theorem pathAux_of_subRoot (P : MerklePrimitives B E) :
+    ∀ (h : ℕ) (hle : h ≤ P.depth) (f : (Fin h → Bool) → B) (pos : Fin h → Bool)
+      {rt : B} {children : Fin h → E × E},
+      subRoot P h hle f = some rt → authChildren P h hle f pos = some children →
+      PathAux P h hle (f pos) rt children pos
+  | 0, _, f, pos, rt, children, hroot, hauth => by
+    refine ⟨fun i => i.elim0, ?_⟩
+    have hrt : f (fun i => i.elim0) = rt := by simpa [subRoot] using hroot
+    have hpos : pos = fun i => i.elim0 := funext fun i => i.elim0
+    simp [nodeAux, Fin.last, hpos, hrt]
+  | h + 1, hle, f, pos, rt, children, hroot, hauth => by
+    obtain ⟨bl, br, hbl, hbr, hcomp⟩ := (subRoot_succ P hle f).mp hroot
+    obtain ⟨bl', br', rest, hbl', hbr', hrest, hch⟩ := (authChildren_succ P hle f pos).mp hauth
+    obtain rfl : bl = bl' := Option.some.inj (hbl.symm.trans hbl')
+    obtain rfl : br = br' := Option.some.inj (hbr.symm.trans hbr')
+    set b := pos (Fin.last h) with hb
+    have hchosen : subRoot P h (Nat.le_of_succ_le hle)
+        (fun p => f (Fin.snoc p b)) = some (cond b br bl) := by
+      rcases Bool.eq_false_or_eq_true b with hbv | hbv <;> rw [hbv] <;>
+        first
+        | exact hbl
+        | exact hbr
+    have hleaf : (fun p => f (Fin.snoc p b)) (Fin.init pos) = f pos := by
+      show f (Fin.snoc (Fin.init pos) b) = f pos
+      rw [hb, Fin.snoc_init_self]
+    have ih := pathAux_of_subRoot P h (Nat.le_of_succ_le hle)
+      (fun p => f (Fin.snoc p b)) (Fin.init pos) hchosen hrest
+    rw [hleaf] at ih
+    subst hch
+    constructor
+    · intro i
+      induction i using Fin.lastCases with
+      | last =>
+          rw [← nodeAux_init P hle, Fin.init_snoc, Fin.snoc_last, ih.2, ← hb]
+          rcases Bool.eq_false_or_eq_true b with hbv | hbv <;>
+            simp [hbv, selectedChild, P.decode_canon]
+      | cast j =>
+          rw [← nodeAux_init P hle, Fin.init_snoc, Fin.snoc_castSucc]
+          exact ih.1 j
+    · rw [← Fin.succ_last]
+      simp only [nodeAux, Fin.cases_succ, Fin.snoc_last]
+      exact hcomp
+
+/-- **Completeness.** If the tree is defined, the honest authentication data forms a
+valid `Path` for the committed leaf, with the position bits as the side selectors. -/
+theorem path_of_root (P : MerklePrimitives B E) {f : (Fin P.depth → Bool) → B}
+    (pos : Fin P.depth → Bool) {rt : B} {children : Fin P.depth → E × E}
+    (hroot : root P f = some rt)
+    (hauth : authChildren P P.depth le_rfl f pos = some children) :
+    Path P (f pos) rt children pos :=
+  (pathAux_depth_iff P).mp (pathAux_of_subRoot P P.depth le_rfl f pos hroot hauth)
+
+/-! ## Position binding -/
+
+/-- **Position binding at subtree height, as an explicit reduction.** A valid path for a
+leaf that is not the committed one at its position, against a defined subtree, computes a
+collision of one height's compression: descend from the top and compare the path's raw
+pair with the honest canonical pair; the first disagreement is the collision (both
+compress to the running node), and full agreement forces the leaf, contradicting the
+hypothesis. Computable, with the contradictions eliminated in dead branches. -/
+def collisionOfWrongLeafAux [DecidableEq E] (P : MerklePrimitives B E) :
+    (h : ℕ) → (hle : h ≤ P.depth) → (f : (Fin h → Bool) → B) → (leaf rt : B) →
+    (children : Fin h → E × E) → (side : Fin h → Bool) →
+    PathAux P h hle leaf rt children side → subRoot P h hle f = some rt →
+    leaf ≠ f side → Collision P
+  | 0, _, f, leaf, rt, _, side, hpath, hroot, hne =>
+    absurd (by
+      have hleaf : leaf = rt := Option.some.inj hpath.2
+      have hfr : f (fun i => i.elim0) = rt := by simpa [subRoot] using hroot
+      have hside : side = fun i => i.elim0 := funext fun i => i.elim0
+      rw [hside, hfr, hleaf]) hne
+  | h + 1, hle, f, leaf, rt, children, side, hpath, hroot, hne =>
+    match hbl : subRoot P h (Nat.le_of_succ_le hle) (fun p => f (Fin.snoc p false)),
+          hbr : subRoot P h (Nat.le_of_succ_le hle) (fun p => f (Fin.snoc p true)) with
+    | some bl, some br =>
+      if hcp : children (Fin.last h) = (P.canon bl, P.canon br) then
+        collisionOfWrongLeafAux P h (Nat.le_of_succ_le hle)
+          (fun p => f (Fin.snoc p (side (Fin.last h)))) leaf
+          (cond (side (Fin.last h)) br bl) (Fin.init children) (Fin.init side)
+          (by
+            refine ⟨fun i => ?_, ?_⟩
+            · rw [nodeAux_init P hle]
+              exact hpath.1 (Fin.castSucc i)
+            · rw [nodeAux_init P hle]
+              have hstep := hpath.1 (Fin.last h)
+              rw [hcp] at hstep
+              rw [hstep]
+              rcases Bool.eq_false_or_eq_true (side (Fin.last h)) with hbv | hbv <;>
+                rw [hbv] <;> simp [selectedChild, P.decode_canon])
+          (by
+            rcases Bool.eq_false_or_eq_true (side (Fin.last h)) with hbv | hbv <;>
+              rw [hbv] <;>
+              first
+              | exact hbl
+              | exact hbr)
+          (by
+            intro heq
+            apply hne
+            have hfs : (fun p => f (Fin.snoc p (side (Fin.last h)))) (Fin.init side)
+                = f side := by
+              show f (Fin.snoc (Fin.init side) (side (Fin.last h))) = f side
+              rw [Fin.snoc_init_self]
+            rwa [hfs] at heq)
+      else
+        ⟨Fin.castLE hle (Fin.last h),
+          { q₁ := children (Fin.last h)
+            q₂ := (P.canon bl, P.canon br)
+            ne := hcp
+            output := rt
+            eval₁ := by
+              have hlast := hpath.2
+              rw [← Fin.succ_last] at hlast
+              simpa only [nodeAux, Fin.cases_succ] using hlast
+            eval₂ := by
+              have hroot' := hroot
+              simp only [subRoot, hbl, hbr] at hroot'
+              exact hroot' }⟩
+    | none, _ => absurd (by simp [subRoot, hbl] at hroot) not_false
+    | some _, none => absurd (by simp [subRoot, hbl, hbr] at hroot) not_false
+
+/-- **Position binding, as an explicit reduction.** From a valid path that validates
+`leaf` at position `side` against a defined tree over `f`, together with
+`leaf ≠ f side`, compute a collision of one height's compression — a computable `def`
+per the breaks-as-computed-data convention. The collision's queries live in the raw
+encoding domain `E × E`, at the height the descent locates: the domain and granularity
+the concrete collision bound counts. -/
+def collisionOfWrongLeaf [DecidableEq E] (P : MerklePrimitives B E)
+    {f : (Fin P.depth → Bool) → B} {leaf rt : B}
+    {children : Fin P.depth → E × E} {side : Fin P.depth → Bool}
+    (hpath : Path P leaf rt children side) (hroot : root P f = some rt)
+    (hne : leaf ≠ f side) : Collision P :=
+  collisionOfWrongLeafAux P P.depth le_rfl f leaf rt children side
+    ((pathAux_depth_iff P).mpr hpath) hroot hne
 
 end Zcash.Security.Ledger.Merkle
+
+/-- The raw-encoding Merkle interface, re-exported at the ledger namespace for the
+statement layer. -/
+abbrev Zcash.Security.Ledger.MerklePrimitives (B E : Type*) :=
+  Zcash.Security.Ledger.Merkle.MerklePrimitives B E

--- a/Zcash/Security/Ledger/Model.lean
+++ b/Zcash/Security/Ledger/Model.lean
@@ -1,0 +1,182 @@
+import Mathlib
+import Zcash.Security.Ledger.Statement
+
+/-!
+# The witness-annotated ledger model
+
+An annotated ledger is a list of transactions (we do not model blocks). Each
+transaction carries its Actions, its net value balance, and the sighash its
+spend-authorization signatures are over. Every action comes annotated with a
+witness satisfying the Action statement — the oracle's hidden bookkeeping from
+the ledger-games-design modelling. So the games quantify over all statement-
+satisfying annotated ledgers — a superset of what a real adversary can reach.
+
+The tree is a deterministic function of public data. Each action appends its
+new note commitment's extracted coordinate `cmx_new`. An anchor is valid when
+it is the Merkle root of the leaf list for some prefix of note commitments
+ending at a transaction boundary, padded with `uncommitted`. Anchors are at
+transaction granularity, so an action can never spend an output of its own
+transaction.
+
+`ValidLedger` collects the consensus rules the games consume: statement
+satisfaction, nullifier uniqueness, anchor validity, tree capacity, signature
+verification, nonnegativity of the transparent pool balance, and a
+per-transaction action-count bound. `output_rho_nodup` is the ρ-uniqueness
+lemma: output notes carry pairwise-distinct ρ, because each is equal to its
+action's revealed nullifier. This is the mechanism for Faerie-Gold protection
+in the Orchard protocol, and it needs no cryptographic hypothesis.
+-/
+
+namespace Zcash.Security.Ledger.Model
+
+variable {F : Type*}
+variable {G : Type*}
+variable {IVK NK RHO PSI MHASH MENC MSG SIG : Type*} {KW : Type*} {d : ℕ}
+
+/-- One Action of a transaction: the public instance, the witness the oracle's
+bookkeeping annotates it with, and the spend-authorization signature over the
+transaction's sighash. -/
+structure Action (KW F G RHO PSI MHASH MENC SIG : Type*) (d : ℕ) where
+  inst : ActionInstance G MHASH RHO
+  w : ActionWitness KW F G RHO PSI MHASH MENC d
+  sig : SIG
+
+/-- A transaction: its Actions, the net value flowing out of the pool (positive
+`vBalance` means value leaving), and the sighash its signatures are over. -/
+structure Tx (KW F G RHO PSI MHASH MENC MSG SIG : Type*) (d : ℕ) where
+  actions : List (Action KW F G RHO PSI MHASH MENC SIG d)
+  vBalance : ℤ
+  sighash : MSG
+
+/-- A ledger: a linearization of transactions (design doc, "Modelling decisions"). -/
+abbrev Ledger (KW F G RHO PSI MHASH MENC MSG SIG : Type*) (d : ℕ) :=
+  List (Tx KW F G RHO PSI MHASH MENC MSG SIG d)
+
+/-- The tree position index of a path-position bit vector: bit `i` weights `2^i`.
+Defined as a fold over `List.finRange` rather than a `Finset` sum, to avoid an
+unnecessary dependency on `Classical.choice`. -/
+def posVal {d : ℕ} (pos : Fin d → Bool) : ℕ :=
+  (List.finRange d).foldr (fun i acc => (pos i).toNat + 2 * acc) 0
+
+/-- One bit off the front: the index is the low bit plus twice the rest. -/
+theorem posVal_succ {d : ℕ} (pos : Fin (d + 1) → Bool) :
+    posVal pos = (pos 0).toNat + 2 * posVal (fun i => pos i.succ) := by
+  simp only [posVal, List.finRange_succ, List.foldr_cons, List.foldr_map]
+
+/-- Position indices lie below the tree capacity. -/
+theorem posVal_lt {d : ℕ} (pos : Fin d → Bool) : posVal pos < 2 ^ d := by
+  induction d with
+  | zero => simp [posVal]
+  | succ d ih =>
+      have h := ih fun i => pos i.succ
+      have hb : (pos 0).toNat ≤ 1 := by cases pos 0 <;> simp
+      rw [posVal_succ, pow_succ]
+      omega
+
+/-- The ledger's leaf list, from public data alone: each action appends its new note
+commitment's extracted coordinate. -/
+def leafList (ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG d) : List MHASH :=
+  ledger.flatMap fun tx => tx.actions.map fun a => a.inst.cmx_new
+
+/-- The tree's leaf function for a leaf list: position `pos` holds the entry at index
+`posVal pos`, and `uncommitted` past the end. -/
+def leafFun (P : Primitives F G IVK NK RHO PSI MHASH MENC MSG SIG) (l : List MHASH) :
+    (Fin P.depth → Bool) → MHASH :=
+  fun pos => l.getD (posVal pos) P.uncommitted
+
+/-- The anchor after the first `j` transactions: the Merkle root of their leaf list, or
+`none` if a compression along the honest tree escapes. This recomputes the full tree,
+which is exponential in `depth` — fine for proofs, but evaluating at realistic depths
+(e.g. against full-depth test vectors) would need the cached empty-subtree roots that
+real implementations use. -/
+def rootAfter (P : Primitives F G IVK NK RHO PSI MHASH MENC MSG SIG)
+    (ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG P.depth) (j : ℕ) : Option MHASH :=
+  Merkle.root P.merkle (leafFun P (leafList (ledger.take j)))
+
+/-- All nullifiers a ledger reveals, in order. -/
+def nullifiers (ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG d) : List RHO :=
+  ledger.flatMap fun tx => tx.actions.map fun a => a.inst.nf_old
+
+/-- The transparent chain value pool balance after the first `i` transactions: issuance
+minted so far, plus the net value the shielded pool has released (positive `vBalance`
+means value leaving the shielded pool). The model tracks the transparent pool only as
+this overall balance — enough to model issuance and to state balance for nonzero value
+balances, with no further transparent structure. -/
+def transparentPoolBalance (issuance : ℕ → ℕ)
+    (ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG d) (i : ℕ) : ℤ :=
+  ((ledger.take i).zipIdx.map fun p => (issuance p.2 : ℤ) + p.1.vBalance).sum
+
+/-- Prefix-roots persist: an anchor of `ledger` is an anchor of any extension of `ledger`. This is
+what makes the tree append-only for the persistence argument. -/
+theorem rootAfter_prefix (P : Primitives F G IVK NK RHO PSI MHASH MENC MSG SIG)
+    {ledger ledger' : Ledger KW F G RHO PSI MHASH MENC MSG SIG P.depth} (hpre : ledger <+: ledger') {j : ℕ}
+    (hj : j ≤ ledger.length) : rootAfter P ledger' j = rootAfter P ledger j := by
+  obtain ⟨t, rfl⟩ := hpre
+  rw [rootAfter, rootAfter, List.take_append_of_le_length hj]
+
+section Validity
+
+variable [Field F] [AddCommGroup G] [Module F G]
+
+/-- Validity of a witness-annotated ledger — the premiss of every game. `issuance` is the
+intended issuance schedule and `maxActions` bounds each transaction's action count; both
+are consensus data the games quantify over. -/
+structure ValidLedger (P : Primitives F G IVK NK RHO PSI MHASH MENC MSG SIG)
+    (kv : KeyBindingInterface KW G IVK NK) (issuance : ℕ → ℕ) (maxActions : ℕ)
+    (ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG P.depth) : Prop where
+  /-- Every action's witness satisfies the Action statement. -/
+  satisfied : ∀ tx ∈ ledger, ∀ a ∈ tx.actions, ActionSatisfied P kv a.inst a.w
+  /-- No nullifier is revealed twice (the consensus nullifier-set rule; this forbids
+  duplicates even within one transaction). -/
+  nf_nodup : (nullifiers ledger).Nodup
+  /-- Each anchor is the root after some earlier transaction boundary: an action of
+  transaction `i` may reference the tree after any `j ≤ i` transactions, so only
+  outputs of strictly earlier transactions. The equation also asserts that the
+  referenced tree is defined (no compression along it escapes). -/
+  anchor_valid : ∀ i : Fin ledger.length, ∀ a ∈ (ledger.get i).actions,
+    ∃ j ≤ (i : ℕ), rootAfter P ledger j = some a.inst.rt
+  /-- The tree never overflows (the consensus capacity rule). -/
+  capacity : (leafList ledger).length ≤ 2 ^ P.depth
+  /-- Each action's spend-authorization signature verifies under its `rk`, over its
+  transaction's sighash. -/
+  sig_verifies : ∀ tx ∈ ledger, ∀ a ∈ tx.actions, P.spendAuthVerify a.inst.rk tx.sighash a.sig
+  /-- The transparent pool balance never goes negative: a transaction can move value
+  into the shielded pool only from issuance already minted, less what earlier
+  transactions consumed. Stated cumulatively because transparent funds accumulate — a
+  per-transaction bound against its own index's issuance would underpower the
+  adversary. -/
+  transparent_nonneg : ∀ i : ℕ, 0 ≤ transparentPoolBalance issuance ledger i
+  /-- Bounded action count per transaction (consumed by the integer-balance lift). -/
+  action_bound : ∀ tx ∈ ledger, tx.actions.length ≤ maxActions
+
+variable {P : Primitives F G IVK NK RHO PSI MHASH MENC MSG SIG}
+variable {kv : KeyBindingInterface KW G IVK NK}
+variable {ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG P.depth}
+
+/-- On a statement-satisfying ledger, the output notes' ρ list is the nullifier list:
+each output's ρ is its action's revealed nullifier (`ρ_new_eq`). -/
+theorem output_rho_eq_nullifiers
+    (hsat : ∀ tx ∈ ledger, ∀ a ∈ tx.actions, ActionSatisfied P kv a.inst a.w) :
+    (ledger.flatMap fun tx => tx.actions.map fun a => a.w.note_new.ρ) = nullifiers ledger := by
+  induction ledger with
+  | nil => rfl
+  | cons tx ledger ih =>
+      rw [List.flatMap_cons, nullifiers, List.flatMap_cons, ← nullifiers,
+        ih fun tx' htx' a ha => hsat tx' (List.mem_cons_of_mem _ htx') a ha]
+      congr 1
+      exact List.map_congr_left fun a ha =>
+        (hsat tx List.mem_cons_self a ha).ρ_new_eq
+
+/-- **ρ-uniqueness.** A valid ledger's output notes carry pairwise-distinct ρ values,
+because each equals its action's revealed nullifier and those are `Nodup`. So two
+outputs of identical notes cannot occur, and a spent note determines the output that
+created it — the Orchard Faerie-Gold protection, with no cryptographic hypothesis. -/
+theorem output_rho_nodup {issuance : ℕ → ℕ} {maxActions : ℕ}
+    (hval : ValidLedger P kv issuance maxActions ledger) :
+    (ledger.flatMap fun tx => tx.actions.map fun a => a.w.note_new.ρ).Nodup := by
+  rw [output_rho_eq_nullifiers hval.satisfied]
+  exact hval.nf_nodup
+
+end Validity
+
+end Zcash.Security.Ledger.Model

--- a/Zcash/Security/Ledger/Model.lean
+++ b/Zcash/Security/Ledger/Model.lean
@@ -130,8 +130,8 @@ structure ValidLedger (P : Primitives F G IVK NK RHO PSI MHASH MENC MSG SIG)
   duplicates even within one transaction). -/
   nf_nodup : (nullifiers ledger).Nodup
   /-- Each anchor is the root after some earlier transaction boundary: an action of
-  transaction `i` may reference the tree after any `j ≤ i` transactions, so only
-  outputs of strictly earlier transactions. The equation also asserts that the
+  transaction `i` (zero-based) may reference the tree after any `j ≤ i` transactions,
+  so only outputs of strictly earlier transactions. The equation also asserts that the
   referenced tree is defined (no compression along it escapes). -/
   anchor_valid : ∀ i : Fin ledger.length, ∀ a ∈ (ledger.get i).actions,
     ∃ j ≤ (i : ℕ), rootAfter P ledger j = some a.inst.rt

--- a/Zcash/Security/Ledger/Model.lean
+++ b/Zcash/Security/Ledger/Model.lean
@@ -52,7 +52,7 @@ structure Tx (KW F G RHO PSI MHASH MENC MSG SIG : Type*) (d : ℕ) where
 abbrev Ledger (KW F G RHO PSI MHASH MENC MSG SIG : Type*) (d : ℕ) :=
   List (Tx KW F G RHO PSI MHASH MENC MSG SIG d)
 
-/-- The tree position index of a path-position bit vector: bit `i` weights `2^i`.
+/-- The tree position index of a path-position bit vector: bit `i` weighs `2^i`.
 Defined as a fold over `List.finRange` rather than a `Finset` sum, to avoid an
 unnecessary dependency on `Classical.choice`. -/
 def posVal {d : ℕ} (pos : Fin d → Bool) : ℕ :=

--- a/Zcash/Security/Ledger/Model.lean
+++ b/Zcash/Security/Ledger/Model.lean
@@ -142,9 +142,10 @@ structure ValidLedger (P : Primitives F G IVK NK RHO PSI MHASH MENC MSG SIG)
   sig_verifies : ∀ tx ∈ ledger, ∀ a ∈ tx.actions, P.spendAuthVerify a.inst.rk tx.sighash a.sig
   /-- The transparent pool balance never goes negative: a transaction can move value
   into the shielded pool only from issuance already minted, less what earlier
-  transactions consumed. Stated cumulatively because transparent funds accumulate — a
-  per-transaction bound against its own index's issuance would underpower the
-  adversary. -/
+  transactions consumed. This is the consensus non-negative chain value balance rule for
+  the transparent pool (ZIP 209). Stated cumulatively because transparent funds
+  accumulate — a per-transaction bound against its own index's issuance would underpower
+  the adversary. -/
   transparent_nonneg : ∀ i : ℕ, 0 ≤ transparentPoolBalance issuance ledger i
   /-- Bounded action count per transaction (consumed by the integer-balance lift). -/
   action_bound : ∀ tx ∈ ledger, tx.actions.length ≤ maxActions

--- a/Zcash/Security/Ledger/SpendAuthority.lean
+++ b/Zcash/Security/Ledger/SpendAuthority.lean
@@ -7,17 +7,19 @@ import Zcash.Security.Ledger.Model
 The deterministic core of the Spend Authority game. Suppose an action spends a note
 addressed to a key witness `wV` (its `pk_d` is `emb (ivk wV) • g_d`), in a transaction
 whose sighash the holder of `wV` never signed. Then the ledger's own data computes one
-of two things. If the action's verification key matches `akP wV` up to sign, the
-action's signature is a `SpendAuthForgery`: a verifying signature under a randomization
-of `± akP wV`, over an unsigned message. If it does not match even up to sign, the two
-key witnesses share an `ivk` (receivability pins it) but not their `akP`, and
-`break_of_akP_ne` turns that into a key-binding break.
+of two things:
+* If the action's verification key matches `akP wV` up to sign, the action's
+  signature is a `SpendAuthForgery`: a verifying signature under a randomization
+  of `± akP wV`, over an unsigned message.
+* If it does not match up to sign, the two key witnesses share an `ivk` (receivability
+  pins it) but not their `akP`, and `break_of_akP_ne` turns that into a key-binding
+  break.
 
 The sign matters because `ak` is consumed as a single extracted coordinate, so the
 statement pins `ak^ℙ` only up to its y-sign. A forgery therefore carries a `negated`
 flag, and the unforgeability hypothesis for the randomized signature scheme must cover
 both `akV` and `-akV`. That is a factor-of-2 security loss, fine with ~2^253 ±-fibres
-remaining.
+remaining, and explicitly accepted in the design (see the note in spec §4.18.4).
 
 What stays outside this layer: unforgeability of the randomized signature scheme itself
 (a named hypothesis; this layer produces the forgery object it consumes), and the

--- a/Zcash/Security/Ledger/SpendAuthority.lean
+++ b/Zcash/Security/Ledger/SpendAuthority.lean
@@ -1,0 +1,122 @@
+import Mathlib
+import Zcash.Security.Ledger.Model
+
+/-!
+# Spend Authority: forgery or break
+
+The deterministic core of the Spend Authority game. Suppose an action spends a note
+addressed to a key witness `wV` (its `pk_d` is `emb (ivk wV) • g_d`), in a transaction
+whose sighash the holder of `wV` never signed. Then the ledger's own data computes one
+of two things. If the action's verification key matches `akP wV` up to sign, the
+action's signature is a `SpendAuthForgery`: a verifying signature under a randomization
+of `± akP wV`, over an unsigned message. If it does not match even up to sign, the two
+key witnesses share an `ivk` (receivability pins it) but not their `akP`, and
+`break_of_akP_ne` turns that into a key-binding break.
+
+The sign matters because `ak` is consumed as a single extracted coordinate, so the
+statement pins `ak^ℙ` only up to its y-sign. A forgery therefore carries a `negated`
+flag, and the unforgeability hypothesis for the randomized signature scheme must cover
+both `akV` and `-akV`. That is a factor-of-2 security loss, fine with ~2^253 ±-fibres
+remaining.
+
+What stays outside this layer: unforgeability of the randomized signature scheme itself
+(a named hypothesis; this layer produces the forgery object it consumes), and the
+probability accounting of the key-binding break (the key-binding layer's bound).
+-/
+
+namespace Zcash.Security.Ledger.Model
+
+open scoped Zcash.Security.RandomOracle
+
+variable {F : Type*}
+variable {G : Type*}
+variable {IVK NK RHO PSI MHASH MENC MSG SIG : Type*} {KW : Type*}
+
+section Validity
+
+variable [Field F] [AddCommGroup G] [Module F G]
+variable {P : Primitives F G IVK NK RHO PSI MHASH MENC MSG SIG}
+variable {kv : KeyBindingInterface KW G IVK NK}
+variable {ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG P.depth}
+variable {issuance : ℕ → ℕ} {maxActions : ℕ}
+
+/-- A spend-authorization forgery against the verification key `akV`, as data: a
+verifying signature under a randomization of `akV` or of `-akV` (recorded by `negated`),
+over a message outside `Signed` — the messages the key's holder actually signed. This is
+the object the named unforgeability hypothesis for the ±-randomized signature scheme
+consumes. -/
+structure SpendAuthForgery (P : Primitives F G IVK NK RHO PSI MHASH MENC MSG SIG)
+    (akV : G) (Signed : MSG → Prop) where
+  negated : Bool
+  α : F
+  rk : G
+  msg : MSG
+  sig : SIG
+  rk_eq : rk = P.randomizePublic α (cond negated (-akV) akV)
+  verifies : P.spendAuthVerify rk msg sig
+  fresh : ¬ Signed msg
+
+/-- A key-binding break between two exhibited witnesses, as data. -/
+structure KeyBindingBreakData (kv : KeyBindingInterface KW G IVK NK) where
+  w₁ : KW
+  w₂ : KW
+  h : kv.Break w₁ w₂
+
+/-- Receivability pins `ivk`: a satisfied spend of a note addressed to `ivkV`
+(`pk_d = emb ivkV • g_d`) has that `ivk` on its key witness. The one-witness form of
+`ivk_pinned`, by the same module algebra. -/
+theorem ivk_eq_of_receivable [NoZeroSMulDivisors F G]
+    {inst : ActionInstance G MHASH RHO}
+    {w : ActionWitness KW F G RHO PSI MHASH MENC P.depth}
+    (h : ActionSatisfied P kv inst w) {ivkV : IVK}
+    (hrecv : w.note_old.pkd = P.emb ivkV • w.note_old.gd) :
+    kv.ivk w.kw = ivkV := by
+  have hs : P.emb (kv.ivk w.kw) • w.note_old.gd = P.emb ivkV • w.note_old.gd := by
+    rw [← h.pkd_eq, hrecv]
+  have hz : (P.emb (kv.ivk w.kw) - P.emb ivkV) • w.note_old.gd = 0 := by
+    rw [sub_smul, hs, sub_self]
+  rcases smul_eq_zero.mp hz with hc | hgd0
+  · exact P.emb_injective (sub_eq_zero.mp hc)
+  · exact absurd hgd0 h.gd_ne
+
+/-- **The Spend Authority core, per action.** A satisfied action spending a note
+addressed to the key witness `wV`, whose signature verifies over a message the holder of
+`wV` never signed, computes a forgery against `akP wV` — or a key-binding break. The
+branch compares the action's `akP` with `± akP wV`: on a match the action's `rk` is a
+randomization of `± akP wV` and the action's signature is the forgery; otherwise the two
+key witnesses share `ivk` (receivability) but not `akP` up to sign, a break. -/
+def spendAuthForgeryOrBreak [DecidableEq G] [NoZeroSMulDivisors F G]
+    {inst : ActionInstance G MHASH RHO}
+    {w : ActionWitness KW F G RHO PSI MHASH MENC P.depth}
+    (h : ActionSatisfied P kv inst w) {wV : KW} (hKB : kv.KB wV)
+    (hrecv : w.note_old.pkd = P.emb (kv.ivk wV) • w.note_old.gd)
+    {msg : MSG} {sig : SIG} (hver : P.spendAuthVerify inst.rk msg sig)
+    {Signed : MSG → Prop} (hfresh : ¬ Signed msg) :
+    SpendAuthForgery P (kv.akP wV) Signed ⊕' KeyBindingBreakData kv :=
+  if hak : kv.akP w.kw = kv.akP wV then
+    .inl ⟨false, w.α, inst.rk, msg, sig, by rw [h.rk_eq, hak]; rfl, hver, hfresh⟩
+  else if hakn : kv.akP w.kw = -kv.akP wV then
+    .inl ⟨true, w.α, inst.rk, msg, sig, by rw [h.rk_eq, hakn]; rfl, hver, hfresh⟩
+  else
+    .inr ⟨w.kw, wV, kv.break_of_akP_ne h.key_binding hKB
+      (ivk_eq_of_receivable h hrecv) fun hpm => hpm.elim hak hakn⟩
+
+/-- **Spend Authority.** In a valid ledger, an action spending a note addressed to the
+key witness `wV`, in a transaction whose sighash the holder of `wV` never signed,
+computes a spend-authorization forgery against `akP wV` — or a key-binding break.
+Statement satisfaction and signature verification come from validity; the reduction is
+`spendAuthForgeryOrBreak`. -/
+def spendAuthorityOrBreak [DecidableEq G] [NoZeroSMulDivisors F G]
+    (hval : ValidLedger P kv issuance maxActions ledger)
+    {tx : Tx KW F G RHO PSI MHASH MENC MSG SIG P.depth} (htx : tx ∈ ledger)
+    {a : Action KW F G RHO PSI MHASH MENC SIG P.depth} (ha : a ∈ tx.actions)
+    {wV : KW} (hKB : kv.KB wV)
+    (hrecv : a.w.note_old.pkd = P.emb (kv.ivk wV) • a.w.note_old.gd)
+    {Signed : MSG → Prop} (hfresh : ¬ Signed tx.sighash) :
+    SpendAuthForgery P (kv.akP wV) Signed ⊕' KeyBindingBreakData kv :=
+  spendAuthForgeryOrBreak (hval.satisfied tx htx a ha) hKB hrecv
+    (hval.sig_verifies tx htx a ha) hfresh
+
+end Validity
+
+end Zcash.Security.Ledger.Model

--- a/Zcash/Security/Ledger/Spendability.lean
+++ b/Zcash/Security/Ledger/Spendability.lean
@@ -14,10 +14,10 @@ named DL/Pedersen-hash hypothesis; for the Recovery Statement, ZIP 2005's Spenda
 theorem reduces it to an `H^rcm` ±-collision.
 
 Persistence says a transaction valid immediately after `ledger` stays valid when
-appended to any valid extension `ledger'`: anchors persist because prefix roots do
-(`rootAfter_prefix`), satisfaction and signatures are per-transaction, and the only live
-conditions are nullifier freshness and the boundary conjuncts (capacity and transparent
-nonnegativity), which appear as hypotheses. The roadblock inversion (`respendOrBreak`)
+appended to any valid extension `ledger'`, under the conditions of nullifier freshness
+and the boundary conjuncts (capacity and transparent nonnegativity), which appear as
+hypotheses. Anchors persist because prefix roots do (`rootAfter_prefix`); satisfaction
+and signatures are per-transaction. The roadblock inversion (`respendOrBreak`)
 classifies what can consume a nullifier first: an action revealing the same nullifier
 either re-spends the same opening (the case Spend Authority handles) or computes a
 break.

--- a/Zcash/Security/Ledger/Spendability.lean
+++ b/Zcash/Security/Ledger/Spendability.lean
@@ -7,11 +7,13 @@ import Zcash.Security.Ledger.Balance
 Two deterministic pieces of the Spendability game. The Faerie-Gold core says nullifiers
 pin note tuples: two satisfied spends with distinct openings and equal revealed
 nullifiers compute a break — a `NoteCommitBreak` when their derive-inputs coincide (the
-same commitment opened two ways), and otherwise a `NullifierCollision`, two distinct
-inputs on which `deriveNullifier` agrees. The collision is terminal vocabulary here:
-nothing in this development reduces it further. The intended deployed discharge is a
-named DL/Pedersen-hash hypothesis; for the Recovery Statement, ZIP 2005's Spendability
-theorem reduces it to an `H^rcm` ±-collision.
+same commitment opened two ways), and otherwise a `NullifierCollision`: two distinct
+note openings whose nullifiers agree. It carries the openings, so `cm` is pinned to a
+real commitment and the collision is a genuine discrete-log relation at the
+instantiation, not a coincidence a free `cm` could fabricate. That reduction — collision
+to a DLR break (deployed), or to an `H^rcm` ±-collision for the Recovery Statement via
+ZIP 2005's Spendability theorem — is nonobvious and not yet formalized; it is planned
+for the stacked capstone PR.
 
 Persistence says a transaction valid immediately after `ledger` stays valid when
 appended to any valid extension `ledger'`, under the conditions of nullifier freshness
@@ -47,25 +49,39 @@ variable {ledger ledger' : Ledger KW F G RHO PSI MHASH MENC MSG SIG P.depth}
 variable {T : Tx KW F G RHO PSI MHASH MENC MSG SIG P.depth}
 variable {issuance : ℕ → ℕ} {maxActions : ℕ}
 
-/-- A nullifier-derivation collision, as data: two distinct derive-inputs on which
-`deriveNullifier` agrees. Terminal vocabulary — nothing in this development reduces it
-further; the intended deployed hypothesis is discrete-log independence of the nullifier
-base 𝒦^Orchard from the note-commitment bases. -/
+/-- A nullifier-derivation collision, as data: two note openings — each a note with its
+commitment (`open₁`, `open₂`) — whose derive-inputs `(nk, ρ, ψ, cm)` differ (`ne`) but
+whose `deriveNullifier` outputs agree (`eq`).
+
+The openings are what make this self-certifying. They pin each `cm` to a genuine note
+commitment, so at the Orchard instantiation the collision expands to a nontrivial
+discrete-log relation among the nullifier base 𝒦^Orchard, the note-commitment base, and
+the two commitments' hash images. Drop them and `cm` is a free group element: the affine
+`extract` (an x-coordinate) lets `cm₂` be solved to match, so the bare `(nk, ρ, ψ, cm)`
+collision is fabricable and certifies nothing.
+
+Reducing this collision to a nontrivial discrete-log relation (independence of 𝒦^Orchard
+from the note-commitment bases) is nonobvious and not yet formalized; it is planned for
+the stacked capstone PR. -/
 structure NullifierCollision (P : Primitives F G IVK NK RHO PSI MHASH MENC MSG SIG) where
   nk₁ : NK
-  ρ₁ : RHO
-  ψ₁ : PSI
+  rcm₁ : F
+  note₁ : Note G RHO PSI
   cm₁ : G
+  open₁ : P.noteCommit rcm₁ note₁ = some cm₁
   nk₂ : NK
-  ρ₂ : RHO
-  ψ₂ : PSI
+  rcm₂ : F
+  note₂ : Note G RHO PSI
   cm₂ : G
-  ne : (nk₁, ρ₁, ψ₁, cm₁) ≠ (nk₂, ρ₂, ψ₂, cm₂)
-  eq : P.deriveNullifier nk₁ ρ₁ ψ₁ cm₁ = P.deriveNullifier nk₂ ρ₂ ψ₂ cm₂
+  open₂ : P.noteCommit rcm₂ note₂ = some cm₂
+  ne : (nk₁, note₁.ρ, note₁.ψ, cm₁) ≠ (nk₂, note₂.ρ, note₂.ψ, cm₂)
+  eq : P.deriveNullifier nk₁ note₁.ρ note₁.ψ cm₁
+    = P.deriveNullifier nk₂ note₂.ρ note₂.ψ cm₂
 
 /-- **The Faerie-Gold core.** Two satisfied spends with distinct openings and equal
 revealed nullifiers compute a break: when the derive-inputs coincide the same
-commitment has two openings, and when they differ they are themselves the collision. -/
+commitment has two openings, and when they differ it packages the two openings as a
+`NullifierCollision`. -/
 def faerieGoldCore [DecidableEq G] [DecidableEq NK] [DecidableEq RHO] [DecidableEq PSI]
     {inst₁ inst₂ : ActionInstance G MHASH RHO}
     {w₁ w₂ : ActionWitness KW F G RHO PSI MHASH MENC P.depth}
@@ -79,7 +95,8 @@ def faerieGoldCore [DecidableEq G] [DecidableEq NK] [DecidableEq RHO] [Decidable
       simp only [Prod.mk.injEq] at hin
       exact noteCommitBreakOfNe h₁ h₂ (congrArg P.extract hin.2.2.2) hne)
   else
-    .inr ⟨_, _, _, _, _, _, _, _, hin, by
+    .inr ⟨kv.nk w₁.kw, w₁.rcm_old, w₁.note_old, w₁.cm_old, h₁.commit_old,
+          kv.nk w₂.kw, w₂.rcm_old, w₂.note_old, w₂.cm_old, h₂.commit_old, hin, by
       rw [← h₁.nf_old_eq, ← h₂.nf_old_eq]
       exact hnf⟩
 

--- a/Zcash/Security/Ledger/Spendability.lean
+++ b/Zcash/Security/Ledger/Spendability.lean
@@ -1,0 +1,171 @@
+import Mathlib
+import Zcash.Security.Ledger.Balance
+
+/-!
+# Spendability: the Faerie-Gold core and persistence
+
+Two deterministic pieces of the Spendability game. The Faerie-Gold core says nullifiers
+pin note tuples: two satisfied spends with distinct openings and equal revealed
+nullifiers compute a break — a `NoteCommitBreak` when their derive-inputs coincide (the
+same commitment opened two ways), and otherwise a `NullifierCollision`, two distinct
+inputs on which `deriveNullifier` agrees. The collision is terminal vocabulary here:
+nothing in this development reduces it further. The intended deployed discharge is a
+named DL/Pedersen-hash hypothesis; for the Recovery Statement, ZIP 2005's Spendability
+theorem reduces it to an `H^rcm` ±-collision.
+
+Persistence says a transaction valid immediately after `ledger` stays valid when
+appended to any valid extension `ledger'`: anchors persist because prefix roots do
+(`rootAfter_prefix`), satisfaction and signatures are per-transaction, and the only live
+conditions are nullifier freshness and the boundary conjuncts (capacity and transparent
+nonnegativity), which appear as hypotheses. The roadblock inversion (`respendOrBreak`)
+classifies what can consume a nullifier first: an action revealing the same nullifier
+either re-spends the same opening (the case Spend Authority handles) or computes a
+break.
+
+Key binding plays no role at this layer: `nk` is carried inside the collision data, and
+ZIP 2005's nf-pinning conditioning belongs to the Recovery instantiation's
+probabilistic layer, not here.
+-/
+
+namespace Zcash.Security.Ledger.Model
+
+variable {F : Type*}
+variable {G : Type*}
+variable {IVK NK RHO PSI MHASH MENC MSG SIG : Type*} {KW : Type*} {d : ℕ}
+
+/-- Nullifiers of an appended ledger split at the append. -/
+theorem nullifiers_append (l₁ l₂ : Ledger KW F G RHO PSI MHASH MENC MSG SIG d) :
+    nullifiers (l₁ ++ l₂) = nullifiers l₁ ++ nullifiers l₂ := by
+  simp [nullifiers, List.flatMap_append]
+
+section Validity
+
+variable [Field F] [AddCommGroup G] [Module F G]
+variable {P : Primitives F G IVK NK RHO PSI MHASH MENC MSG SIG}
+variable {kv : KeyBindingInterface KW G IVK NK}
+variable {ledger ledger' : Ledger KW F G RHO PSI MHASH MENC MSG SIG P.depth}
+variable {T : Tx KW F G RHO PSI MHASH MENC MSG SIG P.depth}
+variable {issuance : ℕ → ℕ} {maxActions : ℕ}
+
+/-- A nullifier-derivation collision, as data: two distinct derive-inputs on which
+`deriveNullifier` agrees. Terminal vocabulary — nothing in this development reduces it
+further; the intended deployed hypothesis is discrete-log independence of the nullifier
+base 𝒦^Orchard from the note-commitment bases. -/
+structure NullifierCollision (P : Primitives F G IVK NK RHO PSI MHASH MENC MSG SIG) where
+  nk₁ : NK
+  ρ₁ : RHO
+  ψ₁ : PSI
+  cm₁ : G
+  nk₂ : NK
+  ρ₂ : RHO
+  ψ₂ : PSI
+  cm₂ : G
+  ne : (nk₁, ρ₁, ψ₁, cm₁) ≠ (nk₂, ρ₂, ψ₂, cm₂)
+  eq : P.deriveNullifier nk₁ ρ₁ ψ₁ cm₁ = P.deriveNullifier nk₂ ρ₂ ψ₂ cm₂
+
+/-- **The Faerie-Gold core.** Two satisfied spends with distinct openings and equal
+revealed nullifiers compute a break: when the derive-inputs coincide the same
+commitment has two openings, and when they differ they are themselves the collision. -/
+def faerieGoldCore [DecidableEq G] [DecidableEq NK] [DecidableEq RHO] [DecidableEq PSI]
+    {inst₁ inst₂ : ActionInstance G MHASH RHO}
+    {w₁ w₂ : ActionWitness KW F G RHO PSI MHASH MENC P.depth}
+    (h₁ : ActionSatisfied P kv inst₁ w₁) (h₂ : ActionSatisfied P kv inst₂ w₂)
+    (hne : (w₁.rcm_old, w₁.note_old) ≠ (w₂.rcm_old, w₂.note_old))
+    (hnf : inst₁.nf_old = inst₂.nf_old) :
+    NoteCommitBreak P ⊕' NullifierCollision P :=
+  if hin : (kv.nk w₁.kw, w₁.note_old.ρ, w₁.note_old.ψ, w₁.cm_old)
+      = (kv.nk w₂.kw, w₂.note_old.ρ, w₂.note_old.ψ, w₂.cm_old) then
+    .inl (by
+      simp only [Prod.mk.injEq] at hin
+      exact noteCommitBreakOfNe h₁ h₂ (congrArg P.extract hin.2.2.2) hne)
+  else
+    .inr ⟨_, _, _, _, _, _, _, _, hin, by
+      rw [← h₁.nf_old_eq, ← h₂.nf_old_eq]
+      exact hnf⟩
+
+/-- **The roadblock inversion.** An action revealing the same nullifier as a satisfied
+spend either re-spends the same opening (the case Spend Authority handles) or computes
+a break. -/
+def respendOrBreak [DecidableEq F] [DecidableEq G] [DecidableEq NK] [DecidableEq RHO]
+    [DecidableEq PSI]
+    {inst₁ inst₂ : ActionInstance G MHASH RHO}
+    {w₁ w₂ : ActionWitness KW F G RHO PSI MHASH MENC P.depth}
+    (h₁ : ActionSatisfied P kv inst₁ w₁) (h₂ : ActionSatisfied P kv inst₂ w₂)
+    (hnf : inst₁.nf_old = inst₂.nf_old) :
+    ((w₁.rcm_old, w₁.note_old) = (w₂.rcm_old, w₂.note_old))
+      ⊕' (NoteCommitBreak P ⊕' NullifierCollision P) :=
+  if h : (w₁.rcm_old, w₁.note_old) = (w₂.rcm_old, w₂.note_old) then .inl h
+  else .inr (faerieGoldCore h₁ h₂ h hnf)
+
+/-- **Persistence.** A transaction valid immediately after `ledger` remains valid when
+appended to any valid extension `ledger'`, given that its nullifiers are still fresh
+and the boundary conjuncts hold for the appended ledger. Anchors persist because prefix
+roots do; satisfaction, signatures, and the action bound are per-transaction. -/
+theorem validLedger_append
+    (hval' : ValidLedger P kv issuance maxActions ledger')
+    (hpre : ledger <+: ledger')
+    (hvalT : ValidLedger P kv issuance maxActions (ledger ++ [T]))
+    (hfresh : ∀ a ∈ T.actions, a.inst.nf_old ∉ nullifiers ledger')
+    (hcap : (leafList (ledger' ++ [T])).length ≤ 2 ^ P.depth)
+    (htrans : ∀ i : ℕ, 0 ≤ transparentPoolBalance issuance (ledger' ++ [T]) i) :
+    ValidLedger P kv issuance maxActions (ledger' ++ [T]) := by
+  have hTmem : T ∈ ledger ++ [T] := by simp
+  have hmem : ∀ tx ∈ ledger' ++ [T], tx ∈ ledger' ∨ tx = T := by
+    intro tx htx
+    rcases List.mem_append.mp htx with h | h
+    · exact Or.inl h
+    · exact Or.inr (by simpa using h)
+  refine ⟨?_, ?_, ?_, hcap, ?_, htrans, ?_⟩
+  · intro tx htx a ha
+    rcases hmem tx htx with h | rfl
+    · exact hval'.satisfied tx h a ha
+    · exact hvalT.satisfied tx hTmem a ha
+  · rw [nullifiers_append]
+    refine List.nodup_append.mpr ⟨hval'.nf_nodup, ?_, ?_⟩
+    · have h := hvalT.nf_nodup
+      rw [nullifiers_append] at h
+      exact (List.nodup_append.mp h).2.1
+    · intro x hx y hy
+      obtain ⟨a, ha, rfl⟩ : ∃ a ∈ T.actions, a.inst.nf_old = y := by
+        simpa [nullifiers] using hy
+      exact fun heq => hfresh a ha (heq ▸ hx)
+  · intro i a hai
+    by_cases hi : (i : ℕ) < ledger'.length
+    · have hget : (ledger' ++ [T]).get i = ledger'.get ⟨(i : ℕ), hi⟩ := by
+        simp [List.get_eq_getElem, List.getElem_append_left hi]
+      rw [hget] at hai
+      obtain ⟨j, hj, hrt⟩ := hval'.anchor_valid ⟨(i : ℕ), hi⟩ a hai
+      refine ⟨j, hj, ?_⟩
+      rw [rootAfter_prefix P ⟨[T], rfl⟩ (le_trans hj (le_of_lt hi))]
+      exact hrt
+    · have hieq : (i : ℕ) = ledger'.length := by
+        have := i.isLt
+        simp only [List.length_append, List.length_singleton] at this
+        omega
+      have hget : (ledger' ++ [T]).get i = T := by
+        simp [List.get_eq_getElem, hieq]
+      rw [hget] at hai
+      have hTfin : (ledger ++ [T]).get ⟨ledger.length, by simp⟩ = T := by
+        simp [List.get_eq_getElem]
+      obtain ⟨j, hj, hrt⟩ := hvalT.anchor_valid ⟨ledger.length, by simp⟩ a
+        (by rw [hTfin]; exact hai)
+      refine ⟨j, ?_, ?_⟩
+      · rw [hieq]
+        exact le_trans hj hpre.length_le
+      · rw [rootAfter_prefix P (⟨[T], rfl⟩ : ledger' <+: ledger' ++ [T])
+            (le_trans hj hpre.length_le),
+          rootAfter_prefix P hpre hj,
+          ← rootAfter_prefix P (⟨[T], rfl⟩ : ledger <+: ledger ++ [T]) hj]
+        exact hrt
+  · intro tx htx a ha
+    rcases hmem tx htx with h | rfl
+    · exact hval'.sig_verifies tx h a ha
+    · exact hvalT.sig_verifies tx hTmem a ha
+  · intro tx htx
+    rcases hmem tx htx with h | rfl
+    · exact hval'.action_bound tx h
+    · exact hvalT.action_bound tx hTmem
+
+end Validity
+
+end Zcash.Security.Ledger.Model

--- a/Zcash/Security/Ledger/Statement.lean
+++ b/Zcash/Security/Ledger/Statement.lean
@@ -40,7 +40,7 @@ namespace Zcash.Security.Ledger
 
 variable {F : Type*} [Field F]
 variable {G : Type*} [AddCommGroup G] [Module F G]
-variable {IVK NK RHO PSI CMX MHASH : Type*} {KW : Type*}
+variable {IVK NK RHO PSI MHASH : Type*} {KW : Type*}
 
 /-- An Orchard-shaped note. Point encodings and type conversions are abstracted away:
 `gd` and `pkd` are group elements, `ρ` and `ψ` base-field values, `v` a natural number
@@ -55,29 +55,28 @@ structure Note (G RHO PSI : Type*) where
 /-- The public inputs of an Action that the games consume: the anchor, the revealed
 nullifier, the randomized verification key, the net value commitment, and the new note
 commitment's extracted coordinate. -/
-structure ActionInstance (G MHASH RHO CMX : Type*) where
+structure ActionInstance (G MHASH RHO : Type*) where
   rt : MHASH
   /-- `⦂ RHO`: nullifiers share ρ's type, forced by ρ-uniqueness (`ρ_new = nf_old`). -/
   nf_old : RHO
   rk : G
   cv_net : G
-  cmx_new : CMX
+  cmx_new : MHASH
 
 /-- The abstract primitives of an Orchard-shaped shielded protocol. No algebraic structure
 is required of the fields themselves; the group algebra enters only through the statement
 and lemmas. `emb` is the embedding of base-field values used as scalars
 (`[0, q) ⊆ [0, r)` concretely). -/
-structure Primitives (F G IVK NK RHO PSI CMX MHASH : Type*) where
+structure Primitives (F G IVK NK RHO PSI MHASH : Type*) where
   depth : ℕ
   valueBound : ℕ
   emb : IVK → F
   emb_injective : Function.Injective emb
-  extract : G → CMX
+  extract : G → MHASH
   noteCommit : F → Note G RHO PSI → Option G
   /-- Nullifiers share ρ's type (`RHO`), forced by ρ-uniqueness (`ρ_new = nf_old`). -/
   deriveNullifier : NK → RHO → PSI → G → RHO
   merkleCRH : MHASH × MHASH → MHASH
-  leafOf : CMX → RHO → MHASH
   randomizePublic : F → G → G
   valueCommit : ℤ → F → G
 
@@ -119,15 +118,15 @@ satisfy this interface (the latter enforces strictly more).
 TODO: It's unclear how well this will compose with Gregor's approach to the circuit proof.
 In particular, should this be `Prop`-only or will we need to apply the break-as-computed-data
 pattern here? -/
-structure ActionSatisfied (P : Primitives F G IVK NK RHO PSI CMX MHASH)
-    (kv : KeyBindingInterface KW G IVK NK) (inst : ActionInstance G MHASH RHO CMX)
+structure ActionSatisfied (P : Primitives F G IVK NK RHO PSI MHASH)
+    (kv : KeyBindingInterface KW G IVK NK) (inst : ActionInstance G MHASH RHO)
     (w : ActionWitness KW F G RHO PSI MHASH P.depth) : Prop where
   /-- Spend-side commitment integrity: `cm_old` opens `note_old` with `rcm_old`. -/
   commit_old : P.noteCommit w.rcm_old w.note_old = some w.cm_old
   /-- Merkle path validity for nonzero-valued spends. -/
   merkle_path : w.note_old.v ≠ 0 →
     Merkle.pathRoot P.merkleCRH P.depth w.pos w.path
-      (P.leafOf (P.extract w.cm_old) w.note_old.ρ) = inst.rt
+      (P.extract w.cm_old) = inst.rt
   /-- Nullifier integrity. -/
   nf_old_eq : inst.nf_old =
     P.deriveNullifier (kv.nk w.kw) w.note_old.ρ w.note_old.ψ w.cm_old
@@ -158,7 +157,7 @@ equal extracted coordinates. Computed by the games' reductions; nothing in this
 development reduces it further. The intended onward reductions are a Sinsemilla/DLR
 relation pre-quantum (spec Theorems 5.4.3 and 5.4.4), and an `H^rcm` ±-collision for the
 Recovery Statement (via the Pedersen lift and the `extract` ±-property). -/
-structure NoteCommitBreak (P : Primitives F G IVK NK RHO PSI CMX MHASH) where
+structure NoteCommitBreak (P : Primitives F G IVK NK RHO PSI MHASH) where
   rcm₁ : F
   n₁ : Note G RHO PSI
   rcm₂ : F
@@ -172,8 +171,9 @@ structure NoteCommitBreak (P : Primitives F G IVK NK RHO PSI CMX MHASH) where
 
 section Pinning
 
-variable {P : Primitives F G IVK NK RHO PSI CMX MHASH} {kv : KeyBindingInterface KW G IVK NK}
-variable {inst₁ inst₂ : ActionInstance G MHASH RHO CMX}
+variable {P : Primitives F G IVK NK RHO PSI MHASH}
+variable {kv : KeyBindingInterface KW G IVK NK}
+variable {inst₁ inst₂ : ActionInstance G MHASH RHO}
 variable {w₁ w₂ : ActionWitness KW F G RHO PSI MHASH P.depth}
 
 /-- **`ivk`-pinning** (ZIP 2005 `lemma-ivk-pinning`): the address `(g_d, pk_d)` of the

--- a/Zcash/Security/Ledger/Statement.lean
+++ b/Zcash/Security/Ledger/Statement.lean
@@ -40,7 +40,7 @@ namespace Zcash.Security.Ledger
 
 variable {F : Type*} [Field F]
 variable {G : Type*} [AddCommGroup G] [Module F G]
-variable {IVK NK RHO PSI CMX RT : Type*} {KW : Type*}
+variable {IVK NK RHO PSI CMX MHASH : Type*} {KW : Type*}
 
 /-- An Orchard-shaped note. Point encodings and type conversions are abstracted away:
 `gd` and `pkd` are group elements, `ρ` and `ψ` base-field values, `v` a natural number
@@ -55,8 +55,8 @@ structure Note (G RHO PSI : Type*) where
 /-- The public inputs of an Action that the games consume: the anchor, the revealed
 nullifier, the randomized verification key, the net value commitment, and the new note
 commitment's extracted coordinate. -/
-structure ActionInstance (G RT RHO CMX : Type*) where
-  rt : RT
+structure ActionInstance (G MHASH RHO CMX : Type*) where
+  rt : MHASH
   /-- `⦂ RHO`: nullifiers share ρ's type, forced by ρ-uniqueness (`ρ_new = nf_old`). -/
   nf_old : RHO
   rk : G
@@ -67,7 +67,7 @@ structure ActionInstance (G RT RHO CMX : Type*) where
 is required of the fields themselves; the group algebra enters only through the statement
 and lemmas. `emb` is the embedding of base-field values used as scalars
 (`[0, q) ⊆ [0, r)` concretely). -/
-structure Primitives (F G IVK NK RHO PSI CMX RT : Type*) where
+structure Primitives (F G IVK NK RHO PSI CMX MHASH : Type*) where
   depth : ℕ
   valueBound : ℕ
   emb : IVK → F
@@ -76,8 +76,8 @@ structure Primitives (F G IVK NK RHO PSI CMX RT : Type*) where
   noteCommit : F → Note G RHO PSI → Option G
   /-- Nullifiers share ρ's type (`RHO`), forced by ρ-uniqueness (`ρ_new = nf_old`). -/
   deriveNullifier : NK → RHO → PSI → G → RHO
-  merkleCRH : RT × RT → RT
-  leafOf : CMX → RHO → RT
+  merkleCRH : MHASH × MHASH → MHASH
+  leafOf : CMX → RHO → MHASH
   randomizePublic : F → G → G
   valueCommit : ℤ → F → G
 
@@ -99,9 +99,9 @@ structure KeyBindingInterface (KW G IVK NK : Type*) where
 
 /-- The auxiliary inputs of an Action. `cm_old`/`cm_new` are carried explicitly so that the
 statement's commitment checks pin them; `kw` is the key-binding witness. -/
-structure ActionWitness (KW F G RHO PSI RT : Type*) (d : ℕ) where
+structure ActionWitness (KW F G RHO PSI MHASH : Type*) (d : ℕ) where
   pos : Fin d → Bool
-  path : Fin d → RT
+  path : Fin d → MHASH
   note_old : Note G RHO PSI
   note_new : Note G RHO PSI
   cm_old : G
@@ -119,9 +119,9 @@ satisfy this interface (the latter enforces strictly more).
 TODO: It's unclear how well this will compose with Gregor's approach to the circuit proof.
 In particular, should this be `Prop`-only or will we need to apply the break-as-computed-data
 pattern here? -/
-structure ActionSatisfied (P : Primitives F G IVK NK RHO PSI CMX RT)
-    (kv : KeyBindingInterface KW G IVK NK) (inst : ActionInstance G RT RHO CMX)
-    (w : ActionWitness KW F G RHO PSI RT P.depth) : Prop where
+structure ActionSatisfied (P : Primitives F G IVK NK RHO PSI CMX MHASH)
+    (kv : KeyBindingInterface KW G IVK NK) (inst : ActionInstance G MHASH RHO CMX)
+    (w : ActionWitness KW F G RHO PSI MHASH P.depth) : Prop where
   /-- Spend-side commitment integrity: `cm_old` opens `note_old` with `rcm_old`. -/
   commit_old : P.noteCommit w.rcm_old w.note_old = some w.cm_old
   /-- Merkle path validity for nonzero-valued spends. -/
@@ -158,7 +158,7 @@ equal extracted coordinates. Computed by the games' reductions; nothing in this
 development reduces it further. The intended onward reductions are a Sinsemilla/DLR
 relation pre-quantum (spec Theorems 5.4.3 and 5.4.4), and an `H^rcm` ±-collision for the
 Recovery Statement (via the Pedersen lift and the `extract` ±-property). -/
-structure NoteCommitBreak (P : Primitives F G IVK NK RHO PSI CMX RT) where
+structure NoteCommitBreak (P : Primitives F G IVK NK RHO PSI CMX MHASH) where
   rcm₁ : F
   n₁ : Note G RHO PSI
   rcm₂ : F
@@ -172,9 +172,9 @@ structure NoteCommitBreak (P : Primitives F G IVK NK RHO PSI CMX RT) where
 
 section Pinning
 
-variable {P : Primitives F G IVK NK RHO PSI CMX RT} {kv : KeyBindingInterface KW G IVK NK}
-variable {inst₁ inst₂ : ActionInstance G RT RHO CMX}
-variable {w₁ w₂ : ActionWitness KW F G RHO PSI RT P.depth}
+variable {P : Primitives F G IVK NK RHO PSI CMX MHASH} {kv : KeyBindingInterface KW G IVK NK}
+variable {inst₁ inst₂ : ActionInstance G MHASH RHO CMX}
+variable {w₁ w₂ : ActionWitness KW F G RHO PSI MHASH P.depth}
 
 /-- **`ivk`-pinning** (ZIP 2005 `lemma-ivk-pinning`): the address `(g_d, pk_d)` of the
 spent note determines `ivk`. Pure module algebra: needs only `g_d ≠ 0`, injectivity of the

--- a/Zcash/Security/Ledger/Statement.lean
+++ b/Zcash/Security/Ledger/Statement.lean
@@ -40,7 +40,7 @@ namespace Zcash.Security.Ledger
 
 variable {F : Type*} [Field F]
 variable {G : Type*} [AddCommGroup G] [Module F G]
-variable {IVK NK RHO PSI MHASH MENC : Type*} {KW : Type*}
+variable {IVK NK RHO PSI MHASH MENC MSG SIG : Type*} {KW : Type*}
 
 /-- An Orchard-shaped note. Point encodings and type conversions are abstracted away:
 `gd` and `pkd` are group elements, `ρ` and `ψ` base-field values, `v` a natural number
@@ -66,8 +66,9 @@ structure ActionInstance (G MHASH RHO : Type*) where
 /-- The abstract primitives of an Orchard-shaped shielded protocol. No algebraic structure
 is required of the fields themselves; the group algebra enters only through the statement
 and lemmas. `emb` is the embedding of base-field values used as scalars
-(`[0, q) ⊆ [0, r)` concretely). -/
-structure Primitives (F G IVK NK RHO PSI MHASH MENC : Type*) where
+(`[0, q) ⊆ [0, r)` concretely). `MSG` and `SIG` are the sighash and signature types of the
+spend-authorization scheme. -/
+structure Primitives (F G IVK NK RHO PSI MHASH MENC MSG SIG : Type*) where
   valueBound : ℕ
   emb : IVK → F
   emb_injective : Function.Injective emb
@@ -81,11 +82,20 @@ structure Primitives (F G IVK NK RHO PSI MHASH MENC : Type*) where
   conscious trade-off from Sapling onward: the circuit does not pay for a canonicity
   check, so collisions are counted over the encoding domain, per height. -/
   merkle : MerklePrimitives MHASH MENC
+  /-- The padding value for tree positions beyond the appended leaves
+  (`Uncommitted^Orchard` concretely). -/
+  uncommitted : MHASH
+  /-- No extracted note commitment collides with the padding value (spec Thm 5.4.6
+  concretely). -/
+  uncommitted_ne : ∀ g, extract g ≠ uncommitted
   randomizePublic : F → G → G
   valueCommit : ℤ → F → G
+  /-- Verification of a spend-authorization signature under the randomized key `rk`, over
+  a transaction sighash. -/
+  spendAuthVerify : G → MSG → SIG → Prop
 
 /-- The tree depth, read off the Merkle interface. -/
-abbrev Primitives.depth (P : Primitives F G IVK NK RHO PSI MHASH MENC) : ℕ :=
+abbrev Primitives.depth (P : Primitives F G IVK NK RHO PSI MHASH MENC MSG SIG) : ℕ :=
   P.merkle.depth
 
 /-- The games-facing view of a key-binding witness type `KW`: projections, the key-binding
@@ -128,7 +138,7 @@ satisfy this interface (the latter enforces strictly more).
 TODO: It's unclear how well this will compose with Gregor's approach to the circuit proof.
 In particular, should this be `Prop`-only or will we need to apply the break-as-computed-data
 pattern here? -/
-structure ActionSatisfied (P : Primitives F G IVK NK RHO PSI MHASH MENC)
+structure ActionSatisfied (P : Primitives F G IVK NK RHO PSI MHASH MENC MSG SIG)
     (kv : KeyBindingInterface KW G IVK NK) (inst : ActionInstance G MHASH RHO)
     (w : ActionWitness KW F G RHO PSI MHASH MENC P.depth) : Prop where
   /-- Spend-side commitment integrity: `cm_old` opens `note_old` with `rcm_old`. -/
@@ -166,7 +176,7 @@ equal extracted coordinates. Computed by the games' reductions; nothing in this
 development reduces it further. The intended onward reductions are a Sinsemilla/DLR
 relation pre-quantum (spec Theorems 5.4.3 and 5.4.4), and an `H^rcm` ±-collision for the
 Recovery Statement (via the Pedersen lift and the `extract` ±-property). -/
-structure NoteCommitBreak (P : Primitives F G IVK NK RHO PSI MHASH MENC) where
+structure NoteCommitBreak (P : Primitives F G IVK NK RHO PSI MHASH MENC MSG SIG) where
   rcm₁ : F
   n₁ : Note G RHO PSI
   rcm₂ : F
@@ -180,7 +190,7 @@ structure NoteCommitBreak (P : Primitives F G IVK NK RHO PSI MHASH MENC) where
 
 section Pinning
 
-variable {P : Primitives F G IVK NK RHO PSI MHASH MENC}
+variable {P : Primitives F G IVK NK RHO PSI MHASH MENC MSG SIG}
 variable {kv : KeyBindingInterface KW G IVK NK}
 variable {inst₁ inst₂ : ActionInstance G MHASH RHO}
 variable {w₁ w₂ : ActionWitness KW F G RHO PSI MHASH MENC P.depth}

--- a/Zcash/Security/Ledger/Statement.lean
+++ b/Zcash/Security/Ledger/Statement.lean
@@ -6,14 +6,17 @@ import Zcash.Security.Ledger.Merkle
 
 This module transcribes the games-relevant conjuncts of an Orchard-shaped Action statement
 (Zcash protocol specification §4.17.4) over abstract primitives, as the interface consumed
-by the ledger-model security games (Balance, Spendability, Spend Authority). Two intended
-instantiations satisfy it:
+by the ledger-model security games (Balance, Spendability, Spend Authority). Two
+instantiations are intended to satisfy it. The statements themselves are not formalized
+yet, though the key-binding layer already reduces breaks of the `Commit^ivk` opening to
+Pedersen-scalar ±-collisions — essentially note-commitment binding:
 
 * the deployed (pre-quantum) Orchard Action statement, where the key-binding condition is
-  the bare `Commit^ivk` opening and note-commitment breaks reduce to Sinsemilla/DLR
-  relations; and
+  the bare `Commit^ivk` opening, and note-commitment breaks reduce on paper to
+  Sinsemilla/DLR relations (spec Theorems 5.4.3 and 5.4.4); and
 * the ZIP 2005 Recovery Statement, which adds derivation constraints (`KB_deriv`, the
-  `H^rcm`/`H^ψ` checks) so that the same breaks reduce to random-oracle collisions.
+  `H^rcm`/`H^ψ` checks) so that the same breaks reduce to random-oracle collisions
+  (ZIP 2005's key-binding theorem).
 
 The key material is decoupled behind `KeyBindingInterface`: the games see only the
 projections (`ivk`, `nk`, `akP`), the key-binding condition `KB` enforced by the statement,
@@ -151,9 +154,10 @@ structure ActionSatisfied (P : Primitives F G IVK NK RHO PSI CMX RT)
 
 /-- A note-commitment break, as data (per the breaks-as-computed-data
 convention in `Zcash.Security.RandomOracle`): two distinct `(rcm, note)` tuples whose commitments have
-equal extracted coordinates. Computed by the games' reductions; each instantiation reduces
-it onward (a Sinsemilla/DLR relation pre-quantum; an `H^rcm` ±-collision for the Recovery
-Statement via the Pedersen lift and the `extract` ±-property). -/
+equal extracted coordinates. Computed by the games' reductions; nothing in this
+development reduces it further. The intended onward reductions are a Sinsemilla/DLR
+relation pre-quantum (spec Theorems 5.4.3 and 5.4.4), and an `H^rcm` ±-collision for the
+Recovery Statement (via the Pedersen lift and the `extract` ±-property). -/
 structure NoteCommitBreak (P : Primitives F G IVK NK RHO PSI CMX RT) where
   rcm₁ : F
   n₁ : Note G RHO PSI

--- a/Zcash/Security/Ledger/Statement.lean
+++ b/Zcash/Security/Ledger/Statement.lean
@@ -105,9 +105,12 @@ abbrev Primitives.depth (P : Primitives F G IVK NK RHO PSI MHASH MENC MSG SIG) :
 /-- The games-facing view of a key-binding witness type `KW`: projections, the key-binding
 condition `KB` enforced by the statement, and a `Break` predicate. `break_of_nk_ne`
 (consumed by Balance) and `break_of_akP_ne` (consumed by Spend Authority) are the
-guarantees the games use; the key-binding layer instantiates `Break` and discharges both,
-reducing breaks onward to random-oracle collisions. `Break` being an
-opaque `Prop` limits the games to certificate-level break exhibition. -/
+guarantees the games use; the key-binding layer instantiates `Break` and discharges
+both, reducing breaks onward to random-oracle collisions. `Break` is deliberately an
+opaque `Prop`: the games exhibit the witness pair as data and certify the break
+propositionally, which is exactly the event the probabilistic bound
+(`toInterface_break_measure_le`) covers; data-level onward reductions
+(`CollisionUpToSign.ofBreak`) live below the interface. -/
 structure KeyBindingInterface (KW G IVK NK : Type*) [Neg G] where
   ivk : KW → IVK
   nk : KW → NK

--- a/Zcash/Security/Ledger/Statement.lean
+++ b/Zcash/Security/Ledger/Statement.lean
@@ -40,7 +40,7 @@ namespace Zcash.Security.Ledger
 
 variable {F : Type*} [Field F]
 variable {G : Type*} [AddCommGroup G] [Module F G]
-variable {IVK NK RHO PSI MHASH : Type*} {KW : Type*}
+variable {IVK NK RHO PSI MHASH MENC : Type*} {KW : Type*}
 
 /-- An Orchard-shaped note. Point encodings and type conversions are abstracted away:
 `gd` and `pkd` are group elements, `ρ` and `ψ` base-field values, `v` a natural number
@@ -67,8 +67,7 @@ structure ActionInstance (G MHASH RHO : Type*) where
 is required of the fields themselves; the group algebra enters only through the statement
 and lemmas. `emb` is the embedding of base-field values used as scalars
 (`[0, q) ⊆ [0, r)` concretely). -/
-structure Primitives (F G IVK NK RHO PSI MHASH : Type*) where
-  depth : ℕ
+structure Primitives (F G IVK NK RHO PSI MHASH MENC : Type*) where
   valueBound : ℕ
   emb : IVK → F
   emb_injective : Function.Injective emb
@@ -76,9 +75,18 @@ structure Primitives (F G IVK NK RHO PSI MHASH : Type*) where
   noteCommit : F → Note G RHO PSI → Option G
   /-- Nullifiers share ρ's type (`RHO`), forced by ρ-uniqueness (`ρ_new = nf_old`). -/
   deriveNullifier : NK → RHO → PSI → G → RHO
-  merkleCRH : MHASH × MHASH → MHASH
+  /-- The raw-encoding partial Merkle interface (`Zcash.Security.Ledger.Merkle`): tree
+  nodes are `MHASH` values, `MENC` is the raw child encoding consumed by the
+  height-personalized partial compression. Non-canonical encodings are accepted — a
+  conscious trade-off from Sapling onward: the circuit does not pay for a canonicity
+  check, so collisions are counted over the encoding domain, per height. -/
+  merkle : MerklePrimitives MHASH MENC
   randomizePublic : F → G → G
   valueCommit : ℤ → F → G
+
+/-- The tree depth, read off the Merkle interface. -/
+abbrev Primitives.depth (P : Primitives F G IVK NK RHO PSI MHASH MENC) : ℕ :=
+  P.merkle.depth
 
 /-- The games-facing view of a key-binding witness type `KW`: projections, the key-binding
 condition `KB` enforced by the statement, and a `Break` predicate. `break_of_nk_ne` is the
@@ -98,9 +106,11 @@ structure KeyBindingInterface (KW G IVK NK : Type*) where
 
 /-- The auxiliary inputs of an Action. `cm_old`/`cm_new` are carried explicitly so that the
 statement's commitment checks pin them; `kw` is the key-binding witness. -/
-structure ActionWitness (KW F G RHO PSI MHASH : Type*) (d : ℕ) where
-  pos : Fin d → Bool
-  path : Fin d → MHASH
+structure ActionWitness (KW F G RHO PSI MHASH MENC : Type*) (d : ℕ) where
+  /-- Both raw child encodings at every height, in leaf-to-root order. -/
+  path : Fin d → MENC × MENC
+  /-- The child encoding selected by the path (`false` = left, `true` = right). -/
+  side : Fin d → Bool
   note_old : Note G RHO PSI
   note_new : Note G RHO PSI
   cm_old : G
@@ -118,15 +128,14 @@ satisfy this interface (the latter enforces strictly more).
 TODO: It's unclear how well this will compose with Gregor's approach to the circuit proof.
 In particular, should this be `Prop`-only or will we need to apply the break-as-computed-data
 pattern here? -/
-structure ActionSatisfied (P : Primitives F G IVK NK RHO PSI MHASH)
+structure ActionSatisfied (P : Primitives F G IVK NK RHO PSI MHASH MENC)
     (kv : KeyBindingInterface KW G IVK NK) (inst : ActionInstance G MHASH RHO)
-    (w : ActionWitness KW F G RHO PSI MHASH P.depth) : Prop where
+    (w : ActionWitness KW F G RHO PSI MHASH MENC P.depth) : Prop where
   /-- Spend-side commitment integrity: `cm_old` opens `note_old` with `rcm_old`. -/
   commit_old : P.noteCommit w.rcm_old w.note_old = some w.cm_old
   /-- Merkle path validity for nonzero-valued spends. -/
   merkle_path : w.note_old.v ≠ 0 →
-    Merkle.pathRoot P.merkleCRH P.depth w.pos w.path
-      (P.extract w.cm_old) = inst.rt
+    Merkle.Path P.merkle (P.extract w.cm_old) inst.rt w.path w.side
   /-- Nullifier integrity. -/
   nf_old_eq : inst.nf_old =
     P.deriveNullifier (kv.nk w.kw) w.note_old.ρ w.note_old.ψ w.cm_old
@@ -157,7 +166,7 @@ equal extracted coordinates. Computed by the games' reductions; nothing in this
 development reduces it further. The intended onward reductions are a Sinsemilla/DLR
 relation pre-quantum (spec Theorems 5.4.3 and 5.4.4), and an `H^rcm` ±-collision for the
 Recovery Statement (via the Pedersen lift and the `extract` ±-property). -/
-structure NoteCommitBreak (P : Primitives F G IVK NK RHO PSI MHASH) where
+structure NoteCommitBreak (P : Primitives F G IVK NK RHO PSI MHASH MENC) where
   rcm₁ : F
   n₁ : Note G RHO PSI
   rcm₂ : F
@@ -171,10 +180,10 @@ structure NoteCommitBreak (P : Primitives F G IVK NK RHO PSI MHASH) where
 
 section Pinning
 
-variable {P : Primitives F G IVK NK RHO PSI MHASH}
+variable {P : Primitives F G IVK NK RHO PSI MHASH MENC}
 variable {kv : KeyBindingInterface KW G IVK NK}
 variable {inst₁ inst₂ : ActionInstance G MHASH RHO}
-variable {w₁ w₂ : ActionWitness KW F G RHO PSI MHASH P.depth}
+variable {w₁ w₂ : ActionWitness KW F G RHO PSI MHASH MENC P.depth}
 
 /-- **`ivk`-pinning** (ZIP 2005 `lemma-ivk-pinning`): the address `(g_d, pk_d)` of the
 spent note determines `ivk`. Pure module algebra: needs only `g_d ≠ 0`, injectivity of the

--- a/Zcash/Security/Ledger/Statement.lean
+++ b/Zcash/Security/Ledger/Statement.lean
@@ -51,6 +51,7 @@ structure Note (G RHO PSI : Type*) where
   v : ℕ
   ρ : RHO
   ψ : PSI
+  deriving DecidableEq
 
 /-- The public inputs of an Action that the games consume: the anchor, the revealed
 nullifier, the randomized verification key, the net value commitment, and the new note

--- a/Zcash/Security/Ledger/Statement.lean
+++ b/Zcash/Security/Ledger/Statement.lean
@@ -20,8 +20,9 @@ Pedersen-scalar ±-collisions — essentially note-commitment binding:
 
 The key material is decoupled behind `KeyBindingInterface`: the games see only the
 projections (`ivk`, `nk`, `akP`), the key-binding condition `KB` enforced by the statement,
-and a `Break` predicate with the guarantee that two `KB`-witnesses sharing an `ivk` but
-disagreeing on `nk` are a break. The concrete witness structure, the factoring
+and a `Break` predicate with two guarantees: `KB`-witnesses sharing an `ivk` are a break
+if they disagree on `nk`, or if their `akP`s are not equal up to sign (`=±`, the notation
+scoped in `Zcash.Security.RandomOracle`). The concrete witness structure, the factoring
 `KB = KBOpening ∧ KBDerivation`, and the reduction from `Break` to random-oracle
 collisions live in the key-binding layer (`keep/keybinding-design.md`).
 
@@ -37,6 +38,8 @@ The lemmas here are the deterministic pinning steps of the Balance argument:
 -/
 
 namespace Zcash.Security.Ledger
+
+open scoped Zcash.Security.RandomOracle
 
 variable {F : Type*} [Field F]
 variable {G : Type*} [AddCommGroup G] [Module F G]
@@ -100,13 +103,12 @@ abbrev Primitives.depth (P : Primitives F G IVK NK RHO PSI MHASH MENC MSG SIG) :
   P.merkle.depth
 
 /-- The games-facing view of a key-binding witness type `KW`: projections, the key-binding
-condition `KB` enforced by the statement, and a `Break` predicate. `break_of_nk_ne` is the
-guarantee the games consume; the key-binding layer instantiates `Break` and discharges it
-(reducing breaks onward to random-oracle collisions or DLR relations). This interface is
-provisional: its shape is to be revisited against what the Balance and Spendability games
-actually consume once they are formalized — in particular `Break` being an opaque `Prop`
-limits the games to certificate-level break exhibition. -/
-structure KeyBindingInterface (KW G IVK NK : Type*) where
+condition `KB` enforced by the statement, and a `Break` predicate. `break_of_nk_ne`
+(consumed by Balance) and `break_of_akP_ne` (consumed by Spend Authority) are the
+guarantees the games use; the key-binding layer instantiates `Break` and discharges both,
+reducing breaks onward to random-oracle collisions. `Break` being an
+opaque `Prop` limits the games to certificate-level break exhibition. -/
+structure KeyBindingInterface (KW G IVK NK : Type*) [Neg G] where
   ivk : KW → IVK
   nk : KW → NK
   akP : KW → G
@@ -114,6 +116,12 @@ structure KeyBindingInterface (KW G IVK NK : Type*) where
   Break : KW → KW → Prop
   break_of_nk_ne : ∀ {w₁ w₂ : KW}, KB w₁ → KB w₂ →
     ivk w₁ = ivk w₂ → nk w₁ ≠ nk w₂ → Break w₁ w₂
+  /-- Two `KB`-witnesses sharing an `ivk` whose `akP`s are not equal up to sign are a
+  break. The key-binding layer discharges this from the ±-property of the `ak`
+  extraction: `ak` is consumed as a single extracted coordinate, pinned only up to
+  y-sign. -/
+  break_of_akP_ne : ∀ {w₁ w₂ : KW}, KB w₁ → KB w₂ →
+    ivk w₁ = ivk w₂ → ¬ akP w₁ =± akP w₂ → Break w₁ w₂
 
 /-- The auxiliary inputs of an Action. `cm_old`/`cm_new` are carried explicitly so that the
 statement's commitment checks pin them; `kw` is the key-binding witness. -/

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -167,6 +167,21 @@ assert_computable spendPinnedOrBreak +choice
 assert_computable allPinnedOrBreak +choice
 assert_computable balanceSubsetOrBreak +choice
 
+/-! ## Balance-value (conservation form)
+
+`+choice` on the two endpoints is again the erased-positions tier: choice arrives with
+the `ring`/`omega` proof terms in their `Prop` fields, never the data path. -/
+
+assert_computable txNetValue
+assert_computable issuanceTotal
+assert_axioms transparentPoolBalance_eq
+assert_axioms positionedOutputs_value_sum
+assert_axioms nonZeroSpends_value_sum
+assert_axioms poolValueBalance_eq_neg
+assert_computable allValueOrBreak
+assert_computable valueConservationOrBreak +choice
+assert_computable balanceValueOrBreak +choice
+
 /-! ## Binding-signature relation reductions
 
 Unlike the ledger break reductions, these depend on `Classical.choice` (`+choice`). It enters

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -1,6 +1,7 @@
 import Zcash.Security.KeyBinding.Instance
 import Zcash.Security.KeyBinding.Probability
 import Zcash.Security.Ledger.Balance
+import Zcash.Security.Ledger.Spendability
 import Zcash.Security.Common.Birthday
 import Zcash.Security.BindingSignature.Orchard
 import Zcash.Security.BindingSignature.Sapling
@@ -181,6 +182,17 @@ assert_axioms poolValueBalance_eq_neg
 assert_computable allValueOrBreak
 assert_computable valueConservationOrBreak +choice
 assert_computable balanceValueOrBreak +choice
+
+/-! ## Spendability
+
+The Faerie-Gold core and the roadblock inversion are computable reductions at the strict
+flagless tier; the nullifier split and the persistence theorem are deterministic list
+facts. -/
+
+assert_axioms nullifiers_append
+assert_computable faerieGoldCore
+assert_computable respendOrBreak
+assert_axioms validLedger_append
 
 /-! ## Binding-signature relation reductions
 

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -1,6 +1,6 @@
 import Zcash.Security.KeyBinding.Instance
 import Zcash.Security.KeyBinding.Probability
-import Zcash.Security.Ledger.Effects
+import Zcash.Security.Ledger.Balance
 import Zcash.Security.Common.Birthday
 import Zcash.Security.BindingSignature.Orchard
 import Zcash.Security.BindingSignature.Sapling
@@ -140,6 +140,32 @@ assert_axioms output_rho_eq_nullifiers
 assert_axioms output_rho_nodup
 assert_axioms leafList_eq_map
 assert_axioms outputOpenings_length
+
+/-! ## Balance-subset
+
+The capstone and the per-spend pinning are computable reductions; `findPair` and the
+anchor search (`Nat.find`, itself axiom-free) keep the branch decisions decidable.
+`+choice` on the three reductions is the erased-positions tier: choice enters only
+through Mathlib proof terms in `Prop` positions (e.g. `List.getD_eq_getElem`'s proof),
+never the data path. -/
+
+assert_computable findPair
+assert_axioms findPair_spec
+assert_axioms findPair_none
+assert_axioms flatMap_sublist
+assert_axioms outputActions_prefix
+assert_axioms nullifiers_prefix
+assert_axioms take_prefix_take
+assert_axioms spendActions_map_nf_sublist
+assert_axioms length_leafList
+assert_axioms length_positionedOutputs
+assert_axioms positionedOutputs_getElem
+assert_computable noteCommitBreakOfOutputNe
+assert_axioms satisfied_of_spendMem
+assert_axioms anchor_of_spendMem
+assert_computable spendPinnedOrBreak +choice
+assert_computable allPinnedOrBreak +choice
+assert_computable balanceSubsetOrBreak +choice
 
 /-! ## Binding-signature relation reductions
 

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -116,6 +116,14 @@ assert_computable Merkle.collisionOfWrongLeaf
 assert_computable noteCommitBreakOfNe
 assert_computable Zcash.Security.Ledger.nfOldEqOrBreak +choice
 
+/-! ## Statement-layer pinning theorems
+
+The statement layer's exported pinning guarantees: an address `(g_d, pk_d)` determines
+`ivk`, and hence `nk` is determined up to an exhibited key-binding break. -/
+
+assert_axioms ivk_pinned
+assert_axioms nk_eq_or_break
+
 /-! ## Ledger model
 
 The ledger-model definitions are plain computable data over public ledger contents; the

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -1,5 +1,6 @@
 import Zcash.Security.KeyBinding.Instance
 import Zcash.Security.KeyBinding.Probability
+import Zcash.Security.Ledger.Model
 import Zcash.Security.Common.Birthday
 import Zcash.Security.BindingSignature.Orchard
 import Zcash.Security.BindingSignature.Sapling
@@ -45,7 +46,7 @@ Two commands from `Zcash.Meta.AxiomCheck`, per the breaks-as-computed-data disci
 -/
 
 open Zcash.Security.KeyBinding Zcash.Security.RandomOracle Zcash.Security.Birthday
-open Zcash.Security.Ledger Zcash.Security.BindingSignature
+open Zcash.Security.Ledger Zcash.Security.Ledger.Model Zcash.Security.BindingSignature
 open Zcash.Meta
 
 /-! ## Key binding — computed break reductions -/
@@ -112,6 +113,26 @@ assert_computable Collision.upToSign
 assert_computable Merkle.collisionOfWrongLeaf
 assert_computable noteCommitBreakOfNe
 assert_computable Zcash.Security.Ledger.nfOldEqOrBreak +choice
+
+/-! ## Ledger model
+
+The ledger-model definitions are plain computable data over public ledger contents; the
+theorems are deterministic list facts. -/
+
+assert_computable posVal
+assert_computable Merkle.subRoot
+assert_computable Merkle.authChildren
+assert_axioms Merkle.Path.compress_isSome
+assert_axioms Merkle.path_of_root
+assert_computable leafList
+assert_computable leafFun
+assert_computable rootAfter
+assert_computable nullifiers
+assert_computable transparentPoolBalance
+assert_axioms posVal_lt
+assert_axioms rootAfter_prefix
+assert_axioms output_rho_eq_nullifiers
+assert_axioms output_rho_nodup
 
 /-! ## Binding-signature relation reductions
 

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -2,6 +2,7 @@ import Zcash.Security.KeyBinding.Instance
 import Zcash.Security.KeyBinding.Probability
 import Zcash.Security.Ledger.Balance
 import Zcash.Security.Ledger.Spendability
+import Zcash.Security.Ledger.SpendAuthority
 import Zcash.Security.Common.Birthday
 import Zcash.Security.BindingSignature.Orchard
 import Zcash.Security.BindingSignature.Sapling
@@ -193,6 +194,18 @@ assert_axioms nullifiers_append
 assert_computable faerieGoldCore
 assert_computable respendOrBreak
 assert_axioms validLedger_append
+
+/-! ## Spend Authority
+
+The per-action core and the valid-ledger capstone are computable reductions; the
+receivability pinning is a deterministic module-algebra theorem. `+choice` on the two
+reductions is the erased-positions tier: choice arrives with `smul_eq_zero`'s Mathlib
+proof inside the receivability pinning, consumed only in `Prop` positions — never the
+data path. -/
+
+assert_axioms ivk_eq_of_receivable
+assert_computable spendAuthForgeryOrBreak +choice
+assert_computable spendAuthorityOrBreak +choice
 
 /-! ## Binding-signature relation reductions
 

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -1,6 +1,6 @@
 import Zcash.Security.KeyBinding.Instance
 import Zcash.Security.KeyBinding.Probability
-import Zcash.Security.Ledger.Model
+import Zcash.Security.Ledger.Effects
 import Zcash.Security.Common.Birthday
 import Zcash.Security.BindingSignature.Orchard
 import Zcash.Security.BindingSignature.Sapling
@@ -129,10 +129,17 @@ assert_computable leafFun
 assert_computable rootAfter
 assert_computable nullifiers
 assert_computable transparentPoolBalance
+assert_computable outputActions
+assert_computable outputOpenings
+assert_computable positionedOutputs
+assert_computable nonZeroSpends
+assert_computable poolValueBalance
 assert_axioms posVal_lt
 assert_axioms rootAfter_prefix
 assert_axioms output_rho_eq_nullifiers
 assert_axioms output_rho_nodup
+assert_axioms leafList_eq_map
+assert_axioms outputOpenings_length
 
 /-! ## Binding-signature relation reductions
 

--- a/book/mermaid-init.js
+++ b/book/mermaid-init.js
@@ -17,7 +17,22 @@
     }
 
     const theme = lastThemeWasLight ? 'default' : 'dark';
-    mermaid.initialize({ startOnLoad: true, theme });
+    // securityLevel 'loose' enables `click` directives and anchors in labels
+    // (all diagram content is repo-authored). Diagram text uses the book's
+    // body font; set here rather than in page CSS so mermaid measures labels
+    // in the font they render in.
+    // DOMPurify strips `target` by default (a reverse-tabnabbing guard that
+    // modern browsers make redundant by implying noopener for _blank);
+    // re-allow it so label links can open in a new tab.
+    // Opaque edge-label background (the default has 0.8 alpha), so edges
+    // passing behind a label are masked rather than showing through it.
+    const edgeLabelBackground = lastThemeWasLight ? '#e8e8e8' : '#3c3f44';
+    mermaid.initialize({
+        startOnLoad: true, theme, securityLevel: 'loose',
+        fontFamily: '"Open Sans", sans-serif',
+        dompurifyConfig: { ADD_ATTR: ['target'] },
+        themeVariables: { edgeLabelBackground },
+    });
 
     // Simplest way to make mermaid re-render the diagrams in the new theme is via refreshing the page
 

--- a/book/src/formal-verification/security-definitions.md
+++ b/book/src/formal-verification/security-definitions.md
@@ -28,56 +28,86 @@ So each definition sits on a three-layer stack:
 ## One connected picture
 
 ```mermaid
+%%{init: {"flowchart": {"nodeSpacing": 20, "rankSpacing": 50, "padding": 6, "diagramPadding": 4, "subGraphTitleMargin": {"top": 2, "bottom": 22}}, "themeCSS": ".cluster-label { font-weight: 700; font-size: 1.1em; }"}}%%
 flowchart TD
   subgraph GAMES["Ledger-model security games — the capstones"]
-    BAL["Balance"]
-    SPEND["Spendability"]
-    SPENDAUTH["Spend authority"]
+    BAL["Balance<br/>balanceSubsetOrBreak<br/>balanceValueOrBreak"]
+    SPEND["Spendability<br/>faerieGoldCore<br/>validLedger_append"]
+    SPENDAUTH["Spend authority<br/>spendAuthorityOrBreak"]
   end
 
-  SPEND --> SPENDAUTH
-
-  BAL ---> NCB["Note-commitment binding"]
-  BAL ---> BS["Binding-signature balance<br/>Zcash/Security/BindingSignature"]
-  BAL ---> KB["Key binding · ZIP 2005 (ROM)<br/>Zcash/Security/KeyBinding"]
+  BAL ---> BS["Binding-signature<br/>balance"]
+  BAL ---> NCB["Note-commitment<br/>binding"]
+  BAL ---> MERK["Merkle-path<br/>binding"]
+  BAL ---> KB["Key binding<br/>ZIP 2005 (ROM)"]
+  SPEND ---> NCB
+  SPEND ---> MERK
   SPEND ---> KB
-  SPEND ---> MERK["Merkle-path binding"]
-
-  BAL --> SPENDAUTH
+  SPEND ---> NFB["Nullifier binding"]
+  SPENDAUTH ---> KB
 
   subgraph ASSUMPTIONS["Computational hardness assumptions"]
     DL[("Discrete log")]
-    CR[("Hash collision resistance")]
+    CR[("Hash collision<br/>resistance")]
   end
 
   subgraph MODELS["Heuristic adversary models"]
     ROM[("Random oracle")]
   end
 
-  BS --->|non-balancing bundle computes| NDLR["NontrivialRelation<br/>(V,R) discrete-log relation"]
-  BS --> STMT["Witness or replay evidence<br/>for the Action statement<br/>ActionSatisfied · spec §4.17.4"]
-  KB --> STMT
-  KB --->|conflicting ivk witnesses compute| CUS["CollisionUpToSign<br/>shifted oracle, distinct queries"]
-  NCB -->|wrong note opening computes| NCBK["NoteCommitBreak"]
+  BS --->|non-balancing<br/>bundle computes| NDLR["NontrivialRelation<br/>(V,R) discrete-log<br/>relation"]
+  BS --> STMT["Witness or replay<br/>evidence<br/>ActionSatisfied<br/>§4.17.4"]
+  NCB -->|wrong note<br/>opening computes<br/><br/>| NCBK["NoteCommitBreak"]
   NCB --> STMT
   MERK --> STMT
-  MERK --->|wrong Merkle path computes| MC["Merkle collision"]
+  MERK --->|wrong Merkle<br/>path computes| MC["DefinedCollision<br/>(one height, encoding<br/>domain, success-only)"]
+  KB --> STMT
+  KB --->|conflicting ivk<br/>witnesses compute| CUS["CollisionUpToSign<br/>shifted oracle,<br/>distinct queries"]
+  NFB --> STMT
+  NFB --->|"distinct derive-inputs +<br/>equal nullifier<br/>computes"| NFC["NullifierCollision"]
+  SPENDAUTH ---->|"verified signature over<br/>unsigned sighash computes"| SAF["SpendAuthForgery<br/>(randomization<br/>of ±ak)"]
 
-  STMT -. "justified by the extractor;<br/>hencodes gap" .-> KS["Knowledge soundness:<br/>an accepting proof yields a computed<br/>witness or break data"]
-  NCBK --> SDLR["Sinsemilla discrete-log relation"]
+  STMT -. "justified by<br/>the extractor;<br/>hencodes gap" .-> KS["Knowledge soundness:<br/>accepting proof yields<br/>witness or break data"]
+  NCBK --> SDLR["Sinsemilla<br/>discrete-log<br/>relation"]
 
-  KS --->|AGM heuristic + independent hash-to-curve bases| DL
-  KS -->|"Fiat–Shamir heuristic"| ROM
-  CUS -->|"birthday counting q(q-1)/r,<br/>no assumption"| ROM
-  NDLR --->|"independent hash-to-curve bases"| DL
-  SDLR --->|"independent hash-to-curve bases"| DL
+  NDLR --->|"independent<br/>hash-to-curve bases"| DL
+  SDLR --->|"independent<br/>hash-to-curve bases"| DL
+  KS --->|AGM heuristic + independent<br/>hash-to-curve bases| DL
+  KS -->|"Fiat–Shamir<br/>heuristic"| ROM
   MC ---> CR
+  CUS -->|"birthday counting q(q-1)/r,<br/>no assumption"| ROM
+  NFC --->|"named hypothesis:<br/>nullifier base independent<br/>of commitment bases"| DL
+  SAF --> RDSA["RedDSA unforgeability,<br/>±-randomized keys"]
+  RDSA -->|"challenge hash<br/>as random oracle"| ROM
+  RDSA --->|"re-randomization reduction<br/>[FKMSSS2016] +<br/>forking extraction"| DL
+
+  classDef proven fill:#1a7f37,stroke:#116329,color:#ffffff
+  classDef checked fill:#0969da,stroke:#0550ae,color:#ffffff
+  classDef partial fill:#9a6700,stroke:#7d4e00,color:#ffffff
+  classDef hyp fill:#cf222e,stroke:#a40e26,color:#ffffff
+  classDef assumed fill:#57606a,stroke:#424a53,color:#ffffff
+  class BAL,SPEND,SPENDAUTH,KS partial
+  class NCB,BS,KB,MERK,NFB,STMT,NDLR,CUS,NCBK,MC,NFC,SAF checked
+  class SDLR,RDSA hyp
+  class DL,CR,ROM assumed
 ```
 
+<p>
+<span style="color:#1a7f37">■</span> fully proven — nothing here yet<br/>
+<span style="color:#0969da">■</span> stated and machine-checked in Lean, over abstract primitives<br/>
+<span style="color:#9a6700">■</span> partly machine-checked; remainder tracked (the games' probabilistic capstones; knowledge soundness's <code>hencodes</code> bridge)<br/>
+<span style="color:#cf222e">■</span> named hypothesis; formalization deferred<br/>
+<span style="color:#57606a">■</span> assumption or heuristic model; terminal by design
+</p>
+
 This picture is a deliberate approximation, and is likely to change as the formalization
-proceeds. Some components may rest on assumptions not shown — for example, nullifier
-derivation may need a PRF assumption that does not reduce to discrete log or to hash
-collision resistance in the random-oracle model.
+proceeds. Some edges are coarser than the eventual argument — for example, the
+`NullifierCollision` edge to discrete log is a named hypothesis whose `PRF^nf` component
+is not yet decomposed, and may not reduce to discrete log alone. The RedDSA node is a
+named hypothesis rather than a terminal assumption: its discharge edge names the
+reduction for security of signatures with re-randomizable keys
+[<a href="https://eprint.iacr.org/2015/395">FKMSSS2016</a>, section 3], adapted
+to the ±-randomized variant, together with forking extraction of the Schnorr witness.
 
 Every solid arrow reads "rests on"; where an edge carries a label, the label names the
 computed break object flowing along it, or the adversary model or side condition under which
@@ -142,7 +172,7 @@ circuit soundness proof.
 <div class="g"><div class="g-head"><span class="term">Action statement satisfied</span><span class="anchor">Security.Ledger.ActionSatisfied</span></div><div class="def">The games-relevant conjuncts of an Orchard-shaped Action statement (spec §4.17.4) over abstract primitives: commitment integrity, Merkle-path validity, nullifier integrity, the key-binding condition, address integrity, value-commitment integrity. This is the interface the games consume, and the target the verifier-soundness proof is meant to deliver.</div></div>
 <div class="g"><div class="g-head"><span class="term">pinning lemmas</span><span class="anchor">ivk_pinned · nk_eq_or_break · nf_old_eq_or_break</span></div><div class="def">The deterministic steps of the Balance argument: an address <code>(g_d, pk_d)</code> determines <code>ivk</code> (needs only <code>g_d ≠ 0</code> and torsion-freeness), hence <code>nk</code> is determined up to an exhibited key-binding break, and spends of the same note tuple reveal the same nullifier up to a break.</div></div>
 <div class="g"><div class="g-head"><span class="term">NoteCommitBreak</span><span class="anchor">Ledger.NoteCommitBreak · noteCommitBreakOfNe</span></div><div class="def">A note-commitment opening collision, as data. <code>noteCommitBreakOfNe</code> computes one when an <code>extract</code>-equal commitment fails to pin the note tuple <code>(rcm, note)</code>. Prequantumly, note-commitment binding reduces to a Sinsemilla / discrete-log-relation break.</div></div>
-<div class="g"><div class="g-head"><span class="term">Merkle position binding</span><span class="anchor">Ledger.Merkle.collisionOfWrongLeaf</span></div><div class="def">Fixed-depth Merkle trees are position-binding up to a hash collision: a validating authentication path for a leaf that is <em>not</em> the committed one computes a <code>RandomOracle.Collision</code> of the tree hash. The vector-commitment property the Balance and Spendability arguments require of the note-commitment tree.</div></div>
+<div class="g"><div class="g-head"><span class="term">Merkle position binding</span><span class="anchor">Ledger.Merkle.collisionOfWrongLeaf</span></div><div class="def">Fixed-depth Merkle trees are position-binding up to a hash collision: a validating authentication path for a leaf that is <em>not</em> the committed one, against a defined tree, computes a <code>DefinedCollision</code> of one height’s compression — escaped (⊥) evaluations never count as collisions. The vector-commitment property the Balance and Spendability arguments require of the note-commitment tree.</div></div>
 </section>
 
 <section>

--- a/book/src/formal-verification/security-definitions.md
+++ b/book/src/formal-verification/security-definitions.md
@@ -28,25 +28,25 @@ So each definition sits on a three-layer stack:
 ## One connected picture
 
 ```mermaid
-%%{init: {"flowchart": {"nodeSpacing": 20, "rankSpacing": 50, "padding": 6, "diagramPadding": 4, "subGraphTitleMargin": {"top": 2, "bottom": 22}}, "themeCSS": ".cluster-label { font-weight: 700; font-size: 1.1em; }"}}%%
+%%{init: {"flowchart": {"nodeSpacing": 20, "rankSpacing": 50, "padding": 6, "diagramPadding": 4, "subGraphTitleMargin": {"top": 4, "bottom": 18}}, "themeCSS": ".cluster-label { font-weight: 700; font-size: 1.1em; font-family: raleway, sans-serif; }"}}%%
 flowchart TD
-  subgraph GAMES["Ledger-model security games — the capstones"]
+  subgraph GAMES["Ledger security games — the capstones"]
     BAL["Balance<br/>balanceSubsetOrBreak<br/>balanceValueOrBreak"]
     SPEND["Spendability<br/>faerieGoldCore<br/>validLedger_append"]
     SPENDAUTH["Spend authority<br/>spendAuthorityOrBreak"]
   end
 
-  BAL ---> BS["Binding-signature<br/>balance"]
-  BAL ---> NCB["Note-commitment<br/>binding"]
-  BAL ---> MERK["Merkle-path<br/>binding"]
-  BAL ---> KB["Key binding<br/>ZIP 2005 (ROM)"]
-  SPEND ---> NCB
-  SPEND ---> MERK
-  SPEND ---> KB
-  SPEND ---> NFB["Nullifier binding"]
-  SPENDAUTH ---> KB
+  BAL --> BS["Binding-signature<br/>balance"]
+  BAL --> NCB["Note-commitment<br/>binding"]
+  BAL --> MERK["Merkle-path<br/>binding"]
+  BAL --> KB["Key binding<br/>ZIP 2005 (ROM)"]
+  SPEND --> NCB
+  SPEND --> MERK
+  SPEND --> KB
+  SPEND --> NFB["Nullifier binding"]
+  SPENDAUTH --> KB
 
-  subgraph ASSUMPTIONS["Computational hardness assumptions"]
+  subgraph ASSUMPTIONS["Hardness assumptions"]
     DL[("Discrete log")]
     CR[("Hash collision<br/>resistance")]
   end
@@ -55,31 +55,53 @@ flowchart TD
     ROM[("Random oracle")]
   end
 
-  BS --->|non-balancing<br/>bundle computes| NDLR["NontrivialRelation<br/>(V,R) discrete-log<br/>relation"]
+  BS --->|"<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Security/BindingSignature/Balance.lean'>non-balancing<br/>bundle computes</a>"| NDLR["NontrivialRelation<br/>(V,R) discrete-log<br/>relation"]
   BS --> STMT["Witness or replay<br/>evidence<br/>ActionSatisfied<br/>§4.17.4"]
-  NCB -->|wrong note<br/>opening computes<br/><br/>| NCBK["NoteCommitBreak"]
+  NCB --->|"<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Security/Ledger/Statement.lean'>wrong note<br/>opening computes</a>"| NCBK["NoteCommitBreak"]
   NCB --> STMT
   MERK --> STMT
-  MERK --->|wrong Merkle<br/>path computes| MC["DefinedCollision<br/>(one height, encoding<br/>domain, success-only)"]
+  MERK ---->|"<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Security/Ledger/Merkle.lean'>wrong Merkle<br/>path computes</a>"| MC["DefinedCollision<br/>(one height, encoding<br/>domain, success-only)"]
   KB --> STMT
-  KB --->|conflicting ivk<br/>witnesses compute| CUS["CollisionUpToSign<br/>shifted oracle,<br/>distinct queries"]
+  KB ---->|"<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Security/KeyBinding/Basic.lean'>conflicting ivk<br/>witnesses compute</a>"| CUS["CollisionUpToSign<br/>shifted oracle,<br/>distinct queries"]
   NFB --> STMT
-  NFB --->|"distinct derive-inputs +<br/>equal nullifier<br/>computes"| NFC["NullifierCollision"]
-  SPENDAUTH ---->|"verified signature over<br/>unsigned sighash computes"| SAF["SpendAuthForgery<br/>(randomization<br/>of ±ak)"]
+  NFB ---->|"<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Security/Ledger/Spendability.lean'>distinct derive-inputs +<br/>equal nullifier<br/>computes</a>"| NFC["NullifierCollision"]
+  SPENDAUTH --->|"<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Security/Ledger/SpendAuthority.lean'>verified signature over<br/>unsigned sighash computes</a>"| SAF["SpendAuthForgery<br/>(randomization<br/>of ±ak)"]
 
-  STMT -. "justified by<br/>the extractor;<br/>hencodes gap" .-> KS["Knowledge soundness:<br/>accepting proof yields<br/>witness or break data"]
+  STMT -. "<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Snark/Soundness/Composition/Bridge.lean'>justified by<br/>the extractor;<br/>hencodes gap</a>" .-> KS["Knowledge soundness:<br/>accepting proof yields<br/>witness or break data"]
   NCBK --> SDLR["Sinsemilla<br/>discrete-log<br/>relation"]
 
-  NDLR --->|"independent<br/>hash-to-curve bases"| DL
-  SDLR --->|"independent<br/>hash-to-curve bases"| DL
-  KS --->|AGM heuristic + independent<br/>hash-to-curve bases| DL
-  KS -->|"Fiat–Shamir<br/>heuristic"| ROM
-  MC ---> CR
-  CUS -->|"birthday counting q(q-1)/r,<br/>no assumption"| ROM
-  NFC --->|"named hypothesis:<br/>nullifier base independent<br/>of commitment bases"| DL
-  SAF --> RDSA["RedDSA unforgeability,<br/>±-randomized keys"]
-  RDSA -->|"challenge hash<br/>as random oracle"| ROM
-  RDSA --->|"re-randomization reduction<br/>[FKMSSS2016] +<br/>forking extraction"| DL
+  NDLR ---->|"<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Snark/Soundness/AGM/BindingSignature.lean'>independent<br/>hash-to-curve bases</a>"| DL
+  SDLR ---->|"<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Snark/Soundness/AGM/BindingSignature.lean'>independent<br/>hash-to-curve bases</a>"| DL
+  KS ---->|"<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Snark/Soundness/AGM/Capstone.lean'>AGM heuristic + independent<br/>hash-to-curve bases</a>"| DL
+  KS ---->|"<a target='_blank' href='https://github.com/zcash/ironwood/tree/main/Zcash/Snark/Soundness/Forking'>Fiat–Shamir<br/>heuristic</a>"| ROM
+  MC ----> CR
+  CUS ---->|"<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Security/Common/Birthday.lean'>birthday counting<br/>q(q-1)/r,<br/>no assumption</a>"| ROM
+  NFC ---->|"<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Security/Ledger/Spendability.lean'>nullifier base<br/>independent of<br/>commitment bases</a>"| DL
+  SAF ---> RDSA["RedDSA unforgeability,<br/>±-randomized keys"]
+  RDSA ---->|"re-rand reduction<br/><a target='_blank' href='https://eprint.iacr.org/2015/395'>[FKMSSS2016]</a> +<br/>forking extraction"| DL
+  RDSA ---->|"challenge hash<br/>as random oracle"| ROM
+
+  click BAL "https://github.com/zcash/ironwood/blob/main/Zcash/Security/Ledger/Balance.lean" _blank
+  click SPEND "https://github.com/zcash/ironwood/blob/main/Zcash/Security/Ledger/Spendability.lean" _blank
+  click SPENDAUTH "https://github.com/zcash/ironwood/blob/main/Zcash/Security/Ledger/SpendAuthority.lean" _blank
+  click BS "https://github.com/zcash/ironwood/blob/main/Zcash/Security/BindingSignature/Balance.lean" _blank
+  click NCB "https://github.com/zcash/ironwood/blob/main/Zcash/Security/Ledger/Statement.lean" _blank
+  click MERK "https://github.com/zcash/ironwood/blob/main/Zcash/Security/Ledger/Merkle.lean" _blank
+  click KB "https://github.com/zcash/ironwood/blob/main/Zcash/Security/KeyBinding/Basic.lean" _blank
+  click NFB "https://github.com/zcash/ironwood/blob/main/Zcash/Security/Ledger/Spendability.lean" _blank
+  click STMT "https://github.com/zcash/ironwood/blob/main/Zcash/Security/Ledger/Statement.lean" _blank
+  click NCBK "https://github.com/zcash/ironwood/blob/main/Zcash/Security/Ledger/Statement.lean" _blank
+  click MC "https://github.com/zcash/ironwood/blob/main/Zcash/Security/Ledger/Merkle.lean" _blank
+  click CUS "https://github.com/zcash/ironwood/blob/main/Zcash/Security/Common/RandomOracle.lean" _blank
+  click NFC "https://github.com/zcash/ironwood/blob/main/Zcash/Security/Ledger/Spendability.lean" _blank
+  click SAF "https://github.com/zcash/ironwood/blob/main/Zcash/Security/Ledger/SpendAuthority.lean" _blank
+  click NDLR "https://github.com/zcash/ironwood/blob/main/Zcash/Common/DiscreteLogRelation.lean" _blank
+  click SDLR "https://github.com/zcash/ironwood/blob/main/Zcash/Common/DiscreteLogRelation.lean" _blank
+  click KS "https://github.com/zcash/ironwood/blob/main/Zcash/Snark/Soundness/KnowledgeSoundness.lean" _blank
+  click DL "https://github.com/zcash/ironwood/blob/main/Zcash/Common/DiscreteLogRelation.lean" _blank
+  click CR "https://github.com/zcash/ironwood/blob/main/Zcash/Security/Common/RandomOracle.lean" _blank
+  click ROM "https://github.com/zcash/ironwood/blob/main/Zcash/Security/Common/RandomOracle.lean" _blank
+  click RDSA "https://github.com/zcash/ironwood/issues/22" _blank
 
   classDef proven fill:#1a7f37,stroke:#116329,color:#ffffff
   classDef checked fill:#0969da,stroke:#0550ae,color:#ffffff
@@ -125,6 +147,18 @@ circuit soundness proof.
 ## The definitions
 
 <style>
+/* "One connected picture" links: labels keep their ordinary colour at rest
+   (blue is reserved for the status coding); hover underlines. */
+.mermaid .edgeLabel a { color: inherit; }
+.mermaid .edgeLabel a:hover,
+.mermaid a:hover .nodeLabel {
+  /* The SVG is scaled down to fit the page, so the default (~1px) underline
+     can fall below one device pixel and drop out on some line boxes; an
+     em-based thickness scales with the text instead. */
+  text-decoration: underline;
+  text-decoration-thickness: 0.12em;
+  text-underline-offset: 0.12em;
+}
 .iw-glossary { margin: 1.3rem 0; display: grid; gap: 26px; }
 .iw-glossary section { display: grid; gap: 9px; }
 .iw-glossary .grp {

--- a/book/src/formal-verification/security-definitions.md
+++ b/book/src/formal-verification/security-definitions.md
@@ -48,7 +48,6 @@ flowchart TD
 
   subgraph ASSUMPTIONS["Hardness assumptions"]
     DL[("Discrete log")]
-    CR[("Hash collision<br/>resistance")]
   end
 
   subgraph MODELS["Heuristic adversary models"]
@@ -60,26 +59,26 @@ flowchart TD
   NCB --->|"<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Security/Ledger/Statement.lean'>wrong note<br/>opening computes</a>"| NCBK["NoteCommitBreak"]
   NCB --> STMT
   MERK --> STMT
-  MERK ---->|"<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Security/Ledger/Merkle.lean'>wrong Merkle<br/>path computes</a>"| MC["DefinedCollision<br/>(one height, encoding<br/>domain, success-only)"]
+  MERK --->|"<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Security/Ledger/Merkle.lean'>wrong Merkle<br/>path computes</a>"| MC["DefinedCollision<br/>(one height, encoding<br/>domain, success-only)"]
   KB --> STMT
-  KB ---->|"<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Security/KeyBinding/Basic.lean'>conflicting ivk<br/>witnesses compute</a>"| CUS["CollisionUpToSign<br/>shifted oracle,<br/>distinct queries"]
+  KB --->|"<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Security/KeyBinding/Basic.lean'>conflicting ivk<br/>witnesses compute</a>"| CUS["CollisionUpToSign<br/>shifted oracle,<br/>distinct queries"]
   NFB --> STMT
-  NFB ---->|"<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Security/Ledger/Spendability.lean'>distinct derive-inputs +<br/>equal nullifier<br/>computes</a>"| NFC["NullifierCollision"]
+  NFB --->|"<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Security/Ledger/Spendability.lean'>distinct derive-inputs +<br/>equal nullifier<br/>computes</a>"| NFC["NullifierCollision"]
   SPENDAUTH --->|"<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Security/Ledger/SpendAuthority.lean'>verified signature over<br/>unsigned sighash computes</a>"| SAF["SpendAuthForgery<br/>(randomization<br/>of ±ak)"]
 
   STMT -. "<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Snark/Soundness/Composition/Bridge.lean'>justified by<br/>the extractor;<br/>hencodes gap</a>" .-> KS["Knowledge soundness:<br/>accepting proof yields<br/>witness or break data"]
   NCBK --> SDLR["Sinsemilla<br/>discrete-log<br/>relation"]
 
-  NDLR ---->|"<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Snark/Soundness/AGM/BindingSignature.lean'>independent<br/>hash-to-curve bases</a>"| DL
-  SDLR ---->|"<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Snark/Soundness/AGM/BindingSignature.lean'>independent<br/>hash-to-curve bases</a>"| DL
-  KS ---->|"<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Snark/Soundness/AGM/Capstone.lean'>AGM heuristic + independent<br/>hash-to-curve bases</a>"| DL
-  KS ---->|"<a target='_blank' href='https://github.com/zcash/ironwood/tree/main/Zcash/Snark/Soundness/Forking'>Fiat–Shamir<br/>heuristic</a>"| ROM
-  MC ----> CR
-  CUS ---->|"<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Security/Common/Birthday.lean'>birthday counting<br/>q(q-1)/r,<br/>no assumption</a>"| ROM
-  NFC ---->|"<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Security/Ledger/Spendability.lean'>nullifier base<br/>independent of<br/>commitment bases</a>"| DL
-  SAF ---> RDSA["RedDSA unforgeability,<br/>±-randomized keys"]
-  RDSA ---->|"re-rand reduction<br/><a target='_blank' href='https://eprint.iacr.org/2015/395'>[FKMSSS2016]</a> +<br/>forking extraction"| DL
-  RDSA ---->|"challenge hash<br/>as random oracle"| ROM
+  NDLR --->|"<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Snark/Soundness/AGM/BindingSignature.lean'>independent<br/>hash-to-curve bases</a>"| DL
+  SDLR -->|"<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Snark/Soundness/AGM/BindingSignature.lean'>independent<br/>hash-to-curve bases</a>"| DL
+  KS --->|"<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Snark/Soundness/AGM/Capstone.lean'>AGM heuristic +<br/>independent<br/>hash-to-curve bases</a>"| DL
+  KS --->|"<a target='_blank' href='https://github.com/zcash/ironwood/tree/main/Zcash/Snark/Soundness/Forking'>Fiat–Shamir<br/>heuristic</a>"| ROM
+  MC --> SDLR
+  CUS --->|"<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Security/Common/Birthday.lean'>birthday counting<br/>q(q-1)/r,<br/>no assumption</a>"| ROM
+  NFC --->|"<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Security/Ledger/Spendability.lean'>nullifier base<br/>independent of<br/>commitment bases</a>"| DL
+  SAF --> RDSA["RedDSA unforgeability,<br/>±-randomized keys"]
+  RDSA --->|"re-rand reduction<br/><a target='_blank' href='https://eprint.iacr.org/2015/395'>[FKMSSS2016]</a> +<br/>forking extraction"| DL
+  RDSA --->|"challenge hash<br/>as random oracle"| ROM
 
   click BAL "https://github.com/zcash/ironwood/blob/main/Zcash/Security/Ledger/Balance.lean" _blank
   click SPEND "https://github.com/zcash/ironwood/blob/main/Zcash/Security/Ledger/Spendability.lean" _blank
@@ -99,7 +98,6 @@ flowchart TD
   click SDLR "https://github.com/zcash/ironwood/blob/main/Zcash/Common/DiscreteLogRelation.lean" _blank
   click KS "https://github.com/zcash/ironwood/blob/main/Zcash/Snark/Soundness/KnowledgeSoundness.lean" _blank
   click DL "https://github.com/zcash/ironwood/blob/main/Zcash/Common/DiscreteLogRelation.lean" _blank
-  click CR "https://github.com/zcash/ironwood/blob/main/Zcash/Security/Common/RandomOracle.lean" _blank
   click ROM "https://github.com/zcash/ironwood/blob/main/Zcash/Security/Common/RandomOracle.lean" _blank
   click RDSA "https://github.com/zcash/ironwood/issues/22" _blank
 
@@ -111,7 +109,7 @@ flowchart TD
   class BAL,SPEND,SPENDAUTH,KS partial
   class NCB,BS,KB,MERK,NFB,STMT,NDLR,CUS,NCBK,MC,NFC,SAF checked
   class SDLR,RDSA hyp
-  class DL,CR,ROM assumed
+  class DL,ROM assumed
 ```
 
 <p>
@@ -206,7 +204,7 @@ circuit soundness proof.
 <div class="g"><div class="g-head"><span class="term">Action statement satisfied</span><span class="anchor">Security.Ledger.ActionSatisfied</span></div><div class="def">The games-relevant conjuncts of an Orchard-shaped Action statement (spec §4.17.4) over abstract primitives: commitment integrity, Merkle-path validity, nullifier integrity, the key-binding condition, address integrity, value-commitment integrity. This is the interface the games consume, and the target the verifier-soundness proof is meant to deliver.</div></div>
 <div class="g"><div class="g-head"><span class="term">pinning lemmas</span><span class="anchor">ivk_pinned · nk_eq_or_break · nf_old_eq_or_break</span></div><div class="def">The deterministic steps of the Balance argument: an address <code>(g_d, pk_d)</code> determines <code>ivk</code> (needs only <code>g_d ≠ 0</code> and torsion-freeness), hence <code>nk</code> is determined up to an exhibited key-binding break, and spends of the same note tuple reveal the same nullifier up to a break.</div></div>
 <div class="g"><div class="g-head"><span class="term">NoteCommitBreak</span><span class="anchor">Ledger.NoteCommitBreak · noteCommitBreakOfNe</span></div><div class="def">A note-commitment opening collision, as data. <code>noteCommitBreakOfNe</code> computes one when an <code>extract</code>-equal commitment fails to pin the note tuple <code>(rcm, note)</code>. Prequantumly, note-commitment binding reduces to a Sinsemilla / discrete-log-relation break.</div></div>
-<div class="g"><div class="g-head"><span class="term">Merkle position binding</span><span class="anchor">Ledger.Merkle.collisionOfWrongLeaf</span></div><div class="def">Fixed-depth Merkle trees are position-binding up to a hash collision: a validating authentication path for a leaf that is <em>not</em> the committed one, against a defined tree, computes a <code>DefinedCollision</code> of one height’s compression — escaped (⊥) evaluations never count as collisions. The vector-commitment property the Balance and Spendability arguments require of the note-commitment tree.</div></div>
+<div class="g"><div class="g-head"><span class="term">Merkle position binding</span><span class="anchor">Ledger.Merkle.collisionOfWrongLeaf</span></div><div class="def">Fixed-depth Merkle trees are position-binding up to a hash collision: a validating authentication path for a leaf that is <em>not</em> the committed one, against a defined tree, computes a <code>DefinedCollision</code> of one height’s compression — escaped (⊥) evaluations never count as collisions. The vector-commitment property the Balance and Spendability arguments require of the note-commitment tree. Prequantumly, the Sinsemilla compression’s collision resistance reduces to a discrete-log-relation break (SDLR) — the same terminal as note-commitment binding — so BLAKE2b collision resistance does not enter the pre-quantum Balance argument.</div></div>
 </section>
 
 <section>


### PR DESCRIPTION
The ledger-model security games (the #72 scope): the witness-annotated ledger that the games run over, the effects read off it, and the deterministic layer of all three games — both Balance theorems, the Spendability core, and the Spend Authority reduction.

- A first commit tightens pre-existing statement-layer docs that described the intended instantiations' onward reductions in the present tense, as if formalized. Throughout the branch, docstrings and commit messages state intended-but-unformalized discharges as intended, checked per commit.

- `Statement.lean`: the mechanical `RT` → `MHASH` rename (fixes #101). The leaf is the extracted commitment itself: `CMX` merges into `MHASH`, matching the spec's typing, and the leaf map is `Extract_ℙ` (`P.extract`, not injective due to ±-fibres) rather than a separate coercion. `leafOf` is deleted — after removing its ρ argument (which only ever came from an offhand suggestion in ZIP 2005 about rehashing the tree), it became the identity function, and the type distinction was not worth the complexity.
- `Merkle.lean` adopts the circuit bridge's raw-encoding partial Merkle interface (from #98 — thanks @gio54321 — so the ledger and circuit layers share one model), and rebuilds the games' tree machinery on it. Hash inputs are raw encodings: an Orchard field element can have more than one accepted 255-bit encoding (the Sapling-era trade-off), so collisions are counted over the encoding domain, per height (counted from the leaves; the spec's root-counted *layer* is recoverable as `MerkleDepth − 1` minus the height), with each height's compression personalized. Compression is partial — `none` is a Sinsemilla exceptional branch — and `Path` records per-height success, so a collision is success-only (`DefinedCollision`): a totalized model would let two escapes masquerade as a collision that the concrete reduction could not consume. On-path encodings are pinned only up to the decode fibre, matching the deployed circuit; siblings are unconstrained; honest tree construction (`subRoot`) uses the canonical encoding. Position binding (`collisionOfWrongLeaf`) and completeness (`path_of_root`) are proven against this model, and the witness carries the pair-plus-side path shape the circuit actually witnesses.
- `Primitives` gains the ledger layer's obligations, following the `emb`/`emb_injective` precedent: `uncommitted` (the sentinel value for unused leaves), `uncommitted_ne` (no extracted note commitment collides with it; spec Thm 5.4.6 concretely), and `spendAuthVerify` over new sighash and signature type parameters `MSG` and `SIG`.
- `Model.lean` (namespace `Model`) defines the ledger the games run over: transactions of witness-annotated Actions with their spend-auth signatures, the leaf list and prefix anchors as deterministic partial functions of public data (an anchor equation also asserts that the referenced tree is defined), and `ValidLedger`'s consensus conjuncts. The transparent chain value pool is tracked only as its overall balance (`transparentPoolBalance`), which validity requires to be nonnegative (the consensus non-negative chain value balance rule for the transparent pool, ZIP 209). This requirement is on the cumulative value rather than per-transaction, because transparent funds accumulate and a per-transaction bound would underpower the adversary. Two deterministic facts come with the model: prefix-roots persist under ledger extension (the append-only tree), and output notes carry pairwise-distinct ρ because each is equal to its action's revealed nullifier — the Orchard Faerie-Gold protection, with no cryptographic hypothesis.
- `Effects.lean` reads a ledger's effects off its witnesses: an `Opening` is the `(rcm, note)` pair a commitment pins, outputs are openings at their leaf indices, and nonzero spends form a multiset of openings at their witnessed path positions. It is a multiset so that a double spend is countable, with Balance-subset to prove it is in fact a set.
- TrustBoundary census entries pin the new definitions at the strict flagless tier. `posVal` folds over `List.finRange` rather than taking a `Finset` sum, because `Fintype (Fin d)` carries `Classical.choice` in current Mathlib. A census-completeness pass also adds axiom probes for the statement layer's exported pinning theorems (`ivk_pinned` and `nk_eq_or_break`), which predate this branch but had no probes.

- `Balance.lean` proves **Balance-subset** as a computed reduction (`balanceSubsetOrBreak`). For a valid ledger, the nonzero spends of the first `i + 1` transactions form a sub-multiset of the positioned outputs of the first `i` — the one-transaction lag captures the strictly-earlier anchor rule, so a transaction can never spend an output of its own transaction. Each spend is the opening of the output that created its commitment, at that output's leaf position, and no positioned opening is spent twice. Otherwise the ledger's own data computes a `BalanceBreak`, with three arms: a Merkle `DefinedCollision` (one height's compression, success-only) when a spend's path validates a leaf that is not the committed one, against a defined tree; a `NoteCommitBreak` when a spend's commitment matches an output's with a different opening; and a key-binding break when two spends of one positioned opening would otherwise reveal the same nullifier twice. The anchor prefix is recovered by decidable search (`Nat.find`, itself axiom-free) rather than extracted from the validity hypothesis's existential. Duplicate spends are located by `findPair`, whose result is certified as a two-element *sublist*; the sublist carries "two distinct occurrences", so the nullifier-uniqueness contradiction is `Sublist.map` plus `Nodup`, with no index arithmetic. `Note`, `Opening`, and `PositionedOpening` gain derived `DecidableEq`, which is what makes the reductions' branch decisions computable.
- `Balance.lean` also proves **Balance-value**, in conservation form (`valueConservationOrBreak`): the shielded pool plus the transparent pool is exactly the minted issuance. The premiss is per-transaction: the net value a transaction's witnesses release from the shielded pool equals its declared `vBalance` — or the premiss hands back a break of an abstract type `VB`. Keeping `VB` abstract keeps the binding-signature machinery out of this layer. The intended deployed discharge is `NontrivialRelation.ofBundleIntImbalance`; that glue — including a binding-signature-verification conjunct on validity — is not yet formalized, and is planned for the stacked capstone PR. The corollary `balanceValueOrBreak` adds validity's `transparent_nonneg` and concludes that the shielded pool holds at most what issuance has minted.
- `Spendability.lean` starts the Spendability game's deterministic layer. The Faerie-Gold core (`faerieGoldCore`) says that nullifiers pin note tuples: two satisfied spends with distinct openings and equal revealed nullifiers compute a break. If the derive-inputs coincide, one commitment has two openings — a `NoteCommitBreak`. If they differ, they are themselves a `NullifierCollision`: two distinct note openings whose nullifiers agree. The collision carries the openings, so `cm` is pinned to a real commitment rather than a free group element — without them a collision would be fabricable (solve the point equation, or use the affine `extract`), certifying nothing. Reducing the collision to a nontrivial discrete-log relation is nonobvious and not yet formalized; it is planned for the stacked capstone PR. `respendOrBreak` inverts the nullifier roadblock: an action revealing the same nullifier as a satisfied spend either re-spends the same opening (the case Spend Authority handles) or computes a break. `validLedger_append` is persistence: a transaction valid just after `ledger` stays valid when appended to any valid extension of `ledger`, given that its nullifiers are still fresh and the boundary conjuncts hold. Anchors persist because prefix roots do. Both reductions sit at the census's strict flagless tier.

- The key-binding interface grows one guarantee for Spend Authority. `ak` is consumed as a single extracted coordinate, so the statement pins `ak^ℙ` only up to its y-sign. `KeyBindingInterface` gains `break_of_akP_ne`: two `KB`-witnesses sharing an `ivk` whose `akP`s are not equal up to sign are a break. `Extractor` gains the matching ±-property `toAK_pm` for the `ak` extraction (both extract maps are `Extract_ℙ` concretely), and `toInterface` discharges the new guarantee from the break projection, exactly as `break_of_nk_ne` is discharged from the `nk` component.
- `SpendAuthority.lean` is the deterministic core of the Spend Authority game. Suppose an action spends a note addressed to a key witness `wV`, in a transaction whose sighash the holder of `wV` never signed. If the action's `akP` matches `akP wV` up to sign, its signature is a `SpendAuthForgery`: a verifying signature under a randomization of `± akP wV`, over an unsigned message, with a `negated` flag recording the sign. The named unforgeability hypothesis for the ±-randomized signature scheme consumes that object; covering both signs is a factor-of-2 loss, fine with ~2^253 ±-fibres remaining. If the keys do not match even up to sign, receivability pins a shared `ivk` (`ivk_eq_of_receivable`, the one-witness form of `ivk_pinned`) and `break_of_akP_ne` yields a key-binding break. The capstone `spendAuthorityOrBreak` reads statement satisfaction and signature verification off `ValidLedger`.

- The book's security-definitions page gets the updated "one connected picture": the capstones grounded in their Lean names, the new nullifier-binding and Spend Authority chains, and nodes colour-coded by formalization status with a key. The Merkle `DefinedCollision` routes to the Sinsemilla discrete-log relation — its prequantum reduction, the same terminal as note-commitment binding — rather than to a hash-collision-resistance node, since BLAKE2b collision resistance does not enter the pre-quantum Balance argument. RedDSA unforgeability with ±-randomized keys is drawn as a named hypothesis rather than a terminal assumption; its intended discharge (the re-randomization reduction of [FKMSSS2016] section 3, adapted to the ± variant, plus forking extraction) is on the diagram, and #22 tracks proving it.

- The map is clickable: every node and each reduction-naming edge label links to its source (links into files added by this branch resolve once it merges; the RedDSA node links to #22), and the diagram's typography matches the book's — Raleway for the grouping titles, Open Sans for labels. The links needed mermaid's `securityLevel` set to `'loose'` in `mermaid-init.js`, which affects every diagram in the book. That widens nothing: mdbook already renders raw HTML from the markdown unsanitized, so diagram text is exactly as trusted as the rest of the book source.

The modelling decisions are recorded in the design doc attached to #72. What stays outside this PR: the named cryptographic hypotheses the reductions' outputs feed (unforgeability of the ±-randomized signature scheme, the reduction of `NullifierCollision` to a discrete-log relation and the hardness it rests on, the key-binding probability bound's composition into game-level statements), and the concrete Orchard instantiation.

Full build green.

Filed using AI (Claude Fable 5).
