### PR TITLE
feat(fv): the ledger-game capstones and shape-level discharges

### DIFF
--- a/Zcash/Security.lean
+++ b/Zcash/Security.lean
@@ -18,6 +18,7 @@ import Zcash.Security.Ledger.SpendAuthority
 import Zcash.Security.Ledger.Completeness
 import Zcash.Security.Ledger.Capstone
 import Zcash.Security.Ledger.Nullifier
+import Zcash.Security.Ledger.Value
 import Zcash.Security.Common.RandomOracle
 import Zcash.Security.Common.Birthday
 import Zcash.Security.KeyBinding.Basic

--- a/Zcash/Security.lean
+++ b/Zcash/Security.lean
@@ -16,6 +16,7 @@ import Zcash.Security.Ledger.Balance
 import Zcash.Security.Ledger.Spendability
 import Zcash.Security.Ledger.SpendAuthority
 import Zcash.Security.Ledger.Completeness
+import Zcash.Security.Ledger.Capstone
 import Zcash.Security.Common.RandomOracle
 import Zcash.Security.Common.Birthday
 import Zcash.Security.KeyBinding.Basic

--- a/Zcash/Security.lean
+++ b/Zcash/Security.lean
@@ -19,6 +19,7 @@ import Zcash.Security.Ledger.Completeness
 import Zcash.Security.Ledger.Capstone
 import Zcash.Security.Ledger.Nullifier
 import Zcash.Security.Ledger.Value
+import Zcash.Security.Ledger.KeyBindingArm
 import Zcash.Security.Common.RandomOracle
 import Zcash.Security.Common.Birthday
 import Zcash.Security.KeyBinding.Basic

--- a/Zcash/Security.lean
+++ b/Zcash/Security.lean
@@ -17,6 +17,7 @@ import Zcash.Security.Ledger.Spendability
 import Zcash.Security.Ledger.SpendAuthority
 import Zcash.Security.Ledger.Completeness
 import Zcash.Security.Ledger.Capstone
+import Zcash.Security.Ledger.Nullifier
 import Zcash.Security.Common.RandomOracle
 import Zcash.Security.Common.Birthday
 import Zcash.Security.KeyBinding.Basic

--- a/Zcash/Security.lean
+++ b/Zcash/Security.lean
@@ -15,6 +15,7 @@ import Zcash.Security.Ledger.Effects
 import Zcash.Security.Ledger.Balance
 import Zcash.Security.Ledger.Spendability
 import Zcash.Security.Ledger.SpendAuthority
+import Zcash.Security.Ledger.Completeness
 import Zcash.Security.Common.RandomOracle
 import Zcash.Security.Common.Birthday
 import Zcash.Security.KeyBinding.Basic

--- a/Zcash/Security/KeyBinding/Instance.lean
+++ b/Zcash/Security/KeyBinding/Instance.lean
@@ -17,7 +17,11 @@ namespace Zcash.Security
 
 open Zcash.Security.KeyBinding Zcash.Security.Ledger Zcash.Security.RandomOracle Zcash.Snark
 
-variable {G IVK AK NK RIVK ASK QK SK : Type*}
+-- A shared universe for the oracle-model types, so the sampling experiment can be
+-- written in `do`-notation: `PMF`'s monad instance fixes one universe for the whole
+-- block, which independent `Type*` universes could not satisfy.
+universe u
+variable {G IVK AK NK RIVK ASK QK SK : Type u}
 
 /-- The concrete key-binding witness, viewed through the games' `KeyBindingInterface`. -/
 def KeyBinding.toInterface
@@ -36,6 +40,25 @@ def KeyBinding.toInterface
     ⟨h₁, h₂, hivk, fun heq => hne ((Extract.toAK_pm _ _).mp (congrArg BreakProj.ak heq))⟩
 
 
+/-- **The key-binding sampling experiment.** Draw the adversary's index `j` from `p`,
+the two key tables uniformly, and the three components of the combined `rivk` oracle
+uniformly and independently; the sample is `(j, Hask, Hnk, O)` with
+`O = FinalQuery.eval Hleg Hext Hint`. `toInterface_break_measure_le` and the ledger
+arm theorems are stated over this one experiment. -/
+noncomputable def kbExperiment {ι : Type u}
+    [Fintype AK] [Fintype NK] [Fintype RIVK] [Fintype ASK] [Fintype QK] [Fintype SK]
+    [Nonempty NK] [Nonempty ASK] [Nonempty RIVK]
+    [DecidableEq AK] [DecidableEq NK] [DecidableEq RIVK] [DecidableEq QK] [DecidableEq SK]
+    (p : PMF ι) :
+    PMF (ι × (SK → ASK) × (SK → NK) × (FinalQuery AK NK RIVK QK SK → RIVK)) := do
+  let j ← p
+  let Hask ← PMF.uniformOfFintype (SK → ASK)
+  let Hnk ← PMF.uniformOfFintype (SK → NK)
+  let Hleg ← PMF.uniformOfFintype (SK → RIVK)
+  let Hext ← PMF.uniformOfFintype (QK → AK → NK → RIVK)
+  let Hint ← PMF.uniformOfFintype (RIVK → AK → NK → RIVK)
+  pure (j, Hask, Hnk, FinalQuery.eval Hleg Hext Hint)
+
 /-- The probabilistic key-binding bound, delivered at the games' interface: over the
 adversary's private randomness (any distribution `p`) and the five independent oracle
 tables, a bounded-query machine — receiving the sampled `H^ask`/`H^nk` tables and querying
@@ -43,7 +66,7 @@ the combined rivk table — has output witnesses exhibiting the interface's `Bre
 probability at most `(n+4)·(n+3)/|F|`. `toInterface` interprets `Break` as
 `KeyBinding.Break` definitionally, so the games' `∨ kv.Break` branches inherit the bound
 directly. -/
-theorem toInterface_break_measure_le {ι : Type*}
+theorem toInterface_break_measure_le {ι : Type u}
     [AddCommGroup G] [Field IVK] [Field RIVK] [Module RIVK G] [NoZeroSMulDivisors RIVK G]
     [SMul ASK G] [Fintype AK] [Fintype NK] [Fintype RIVK] [Fintype ASK] [Fintype QK]
     [Fintype SK] [Nonempty NK] [Nonempty ASK]
@@ -52,12 +75,7 @@ theorem toInterface_break_measure_le {ι : Type*}
     {A : ι → (SK → ASK) → (SK → NK) → OracleComp (FinalQuery AK NK RIVK QK SK) RIVK
       (KeyBinding.Witness G IVK AK NK RIVK QK SK × KeyBinding.Witness G IVK AK NK RIVK QK SK)}
     {n : ℕ} (hQ : ∀ i Hask Hnk, (A i Hask Hnk).QueryBound n) :
-    ((p.bind fun i => (PMF.uniformOfFintype (SK → ASK)).bind fun Hask =>
-        (PMF.uniformOfFintype (SK → NK)).bind fun Hnk =>
-          (PMF.uniformOfFintype (SK → RIVK)).bind fun Hleg =>
-            (PMF.uniformOfFintype (QK → AK → NK → RIVK)).bind fun Hext =>
-              (PMF.uniformOfFintype (RIVK → AK → NK → RIVK)).map fun Hint =>
-                (i, Hask, Hnk, FinalQuery.eval Hleg Hext Hint))).toOuterMeasure
+    ((kbExperiment p)).toOuterMeasure
         (setOf fun (i, Hask, Hnk, O) =>
           (KeyBinding.toInterface Extract S hfn Ggen
               ⟨Hask, Hnk, fun sk => O (.legacy sk),

--- a/Zcash/Security/Ledger/Balance.lean
+++ b/Zcash/Security/Ledger/Balance.lean
@@ -332,6 +332,79 @@ def balanceSubsetOrBreak [DecidableEq F] [DecidableEq G] [DecidableEq RHO]
             obtain ⟨a, haL, rfl⟩ := List.mem_map.mp (by simpa using hx)
             simpa using hall a haL)
 
+/-- The key-binding arm's witness pair, when the break lies in that arm. -/
+def BalanceBreak.kbPair : BalanceBreak P kv → Option (KW × KW)
+  | .keyBinding w₁ w₂ _ => some (w₁, w₂)
+  | .merkle _ => none
+  | .noteCommit _ => none
+
+/-- The key-binding pair read directly off the ledger: the two key witnesses of the
+duplicate positioned opening that `findPair` locates. Oracle-free — it consumes no
+validity proof — so an oracle machine can output it. `balanceSubsetOrBreak_kbPair` shows
+it is exactly the pair of whatever break the reduction computes. -/
+def kbPairOf [DecidableEq F] [DecidableEq G] [DecidableEq RHO] [DecidableEq PSI]
+    (ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG P.depth) (i : ℕ) :
+    Option (KW × KW) :=
+  (findPair spendRecord (spendActions ledger (i + 1))).map fun p => (p.1.w.kw, p.2.w.kw)
+
+/-- Per-spend pinning never computes a key-binding break: its breaks are the
+note-commitment collision (`hop` fails) and the Merkle collision (`hleaf` fails). -/
+theorem spendPinnedOrBreak_kbPair [DecidableEq F] [DecidableEq G] [DecidableEq RHO]
+    [DecidableEq PSI] [DecidableEq MHASH] [DecidableEq MENC]
+    (hval : ValidLedger P kv issuance maxActions ledger) {i : ℕ}
+    {a : Action KW F G RHO PSI MHASH MENC SIG P.depth}
+    (ha : a ∈ spendActions ledger (i + 1)) {b : BalanceBreak P kv} :
+    spendPinnedOrBreak hval ha = .inr b → b.kbPair = none := by
+  revert b
+  fun_cases spendPinnedOrBreak hval ha <;>
+    intro b hb <;>
+    (try simp_all only [reduceCtorEq, PSum.inr.injEq, BalanceBreak.kbPair]) <;>
+    (subst hb; rfl)
+
+/-- The pinning scan never computes a key-binding break (`spendPinnedOrBreak_kbPair`,
+propagated through the recursion). -/
+theorem allPinnedOrBreak_kbPair [DecidableEq F] [DecidableEq G] [DecidableEq RHO]
+    [DecidableEq PSI] [DecidableEq MHASH] [DecidableEq MENC]
+    (hval : ValidLedger P kv issuance maxActions ledger) {i : ℕ} :
+    ∀ (L : List (Action KW F G RHO PSI MHASH MENC SIG P.depth))
+      (hL : ∀ a ∈ L, a ∈ spendActions ledger (i + 1)) {b : BalanceBreak P kv},
+      allPinnedOrBreak hval L hL = .inr b → b.kbPair = none := by
+  intro L
+  induction L with
+  | nil => intro hL b hb; simp only [allPinnedOrBreak, reduceCtorEq] at hb
+  | cons a t ih =>
+      intro hL b hb
+      rw [allPinnedOrBreak] at hb
+      split at hb
+      · rename_i b' hsp
+        rw [PSum.inr.injEq] at hb; subst hb
+        exact spendPinnedOrBreak_kbPair hval _ hsp
+      · split at hb
+        · rename_i b' hall
+          rw [PSum.inr.injEq] at hb; subst hb
+          exact ih (fun x hx => hL x (by simp [hx])) hall
+        · simp only [reduceCtorEq] at hb
+
+/-- **Key-binding-arm localization.** Whatever break `balanceSubsetOrBreak` computes, its
+key-binding pair is the oracle-free `kbPairOf`: a key-binding break arises only from the
+`findPair` duplicate, whose pair is `kbPairOf`, and every other break has no pair. This is
+what lets an oracle machine output the arm's pair without running the reduction. -/
+theorem balanceSubsetOrBreak_kbPair [DecidableEq F] [DecidableEq G] [DecidableEq RHO]
+    [DecidableEq PSI] [DecidableEq MHASH] [DecidableEq MENC] [DecidableEq NK]
+    [NoZeroSMulDivisors F G]
+    (hval : ValidLedger P kv issuance maxActions ledger) (i : ℕ) {b : BalanceBreak P kv} :
+    balanceSubsetOrBreak hval i = .inr b → b.kbPair = kbPairOf ledger i := by
+  revert b
+  fun_cases balanceSubsetOrBreak hval i <;> intro b hb <;>
+    (try (rw [PSum.inr.injEq] at hb; subst hb)) <;>
+    (try simp_all only [reduceCtorEq])
+  · -- key-binding break from a `findPair` duplicate: its pair is `kbPairOf`
+    simp_all [BalanceBreak.kbPair, kbPairOf]
+  · -- no duplicate: the pinning scan's break has no pair, and `kbPairOf` is `none`
+    rename_i hfpNone _ _ hallp
+    have hnone := allPinnedOrBreak_kbPair hval _ _ hallp
+    simp [kbPairOf, hfpNone, hnone]
+
 end Validity
 
 /-! ## Balance-value, in conservation form

--- a/Zcash/Security/Ledger/Bridge.lean
+++ b/Zcash/Security/Ledger/Bridge.lean
@@ -162,13 +162,13 @@ private theorem commitIvkHash_of_action_hash {ak nk : Fp} {bp : Point Fp}
 
 /-- The circuit's randomized-key public coordinates are the affine view of the
 concrete ledger randomization. -/
-theorem public_rk_eq_randomizePublic (verify : PallasGroup → MSG → SIG → Prop)
+theorem public_rk_eq_randomizePublic (verify bverify : PallasGroup → MSG → SIG → Prop)
     {wit : ActionData}
     (hak : wit.akP.OnCurve)
     (h : ({ x := wit.rkX, y := wit.rkY } : Point Fp) =
       wit.alpha.2 • orchardBases.spendAuthG + wit.akP) :
     PallasGroup.toPoint
-      ((Pool.primitives verify).randomizePublic wit.alpha.2
+      ((Pool.primitives verify bverify).randomizePublic wit.alpha.2
         (PallasGroup.ofPoint wit.akP (.inl hak))) =
       ({ x := wit.rkX, y := wit.rkY } : Point Fp) := by
   change PallasGroup.toPoint
@@ -181,7 +181,7 @@ theorem public_rk_eq_randomizePublic (verify : PallasGroup → MSG → SIG → P
 /-- The circuit's signed-magnitude value-commitment equation has the same
 affine public coordinates as the ledger's integer-valued commitment.  The
 64-bit bounds are precisely what make the field subtraction no-wrap. -/
-theorem public_cv_net_eq_valueCommit (verify : PallasGroup → MSG → SIG → Prop)
+theorem public_cv_net_eq_valueCommit (verify bverify : PallasGroup → MSG → SIG → Prop)
     {wit : ActionData}
     (hvOld : wit.vOld.val < 2 ^ 64) (hvNew : wit.vNew.val < 2 ^ 64)
     (hmag : wit.magnitude.val < 2 ^ 64)
@@ -194,7 +194,7 @@ theorem public_cv_net_eq_valueCommit (verify : PallasGroup → MSG → SIG → P
         -(wit.magnitude.val : Fq) • orchardBases.valueCommitV +
           wit.rcv.2 • orchardBases.valueCommitR)) :
     PallasGroup.toPoint
-      ((Pool.primitives verify).valueCommit
+      ((Pool.primitives verify bverify).valueCommit
         ((wit.vOld.val : ℤ) - (wit.vNew.val : ℤ)) wit.rcv.2) =
       ({ x := wit.cvX, y := wit.cvY } : Point Fp) := by
   change PallasGroup.toPoint
@@ -603,13 +603,13 @@ def NoteCommitNewSuccess (wit : ActionData) : Prop :=
 into the concrete ledger commitment.  Unlike the circuit public input, the
 ledger keeps the full commitment point; this lemma supplies that point together
 with the coordinate equation used for `cmx_new_eq`. -/
-theorem noteCommitNewSuccess_to_ledger (verify : PallasGroup → MSG → SIG → Prop)
+theorem noteCommitNewSuccess_to_ledger (verify bverify : PallasGroup → MSG → SIG → Prop)
     {wit : ActionData}
     (hgd : wit.gdNew.OnCurve) (hpkd : wit.pkdNew.OnCurve)
     (h : NoteCommitNewSuccess wit) :
     ∃ (cmNewP : Point Fp) (hcmNewP : cmNewP.Valid),
       cmNewP.x = wit.cmx ∧
-      (Pool.primitives verify).noteCommit wit.rcmNew.2
+      (Pool.primitives verify bverify).noteCommit wit.rcmNew.2
         { gd := PallasGroup.ofPoint wit.gdNew (.inl hgd),
           pkd := PallasGroup.ofPoint wit.pkdNew (.inl hpkd),
           v := wit.vNew.val, ρ := wit.nfOld, ψ := wit.psiNew } =
@@ -780,12 +780,12 @@ theorem merkle_path_of_exact {wit : ActionData} {root : Fp}
 Sinsemilla escapes or a fully satisfied concrete Orchard ledger action.  The ledger
 alternative additionally reports the spend/output enable gates as a side fact
 (`EnableFlagsSatisfied`), with their exact circuit semantics. -/
-theorem specPost_to_ledger (verify : PallasGroup → MSG → SIG → Prop)
+theorem specPost_to_ledger (verify bverify : PallasGroup → MSG → SIG → Prop)
     {input : Halo2.Value PrivateInputs Fp} {wit : ActionData}
     (h : SpecPost orchardGenerators orchardBases input () wit) :
     ActionBreak wit ∨
       ∃ inst w, PublicProjection wit inst ∧
-        ActionSatisfied (Pool.primitives verify) Pool.keyBinding inst w ∧
+        ActionSatisfied (Pool.primitives verify bverify) Pool.keyBinding inst w ∧
         CrossAddressSatisfied wit w ∧
         EnableFlagsSatisfied wit w := by
   rcases successes_or_break h with hs | hbreak
@@ -798,7 +798,7 @@ theorem specPost_to_ledger (verify : PallasGroup → MSG → SIG → Prop)
     rcases commitIvkSuccess_to_ledger hgdOld hakP hpkdOld hivk with
       ⟨ivk, kw, hkb, hivne, hkwivk, hkwNk, hkwAk, hpkdLedger⟩
     have hkwNk' : kw.nk = wit.nk := hkwNk
-    rcases noteCommitNewSuccess_to_ledger verify hgdNew hpkdNew hnew with
+    rcases noteCommitNewSuccess_to_ledger verify bverify hgdNew hpkdNew hnew with
       ⟨cmNewP, hcmNewP, hcmNewX, hcommitNew⟩
     have hcmOldEq' : wit.cmOld =
         bold + wit.rcmOld.2.val • Ecc.MulFixed.Certs.noteCommitR.point := by
@@ -825,9 +825,9 @@ theorem specPost_to_ledger (verify : PallasGroup → MSG → SIG → Prop)
     let inst : ActionInstance PallasGroup Fp Fp :=
       { rt := wit.anchor,
         nf_old := wit.nfOld,
-        rk := (Pool.primitives verify).randomizePublic wit.alpha.2
+        rk := (Pool.primitives verify bverify).randomizePublic wit.alpha.2
           (PallasGroup.ofPoint wit.akP (.inl hakP)),
-        cv_net := (Pool.primitives verify).valueCommit
+        cv_net := (Pool.primitives verify bverify).valueCommit
           ((wit.vOld.val : ℤ) - (wit.vNew.val : ℤ)) wit.rcv.2,
         cmx_new := wit.cmx }
     let w : LedgerWitness :=
@@ -850,9 +850,9 @@ theorem specPost_to_ledger (verify : PallasGroup → MSG → SIG → Prop)
         rcm_new := wit.rcmNew.2 }
     refine Or.inr ⟨inst, w, ?_, ?_, ?_, ?_⟩
     · refine ⟨rfl, rfl, ?_, ?_, rfl⟩
-      · simpa [inst] using public_rk_eq_randomizePublic verify hakP hrk
+      · simpa [inst] using public_rk_eq_randomizePublic verify bverify hakP hrk
       · simpa [inst] using
-          public_cv_net_eq_valueCommit verify hvOld hvNew hmag hvalue hcv
+          public_cv_net_eq_valueCommit verify bverify hvOld hvNew hmag hvalue hcv
     · refine
         { commit_old := ?_,
           merkle_path := ?_,
@@ -889,9 +889,9 @@ theorem specPost_to_ledger (verify : PallasGroup → MSG → SIG → Prop)
           have hz := congrArg PallasGroup.toPoint hzero
           simpa [w] using hz
         exact Point.ne_zero_of_onCurve hgdOld hpzero
-      · change (Pool.primitives verify).randomizePublic wit.alpha.2
+      · change (Pool.primitives verify bverify).randomizePublic wit.alpha.2
             (PallasGroup.ofPoint wit.akP (.inl hakP)) =
-          (Pool.primitives verify).randomizePublic wit.alpha.2
+          (Pool.primitives verify bverify).randomizePublic wit.alpha.2
             (Pool.keyBinding.akP kw)
         rw [hkwAk]
       · simpa [w] using hcommitNew
@@ -929,7 +929,7 @@ theorem specPost_to_ledger (verify : PallasGroup → MSG → SIG → Prop)
 Action circuit.  This is the direct composition of the circuit soundness
 contract with `specPost_to_ledger`; it deliberately leaves the exceptional
 Sinsemilla branch explicit and reports the enable gates as `EnableFlagsSatisfied`. -/
-theorem circuit_soundness_to_ledger (verify : PallasGroup → MSG → SIG → Prop)
+theorem circuit_soundness_to_ledger (verify bverify : PallasGroup → MSG → SIG → Prop)
     (cfg : Config) (i₀ : RegionIndex)
     (env : Placed Environment Fp) (input : Var PrivateInputs Fp)
     (henv : EnvAssumptions orchardGenerators cfg env)
@@ -937,11 +937,11 @@ theorem circuit_soundness_to_ledger (verify : PallasGroup → MSG → SIG → Pr
       ((mainPost orchardGenerators orchardBases cfg input).operations i₀) i₀) :
     ActionBreak (extract cfg input i₀ env) ∨
       ∃ inst w, PublicProjection (extract cfg input i₀ env) inst ∧
-        ActionSatisfied (Pool.primitives verify) Pool.keyBinding inst w ∧
+        ActionSatisfied (Pool.primitives verify bverify) Pool.keyBinding inst w ∧
         CrossAddressSatisfied (extract cfg input i₀ env) w ∧
         EnableFlagsSatisfied (extract cfg input i₀ env) w := by
   have hpost := soundnessPost orchardGenerators orchardBases cfg i₀ env input
     henv trivial hconstraints
-  exact specPost_to_ledger verify (by simpa using hpost)
+  exact specPost_to_ledger verify bverify (by simpa using hpost)
 
 end Zcash.Security.Ledger.Bridge

--- a/Zcash/Security/Ledger/BridgeTests.lean
+++ b/Zcash/Security/Ledger/BridgeTests.lean
@@ -167,19 +167,19 @@ theorem path_iff_guarded_smoke
 
 /-- The circuit-level postcondition refines directly to the ledger action alternative. -/
 theorem spec_post_bridge_smoke {MSG SIG : Type*}
-    (verify : PallasGroup → MSG → SIG → Prop)
+    (verify bverify : PallasGroup → MSG → SIG → Prop)
     {input : Halo2.Value PrivateInputs Fp} {wit : ActionData}
     (h : SpecPost orchardGenerators orchardBases input () wit) :
     ActionBreak wit ∨
       ∃ inst w, PublicProjection wit inst ∧
-        ActionSatisfied (Pool.primitives verify) Pool.keyBinding inst w ∧
+        ActionSatisfied (Pool.primitives verify bverify) Pool.keyBinding inst w ∧
         CrossAddressSatisfied wit w ∧
         EnableFlagsSatisfied wit w :=
-  specPost_to_ledger verify h
+  specPost_to_ledger verify bverify h
 
 /-- Keep the exported end-to-end soundness theorem at its intended public shape. -/
 theorem circuit_soundness_bridge_smoke {MSG SIG : Type*}
-    (verify : PallasGroup → MSG → SIG → Prop)
+    (verify bverify : PallasGroup → MSG → SIG → Prop)
     (cfg : Config) (i₀ : RegionIndex)
     (env : Placed Environment Fp) (input : Var PrivateInputs Fp)
     (henv : EnvAssumptions orchardGenerators cfg env)
@@ -187,10 +187,10 @@ theorem circuit_soundness_bridge_smoke {MSG SIG : Type*}
       ((mainPost orchardGenerators orchardBases cfg input).operations i₀) i₀) :
     ActionBreak (extract cfg input i₀ env) ∨
       ∃ inst w, PublicProjection (extract cfg input i₀ env) inst ∧
-        ActionSatisfied (Pool.primitives verify) Pool.keyBinding inst w ∧
+        ActionSatisfied (Pool.primitives verify bverify) Pool.keyBinding inst w ∧
         CrossAddressSatisfied (extract cfg input i₀ env) w ∧
         EnableFlagsSatisfied (extract cfg input i₀ env) w :=
-  circuit_soundness_to_ledger verify cfg i₀ env input henv hconstraints
+  circuit_soundness_to_ledger verify bverify cfg i₀ env input henv hconstraints
 
 open Zcash.Meta
 

--- a/Zcash/Security/Ledger/Capstone.lean
+++ b/Zcash/Security/Ledger/Capstone.lean
@@ -1,5 +1,6 @@
 import Mathlib
 import Zcash.Security.Ledger.Balance
+import Zcash.Security.Ledger.SpendAuthority
 
 /-!
 # Probabilistic capstones
@@ -37,6 +38,13 @@ variable {IVK NK RHO PSI MHASH MENC MSG SIG : Type*} {KW : Type*}
 
 /-! ## Event algebra -/
 
+/-- Union bound over two events: an event contained in a union is bounded by the sum
+of the two measures. -/
+theorem toOuterMeasure_le_add₂ {α : Type*} (p : PMF α) {E B₁ B₂ : Set α}
+    (h : E ⊆ B₁ ∪ B₂) :
+    p.toOuterMeasure E ≤ p.toOuterMeasure B₁ + p.toOuterMeasure B₂ :=
+  le_trans (MeasureTheory.measure_mono h) (MeasureTheory.measure_union_le _ _)
+
 /-- Union bound over three events: an event contained in a triple union is bounded by
 the sum of the three measures. -/
 theorem toOuterMeasure_le_add₃ {α : Type*} (p : PMF α) {E B₁ B₂ B₃ : Set α}
@@ -63,6 +71,78 @@ abbrev ValidAnnotated :=
   {ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG P.depth //
     ValidLedger P kv issuance maxActions ledger}
 
+/-! ## Balance-value -/
+
+/-- The value-premiss arm event: the samples on which the per-transaction value
+premiss hands the conservation reduction a break of the abstract type `VB`. -/
+def valueBreakEvent {VB : Type*}
+    (perTx : ∀ ω : ValidAnnotated P kv issuance maxActions,
+      (tx : Tx KW F G RHO PSI MHASH MENC MSG SIG P.depth) → tx ∈ ω.1 →
+        (txNetValue tx = tx.vBalance) ⊕' VB) (i : ℕ) :
+    Set (ValidAnnotated P kv issuance maxActions) :=
+  {ω | ∃ b : VB, valueConservationOrBreak (issuance := issuance) (perTx ω) i = .inr b}
+
+/-- The value-conservation violation event: the shielded pool plus the transparent
+pool differs from the minted issuance after the first `i` transactions. -/
+def valueConservationViolation (i : ℕ) :
+    Set (ValidAnnotated P kv issuance maxActions) :=
+  {ω | poolValueBalance ω.1 i + transparentPoolBalance issuance ω.1 i
+    ≠ issuanceTotal issuance ω.1 i}
+
+/-- The Balance-value violation event: the shielded pool exceeds the minted issuance
+after the first `i` transactions. -/
+def balanceValueViolation (i : ℕ) :
+    Set (ValidAnnotated P kv issuance maxActions) :=
+  {ω | ¬ poolValueBalance ω.1 i ≤ issuanceTotal issuance ω.1 i}
+
+/-- A conservation-violating sample lands in the value-premiss arm: on it, the
+conservation reduction cannot return the equation. -/
+theorem valueConservationViolation_subset {VB : Type*}
+    (perTx : ∀ ω : ValidAnnotated P kv issuance maxActions,
+      (tx : Tx KW F G RHO PSI MHASH MENC MSG SIG P.depth) → tx ∈ ω.1 →
+        (txNetValue tx = tx.vBalance) ⊕' VB) (i : ℕ) :
+    valueConservationViolation (P := P) (kv := kv) (maxActions := maxActions) i
+      ⊆ valueBreakEvent perTx i := by
+  intro ω hω
+  rcases h : valueConservationOrBreak (issuance := issuance) (perTx ω) i with heq | b
+  · exact absurd heq hω
+  · exact ⟨b, h⟩
+
+/-- A balance-violating sample lands in the value-premiss arm too: if the reduction
+returned the conservation equation, transparent nonnegativity would force the bound. -/
+theorem balanceValueViolation_subset {VB : Type*}
+    (perTx : ∀ ω : ValidAnnotated P kv issuance maxActions,
+      (tx : Tx KW F G RHO PSI MHASH MENC MSG SIG P.depth) → tx ∈ ω.1 →
+        (txNetValue tx = tx.vBalance) ⊕' VB) (i : ℕ) :
+    balanceValueViolation (P := P) (kv := kv) (maxActions := maxActions) i
+      ⊆ valueBreakEvent perTx i := by
+  intro ω hω
+  rcases h : valueConservationOrBreak (issuance := issuance) (perTx ω) i with heq | b
+  · exact absurd (by have := ω.2.transparent_nonneg i; omega) hω
+  · exact ⟨b, h⟩
+
+/-- **Value conservation, probabilistically.** For any adversary, the probability that
+the value ledger fails to balance is at most the value-premiss arm's ε. -/
+theorem valueConservation_measure_le {VB : Type*}
+    (A : PMF (ValidAnnotated P kv issuance maxActions))
+    (perTx : ∀ ω : ValidAnnotated P kv issuance maxActions,
+      (tx : Tx KW F G RHO PSI MHASH MENC MSG SIG P.depth) → tx ∈ ω.1 →
+        (txNetValue tx = tx.vBalance) ⊕' VB) (i : ℕ) {εvb : ℝ≥0∞}
+    (hvb : A.toOuterMeasure (valueBreakEvent perTx i) ≤ εvb) :
+    A.toOuterMeasure (valueConservationViolation i) ≤ εvb :=
+  le_trans (MeasureTheory.measure_mono (valueConservationViolation_subset perTx i)) hvb
+
+/-- **Balance-value, probabilistically.** For any adversary, the probability that the
+shielded pool exceeds the minted issuance is at most the value-premiss arm's ε. -/
+theorem balanceValue_measure_le {VB : Type*}
+    (A : PMF (ValidAnnotated P kv issuance maxActions))
+    (perTx : ∀ ω : ValidAnnotated P kv issuance maxActions,
+      (tx : Tx KW F G RHO PSI MHASH MENC MSG SIG P.depth) → tx ∈ ω.1 →
+        (txNetValue tx = tx.vBalance) ⊕' VB) (i : ℕ) {εvb : ℝ≥0∞}
+    (hvb : A.toOuterMeasure (valueBreakEvent perTx i) ≤ εvb) :
+    A.toOuterMeasure (balanceValueViolation i) ≤ εvb :=
+  le_trans (MeasureTheory.measure_mono (balanceValueViolation_subset perTx i)) hvb
+
 /-! ## Balance-subset -/
 
 /-- The three arms of a `BalanceBreak`, as a plain tag for naming the arm events. -/
@@ -76,6 +156,8 @@ def BalanceBreak.arm : BalanceBreak P kv → BalanceArm
   | .merkle _ => .merkle
   | .noteCommit _ => .noteCommit
   | .keyBinding _ _ _ => .keyBinding
+
+section BalanceSubset
 
 variable [DecidableEq F] [DecidableEq G] [DecidableEq RHO] [DecidableEq PSI]
   [DecidableEq MHASH] [DecidableEq MENC] [DecidableEq NK] [NoZeroSMulDivisors F G]
@@ -118,6 +200,66 @@ theorem balanceSubset_measure_le (A : PMF (ValidAnnotated P kv issuance maxActio
     A.toOuterMeasure (balanceSubsetViolation i) ≤ εm + εnc + εkb :=
   le_trans (toOuterMeasure_le_add₃ A (balanceSubsetViolation_subset i))
     (add_le_add (add_le_add hm hnc) hkb)
+
+end BalanceSubset
+
+/-! ## Spend Authority -/
+
+section SpendAuthority
+
+variable [DecidableEq G] [NoZeroSMulDivisors F G]
+
+/-- The forgery arm event, for a victim key witness `wV` with signing history
+`Signed`: the samples with an Action spending a note addressed to `wV` in a
+transaction with an unsigned sighash, on which the Spend Authority reduction lands in
+the forgery arm. -/
+def spendAuthorityForgeryEvent (wV : KW) (hKB : kv.KB wV) (Signed : MSG → Prop) :
+    Set (ValidAnnotated P kv issuance maxActions) :=
+  {ω | ∃ tx, ∃ htx : tx ∈ ω.1, ∃ a, ∃ ha : a ∈ tx.actions,
+    ∃ hrecv : a.w.note_old.pkd = P.emb (kv.ivk wV) • a.w.note_old.gd,
+    ∃ hfresh : ¬ Signed tx.sighash, ∃ f,
+    spendAuthorityOrBreak ω.2 htx ha hKB hrecv hfresh = .inl f}
+
+/-- The key-binding arm event: as `spendAuthorityForgeryEvent`, with the reduction
+landing in the break arm. -/
+def spendAuthorityBreakEvent (wV : KW) (hKB : kv.KB wV) (Signed : MSG → Prop) :
+    Set (ValidAnnotated P kv issuance maxActions) :=
+  {ω | ∃ tx, ∃ htx : tx ∈ ω.1, ∃ a, ∃ ha : a ∈ tx.actions,
+    ∃ hrecv : a.w.note_old.pkd = P.emb (kv.ivk wV) • a.w.note_old.gd,
+    ∃ hfresh : ¬ Signed tx.sighash, ∃ b,
+    spendAuthorityOrBreak ω.2 htx ha hKB hrecv hfresh = .inr b}
+
+/-- The Spend Authority violation event: some Action spends a note addressed to `wV`
+in a transaction whose sighash the holder of `wV` never signed. -/
+def spendAuthorityViolation (wV : KW) (Signed : MSG → Prop) :
+    Set (ValidAnnotated P kv issuance maxActions) :=
+  {ω | ∃ tx ∈ ω.1, ∃ a ∈ tx.actions,
+    a.w.note_old.pkd = P.emb (kv.ivk wV) • a.w.note_old.gd ∧ ¬ Signed tx.sighash}
+
+/-- A violating sample lands in the forgery arm or the break arm: the reduction runs
+on the violating Action, and its branch classifies the sample. -/
+theorem spendAuthorityViolation_subset (wV : KW) (hKB : kv.KB wV)
+    (Signed : MSG → Prop) :
+    spendAuthorityViolation (P := P) (kv := kv) (issuance := issuance)
+        (maxActions := maxActions) wV Signed
+      ⊆ spendAuthorityForgeryEvent wV hKB Signed ∪ spendAuthorityBreakEvent wV hKB Signed := by
+  rintro ω ⟨tx, htx, a, ha, hrecv, hfresh⟩
+  rcases h : spendAuthorityOrBreak ω.2 htx ha hKB hrecv hfresh with f | b
+  · exact Or.inl ⟨tx, htx, a, ha, hrecv, hfresh, f, h⟩
+  · exact Or.inr ⟨tx, htx, a, ha, hrecv, hfresh, b, h⟩
+
+/-- **Spend Authority, probabilistically.** For any adversary, the probability that
+some Action spends a note addressed to `wV` over an unsigned sighash is at most the
+forgery arm's ε plus the key-binding arm's ε. -/
+theorem spendAuthority_measure_le (A : PMF (ValidAnnotated P kv issuance maxActions))
+    (wV : KW) (hKB : kv.KB wV) (Signed : MSG → Prop) {εf εkb : ℝ≥0∞}
+    (hf : A.toOuterMeasure (spendAuthorityForgeryEvent wV hKB Signed) ≤ εf)
+    (hkb : A.toOuterMeasure (spendAuthorityBreakEvent wV hKB Signed) ≤ εkb) :
+    A.toOuterMeasure (spendAuthorityViolation wV Signed) ≤ εf + εkb :=
+  le_trans (toOuterMeasure_le_add₂ A (spendAuthorityViolation_subset wV hKB Signed))
+    (add_le_add hf hkb)
+
+end SpendAuthority
 
 end Validity
 

--- a/Zcash/Security/Ledger/Capstone.lean
+++ b/Zcash/Security/Ledger/Capstone.lean
@@ -23,9 +23,11 @@ branch of a computed reduction needs none. The composition is pure event algebra
 violation event is contained in the union of the arm events, so its probability is at
 most the sum of the per-arm probabilities (`measure_mono` plus `measure_union_le`).
 No independence, no counting. Each arm's probability is then bounded by a named ε
-hypothesis. The intended discharges — the key-binding arm against the key-binding
-layer's probability bound (`toInterface_break_measure_le`), the Merkle and
-note-commitment arms against Sinsemilla/DLR hardness — are not wired here yet.
+hypothesis. The key-binding arm's ε is discharged in `KeyBindingArm.lean` against the
+key-binding layer's probability bound (`toInterface_break_measure_le`), for a ledger
+adversary in the oracle model. Connecting that bound to this layer's named-ε slot — an
+oracle machine against a `PMF` over valid annotated ledgers — is still open, as are the
+Merkle and note-commitment arms (against Sinsemilla/DLR hardness).
 -/
 
 namespace Zcash.Security.Ledger.Model

--- a/Zcash/Security/Ledger/Capstone.lean
+++ b/Zcash/Security/Ledger/Capstone.lean
@@ -1,0 +1,124 @@
+import Mathlib
+import Zcash.Security.Ledger.Balance
+
+/-!
+# Probabilistic capstones
+
+The deterministic layer quantifies over valid annotated ledgers. This layer quantifies
+over a distribution of them: an adversary is an arbitrary `PMF` over `ValidAnnotated`,
+and we do not model the interaction that produced it. That matches the games' stance —
+the annotated-ledger quantification is a superset of what a real adversary can reach —
+and it keeps the oracle bookkeeping inside the discharge of each per-arm hypothesis,
+where the machine models exist.
+
+Restricting the distribution to *valid* ledgers loses no generality. Every game's bad
+event requires validity, so mass on invalid ledgers contributes nothing to success:
+conditioning any adversary on validity can only increase its success probability, and
+a bound for valid-only adversaries implies the bound for all of them.
+
+Events are reduction-branch preimages: "the reduction lands in this arm on this
+sample". An existential break predicate would need choice to extract data from; the
+branch of a computed reduction needs none. The composition is pure event algebra — the
+violation event is contained in the union of the arm events, so its probability is at
+most the sum of the per-arm probabilities (`measure_mono` plus `measure_union_le`).
+No independence, no counting. Each arm's probability is then bounded by a named ε
+hypothesis. The intended discharges — the key-binding arm against the key-binding
+layer's probability bound (`toInterface_break_measure_le`), the Merkle and
+note-commitment arms against Sinsemilla/DLR hardness — are not wired here yet.
+-/
+
+namespace Zcash.Security.Ledger.Model
+
+open scoped ENNReal
+
+variable {F : Type*}
+variable {G : Type*}
+variable {IVK NK RHO PSI MHASH MENC MSG SIG : Type*} {KW : Type*}
+
+/-! ## Event algebra -/
+
+/-- Union bound over three events: an event contained in a triple union is bounded by
+the sum of the three measures. -/
+theorem toOuterMeasure_le_add₃ {α : Type*} (p : PMF α) {E B₁ B₂ B₃ : Set α}
+    (h : E ⊆ B₁ ∪ B₂ ∪ B₃) :
+    p.toOuterMeasure E
+      ≤ p.toOuterMeasure B₁ + p.toOuterMeasure B₂ + p.toOuterMeasure B₃ :=
+  le_trans (MeasureTheory.measure_mono h)
+    (le_trans (MeasureTheory.measure_union_le _ _)
+      (add_le_add (MeasureTheory.measure_union_le _ _) le_rfl))
+
+section Validity
+
+variable [Field F] [AddCommGroup G] [Module F G]
+variable {P : Primitives F G IVK NK RHO PSI MHASH MENC MSG SIG}
+variable {kv : KeyBindingInterface KW G IVK NK}
+variable {issuance : ℕ → ℕ} {maxActions : ℕ}
+
+variable (P kv issuance maxActions) in
+/-- The adversary's sample space: a valid witness-annotated ledger, with its validity
+proof. Bundling validity is a convenience, not a restriction — a bad event requires
+validity, so conditioning any distribution on validity can only increase its success
+probability, and a bound over this space implies the bound over bare ledgers. -/
+abbrev ValidAnnotated :=
+  {ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG P.depth //
+    ValidLedger P kv issuance maxActions ledger}
+
+/-! ## Balance-subset -/
+
+/-- The three arms of a `BalanceBreak`, as a plain tag for naming the arm events. -/
+inductive BalanceArm
+  | merkle
+  | noteCommit
+  | keyBinding
+
+/-- The arm a break lies in. -/
+def BalanceBreak.arm : BalanceBreak P kv → BalanceArm
+  | .merkle _ => .merkle
+  | .noteCommit _ => .noteCommit
+  | .keyBinding _ _ _ => .keyBinding
+
+variable [DecidableEq F] [DecidableEq G] [DecidableEq RHO] [DecidableEq PSI]
+  [DecidableEq MHASH] [DecidableEq MENC] [DecidableEq NK] [NoZeroSMulDivisors F G]
+
+/-- The branch-preimage event for one arm: the samples on which the Balance-subset
+reduction lands in that arm. -/
+def balanceSubsetBreakEvent (i : ℕ) (arm : BalanceArm) :
+    Set (ValidAnnotated P kv issuance maxActions) :=
+  {ω | ∃ b : BalanceBreak P kv, balanceSubsetOrBreak ω.2 i = .inr b ∧ b.arm = arm}
+
+/-- The Balance-subset violation event: the nonzero spends of the first `i + 1`
+transactions are not covered by the positioned outputs of the first `i`. -/
+def balanceSubsetViolation (i : ℕ) : Set (ValidAnnotated P kv issuance maxActions) :=
+  {ω | ¬ nonZeroSpends ω.1 (i + 1) ≤ ↑(positionedOutputs ω.1 i)}
+
+/-- A violating sample lands in one of the three arms: on it, the reduction cannot
+return the subset proof, so it returns a break, and the break's arm classifies it. -/
+theorem balanceSubsetViolation_subset (i : ℕ) :
+    balanceSubsetViolation (P := P) (kv := kv) (issuance := issuance)
+        (maxActions := maxActions) i
+      ⊆ balanceSubsetBreakEvent i .merkle ∪ balanceSubsetBreakEvent i .noteCommit
+        ∪ balanceSubsetBreakEvent i .keyBinding := by
+  intro ω hω
+  rcases h : balanceSubsetOrBreak ω.2 i with hle | b
+  · exact absurd hle hω
+  · cases b with
+    | merkle c => exact Or.inl (Or.inl ⟨_, h, rfl⟩)
+    | noteCommit nb => exact Or.inl (Or.inr ⟨_, h, rfl⟩)
+    | keyBinding w₁ w₂ hbr => exact Or.inr ⟨_, h, rfl⟩
+
+/-- **Balance-subset, probabilistically.** For any adversary — a distribution over
+valid annotated ledgers — the probability that the nonzero spends of the first `i + 1`
+transactions are not covered by the positioned outputs of the first `i` is at most the
+sum of the three break-arm probabilities, each bounded by its named ε hypothesis. -/
+theorem balanceSubset_measure_le (A : PMF (ValidAnnotated P kv issuance maxActions))
+    (i : ℕ) {εm εnc εkb : ℝ≥0∞}
+    (hm : A.toOuterMeasure (balanceSubsetBreakEvent i .merkle) ≤ εm)
+    (hnc : A.toOuterMeasure (balanceSubsetBreakEvent i .noteCommit) ≤ εnc)
+    (hkb : A.toOuterMeasure (balanceSubsetBreakEvent i .keyBinding) ≤ εkb) :
+    A.toOuterMeasure (balanceSubsetViolation i) ≤ εm + εnc + εkb :=
+  le_trans (toOuterMeasure_le_add₃ A (balanceSubsetViolation_subset i))
+    (add_le_add (add_le_add hm hnc) hkb)
+
+end Validity
+
+end Zcash.Security.Ledger.Model

--- a/Zcash/Security/Ledger/Completeness.lean
+++ b/Zcash/Security/Ledger/Completeness.lean
@@ -2,6 +2,9 @@ import Mathlib
 import Zcash.Security.Ledger.Balance
 import Zcash.Security.Ledger.Spendability
 
+-- This lint enforces Mathlib's minimal-hypothesis style, from which we deliberately depart.
+set_option linter.unusedSectionVars false
+
 /-!
 # Honest-spend completeness
 
@@ -26,6 +29,14 @@ The Actions of one honest transaction may reference different anchors, matching 
 model's per-action anchor rule — a documented simplification: deployed Orchard
 encodes one anchor for the whole transaction (Sapling v4 allowed per-spend anchors).
 The deployed case is the instance with all `anchor` fields equal.
+
+`spendabilityOrBreak` is the Spendability capstone at this deterministic layer: the
+owner of a received note can spend it. Either appending the honest transaction keeps
+the ledger valid, or the ledger's own data computes the obstruction — an action
+already spending the owner's exact opening (`Respend`, the case Spend Authority
+covers), a note-commitment break, or a nullifier collision. The nullifier roadblock
+is decided by searching the ledger for the revealing action and running the roadblock
+inversion (`respendOrBreak`) against the owner's satisfied action.
 -/
 
 namespace Zcash.Security.Ledger.Model
@@ -352,6 +363,88 @@ theorem honestTx_valid
     rcases hmem tx htx with h | rfl
     · exact hval.action_bound tx h
     · simpa [honestTx] using hbound
+
+/-! ## The Spendability capstone -/
+
+/-- All actions of a ledger, each paired with its transaction — the searchable form
+of "some action reveals this nullifier". -/
+def actionsWithTx (ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG P.depth) :
+    List (Tx KW F G RHO PSI MHASH MENC MSG SIG P.depth
+      × Action KW F G RHO PSI MHASH MENC SIG P.depth) :=
+  ledger.flatMap fun tx => tx.actions.map fun a => (tx, a)
+
+/-- Membership in the paired action list gives both memberships. -/
+theorem mem_of_mem_actionsWithTx
+    {p : Tx KW F G RHO PSI MHASH MENC MSG SIG P.depth
+      × Action KW F G RHO PSI MHASH MENC SIG P.depth}
+    (h : p ∈ actionsWithTx ledger) : p.1 ∈ ledger ∧ p.2 ∈ p.1.actions := by
+  obtain ⟨tx, htx, hp⟩ := List.mem_flatMap.mp h
+  obtain ⟨a, ha, rfl⟩ := List.mem_map.mp hp
+  exact ⟨htx, ha⟩
+
+/-- A revealed nullifier comes from some action of the paired list. -/
+theorem exists_actionsWithTx_of_mem_nullifiers {x : RHO} (h : x ∈ nullifiers ledger) :
+    ∃ p ∈ actionsWithTx ledger, p.2.inst.nf_old = x := by
+  simp only [nullifiers, List.mem_flatMap, List.mem_map] at h
+  obtain ⟨tx, htx, a, ha, rfl⟩ := h
+  exact ⟨(tx, a),
+    List.mem_flatMap.mpr ⟨tx, htx, List.mem_map.mpr ⟨a, ha, rfl⟩⟩, rfl⟩
+
+/-- A ledger action spending the given opening. For the owner's opening this is the
+roadblock's benign arm — the case Spend Authority covers: the action's signature
+verifies under a randomization of ± the owner's key. -/
+structure Respend (ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG P.depth)
+    (rcm : F) (note : Note G RHO PSI) where
+  tx : Tx KW F G RHO PSI MHASH MENC MSG SIG P.depth
+  htx : tx ∈ ledger
+  a : Action KW F G RHO PSI MHASH MENC SIG P.depth
+  ha : a ∈ tx.actions
+  opening_eq : (a.w.rcm_old, a.w.note_old) = (rcm, note)
+
+/-- **The Spendability capstone.** The owner of a received note — an `HonestAction` —
+can spend it: either appending the honest transaction keeps the ledger valid, or the
+ledger's own data computes the obstruction. The arms: an action already spending the
+owner's exact opening (`Respend` — the case Spend Authority covers); a
+note-commitment break; a nullifier collision. The nullifier roadblock is decided by
+searching the ledger for the revealing action and running `respendOrBreak` against
+the owner's satisfied action. -/
+def spendabilityOrBreak [DecidableEq F] [DecidableEq G] [DecidableEq NK]
+    [DecidableEq RHO] [DecidableEq PSI]
+    (hval : ValidLedger P kv issuance maxActions ledger)
+    (hs : HonestAction P kv ledger) (sig : SIG) (sighash : MSG)
+    (hsig : P.spendAuthVerify (P.randomizePublic hs.α (kv.akP hs.kw)) sighash sig)
+    (hcap : (leafList ledger).length + 1 ≤ 2 ^ P.depth)
+    (htrans : 0 ≤ transparentPoolBalance issuance ledger ledger.length
+        + ((issuance ledger.length : ℤ) + (honestTx [(hs, sig)] sighash).vBalance))
+    (hbound : 1 ≤ maxActions) :
+    ValidLedger P kv issuance maxActions (ledger ++ [honestTx [(hs, sig)] sighash])
+      ⊕' Respend ledger hs.rcm_old hs.note_old
+      ⊕' (NoteCommitBreak P ⊕' NullifierCollision P) :=
+  if hmem : hs.nf ∈ nullifiers ledger then
+    have hex : ((actionsWithTx ledger).find? fun q => q.2.inst.nf_old = hs.nf).isSome := by
+      rw [List.find?_isSome]
+      obtain ⟨q, hq, hnf⟩ := exists_actionsWithTx_of_mem_nullifiers hmem
+      exact ⟨q, hq, by simp [hnf]⟩
+    let p := ((actionsWithTx ledger).find? fun q => q.2.inst.nf_old = hs.nf).get hex
+    have hfind : (actionsWithTx ledger).find? (fun q => q.2.inst.nf_old = hs.nf)
+        = some p := (Option.some_get hex).symm
+    have hpmem := mem_of_mem_actionsWithTx (List.mem_of_find?_eq_some hfind)
+    have hpnf : p.2.inst.nf_old = hs.nf := by
+      have := List.find?_some hfind
+      simpa using this
+    have hsat : ActionSatisfied P kv p.2.inst p.2.w :=
+      hval.satisfied p.1 hpmem.1 p.2 hpmem.2
+    match respendOrBreak hsat hs.satisfied hpnf with
+    | .inl heq => .inr (.inl ⟨p.1, hpmem.1, p.2, hpmem.2, heq⟩)
+    | .inr b => .inr (.inr b)
+  else
+    .inl (honestTx_valid hval [(hs, sig)] sighash
+      (by rintro q hq; rw [List.mem_singleton] at hq; subst hq; exact hsig)
+      (by rintro q hq; rw [List.mem_singleton] at hq; subst hq; exact hmem)
+      (by simp)
+      (by simpa using hcap)
+      htrans
+      (by simpa using hbound))
 
 end Honest
 

--- a/Zcash/Security/Ledger/Completeness.lean
+++ b/Zcash/Security/Ledger/Completeness.lean
@@ -1,0 +1,358 @@
+import Mathlib
+import Zcash.Security.Ledger.Balance
+import Zcash.Security.Ledger.Spendability
+
+/-!
+# Honest-spend completeness
+
+The games constrain what an adversary can do. This module checks the other direction:
+the protocol's intended use actually works. `HonestAction` packages what an honest
+wallet knows for one Action. The spend may either be a dummy, or spend a note that
+the wallet received; the package holds the spent note's opening and key witness, the
+note's tree position under an anchor the ledger accepted, and fresh output data.
+From that data alone we construct the Action (`witness`, `inst`, `action`) and prove
+the Action statement (`satisfied`). An honest transaction (`honestTx`) bundles any
+number of such Actions up to the action bound; appending it preserves ledger
+validity (`honestTx_valid`).
+
+The Merkle side rests on `Merkle.path_of_root`: the honest authentication data
+exists because the referenced tree is defined (`root_defined`). Inclusion is only
+required of nonzero-valued spends, so zero-valued dummy spends — whose path data is
+arbitrary — are covered; `HonestAction.withDummySpend` constructs one. The honest
+transaction declares its true net value, so the Balance game's per-transaction value
+premiss holds for it (`txNetValue_honestTx`).
+
+The Actions of one honest transaction may reference different anchors, matching the
+model's per-action anchor rule — a documented simplification: deployed Orchard
+encodes one anchor for the whole transaction (Sapling v4 allowed per-spend anchors).
+The deployed case is the instance with all `anchor` fields equal.
+-/
+
+namespace Zcash.Security.Ledger.Model
+
+variable {F : Type*}
+variable {G : Type*}
+variable {IVK NK RHO PSI MHASH MENC MSG SIG : Type*} {KW : Type*}
+
+section Honest
+
+variable [Field F] [AddCommGroup G] [Module F G]
+
+/-- What an honest wallet knows for one Action. The spend may either be a dummy, or
+spend a note that the wallet received; in the latter case the wallet supplies the
+spent note's opening and key witness `kw`, the note's tree position `pos` under the
+anchor after `anchor` transactions, and the output data with the signature
+randomizer `α` and the value commitment randomness `rcv`. The opening comprises
+`rcm_old`, `note_old`, and `cm_old`; the output data comprise `rcm_new`, `note_new`,
+and `cm_new`. The Prop fields are the facts the wallet's own records give it;
+`root_defined` holds for every anchor the ledger accepted, and `included` says the
+tree position holds the spent commitment — required only of nonzero-valued spends,
+so a zero-valued dummy may use arbitrary position data. -/
+structure HonestAction (P : Primitives F G IVK NK RHO PSI MHASH MENC MSG SIG)
+    (kv : KeyBindingInterface KW G IVK NK)
+    (ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG P.depth) where
+  kw : KW
+  rcm_old : F
+  note_old : Note G RHO PSI
+  cm_old : G
+  /-- The spent note's tree position, leaf-to-root bits. -/
+  pos : Fin P.depth → Bool
+  /-- The referenced anchor is the root after this many transactions. -/
+  anchor : ℕ
+  rcm_new : F
+  note_new : Note G RHO PSI
+  cm_new : G
+  α : F
+  rcv : F
+  /-- The spent note's commitment opens. -/
+  commit_old : P.noteCommit rcm_old note_old = some cm_old
+  /-- The key witness satisfies the key-binding condition. -/
+  key_binding : kv.KB kw
+  /-- The spent note is addressed to the key witness. -/
+  pkd_eq : note_old.pkd = P.emb (kv.ivk kw) • note_old.gd
+  /-- The spent note's diversified base is not zero. -/
+  gd_ne : note_old.gd ≠ 0
+  /-- The output note's commitment opens. -/
+  commit_new : P.noteCommit rcm_new note_new = some cm_new
+  /-- The output note's ρ is the revealed nullifier (ρ-uniqueness). -/
+  ρ_new_eq : note_new.ρ = P.deriveNullifier (kv.nk kw) note_old.ρ note_old.ψ cm_old
+  /-- Spent-note value range. -/
+  v_old_lt : note_old.v < P.valueBound
+  /-- Output-note value range. -/
+  v_new_lt : note_new.v < P.valueBound
+  /-- The anchor is at or before the ledger's end. -/
+  anchor_le : anchor ≤ ledger.length
+  /-- The referenced tree is defined (no compression along it escapes). -/
+  root_defined : (rootAfter P ledger anchor).isSome
+  /-- For a nonzero-valued spend, the tree position holds the spent commitment's
+  extracted coordinate. A zero-valued dummy needs no inclusion. -/
+  included : note_old.v ≠ 0 →
+    leafFun P (leafList (ledger.take anchor)) pos = P.extract cm_old
+
+namespace HonestAction
+
+variable {P : Primitives F G IVK NK RHO PSI MHASH MENC MSG SIG}
+variable {kv : KeyBindingInterface KW G IVK NK}
+variable {ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG P.depth}
+
+/-- The referenced anchor value. -/
+def rt (hs : HonestAction P kv ledger) : MHASH :=
+  (rootAfter P ledger hs.anchor).get hs.root_defined
+
+/-- The anchor equation, in the form `ValidLedger`'s anchor rule consumes. -/
+theorem root_eq (hs : HonestAction P kv ledger) :
+    rootAfter P ledger hs.anchor = some hs.rt :=
+  (Option.some_get hs.root_defined).symm
+
+/-- The honest authentication data exists because the referenced tree is defined. -/
+theorem authChildren_isSome (hs : HonestAction P kv ledger) :
+    (Merkle.authChildren P.merkle P.depth le_rfl
+      (leafFun P (leafList (ledger.take hs.anchor))) hs.pos).isSome :=
+  Merkle.authChildren_isSome P.merkle P.depth le_rfl _ hs.pos hs.root_eq
+
+/-- The honest authentication data: at each height, the canonical encodings of the two
+child subroots along the spent position's path. -/
+def authData (hs : HonestAction P kv ledger) : Fin P.depth → MENC × MENC :=
+  (Merkle.authChildren P.merkle P.depth le_rfl
+    (leafFun P (leafList (ledger.take hs.anchor))) hs.pos).get hs.authChildren_isSome
+
+/-- The witness of the honest Action. -/
+def witness (hs : HonestAction P kv ledger) :
+    ActionWitness KW F G RHO PSI MHASH MENC P.depth where
+  path := hs.authData
+  side := hs.pos
+  note_old := hs.note_old
+  note_new := hs.note_new
+  cm_old := hs.cm_old
+  cm_new := hs.cm_new
+  kw := hs.kw
+  α := hs.α
+  rcv := hs.rcv
+  rcm_old := hs.rcm_old
+  rcm_new := hs.rcm_new
+
+/-- The revealed nullifier of the honest spend. -/
+def nf (hs : HonestAction P kv ledger) : RHO :=
+  P.deriveNullifier (kv.nk hs.kw) hs.note_old.ρ hs.note_old.ψ hs.cm_old
+
+/-- The public instance of the honest Action. -/
+def inst (hs : HonestAction P kv ledger) : ActionInstance G MHASH RHO where
+  rt := hs.rt
+  nf_old := hs.nf
+  rk := P.randomizePublic hs.α (kv.akP hs.kw)
+  cv_net := P.valueCommit ((hs.note_old.v : ℤ) - hs.note_new.v) hs.rcv
+  cmx_new := P.extract hs.cm_new
+
+/-- **Statement completeness.** The honest Action satisfies the Action statement. The
+Merkle conjunct is `Merkle.path_of_root` on the honest authentication data, with the
+committed leaf rewritten to the spent commitment by `included`; every other conjunct
+is a field or definitional. -/
+theorem satisfied (hs : HonestAction P kv ledger) :
+    ActionSatisfied P kv hs.inst hs.witness where
+  commit_old := hs.commit_old
+  merkle_path := fun hv => by
+    have hauth : Merkle.authChildren P.merkle P.depth le_rfl
+        (leafFun P (leafList (ledger.take hs.anchor))) hs.pos = some hs.authData :=
+      (Option.some_get hs.authChildren_isSome).symm
+    have hpath := Merkle.path_of_root P.merkle hs.pos hs.root_eq hauth
+    rw [hs.included hv] at hpath
+    exact hpath
+  nf_old_eq := rfl
+  key_binding := hs.key_binding
+  pkd_eq := hs.pkd_eq
+  gd_ne := hs.gd_ne
+  rk_eq := rfl
+  commit_new := hs.commit_new
+  cmx_new_eq := rfl
+  ρ_new_eq := hs.ρ_new_eq
+  v_old_lt := hs.v_old_lt
+  v_new_lt := hs.v_new_lt
+  cv_net_eq := rfl
+
+/-- The honest Action, with its spend-authorization signature. -/
+def action (hs : HonestAction P kv ledger) (sig : SIG) :
+    Action KW F G RHO PSI MHASH MENC SIG P.depth where
+  inst := hs.inst
+  w := hs.witness
+  sig := sig
+
+/-- A dummy note: zero value, addressed to `kw` (`pk_d = [ivk] g_d`) with diversified
+base `gd`. The wallet's random samples (`gd`, `ρ`, `ψ`) are parameters, since the
+model has no randomness. -/
+def dummyNote (P : Primitives F G IVK NK RHO PSI MHASH MENC MSG SIG)
+    (kv : KeyBindingInterface KW G IVK NK) (kw : KW) (gd : G) (ρ : RHO) (ψ : PSI) :
+    Note G RHO PSI :=
+  ⟨gd, P.emb (kv.ivk kw) • gd, 0, ρ, ψ⟩
+
+/-- An honest Action whose spend half is a dummy: it spends `dummyNote` — with
+default `ρ`/`ψ` samples and `rcm = 0` — at an arbitrary tree position (all-`false`).
+This demonstrates that an honest wallet does not need a received note to create an
+Action. The input side reduces to a nonzero `gd` and the definedness of the dummy's
+commitment (`hcm`; `noteCommit` is partial), with the spent commitment recovered from
+`hcm`; the spent-note value range reduces to `0 < P.valueBound`. Address integrity
+and inclusion are discharged by construction (the latter vacuously). -/
+def withDummySpend [Inhabited RHO] [Inhabited PSI] (kw : KW) (key_binding : kv.KB kw)
+    (gd : G) (gd_ne : gd ≠ 0)
+    (hcm : (P.noteCommit 0 (dummyNote P kv kw gd default default)).isSome)
+    (hvb : 0 < P.valueBound)
+    (anchor : ℕ) (anchor_le : anchor ≤ ledger.length)
+    (root_defined : (rootAfter P ledger anchor).isSome)
+    (rcm_new : F) (note_new : Note G RHO PSI) (cm_new : G)
+    (commit_new : P.noteCommit rcm_new note_new = some cm_new)
+    (ρ_new_eq : note_new.ρ = P.deriveNullifier (kv.nk kw) default default
+      ((P.noteCommit 0 (dummyNote P kv kw gd default default)).get hcm))
+    (v_new_lt : note_new.v < P.valueBound)
+    (α rcv : F) : HonestAction P kv ledger where
+  kw := kw
+  rcm_old := 0
+  note_old := dummyNote P kv kw gd default default
+  cm_old := (P.noteCommit 0 (dummyNote P kv kw gd default default)).get hcm
+  pos := fun _ => false
+  anchor := anchor
+  rcm_new := rcm_new
+  note_new := note_new
+  cm_new := cm_new
+  α := α
+  rcv := rcv
+  commit_old := (Option.some_get hcm).symm
+  key_binding := key_binding
+  pkd_eq := rfl
+  gd_ne := gd_ne
+  commit_new := commit_new
+  ρ_new_eq := ρ_new_eq
+  v_old_lt := hvb
+  v_new_lt := v_new_lt
+  anchor_le := anchor_le
+  root_defined := root_defined
+  included := fun hv => absurd rfl hv
+
+end HonestAction
+
+variable {P : Primitives F G IVK NK RHO PSI MHASH MENC MSG SIG}
+variable {kv : KeyBindingInterface KW G IVK NK}
+variable {ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG P.depth}
+
+/-- The honest transaction over a list of honest Actions, each with its
+spend-authorization signature: it declares the true summed net value. -/
+def honestTx (spends : List (HonestAction P kv ledger × SIG)) (sighash : MSG) :
+    Tx KW F G RHO PSI MHASH MENC MSG SIG P.depth where
+  actions := spends.map fun p => p.1.action p.2
+  vBalance := (spends.map fun p => (p.1.note_old.v : ℤ) - p.1.note_new.v).sum
+  sighash := sighash
+
+/-- The honest transaction declares its true net value, so the Balance game's
+per-transaction value premiss holds for it. -/
+theorem txNetValue_honestTx (spends : List (HonestAction P kv ledger × SIG))
+    (sighash : MSG) :
+    txNetValue (honestTx spends sighash) = (honestTx spends sighash).vBalance := by
+  simp [txNetValue, honestTx, HonestAction.action, HonestAction.witness, List.map_map,
+    Function.comp_def]
+
+/-- The honest transaction's nullifier list is the spends' nullifiers, in order. -/
+theorem nullifiers_honestTx (spends : List (HonestAction P kv ledger × SIG))
+    (sighash : MSG) :
+    nullifiers [honestTx spends sighash] = spends.map fun p => p.1.nf := by
+  simp [nullifiers, honestTx, HonestAction.action, HonestAction.inst, List.map_map,
+    Function.comp_def]
+
+variable {issuance : ℕ → ℕ} {maxActions : ℕ}
+
+/-- **Ledger completeness.** Appending an honest transaction to a valid ledger keeps it
+valid, given the boundary facts the wallet checks: the signatures verify over the
+shared sighash, the revealed nullifiers are fresh and pairwise distinct, the tree has
+room, the transparent pool stays nonnegative at the new index, and the action bound
+admits the action count. Anchors transport by `rootAfter_prefix`, exactly as in
+`validLedger_append`; the difference is that here the new transaction's own validity
+conjuncts are proven from `HonestAction`, not assumed. -/
+theorem honestTx_valid
+    (hval : ValidLedger P kv issuance maxActions ledger)
+    (spends : List (HonestAction P kv ledger × SIG)) (sighash : MSG)
+    (hsig : ∀ p ∈ spends,
+      P.spendAuthVerify (P.randomizePublic p.1.α (kv.akP p.1.kw)) sighash p.2)
+    (hfresh : ∀ p ∈ spends, p.1.nf ∉ nullifiers ledger)
+    (hnodup : (spends.map fun p => p.1.nf).Nodup)
+    (hcap : (leafList ledger).length + spends.length ≤ 2 ^ P.depth)
+    (htrans : 0 ≤ transparentPoolBalance issuance ledger ledger.length
+        + ((issuance ledger.length : ℤ) + (honestTx spends sighash).vBalance))
+    (hbound : spends.length ≤ maxActions) :
+    ValidLedger P kv issuance maxActions (ledger ++ [honestTx spends sighash]) := by
+  have hmem : ∀ tx ∈ ledger ++ [honestTx spends sighash],
+      tx ∈ ledger ∨ tx = honestTx spends sighash := by
+    intro tx htx
+    rcases List.mem_append.mp htx with h | h
+    · exact Or.inl h
+    · exact Or.inr (by simpa using h)
+  have hact : ∀ a ∈ (honestTx spends sighash).actions,
+      ∃ p ∈ spends, a = p.1.action p.2 := by
+    intro a ha
+    obtain ⟨p, hp, rfl⟩ := List.mem_map.mp ha
+    exact ⟨p, hp, rfl⟩
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  -- `satisfied`: per-Action; old Actions from `hval`, new ones from `HonestAction.satisfied`.
+  · intro tx htx a ha
+    rcases hmem tx htx with h | rfl
+    · exact hval.satisfied tx h a ha
+    · obtain ⟨p, hp, rfl⟩ := hact a ha
+      exact p.1.satisfied
+  -- `nf_nodup`: split at the append; the new nullifiers are pairwise distinct
+  -- (`hnodup`) and fresh against the old list (`hfresh`).
+  · rw [nullifiers_append, nullifiers_honestTx]
+    refine List.nodup_append.mpr ⟨hval.nf_nodup, hnodup, ?_⟩
+    intro x hx y hy
+    obtain ⟨p, hp, rfl⟩ := List.mem_map.mp hy
+    exact fun heq => hfresh p hp (heq ▸ hx)
+  -- `anchor_valid`: old anchors transport along the extension by `rootAfter_prefix`;
+  -- the new Actions' anchors are `root_eq`, transported the same way.
+  · intro i a hai
+    by_cases hi : (i : ℕ) < ledger.length
+    · have hget : (ledger ++ [honestTx spends sighash]).get i = ledger.get ⟨(i : ℕ), hi⟩ := by
+        simp [List.get_eq_getElem, List.getElem_append_left hi]
+      rw [hget] at hai
+      obtain ⟨j, hj, hrt⟩ := hval.anchor_valid ⟨(i : ℕ), hi⟩ a hai
+      refine ⟨j, hj, ?_⟩
+      rw [rootAfter_prefix P ⟨[honestTx spends sighash], rfl⟩ (le_trans hj (le_of_lt hi))]
+      exact hrt
+    · have hieq : (i : ℕ) = ledger.length := by
+        have := i.isLt
+        simp only [List.length_append, List.length_singleton] at this
+        omega
+      have hget : (ledger ++ [honestTx spends sighash]).get i = honestTx spends sighash := by
+        simp [List.get_eq_getElem, hieq]
+      rw [hget] at hai
+      obtain ⟨p, hp, rfl⟩ := hact a hai
+      refine ⟨p.1.anchor, hieq ▸ p.1.anchor_le, ?_⟩
+      rw [rootAfter_prefix P ⟨[honestTx spends sighash], rfl⟩ p.1.anchor_le]
+      exact p.1.root_eq
+  -- `capacity`: the honest transaction appends one leaf per spend.
+  · rw [leafList_append]
+    have hlen : (leafList [honestTx spends sighash]).length = spends.length := by
+      simp [leafList, honestTx]
+    rw [List.length_append, hlen]
+    exact hcap
+  -- `sig_verifies`: old Actions from `hval`; new ones from `hsig` (the honest `rk`
+  -- is the α-randomization of the key witness's `akP`).
+  · intro tx htx a ha
+    rcases hmem tx htx with h | rfl
+    · exact hval.sig_verifies tx h a ha
+    · obtain ⟨p, hp, rfl⟩ := hact a ha
+      exact hsig p hp
+  -- `transparent_nonneg`: prefix indices see the old balance; indices past the end
+  -- saturate at the new length, where the balance steps by issuance plus `vBalance`
+  -- (`htrans`).
+  · intro i
+    by_cases hi : i ≤ ledger.length
+    · rw [transparentPoolBalance_append_of_le issuance hi]
+      exact hval.transparent_nonneg i
+    · rw [transparentPoolBalance_of_length_le issuance
+        (by simp; omega), List.length_append, List.length_singleton,
+        transparentPoolBalance_append_singleton]
+      exact htrans
+  -- `action_bound`: old transactions from `hval`; the new count is `hbound`.
+  · intro tx htx
+    rcases hmem tx htx with h | rfl
+    · exact hval.action_bound tx h
+    · simpa [honestTx] using hbound
+
+end Honest
+
+end Zcash.Security.Ledger.Model

--- a/Zcash/Security/Ledger/Completeness.lean
+++ b/Zcash/Security/Ledger/Completeness.lean
@@ -244,25 +244,28 @@ variable {kv : KeyBindingInterface KW G IVK NK}
 variable {ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG P.depth}
 
 /-- The honest transaction over a list of honest Actions, each with its
-spend-authorization signature: it declares the true summed net value. -/
-def honestTx (spends : List (HonestAction P kv ledger × SIG)) (sighash : MSG) :
+spend-authorization signature: it declares the true summed net value and carries the
+given binding signature. -/
+def honestTx (spends : List (HonestAction P kv ledger × SIG)) (sighash : MSG)
+    (bindingSig : SIG) :
     Tx KW F G RHO PSI MHASH MENC MSG SIG P.depth where
   actions := spends.map fun p => p.1.action p.2
   vBalance := (spends.map fun p => (p.1.note_old.v : ℤ) - p.1.note_new.v).sum
   sighash := sighash
+  bindingSig := bindingSig
 
 /-- The honest transaction declares its true net value, so the Balance game's
 per-transaction value premiss holds for it. -/
 theorem txNetValue_honestTx (spends : List (HonestAction P kv ledger × SIG))
-    (sighash : MSG) :
-    txNetValue (honestTx spends sighash) = (honestTx spends sighash).vBalance := by
+    (sighash : MSG) (bindingSig : SIG) :
+    txNetValue (honestTx spends sighash bindingSig) = (honestTx spends sighash bindingSig).vBalance := by
   simp [txNetValue, honestTx, HonestAction.action, HonestAction.witness, List.map_map,
     Function.comp_def]
 
 /-- The honest transaction's nullifier list is the spends' nullifiers, in order. -/
 theorem nullifiers_honestTx (spends : List (HonestAction P kv ledger × SIG))
-    (sighash : MSG) :
-    nullifiers [honestTx spends sighash] = spends.map fun p => p.1.nf := by
+    (sighash : MSG) (bindingSig : SIG) :
+    nullifiers [honestTx spends sighash bindingSig] = spends.map fun p => p.1.nf := by
   simp [nullifiers, honestTx, HonestAction.action, HonestAction.inst, List.map_map,
     Function.comp_def]
 
@@ -278,27 +281,31 @@ conjuncts are proven from `HonestAction`, not assumed. -/
 theorem honestTx_valid
     (hval : ValidLedger P kv issuance maxActions ledger)
     (spends : List (HonestAction P kv ledger × SIG)) (sighash : MSG)
+    (bindingSig : SIG)
     (hsig : ∀ p ∈ spends,
       P.spendAuthVerify (P.randomizePublic p.1.α (kv.akP p.1.kw)) sighash p.2)
     (hfresh : ∀ p ∈ spends, p.1.nf ∉ nullifiers ledger)
     (hnodup : (spends.map fun p => p.1.nf).Nodup)
     (hcap : (leafList ledger).length + spends.length ≤ 2 ^ P.depth)
     (htrans : 0 ≤ transparentPoolBalance issuance ledger ledger.length
-        + ((issuance ledger.length : ℤ) + (honestTx spends sighash).vBalance))
+        + ((issuance ledger.length : ℤ) + (honestTx spends sighash bindingSig).vBalance))
+    (hbind : P.bindingVerify ((honestTx spends sighash bindingSig).bvk P) sighash
+        bindingSig)
+    (hvb : (honestTx spends sighash bindingSig).vBalance.natAbs < P.valueBound)
     (hbound : spends.length ≤ maxActions) :
-    ValidLedger P kv issuance maxActions (ledger ++ [honestTx spends sighash]) := by
-  have hmem : ∀ tx ∈ ledger ++ [honestTx spends sighash],
-      tx ∈ ledger ∨ tx = honestTx spends sighash := by
+    ValidLedger P kv issuance maxActions (ledger ++ [honestTx spends sighash bindingSig]) := by
+  have hmem : ∀ tx ∈ ledger ++ [honestTx spends sighash bindingSig],
+      tx ∈ ledger ∨ tx = honestTx spends sighash bindingSig := by
     intro tx htx
     rcases List.mem_append.mp htx with h | h
     · exact Or.inl h
     · exact Or.inr (by simpa using h)
-  have hact : ∀ a ∈ (honestTx spends sighash).actions,
+  have hact : ∀ a ∈ (honestTx spends sighash bindingSig).actions,
       ∃ p ∈ spends, a = p.1.action p.2 := by
     intro a ha
     obtain ⟨p, hp, rfl⟩ := List.mem_map.mp ha
     exact ⟨p, hp, rfl⟩
-  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
   -- `satisfied`: per-Action; old Actions from `hval`, new ones from `HonestAction.satisfied`.
   · intro tx htx a ha
     rcases hmem tx htx with h | rfl
@@ -316,27 +323,27 @@ theorem honestTx_valid
   -- the new Actions' anchors are `root_eq`, transported the same way.
   · intro i a hai
     by_cases hi : (i : ℕ) < ledger.length
-    · have hget : (ledger ++ [honestTx spends sighash]).get i = ledger.get ⟨(i : ℕ), hi⟩ := by
+    · have hget : (ledger ++ [honestTx spends sighash bindingSig]).get i = ledger.get ⟨(i : ℕ), hi⟩ := by
         simp [List.get_eq_getElem, List.getElem_append_left hi]
       rw [hget] at hai
       obtain ⟨j, hj, hrt⟩ := hval.anchor_valid ⟨(i : ℕ), hi⟩ a hai
       refine ⟨j, hj, ?_⟩
-      rw [rootAfter_prefix P ⟨[honestTx spends sighash], rfl⟩ (le_trans hj (le_of_lt hi))]
+      rw [rootAfter_prefix P ⟨[honestTx spends sighash bindingSig], rfl⟩ (le_trans hj (le_of_lt hi))]
       exact hrt
     · have hieq : (i : ℕ) = ledger.length := by
         have := i.isLt
         simp only [List.length_append, List.length_singleton] at this
         omega
-      have hget : (ledger ++ [honestTx spends sighash]).get i = honestTx spends sighash := by
+      have hget : (ledger ++ [honestTx spends sighash bindingSig]).get i = honestTx spends sighash bindingSig := by
         simp [List.get_eq_getElem, hieq]
       rw [hget] at hai
       obtain ⟨p, hp, rfl⟩ := hact a hai
       refine ⟨p.1.anchor, hieq ▸ p.1.anchor_le, ?_⟩
-      rw [rootAfter_prefix P ⟨[honestTx spends sighash], rfl⟩ p.1.anchor_le]
+      rw [rootAfter_prefix P ⟨[honestTx spends sighash bindingSig], rfl⟩ p.1.anchor_le]
       exact p.1.root_eq
   -- `capacity`: the honest transaction appends one leaf per spend.
   · rw [leafList_append]
-    have hlen : (leafList [honestTx spends sighash]).length = spends.length := by
+    have hlen : (leafList [honestTx spends sighash bindingSig]).length = spends.length := by
       simp [leafList, honestTx]
     rw [List.length_append, hlen]
     exact hcap
@@ -347,6 +354,17 @@ theorem honestTx_valid
     · exact hval.sig_verifies tx h a ha
     · obtain ⟨p, hp, rfl⟩ := hact a ha
       exact hsig p hp
+  -- `binding_verified`: old transactions from `hval`; the new one is the boundary
+  -- hypothesis `hbind`.
+  · intro tx htx
+    rcases hmem tx htx with h | rfl
+    · exact hval.binding_verified tx h
+    · exact hbind
+  -- `vbalance_bound`: old from `hval`; the new declared balance is in range (`hvb`).
+  · intro tx htx
+    rcases hmem tx htx with h | rfl
+    · exact hval.vbalance_bound tx h
+    · exact hvb
   -- `transparent_nonneg`: prefix indices see the old balance; indices past the end
   -- saturate at the new length, where the balance steps by issuance plus `vBalance`
   -- (`htrans`).
@@ -411,13 +429,15 @@ the owner's satisfied action. -/
 def spendabilityOrBreak [DecidableEq F] [DecidableEq G] [DecidableEq NK]
     [DecidableEq RHO] [DecidableEq PSI]
     (hval : ValidLedger P kv issuance maxActions ledger)
-    (hs : HonestAction P kv ledger) (sig : SIG) (sighash : MSG)
+    (hs : HonestAction P kv ledger) (sig : SIG) (sighash : MSG) (bsig : SIG)
     (hsig : P.spendAuthVerify (P.randomizePublic hs.α (kv.akP hs.kw)) sighash sig)
     (hcap : (leafList ledger).length + 1 ≤ 2 ^ P.depth)
     (htrans : 0 ≤ transparentPoolBalance issuance ledger ledger.length
-        + ((issuance ledger.length : ℤ) + (honestTx [(hs, sig)] sighash).vBalance))
+        + ((issuance ledger.length : ℤ) + (honestTx [(hs, sig)] sighash bsig).vBalance))
+    (hbind : P.bindingVerify ((honestTx [(hs, sig)] sighash bsig).bvk P) sighash bsig)
+    (hvb : (honestTx [(hs, sig)] sighash bsig).vBalance.natAbs < P.valueBound)
     (hbound : 1 ≤ maxActions) :
-    ValidLedger P kv issuance maxActions (ledger ++ [honestTx [(hs, sig)] sighash])
+    ValidLedger P kv issuance maxActions (ledger ++ [honestTx [(hs, sig)] sighash bsig])
       ⊕' Respend ledger hs.rcm_old hs.note_old
       ⊕' (NoteCommitBreak P ⊕' NullifierCollision P) :=
   if hmem : hs.nf ∈ nullifiers ledger then
@@ -438,12 +458,14 @@ def spendabilityOrBreak [DecidableEq F] [DecidableEq G] [DecidableEq NK]
     | .inl heq => .inr (.inl ⟨p.1, hpmem.1, p.2, hpmem.2, heq⟩)
     | .inr b => .inr (.inr b)
   else
-    .inl (honestTx_valid hval [(hs, sig)] sighash
+    .inl (honestTx_valid hval [(hs, sig)] sighash bsig
       (by rintro q hq; rw [List.mem_singleton] at hq; subst hq; exact hsig)
       (by rintro q hq; rw [List.mem_singleton] at hq; subst hq; exact hmem)
       (by simp)
       (by simpa using hcap)
       htrans
+      hbind
+      hvb
       (by simpa using hbound))
 
 end Honest

--- a/Zcash/Security/Ledger/KeyBindingArm.lean
+++ b/Zcash/Security/Ledger/KeyBindingArm.lean
@@ -37,16 +37,6 @@ namespace Zcash.Security.Ledger.Model
 
 open Zcash.Security.KeyBinding Zcash.Snark
 
-/-- The key-binding arm's witness pair, when the break lies in that arm. -/
-def BalanceBreak.kbPair {F G IVK NK RHO PSI MHASH MENC MSG SIG KW : Type*}
-    [Field F] [AddCommGroup G] [Module F G]
-    {P : Primitives F G IVK NK RHO PSI MHASH MENC MSG SIG}
-    {kv : KeyBindingInterface KW G IVK NK} :
-    BalanceBreak P kv → Option (KW × KW)
-  | .keyBinding w₁ w₂ _ => some (w₁, w₂)
-  | .merkle _ => none
-  | .noteCommit _ => none
-
 -- A shared universe for the oracle-model types, so the sampling experiment can be
 -- written in `do`-notation: `PMF`'s monad instance fixes one universe for the whole
 -- block, which the independent `Type*` universes could not satisfy.
@@ -74,14 +64,19 @@ abbrev kvAt (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK) (G
       fun qk ak nk => O (.ext qk ak nk),
       fun rivk_ext ak nk => O (.int rivk_ext ak nk)⟩
 
-/-- **The key-binding arm's ε, discharged.** For any `n`-query-bounded pair-annotated
-ledger adversary in the key-binding oracle model, the probability that its output
-ledger is valid and the Balance-subset reduction lands in the key-binding arm with
-exactly its output pair is at most `(n + 4) · (n + 3) / |RIVK|`. The event is
-contained in "the output pair breaks the sampled interface", and the composite that
-returns the pair makes no queries beyond the adversary's own, so
-`toInterface_break_measure_le` applies unchanged. -/
+/-- **The key-binding arm's ε, discharged.** For any `n`-query-bounded ledger adversary
+in the key-binding oracle model, the probability that its output ledger is valid and the
+Balance-subset reduction lands in the key-binding arm is at most
+`(n + 4) · (n + 3) / |RIVK|`. The adversary outputs only a ledger; the arm's witness pair
+is recovered from that ledger by the oracle-free `kbPairOf` (`balanceSubsetOrBreak_kbPair`
+identifies it with the reduction's own pair), so the composite that returns the pair makes
+no queries beyond the adversary's own and `toInterface_break_measure_le` applies unchanged.
+`kbPairOf` is `Option`-valued (`findPair` may find no duplicate) while the bound's machine
+must return a concrete pair, so the composite collapses it with `Option.getD default`; the
+default is furnished by `[Inhabited (Witness …)]`, present at the concrete instantiation. On
+every sample of the bounded event `kbPairOf` is `some`, so the default is never used. -/
 theorem balanceSubset_keyBindingArm_measure_le {ι : Type u}
+    [Inhabited (KeyBinding.Witness G IVK AK NK RIVK QK SK)]
     (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK) (Ggen : G) (hS : S ≠ 0)
     (p : PMF ι)
     (P : Primitives RIVK G IVK NK RHO PSI MHASH MENC MSG SIG)
@@ -89,32 +84,28 @@ theorem balanceSubset_keyBindingArm_measure_le {ι : Type u}
     {LA : ι → (SK → ASK) → (SK → NK) →
       OracleComp (FinalQuery AK NK RIVK QK SK) RIVK
         (Ledger (KeyBinding.Witness G IVK AK NK RIVK QK SK) RIVK G RHO PSI MHASH MENC
-            MSG SIG P.depth
-          × (KeyBinding.Witness G IVK AK NK RIVK QK SK
-            × KeyBinding.Witness G IVK AK NK RIVK QK SK))}
+            MSG SIG P.depth)}
     {n : ℕ} (hQ : ∀ j Hask Hnk, (LA j Hask Hnk).QueryBound n) :
     ((kbExperiment p)).toOuterMeasure
         (setOf fun (j, Hask, Hnk, O) =>
           ∃ hval : ValidLedger P (kvAt Extract S hfn Ggen Hask Hnk O)
-              issuance maxActions ((LA j Hask Hnk).run O).1,
-            ∃ b, balanceSubsetOrBreak hval i = PSum.inr b
-              ∧ b.kbPair = some ((LA j Hask Hnk).run O).2)
+              issuance maxActions ((LA j Hask Hnk).run O),
+            ∃ w₁ w₂ h, balanceSubsetOrBreak hval i
+              = PSum.inr (BalanceBreak.keyBinding w₁ w₂ h))
       ≤ ((n + 4) * (n + 3) : ℕ) / Fintype.card RIVK := by
   refine le_trans (MeasureTheory.measure_mono ?_)
     (toInterface_break_measure_le Extract S hfn Ggen hS p
-      (A := fun j Hask Hnk => (LA j Hask Hnk).bind fun out => .pure out.2)
+      (A := fun j Hask Hnk => (LA j Hask Hnk).bind fun L => .pure ((kbPairOf L i).getD default))
       (n := n) (fun j Hask Hnk => ?_))
-  · rintro ⟨j, Hask, Hnk, O⟩ ⟨hval, b, heq, hpair⟩
-    cases b with
-    | keyBinding w₁ w₂ hbr =>
-        simp only [BalanceBreak.kbPair, Option.some.injEq] at hpair
-        simp only [Set.mem_setOf_eq, OracleComp.run_bind, OracleComp.run_pure]
-        rw [← hpair]
-        exact hbr
-    | merkle c => simp [BalanceBreak.kbPair] at hpair
-    | noteCommit nb => simp [BalanceBreak.kbPair] at hpair
+  · rintro ⟨j, Hask, Hnk, O⟩ ⟨hval, w₁, w₂, h, heq⟩
+    simp only [Set.mem_setOf_eq, OracleComp.run_bind, OracleComp.run_pure]
+    have hkp : kbPairOf ((LA j Hask Hnk).run O) i = some (w₁, w₂) := by
+      have := balanceSubsetOrBreak_kbPair hval i heq
+      simpa [BalanceBreak.kbPair] using this.symm
+    rw [hkp]
+    exact h
   · exact OracleComp.queryBound_bind (hQ j Hask Hnk)
-      fun out => OracleComp.QueryBound.pure out.2 0
+      fun L => OracleComp.QueryBound.pure _ 0
 
 /-- **The Spend Authority key-binding arm's ε, discharged.** For any
 `n`-query-bounded pair-annotated ledger adversary in the key-binding oracle model,

--- a/Zcash/Security/Ledger/KeyBindingArm.lean
+++ b/Zcash/Security/Ledger/KeyBindingArm.lean
@@ -1,0 +1,118 @@
+import Mathlib
+import Zcash.Security.KeyBinding.Instance
+import Zcash.Security.Ledger.Balance
+
+-- This lint enforces Mathlib's minimal-hypothesis style, from which we deliberately depart.
+set_option linter.unusedSectionVars false
+
+/-!
+# The key-binding arm's ε, discharged in the oracle model
+
+The capstone layer bounds each game's break arms by named ε hypotheses. This module
+discharges the Balance-subset key-binding arm in the key-binding oracle model:
+`(n + 4) · (n + 3) / |RIVK|` for any `n`-query-bounded adversary — the bound of
+`toInterface_break_measure_le`, inherited at an unchanged query count because the
+reduction makes no oracle queries.
+
+The adversary is pair-annotated: an oracle machine producing a ledger together with a
+candidate witness pair. It cannot run the reduction itself — `balanceSubsetOrBreak`
+consumes a validity proof whose meaning depends on the sampled oracle (through the
+sampled interface `kvAt`), and an oracle machine's result type cannot depend on the
+table it is run against. The bad event ties the annotation to the reduction instead:
+the output ledger is valid, and the reduction at that validity lands in the
+key-binding arm with exactly the output pair (`BalanceBreak.kbPair`). Proof
+irrelevance makes the tie independent of which validity proof the event exhibits.
+That event is contained in "the output pair breaks the sampled interface", so the
+key-binding bound applies to the composite machine that returns the pair.
+
+The same pattern fits Spend Authority's key-binding arm; only Balance-subset is
+discharged here.
+-/
+
+namespace Zcash.Security.Ledger.Model
+
+open Zcash.Security.KeyBinding Zcash.Snark
+
+/-- The key-binding arm's witness pair, when the break lies in that arm. -/
+def BalanceBreak.kbPair {F G IVK NK RHO PSI MHASH MENC MSG SIG KW : Type*}
+    [Field F] [AddCommGroup G] [Module F G]
+    {P : Primitives F G IVK NK RHO PSI MHASH MENC MSG SIG}
+    {kv : KeyBindingInterface KW G IVK NK} :
+    BalanceBreak P kv → Option (KW × KW)
+  | .keyBinding w₁ w₂ _ => some (w₁, w₂)
+  | .merkle _ => none
+  | .noteCommit _ => none
+
+variable {G IVK AK NK RIVK ASK QK SK : Type*}
+variable {RHO PSI MHASH MENC MSG SIG : Type*}
+
+section OracleModel
+
+variable [AddCommGroup G] [Field IVK] [Field RIVK] [Module RIVK G]
+  [NoZeroSMulDivisors RIVK G] [SMul ASK G]
+  [Fintype AK] [Fintype NK] [Fintype RIVK] [Fintype ASK] [Fintype QK] [Fintype SK]
+  [Nonempty NK] [Nonempty ASK]
+  [DecidableEq AK] [DecidableEq NK] [DecidableEq RIVK] [DecidableEq QK] [DecidableEq SK]
+  [DecidableEq G] [DecidableEq RHO] [DecidableEq PSI] [DecidableEq MHASH]
+  [DecidableEq MENC]
+
+/-- The games-facing key-binding interface at a sampled oracle assignment: the two
+sampled key tables plus the three components of the combined `rivk` oracle. -/
+abbrev kvAt (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK) (Ggen : G)
+    (Hask : SK → ASK) (Hnk : SK → NK) (O : FinalQuery AK NK RIVK QK SK → RIVK) :
+    KeyBindingInterface (KeyBinding.Witness G IVK AK NK RIVK QK SK) G IVK NK :=
+  KeyBinding.toInterface Extract S hfn Ggen
+    ⟨Hask, Hnk, fun sk => O (.legacy sk),
+      fun qk ak nk => O (.ext qk ak nk),
+      fun rivk_ext ak nk => O (.int rivk_ext ak nk)⟩
+
+/-- **The key-binding arm's ε, discharged.** For any `n`-query-bounded pair-annotated
+ledger adversary in the key-binding oracle model, the probability that its output
+ledger is valid and the Balance-subset reduction lands in the key-binding arm with
+exactly its output pair is at most `(n + 4) · (n + 3) / |RIVK|`. The event is
+contained in "the output pair breaks the sampled interface", and the composite that
+returns the pair makes no queries beyond the adversary's own, so
+`toInterface_break_measure_le` applies unchanged. -/
+theorem balanceSubset_keyBindingArm_measure_le {ι : Type*}
+    (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK) (Ggen : G) (hS : S ≠ 0)
+    (p : PMF ι)
+    (P : Primitives RIVK G IVK NK RHO PSI MHASH MENC MSG SIG)
+    (issuance : ℕ → ℕ) (maxActions : ℕ) (i : ℕ)
+    {LA : ι → (SK → ASK) → (SK → NK) →
+      OracleComp (FinalQuery AK NK RIVK QK SK) RIVK
+        (Ledger (KeyBinding.Witness G IVK AK NK RIVK QK SK) RIVK G RHO PSI MHASH MENC
+            MSG SIG P.depth
+          × (KeyBinding.Witness G IVK AK NK RIVK QK SK
+            × KeyBinding.Witness G IVK AK NK RIVK QK SK))}
+    {n : ℕ} (hQ : ∀ j Hask Hnk, (LA j Hask Hnk).QueryBound n) :
+    ((p.bind fun j => (PMF.uniformOfFintype (SK → ASK)).bind fun Hask =>
+        (PMF.uniformOfFintype (SK → NK)).bind fun Hnk =>
+          (PMF.uniformOfFintype (SK → RIVK)).bind fun Hleg =>
+            (PMF.uniformOfFintype (QK → AK → NK → RIVK)).bind fun Hext =>
+              (PMF.uniformOfFintype (RIVK → AK → NK → RIVK)).map fun Hint =>
+                (j, Hask, Hnk, FinalQuery.eval Hleg Hext Hint))).toOuterMeasure
+        (setOf fun (j, Hask, Hnk, O) =>
+          ∃ hval : ValidLedger P (kvAt Extract S hfn Ggen Hask Hnk O)
+              issuance maxActions ((LA j Hask Hnk).run O).1,
+            ∃ b, balanceSubsetOrBreak hval i = PSum.inr b
+              ∧ b.kbPair = some ((LA j Hask Hnk).run O).2)
+      ≤ ((n + 4) * (n + 3) : ℕ) / Fintype.card RIVK := by
+  refine le_trans (MeasureTheory.measure_mono ?_)
+    (toInterface_break_measure_le Extract S hfn Ggen hS p
+      (A := fun j Hask Hnk => (LA j Hask Hnk).bind fun out => .pure out.2)
+      (n := n) (fun j Hask Hnk => ?_))
+  · rintro ⟨j, Hask, Hnk, O⟩ ⟨hval, b, heq, hpair⟩
+    cases b with
+    | keyBinding w₁ w₂ hbr =>
+        simp only [BalanceBreak.kbPair, Option.some.injEq] at hpair
+        simp only [Set.mem_setOf_eq, OracleComp.run_bind, OracleComp.run_pure]
+        rw [← hpair]
+        exact hbr
+    | merkle c => simp [BalanceBreak.kbPair] at hpair
+    | noteCommit nb => simp [BalanceBreak.kbPair] at hpair
+  · exact OracleComp.queryBound_bind (hQ j Hask Hnk)
+      fun out => OracleComp.QueryBound.pure out.2 0
+
+end OracleModel
+
+end Zcash.Security.Ledger.Model

--- a/Zcash/Security/Ledger/KeyBindingArm.lean
+++ b/Zcash/Security/Ledger/KeyBindingArm.lean
@@ -10,27 +10,30 @@ set_option linter.unusedSectionVars false
 # The key-binding arm's ε, discharged in the oracle model
 
 The capstone layer bounds each game's break arms by named ε hypotheses. This module
-discharges the Balance-subset key-binding arm in the key-binding oracle model:
-`(n + 4) · (n + 3) / |RIVK|` for any `n`-query-bounded adversary — the bound of
-`toInterface_break_measure_le`, inherited at an unchanged query count because the
-reduction makes no oracle queries.
+bounds the key-binding arms in the key-binding oracle model at the reductions' own
+events: `(n + 4) · (n + 3) / |RIVK|` for any `n`-query-bounded adversary — the bound
+of `toInterface_break_measure_le`, inherited at an unchanged query count because
+recovering the arm's witness pair makes no oracle queries.
 
-The adversary is pair-annotated: an oracle machine producing a ledger together with a
-candidate witness pair. It cannot run the reduction itself — `balanceSubsetOrBreak`
-consumes a validity proof whose meaning depends on the sampled oracle (through the
-sampled interface `kvAt`), and an oracle machine's result type cannot depend on the
-table it is run against. The bad event ties the annotation to the reduction instead:
-the output ledger is valid, and the reduction at that validity lands in the
-key-binding arm with exactly the output pair (`BalanceBreak.kbPair`). Proof
-irrelevance makes the tie independent of which validity proof the event exhibits.
-That event is contained in "the output pair breaks the sampled interface", so the
-key-binding bound applies to the composite machine that returns the pair.
+The adversary outputs a ledger; it cannot run the reduction itself, because
+`balanceSubsetOrBreak` consumes a validity proof whose meaning depends on the sampled
+oracle (through the sampled interface `kvAt`) and an oracle machine's result type
+cannot depend on the table it is run against. But the machine does not need to: the
+arm's witness pair is an oracle-free function of the ledger. For Balance it is
+`kbPairOf` — the duplicate positioned opening `findPair` locates, projected to its
+key witnesses — and `balanceSubsetOrBreak_kbPair` identifies it with the pair of
+whatever break the reduction computes, so the bounded event is simply "the reduction
+lands in the key-binding arm". The composite machine returning the pair is covered by
+the key-binding bound, and validity lives only inside the event.
 
-Spend Authority's key-binding arm is discharged the same way
-(`spendAuthority_keyBindingArm_measure_le`): the victim's key witness is a theorem
-parameter — the `Witness` type is oracle-independent — while its `KB` certificate,
-whose meaning is oracle-dependent, moves inside the event, and the break data's own
-fields supply the pair.
+Spend Authority's arm differs in one respect: its selection criterion includes the
+undecidable `¬ Signed`, so no computable scan can locate the offending action. The
+adversary therefore announces a transaction and action index alongside its ledger —
+pointing at its own break, as is standard in security games — and the machine reads
+the first witness off the announced indices (`kwAt`, oracle-free) with the victim
+`wV` as the second. `spendAuthorityOrBreak_pair` identifies the reduction's pair with
+that output, and the event is the bundled `SpendAuthorityKBArm` at the announced
+indices.
 -/
 
 namespace Zcash.Security.Ledger.Model
@@ -107,13 +110,19 @@ theorem balanceSubset_keyBindingArm_measure_le {ι : Type u}
   · exact OracleComp.queryBound_bind (hQ j Hask Hnk)
       fun L => OracleComp.QueryBound.pure _ 0
 
-/-- **The Spend Authority key-binding arm's ε, discharged.** For any
-`n`-query-bounded pair-annotated ledger adversary in the key-binding oracle model,
-the probability that its output ledger is valid and the Spend Authority reduction —
-at some Action spending a note addressed to the victim `wV` over an unsigned
-sighash — lands in the key-binding arm with exactly its output pair is at most
-`(n + 4) · (n + 3) / |RIVK|`. -/
+/-- **The Spend Authority key-binding arm's ε, discharged.** For any `n`-query-bounded
+ledger adversary in the key-binding oracle model that announces its ledger together with
+a transaction and action index — pointing at its own break, as is standard in security
+games — the probability that the ledger is valid and the Spend Authority reduction, at
+the announced action spending a note addressed to the victim `wV` over an unsigned
+sighash, lands in the key-binding arm is at most `(n + 4) · (n + 3) / |RIVK|`. The
+indices are announced because the arm's selection criterion includes the undecidable
+`¬ Signed`, so no computable scan can locate the action the way `kbPairOf` does for
+Balance; the arm's pair is still derived, never announced — `kwAt` reads the first
+witness off the announced indices (oracle-free) and `spendAuthorityOrBreak_pair`
+identifies the reduction's pair with `(kwAt …, wV)`. -/
 theorem spendAuthority_keyBindingArm_measure_le {ι : Type u}
+    [Inhabited (KeyBinding.Witness G IVK AK NK RIVK QK SK)]
     (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK) (Ggen : G) (hS : S ≠ 0)
     (p : PMF ι)
     (P : Primitives RIVK G IVK NK RHO PSI MHASH MENC MSG SIG)
@@ -123,34 +132,30 @@ theorem spendAuthority_keyBindingArm_measure_le {ι : Type u}
       OracleComp (FinalQuery AK NK RIVK QK SK) RIVK
         (Ledger (KeyBinding.Witness G IVK AK NK RIVK QK SK) RIVK G RHO PSI MHASH MENC
             MSG SIG P.depth
-          × (KeyBinding.Witness G IVK AK NK RIVK QK SK
-            × KeyBinding.Witness G IVK AK NK RIVK QK SK))}
+          × ℕ × ℕ)}
     {n : ℕ} (hQ : ∀ j Hask Hnk, (LA j Hask Hnk).QueryBound n) :
     ((kbExperiment p)).toOuterMeasure
         (setOf fun (j, Hask, Hnk, O) =>
-          ∃ hval : ValidLedger P (kvAt Extract S hfn Ggen Hask Hnk O)
-              issuance maxActions ((LA j Hask Hnk).run O).1,
-            ∃ tx, ∃ htx : tx ∈ ((LA j Hask Hnk).run O).1, ∃ a, ∃ ha : a ∈ tx.actions,
-              ∃ hKB : (kvAt Extract S hfn Ggen Hask Hnk O).KB wV,
-                ∃ hrecv : a.w.note_old.pkd
-                    = P.emb ((kvAt Extract S hfn Ggen Hask Hnk O).ivk wV)
-                      • a.w.note_old.gd,
-                  ∃ hfresh : ¬ Signed tx.sighash,
-                    ∃ b, spendAuthorityOrBreak hval htx ha hKB hrecv hfresh = PSum.inr b
-                      ∧ b.w₁ = ((LA j Hask Hnk).run O).2.1
-                      ∧ b.w₂ = ((LA j Hask Hnk).run O).2.2)
+          Nonempty (SpendAuthorityKBArm P (kvAt Extract S hfn Ggen Hask Hnk O)
+            issuance maxActions ((LA j Hask Hnk).run O).1
+            ((LA j Hask Hnk).run O).2.1 ((LA j Hask Hnk).run O).2.2 wV Signed))
       ≤ ((n + 4) * (n + 3) : ℕ) / Fintype.card RIVK := by
   refine le_trans (MeasureTheory.measure_mono ?_)
     (toInterface_break_measure_le Extract S hfn Ggen hS p
-      (A := fun j Hask Hnk => (LA j Hask Hnk).bind fun out => .pure out.2)
+      (A := fun j Hask Hnk => (LA j Hask Hnk).bind fun out =>
+        .pure ((kwAt out.1 out.2.1 out.2.2).getD default, wV))
       (n := n) (fun j Hask Hnk => ?_))
-  · rintro ⟨j, Hask, Hnk, O⟩
-      ⟨hval, tx, htx, a, ha, hKB, hrecv, hfresh, b, heq, hw₁, hw₂⟩
+  · rintro ⟨j, Hask, Hnk, O⟩ ⟨hf⟩
     simp only [Set.mem_setOf_eq, OracleComp.run_bind, OracleComp.run_pure]
-    rw [← hw₁, ← hw₂]
-    exact b.h
+    obtain ⟨hw₁, hw₂⟩ :=
+      spendAuthorityOrBreak_pair hf.hval _ _ hf.hKB hf.hrecv hf.hfresh hf.hb
+    have hkw : kwAt ((LA j Hask Hnk).run O).1 ((LA j Hask Hnk).run O).2.1
+        ((LA j Hask Hnk).run O).2.2 = some hf.a.w.kw := by
+      simp [kwAt, hf.htx, hf.ha]
+    rw [hkw]
+    simpa [hw₁, hw₂] using hf.b.h
   · exact OracleComp.queryBound_bind (hQ j Hask Hnk)
-      fun out => OracleComp.QueryBound.pure out.2 0
+      fun out => OracleComp.QueryBound.pure _ 0
 
 end OracleModel
 

--- a/Zcash/Security/Ledger/KeyBindingArm.lean
+++ b/Zcash/Security/Ledger/KeyBindingArm.lean
@@ -47,7 +47,11 @@ def BalanceBreak.kbPair {F G IVK NK RHO PSI MHASH MENC MSG SIG KW : Type*}
   | .merkle _ => none
   | .noteCommit _ => none
 
-variable {G IVK AK NK RIVK ASK QK SK : Type*}
+-- A shared universe for the oracle-model types, so the sampling experiment can be
+-- written in `do`-notation: `PMF`'s monad instance fixes one universe for the whole
+-- block, which the independent `Type*` universes could not satisfy.
+universe u
+variable {G IVK AK NK RIVK ASK QK SK : Type u}
 variable {RHO PSI MHASH MENC MSG SIG : Type*}
 
 section OracleModel
@@ -77,7 +81,7 @@ exactly its output pair is at most `(n + 4) · (n + 3) / |RIVK|`. The event is
 contained in "the output pair breaks the sampled interface", and the composite that
 returns the pair makes no queries beyond the adversary's own, so
 `toInterface_break_measure_le` applies unchanged. -/
-theorem balanceSubset_keyBindingArm_measure_le {ι : Type*}
+theorem balanceSubset_keyBindingArm_measure_le {ι : Type u}
     (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK) (Ggen : G) (hS : S ≠ 0)
     (p : PMF ι)
     (P : Primitives RIVK G IVK NK RHO PSI MHASH MENC MSG SIG)
@@ -89,12 +93,7 @@ theorem balanceSubset_keyBindingArm_measure_le {ι : Type*}
           × (KeyBinding.Witness G IVK AK NK RIVK QK SK
             × KeyBinding.Witness G IVK AK NK RIVK QK SK))}
     {n : ℕ} (hQ : ∀ j Hask Hnk, (LA j Hask Hnk).QueryBound n) :
-    ((p.bind fun j => (PMF.uniformOfFintype (SK → ASK)).bind fun Hask =>
-        (PMF.uniformOfFintype (SK → NK)).bind fun Hnk =>
-          (PMF.uniformOfFintype (SK → RIVK)).bind fun Hleg =>
-            (PMF.uniformOfFintype (QK → AK → NK → RIVK)).bind fun Hext =>
-              (PMF.uniformOfFintype (RIVK → AK → NK → RIVK)).map fun Hint =>
-                (j, Hask, Hnk, FinalQuery.eval Hleg Hext Hint))).toOuterMeasure
+    ((kbExperiment p)).toOuterMeasure
         (setOf fun (j, Hask, Hnk, O) =>
           ∃ hval : ValidLedger P (kvAt Extract S hfn Ggen Hask Hnk O)
               issuance maxActions ((LA j Hask Hnk).run O).1,
@@ -123,7 +122,7 @@ the probability that its output ledger is valid and the Spend Authority reductio
 at some Action spending a note addressed to the victim `wV` over an unsigned
 sighash — lands in the key-binding arm with exactly its output pair is at most
 `(n + 4) · (n + 3) / |RIVK|`. -/
-theorem spendAuthority_keyBindingArm_measure_le {ι : Type*}
+theorem spendAuthority_keyBindingArm_measure_le {ι : Type u}
     (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK) (Ggen : G) (hS : S ≠ 0)
     (p : PMF ι)
     (P : Primitives RIVK G IVK NK RHO PSI MHASH MENC MSG SIG)
@@ -136,12 +135,7 @@ theorem spendAuthority_keyBindingArm_measure_le {ι : Type*}
           × (KeyBinding.Witness G IVK AK NK RIVK QK SK
             × KeyBinding.Witness G IVK AK NK RIVK QK SK))}
     {n : ℕ} (hQ : ∀ j Hask Hnk, (LA j Hask Hnk).QueryBound n) :
-    ((p.bind fun j => (PMF.uniformOfFintype (SK → ASK)).bind fun Hask =>
-        (PMF.uniformOfFintype (SK → NK)).bind fun Hnk =>
-          (PMF.uniformOfFintype (SK → RIVK)).bind fun Hleg =>
-            (PMF.uniformOfFintype (QK → AK → NK → RIVK)).bind fun Hext =>
-              (PMF.uniformOfFintype (RIVK → AK → NK → RIVK)).map fun Hint =>
-                (j, Hask, Hnk, FinalQuery.eval Hleg Hext Hint))).toOuterMeasure
+    ((kbExperiment p)).toOuterMeasure
         (setOf fun (j, Hask, Hnk, O) =>
           ∃ hval : ValidLedger P (kvAt Extract S hfn Ggen Hask Hnk O)
               issuance maxActions ((LA j Hask Hnk).run O).1,

--- a/Zcash/Security/Ledger/KeyBindingArm.lean
+++ b/Zcash/Security/Ledger/KeyBindingArm.lean
@@ -1,6 +1,7 @@
 import Mathlib
 import Zcash.Security.KeyBinding.Instance
 import Zcash.Security.Ledger.Balance
+import Zcash.Security.Ledger.SpendAuthority
 
 -- This lint enforces Mathlib's minimal-hypothesis style, from which we deliberately depart.
 set_option linter.unusedSectionVars false
@@ -25,8 +26,11 @@ irrelevance makes the tie independent of which validity proof the event exhibits
 That event is contained in "the output pair breaks the sampled interface", so the
 key-binding bound applies to the composite machine that returns the pair.
 
-The same pattern fits Spend Authority's key-binding arm; only Balance-subset is
-discharged here.
+Spend Authority's key-binding arm is discharged the same way
+(`spendAuthority_keyBindingArm_measure_le`): the victim's key witness is a theorem
+parameter — the `Witness` type is oracle-independent — while its `KB` certificate,
+whose meaning is oracle-dependent, moves inside the event, and the break data's own
+fields supply the pair.
 -/
 
 namespace Zcash.Security.Ledger.Model
@@ -110,6 +114,56 @@ theorem balanceSubset_keyBindingArm_measure_le {ι : Type*}
         exact hbr
     | merkle c => simp [BalanceBreak.kbPair] at hpair
     | noteCommit nb => simp [BalanceBreak.kbPair] at hpair
+  · exact OracleComp.queryBound_bind (hQ j Hask Hnk)
+      fun out => OracleComp.QueryBound.pure out.2 0
+
+/-- **The Spend Authority key-binding arm's ε, discharged.** For any
+`n`-query-bounded pair-annotated ledger adversary in the key-binding oracle model,
+the probability that its output ledger is valid and the Spend Authority reduction —
+at some Action spending a note addressed to the victim `wV` over an unsigned
+sighash — lands in the key-binding arm with exactly its output pair is at most
+`(n + 4) · (n + 3) / |RIVK|`. -/
+theorem spendAuthority_keyBindingArm_measure_le {ι : Type*}
+    (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK) (Ggen : G) (hS : S ≠ 0)
+    (p : PMF ι)
+    (P : Primitives RIVK G IVK NK RHO PSI MHASH MENC MSG SIG)
+    (issuance : ℕ → ℕ) (maxActions : ℕ)
+    (wV : KeyBinding.Witness G IVK AK NK RIVK QK SK) (Signed : MSG → Prop)
+    {LA : ι → (SK → ASK) → (SK → NK) →
+      OracleComp (FinalQuery AK NK RIVK QK SK) RIVK
+        (Ledger (KeyBinding.Witness G IVK AK NK RIVK QK SK) RIVK G RHO PSI MHASH MENC
+            MSG SIG P.depth
+          × (KeyBinding.Witness G IVK AK NK RIVK QK SK
+            × KeyBinding.Witness G IVK AK NK RIVK QK SK))}
+    {n : ℕ} (hQ : ∀ j Hask Hnk, (LA j Hask Hnk).QueryBound n) :
+    ((p.bind fun j => (PMF.uniformOfFintype (SK → ASK)).bind fun Hask =>
+        (PMF.uniformOfFintype (SK → NK)).bind fun Hnk =>
+          (PMF.uniformOfFintype (SK → RIVK)).bind fun Hleg =>
+            (PMF.uniformOfFintype (QK → AK → NK → RIVK)).bind fun Hext =>
+              (PMF.uniformOfFintype (RIVK → AK → NK → RIVK)).map fun Hint =>
+                (j, Hask, Hnk, FinalQuery.eval Hleg Hext Hint))).toOuterMeasure
+        (setOf fun (j, Hask, Hnk, O) =>
+          ∃ hval : ValidLedger P (kvAt Extract S hfn Ggen Hask Hnk O)
+              issuance maxActions ((LA j Hask Hnk).run O).1,
+            ∃ tx, ∃ htx : tx ∈ ((LA j Hask Hnk).run O).1, ∃ a, ∃ ha : a ∈ tx.actions,
+              ∃ hKB : (kvAt Extract S hfn Ggen Hask Hnk O).KB wV,
+                ∃ hrecv : a.w.note_old.pkd
+                    = P.emb ((kvAt Extract S hfn Ggen Hask Hnk O).ivk wV)
+                      • a.w.note_old.gd,
+                  ∃ hfresh : ¬ Signed tx.sighash,
+                    ∃ b, spendAuthorityOrBreak hval htx ha hKB hrecv hfresh = PSum.inr b
+                      ∧ b.w₁ = ((LA j Hask Hnk).run O).2.1
+                      ∧ b.w₂ = ((LA j Hask Hnk).run O).2.2)
+      ≤ ((n + 4) * (n + 3) : ℕ) / Fintype.card RIVK := by
+  refine le_trans (MeasureTheory.measure_mono ?_)
+    (toInterface_break_measure_le Extract S hfn Ggen hS p
+      (A := fun j Hask Hnk => (LA j Hask Hnk).bind fun out => .pure out.2)
+      (n := n) (fun j Hask Hnk => ?_))
+  · rintro ⟨j, Hask, Hnk, O⟩
+      ⟨hval, tx, htx, a, ha, hKB, hrecv, hfresh, b, heq, hw₁, hw₂⟩
+    simp only [Set.mem_setOf_eq, OracleComp.run_bind, OracleComp.run_pure]
+    rw [← hw₁, ← hw₂]
+    exact b.h
   · exact OracleComp.queryBound_bind (hQ j Hask Hnk)
       fun out => OracleComp.QueryBound.pure out.2 0
 

--- a/Zcash/Security/Ledger/Model.lean
+++ b/Zcash/Security/Ledger/Model.lean
@@ -42,11 +42,13 @@ structure Action (KW F G RHO PSI MHASH MENC SIG : Type*) (d : ℕ) where
   sig : SIG
 
 /-- A transaction: its Actions, the net value flowing out of the pool (positive
-`vBalance` means value leaving), and the sighash its signatures are over. -/
+`vBalance` means value leaving), the sighash its signatures are over, and its binding
+signature (verified under `Tx.bvk` by validity). -/
 structure Tx (KW F G RHO PSI MHASH MENC MSG SIG : Type*) (d : ℕ) where
   actions : List (Action KW F G RHO PSI MHASH MENC SIG d)
   vBalance : ℤ
   sighash : MSG
+  bindingSig : SIG
 
 /-- A ledger: a linearization of transactions (design doc, "Modelling decisions"). -/
 abbrev Ledger (KW F G RHO PSI MHASH MENC MSG SIG : Type*) (d : ℕ) :=
@@ -153,6 +155,13 @@ section Validity
 
 variable [Field F] [AddCommGroup G] [Module F G]
 
+/-- The binding verification key of a transaction: the sum of its actions' net value
+commitments, minus a zero-randomness commitment to its declared `vBalance`
+(`bvk = ∑ cv_net − ValueCommit_0(vBalance)`). -/
+def Tx.bvk (P : Primitives F G IVK NK RHO PSI MHASH MENC MSG SIG)
+    (tx : Tx KW F G RHO PSI MHASH MENC MSG SIG d) : G :=
+  (tx.actions.map fun a => a.inst.cv_net).sum - P.valueCommit tx.vBalance 0
+
 /-- Validity of a witness-annotated ledger — the premiss of every game. `issuance` is the
 intended issuance schedule and `maxActions` bounds each transaction's action count; both
 are consensus data the games quantify over. -/
@@ -178,6 +187,12 @@ structure ValidLedger (P : Primitives F G IVK NK RHO PSI MHASH MENC MSG SIG)
   /-- Each action's spend-authorization signature verifies under its `rk`, over its
   transaction's sighash. -/
   sig_verifies : ∀ tx ∈ ledger, ∀ a ∈ tx.actions, P.spendAuthVerify a.inst.rk tx.sighash a.sig
+  /-- Each transaction's binding signature verifies under its binding verification key,
+  over its sighash (the consensus binding-signature rule). -/
+  binding_verified : ∀ tx ∈ ledger, P.bindingVerify (tx.bvk P) tx.sighash tx.bindingSig
+  /-- Each transaction's declared value balance is in range (the consensus `valueBalance`
+  range rule; `|vBalance| ≤ 2^63 − 1 < 2^64 = valueBound` concretely). -/
+  vbalance_bound : ∀ tx ∈ ledger, tx.vBalance.natAbs < P.valueBound
   /-- The transparent pool balance never goes negative: a transaction can move value
   into the shielded pool only from issuance already minted, less what earlier
   transactions consumed. This is the consensus non-negative chain value balance rule for

--- a/Zcash/Security/Ledger/Model.lean
+++ b/Zcash/Security/Ledger/Model.lean
@@ -114,6 +114,41 @@ theorem rootAfter_prefix (P : Primitives F G IVK NK RHO PSI MHASH MENC MSG SIG)
   obtain ⟨t, rfl⟩ := hpre
   rw [rootAfter, rootAfter, List.take_append_of_le_length hj]
 
+/-- The leaf list distributes over ledger concatenation. -/
+theorem leafList_append (ledger ledger' : Ledger KW F G RHO PSI MHASH MENC MSG SIG d) :
+    leafList (ledger ++ ledger') = leafList ledger ++ leafList ledger' := by
+  simp [leafList]
+
+/-- A prefix balance ignores an extension: the first `i` transactions of `ledger ++ ledger'`
+are those of `ledger` when `i` is within `ledger`. -/
+theorem transparentPoolBalance_append_of_le (issuance : ℕ → ℕ)
+    {ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG d} {i : ℕ} (hi : i ≤ ledger.length)
+    (ledger' : Ledger KW F G RHO PSI MHASH MENC MSG SIG d) :
+    transparentPoolBalance issuance (ledger ++ ledger') i =
+      transparentPoolBalance issuance ledger i := by
+  rw [transparentPoolBalance, transparentPoolBalance, List.take_append_of_le_length hi]
+
+/-- The balance saturates at the ledger's length: taking more transactions than exist
+changes nothing. -/
+theorem transparentPoolBalance_of_length_le (issuance : ℕ → ℕ)
+    {ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG d} {i : ℕ} (hi : ledger.length ≤ i) :
+    transparentPoolBalance issuance ledger i =
+      transparentPoolBalance issuance ledger ledger.length := by
+  rw [transparentPoolBalance, transparentPoolBalance, List.take_of_length_le hi,
+    List.take_length]
+
+/-- The balance across an appended transaction: the previous total, plus the issuance
+minted at the new index, plus the transaction's declared net value. -/
+theorem transparentPoolBalance_append_singleton (issuance : ℕ → ℕ)
+    (ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG d)
+    (tx : Tx KW F G RHO PSI MHASH MENC MSG SIG d) :
+    transparentPoolBalance issuance (ledger ++ [tx]) (ledger.length + 1) =
+      transparentPoolBalance issuance ledger ledger.length
+        + ((issuance ledger.length : ℤ) + tx.vBalance) := by
+  rw [transparentPoolBalance, transparentPoolBalance, List.take_length,
+    List.take_of_length_le (by simp), List.zipIdx_append, List.map_append, List.sum_append]
+  simp
+
 section Validity
 
 variable [Field F] [AddCommGroup G] [Module F G]

--- a/Zcash/Security/Ledger/Model.lean
+++ b/Zcash/Security/Ledger/Model.lean
@@ -190,8 +190,11 @@ structure ValidLedger (P : Primitives F G IVK NK RHO PSI MHASH MENC MSG SIG)
   /-- Each transaction's binding signature verifies under its binding verification key,
   over its sighash (the consensus binding-signature rule). -/
   binding_verified : ∀ tx ∈ ledger, P.bindingVerify (tx.bvk P) tx.sighash tx.bindingSig
-  /-- Each transaction's declared value balance is in range (the consensus `valueBalance`
-  range rule; `|vBalance| ≤ 2^63 − 1 < 2^64 = valueBound` concretely). -/
+  /-- Each transaction's declared value balance is in range. The consensus rule
+  (§7.1.2, [NU5 onward]) is `valueBalanceOrchard ∈ {-MAX_MONEY .. MAX_MONEY}` (inclusive;
+  MAX_MONEY ~2^51 zatoshi), i.e. `|vBalance| <= MAX_MONEY`. This conjunct states the
+  weaker `natAbs < valueBound` (= 2^64 at the intended instantiation), a loose consequence
+  that suffices for the no-overflow bound in the integer-balance lift. -/
   vbalance_bound : ∀ tx ∈ ledger, tx.vBalance.natAbs < P.valueBound
   /-- The transparent pool balance never goes negative: a transaction can move value
   into the shielded pool only from issuance already minted, less what earlier

--- a/Zcash/Security/Ledger/Model.lean
+++ b/Zcash/Security/Ledger/Model.lean
@@ -167,7 +167,10 @@ structure ValidLedger (P : Primitives F G IVK NK RHO PSI MHASH MENC MSG SIG)
   /-- Each anchor is the root after some earlier transaction boundary: an action of
   transaction `i` (zero-based) may reference the tree after any `j ≤ i` transactions,
   so only outputs of strictly earlier transactions. The equation also asserts that the
-  referenced tree is defined (no compression along it escapes). -/
+  referenced tree is defined (no compression along it escapes). Anchors are
+  per-action, a documented simplification: deployed Orchard encodes one anchor for
+  the whole transaction (Sapling v4 allowed per-spend anchors), and per-action
+  anchors only widen what the adversary may do. -/
   anchor_valid : ∀ i : Fin ledger.length, ∀ a ∈ (ledger.get i).actions,
     ∃ j ≤ (i : ℕ), rootAfter P ledger j = some a.inst.rt
   /-- The tree never overflows (the consensus capacity rule). -/

--- a/Zcash/Security/Ledger/Nullifier.lean
+++ b/Zcash/Security/Ledger/Nullifier.lean
@@ -1,0 +1,199 @@
+import Mathlib
+import Zcash.Security.Ledger.Spendability
+import Zcash.Common.DiscreteLogRelation
+
+/-!
+# The nullifier-binding reduction
+
+`NullifierCollision` (two distinct note openings whose nullifiers agree) reduces to a
+nontrivial discrete-log relation, once the derivation's shape is given. The deployed
+shape (the [Orchard nullifier design](https://zcash.github.io/orchard/design/nullifiers.html))
+is additive:
+
+    DeriveNullifier_nk(ρ, ψ, cm) = Extract((scalar nk ρ ψ) • K + cm)
+    NoteCommit_rcm(note)         = (∑ i, coeff(note) i • bases i) + rcm • R
+
+with `K` the nullifier base (𝒦^Orchard), `R` the commitment randomness base, `scalar`
+the composite `PRF^nf_nk(ρ) + ψ` — the addition taken in the Pallas *base* field, with
+the sum then reinterpreted as a scalar — and the commitment's hash point exposed as a
+fixed-base combination: for Sinsemilla, `2^n • 𝒬 + ∑ 2^(n-i) • 𝒮(m_i)` over the fixed
+bases `𝒬, 𝒮(0), …`, with the coefficients determined by the note's encoding. Adding
+`cm` is what lets the collision argument avoid a PRF-collision assumption: the
+nullifier is in effect a Pedersen hash whose input includes ρ directly, so Faerie
+Resistance rests on discrete log alone (see the
+[design page's rationale](https://zcash.github.io/orchard/design/nullifiers.html#rationale)).
+
+`NontrivialRelation.ofNullifierCollision` computes the reduction: a collision between
+*distinct* notes yields a `NontrivialRelation` among the commitment bases, `K`, and
+`R` — the same terminal, under the same independent-hash-to-curve-bases discharge, as
+the balance argument's relations. The extract ±-property splits into two sign cases;
+nontriviality comes from the coefficient vectors (their difference is nonzero for
+distinct notes, and their sum is never zero — concretely both hold via the initial
+`2^n • 𝒬` term, whose binary-expansion coefficients determine the message).
+
+The distinct-notes premiss is the consumer's obligation. The intended discharge is
+ledger-level ρ-uniqueness — output notes carry pairwise-distinct ρ in a valid ledger
+(`output_rho_nodup`, the consensus nullifier checks), and equal note records would
+share a ρ — but that composition is not yet formalized: this module sees only the
+collision, not the ledger, and nothing yet connects a game-level collision's notes to
+the ledger's outputs.
+-/
+
+namespace Zcash.Security.Ledger.Model
+
+open scoped Zcash.Security.RandomOracle
+
+variable {F : Type*}
+variable {G : Type*}
+variable {IVK NK RHO PSI MHASH MENC MSG SIG : Type*} {KW : Type*}
+
+section Validity
+
+variable [Field F] [AddCommGroup G] [Module F G]
+variable {P : Primitives F G IVK NK RHO PSI MHASH MENC MSG SIG}
+
+/-- The deployed additive shape of nullifier derivation: derivation is a scalar
+multiple of the nullifier base `K` plus the commitment point, extracted to `RHO`
+(nullifiers share ρ's type), and commitments open as a coefficient combination of the
+fixed `bases` plus a multiple of the randomness base `R`. `extract` is the shape's own
+coordinate extractor — the model types nullifiers as `RHO` while `P.extract` lands in
+`MHASH`, though both are `Extract_ℙ` concretely — and `extract_pm` is its ±-property
+(fibres `{P, −P}`).
+
+Intended model: the Orchard nullifier design, with `scalar nk ρ ψ` the composite
+`PRF^nf_nk(ρ) + ψ` — added in the Pallas base field, the sum then reinterpreted as a
+scalar — and the commitment hash Sinsemilla, whose defined values are the fixed-base
+combinations `2^n • 𝒬 + ∑ 2^(n-i) • 𝒮(m_i)`. The two coefficient conditions hold
+there because every coefficient vector carries the initial term's `2^n` at `𝒬`, and
+the per-base coefficients' binary expansions determine the message. -/
+structure NullifierShape (P : Primitives F G IVK NK RHO PSI MHASH MENC MSG SIG) where
+  /-- The number of fixed commitment bases. -/
+  numBases : ℕ
+  /-- The commitment's fixed bases (for Sinsemilla: `𝒬, 𝒮(0), 𝒮(1), …`). -/
+  bases : Fin numBases → G
+  /-- The nullifier base (𝒦^Orchard). -/
+  K : G
+  /-- The commitment randomness base. -/
+  R : G
+  scalar : NK → RHO → PSI → F
+  extract : G → RHO
+  /-- The commitment hash's coefficient vector at a note's encoding; `none` is an
+  escaped hash. -/
+  coeff : Note G RHO PSI → Option (Fin numBases → F)
+  derive_eq : ∀ nk ρ ψ cm,
+    P.deriveNullifier nk ρ ψ cm = extract (scalar nk ρ ψ • K + cm)
+  commit_eq : ∀ rcm note,
+    P.noteCommit rcm note
+      = (coeff note).map (fun cf => (∑ i, cf i • bases i) + rcm • R)
+  extract_pm : ∀ x y : G, extract x = extract y → x =± y
+  /-- Distinct notes have distinct coefficient vectors (injective encoding). -/
+  coeff_sub_ne : ∀ {note₁ note₂ : Note G RHO PSI} {cf₁ cf₂ : Fin numBases → F},
+    coeff note₁ = some cf₁ → coeff note₂ = some cf₂ → note₁ ≠ note₂ → cf₁ - cf₂ ≠ 0
+  /-- Coefficient vectors never cancel additively (the initial-base term). -/
+  coeff_add_ne : ∀ {note₁ note₂ : Note G RHO PSI} {cf₁ cf₂ : Fin numBases → F},
+    coeff note₁ = some cf₁ → coeff note₂ = some cf₂ → cf₁ + cf₂ ≠ 0
+
+namespace NullifierShape
+
+variable (S : NullifierShape P) (c : NullifierCollision P)
+
+/-- The first opening's coefficient vector is defined, from the opening. -/
+theorem coeff₁_isSome : (S.coeff c.note₁).isSome := by
+  have h := c.open₁
+  rw [S.commit_eq] at h
+  rcases Option.map_eq_some_iff.mp h with ⟨cf, hcf, -⟩
+  simp [hcf]
+
+/-- The second opening's coefficient vector is defined, from the opening. -/
+theorem coeff₂_isSome : (S.coeff c.note₂).isSome := by
+  have h := c.open₂
+  rw [S.commit_eq] at h
+  rcases Option.map_eq_some_iff.mp h with ⟨cf, hcf, -⟩
+  simp [hcf]
+
+/-- The first commitment decomposes over the fixed bases. -/
+theorem cm₁_eq :
+    c.cm₁ = (∑ i, (S.coeff c.note₁).get (S.coeff₁_isSome c) i • S.bases i)
+      + c.rcm₁ • S.R := by
+  have h := c.open₁
+  rw [S.commit_eq] at h
+  rcases Option.map_eq_some_iff.mp h with ⟨cf, hcf, hcm⟩
+  have hget : (S.coeff c.note₁).get (S.coeff₁_isSome c) = cf :=
+    Option.some.inj (by rw [Option.some_get, hcf])
+  rw [hget]
+  exact hcm.symm
+
+/-- The second commitment decomposes over the fixed bases. -/
+theorem cm₂_eq :
+    c.cm₂ = (∑ i, (S.coeff c.note₂).get (S.coeff₂_isSome c) i • S.bases i)
+      + c.rcm₂ • S.R := by
+  have h := c.open₂
+  rw [S.commit_eq] at h
+  rcases Option.map_eq_some_iff.mp h with ⟨cf, hcf, hcm⟩
+  have hget : (S.coeff c.note₂).get (S.coeff₂_isSome c) = cf :=
+    Option.some.inj (by rw [Option.some_get, hcf])
+  rw [hget]
+  exact hcm.symm
+
+end NullifierShape
+
+/-- **The nullifier-binding reduction.** A nullifier collision between distinct notes
+computes a nontrivial relation among the commitment bases, `K`, and `R`: the extract
+±-property turns the collision into a point equation, the openings decompose both
+commitments over the fixed bases, and the coefficient conditions certify
+nontriviality in either sign case. The distinct-notes premiss is the consumer's
+obligation; its intended discharge — not yet formalized — is ledger-level
+ρ-uniqueness (`output_rho_nodup`). -/
+def NontrivialRelation.ofNullifierCollision [DecidableEq G] (S : NullifierShape P)
+    (c : NullifierCollision P) (hne : c.note₁ ≠ c.note₂) :
+    NontrivialRelation (F := F) S.bases S.K S.R :=
+  have hcf₁ : S.coeff c.note₁ = some ((S.coeff c.note₁).get (S.coeff₁_isSome c)) :=
+    (Option.some_get _).symm
+  have hcf₂ : S.coeff c.note₂ = some ((S.coeff c.note₂).get (S.coeff₂_isSome c)) :=
+    (Option.some_get _).symm
+  have hx : S.extract (S.scalar c.nk₁ c.note₁.ρ c.note₁.ψ • S.K + c.cm₁)
+      = S.extract (S.scalar c.nk₂ c.note₂.ρ c.note₂.ψ • S.K + c.cm₂) := by
+    rw [← S.derive_eq, ← S.derive_eq]
+    exact c.eq
+  if hplus : S.scalar c.nk₁ c.note₁.ρ c.note₁.ψ • S.K + c.cm₁
+      = S.scalar c.nk₂ c.note₂.ρ c.note₂.ψ • S.K + c.cm₂ then
+    { a := (S.coeff c.note₁).get (S.coeff₁_isSome c)
+        - (S.coeff c.note₂).get (S.coeff₂_isSome c)
+      α := S.scalar c.nk₁ c.note₁.ρ c.note₁.ψ - S.scalar c.nk₂ c.note₂.ρ c.note₂.ψ
+      β := c.rcm₁ - c.rcm₂
+      nontrivial := Or.inl (S.coeff_sub_ne hcf₁ hcf₂ hne)
+      relation := by
+        have h := hplus
+        rw [S.cm₁_eq c, S.cm₂_eq c] at h
+        have h0 := sub_eq_zero.mpr h
+        rw [← h0]
+        simp only [Pi.sub_apply, sub_smul, Finset.sum_sub_distrib]
+        abel }
+  else
+    have hminus : S.scalar c.nk₁ c.note₁.ρ c.note₁.ψ • S.K + c.cm₁
+        = -(S.scalar c.nk₂ c.note₂.ρ c.note₂.ψ • S.K + c.cm₂) :=
+      (S.extract_pm _ _ hx).resolve_left hplus
+    { a := (S.coeff c.note₁).get (S.coeff₁_isSome c)
+        + (S.coeff c.note₂).get (S.coeff₂_isSome c)
+      α := S.scalar c.nk₁ c.note₁.ρ c.note₁.ψ + S.scalar c.nk₂ c.note₂.ρ c.note₂.ψ
+      β := c.rcm₁ + c.rcm₂
+      nontrivial := Or.inl (S.coeff_add_ne hcf₁ hcf₂)
+      relation := by
+        have h := hminus
+        rw [S.cm₁_eq c, S.cm₂_eq c] at h
+        have h0 : (S.scalar c.nk₁ c.note₁.ρ c.note₁.ψ • S.K
+            + ((∑ i, (S.coeff c.note₁).get (S.coeff₁_isSome c) i • S.bases i)
+              + c.rcm₁ • S.R))
+            + (S.scalar c.nk₂ c.note₂.ρ c.note₂.ψ • S.K
+            + ((∑ i, (S.coeff c.note₂).get (S.coeff₂_isSome c) i • S.bases i)
+              + c.rcm₂ • S.R))
+            = 0 := by
+          rw [h]
+          abel
+        rw [← h0]
+        simp only [Pi.add_apply, add_smul, Finset.sum_add_distrib]
+        abel }
+
+end Validity
+
+end Zcash.Security.Ledger.Model

--- a/Zcash/Security/Ledger/Nullifier.lean
+++ b/Zcash/Security/Ledger/Nullifier.lean
@@ -52,7 +52,7 @@ section Validity
 variable [Field F] [AddCommGroup G] [Module F G]
 variable {P : Primitives F G IVK NK RHO PSI MHASH MENC MSG SIG}
 
-/-- The deployed additive shape of nullifier derivation: derivation is a scalar
+/-- The additive shape of the deployed nullifier derivation: derivation is a scalar
 multiple of the nullifier base `K` plus the commitment point, extracted to `RHO`
 (nullifiers share ρ's type), and commitments open as a coefficient combination of the
 fixed `bases` plus a multiple of the randomness base `R`. `extract` is the shape's own

--- a/Zcash/Security/Ledger/Nullifier.lean
+++ b/Zcash/Security/Ledger/Nullifier.lean
@@ -23,20 +23,21 @@ nullifier is in effect a Pedersen hash whose input includes ρ directly, so Faer
 Resistance rests on discrete log alone (see the
 [design page's rationale](https://zcash.github.io/orchard/design/nullifiers.html#rationale)).
 
-`NontrivialRelation.ofNullifierCollision` computes the reduction: a collision between
-*distinct* notes yields a `NontrivialRelation` among the commitment bases, `K`, and
-`R` — the same terminal, under the same independent-hash-to-curve-bases discharge, as
-the balance argument's relations. The extract ±-property splits into two sign cases;
-nontriviality comes from the coefficient vectors (their difference is nonzero for
-distinct notes, and their sum is never zero — concretely both hold via the initial
-`2^n • 𝒬` term, whose binary-expansion coefficients determine the message).
+`NontrivialRelation.ofNullifierCollision` computes the reduction: a `NullifierCollision`
+yields a `NontrivialRelation` among the commitment bases, `K`, and `R` — the same
+terminal, under the same independent-hash-to-curve-bases discharge, as the balance
+argument's relations. The extract ±-property splits into two sign cases; nontriviality
+comes from the coefficient vectors (their difference is nonzero for distinct notes,
+their sum is never zero — concretely both hold via the initial `2^n • 𝒬` term, whose
+binary-expansion coefficients determine the message).
 
-The distinct-notes premiss is the consumer's obligation. The intended discharge is
-ledger-level ρ-uniqueness — output notes carry pairwise-distinct ρ in a valid ledger
-(`output_rho_nodup`, the consensus nullifier checks), and equal note records would
-share a ρ — but that composition is not yet formalized: this module sees only the
-collision, not the ledger, and nothing yet connects a game-level collision's notes to
-the ledger's outputs.
+The reduction needs no distinct-notes premiss: the collision's own opening distinctness
+(`(rcm₁, note₁) ≠ (rcm₂, note₂)`) covers every case — distinct notes use the coefficient
+difference, and equal notes force `rcm₁ ≠ rcm₂`, a nonzero randomness coefficient. So it
+composes directly with the game-produced collisions of `faerieGoldCore` /
+`spendabilityOrBreak`, which hold exactly that inequality at construction. (The
+equal-note, equal-`rcm`, distinct-`nk` case — the PRF collision the design page
+discusses — cannot arise: equal openings pin `cm`, so the two spends would coincide.)
 -/
 
 namespace Zcash.Security.Ledger.Model
@@ -137,15 +138,16 @@ theorem cm₂_eq :
 
 end NullifierShape
 
-/-- **The nullifier-binding reduction.** A nullifier collision between distinct notes
-computes a nontrivial relation among the commitment bases, `K`, and `R`: the extract
-±-property turns the collision into a point equation, the openings decompose both
-commitments over the fixed bases, and the coefficient conditions certify
-nontriviality in either sign case. The distinct-notes premiss is the consumer's
-obligation; its intended discharge — not yet formalized — is ledger-level
-ρ-uniqueness (`output_rho_nodup`). -/
+/-- **The nullifier-binding reduction.** A nullifier collision computes a nontrivial
+relation among the commitment bases, `K`, and `R`: the extract ±-property turns the
+collision into a point equation, the openings decompose both commitments over the
+fixed bases, and the coefficient conditions certify nontriviality in either sign case.
+No distinct-notes premiss is needed — the opening distinctness `c.ne` suffices: in the
+`+` case, distinct notes give a nonzero base-coefficient difference (`coeff_sub_ne`),
+and equal notes force `rcm₁ ≠ rcm₂` (a nonzero randomness coefficient); the `−` case
+needs no distinctness at all (`coeff_add_ne`). -/
 def NontrivialRelation.ofNullifierCollision [DecidableEq G] (S : NullifierShape P)
-    (c : NullifierCollision P) (hne : c.note₁ ≠ c.note₂) :
+    (c : NullifierCollision P) :
     NontrivialRelation (F := F) S.bases S.K S.R :=
   have hcf₁ : S.coeff c.note₁ = some ((S.coeff c.note₁).get (S.coeff₁_isSome c)) :=
     (Option.some_get _).symm
@@ -161,7 +163,13 @@ def NontrivialRelation.ofNullifierCollision [DecidableEq G] (S : NullifierShape 
         - (S.coeff c.note₂).get (S.coeff₂_isSome c)
       α := S.scalar c.nk₁ c.note₁.ρ c.note₁.ψ - S.scalar c.nk₂ c.note₂.ρ c.note₂.ψ
       β := c.rcm₁ - c.rcm₂
-      nontrivial := Or.inl (S.coeff_sub_ne hcf₁ hcf₂ hne)
+      nontrivial := by
+        by_cases hnn : c.note₁ = c.note₂
+        · -- equal notes ⇒ the openings differ only in randomness
+          refine Or.inr (Or.inr ?_)
+          intro hβ
+          exact c.ne (Prod.ext (sub_eq_zero.mp hβ) hnn)
+        · exact Or.inl (S.coeff_sub_ne hcf₁ hcf₂ hnn)
       relation := by
         have h := hplus
         rw [S.cm₁_eq c, S.cm₂_eq c] at h

--- a/Zcash/Security/Ledger/Pool.lean
+++ b/Zcash/Security/Ledger/Pool.lean
@@ -204,11 +204,11 @@ def uncommitted : Fp := 2
 
 variable {MSG SIG : Type*}
 
-/-- The deployed pool's concrete primitives.  The spend-authorization verification
-predicate is a parameter: the Action circuit neither constrains nor witnesses
-signatures, so every bridge statement holds for an arbitrary scheme; the concrete
-RedPallas instantiation composes downstream. -/
-def primitives (spendAuthVerify : PallasGroup → MSG → SIG → Prop) :
+/-- The deployed pool's concrete primitives.  The spend-authorization and
+binding-signature verification predicates are parameters: the Action circuit neither
+constrains nor witnesses signatures, so every bridge statement holds for arbitrary
+schemes; the concrete RedPallas instantiations compose downstream. -/
+def primitives (spendAuthVerify bindingVerify : PallasGroup → MSG → SIG → Prop) :
     Primitives Fq PallasGroup Fp Fp Fp Fp Fp Encoding MSG SIG where
   valueBound := 2 ^ 64
   emb := PallasGroup.embedFp
@@ -222,6 +222,7 @@ def primitives (spendAuthVerify : PallasGroup → MSG → SIG → Prop) :
   randomizePublic := randomizePublic
   valueCommit := valueCommit
   spendAuthVerify := spendAuthVerify
+  bindingVerify := bindingVerify
 
 def commitIvkHash (ak nk : Fp) : Option PallasGroup :=
   (hashToPoint orchardGenerators.S ivkQ

--- a/Zcash/Security/Ledger/SpendAuthority.lean
+++ b/Zcash/Security/Ledger/SpendAuthority.lean
@@ -119,6 +119,54 @@ def spendAuthorityOrBreak [DecidableEq G] [NoZeroSMulDivisors F G]
   spendAuthForgeryOrBreak (hval.satisfied tx htx a ha) hKB hrecv
     (hval.sig_verifies tx htx a ha) hfresh
 
+/-- The key witness of the action at transaction index `t`, action index `i` — the
+oracle-free lookup an oracle machine uses to output the Spend Authority key-binding
+arm's first witness, given the indices the adversary announces. -/
+def kwAt {d : ℕ} (ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG d) (t i : ℕ) : Option KW :=
+  (ledger[t]?.bind fun tx => tx.actions[i]?).map fun a => a.w.kw
+
+/-- **Spend Authority key-binding localization.** Whatever break the reduction computes,
+its witnesses are the spending action's key witness and the victim: the sole `.inr` site
+packages exactly `⟨a.w.kw, wV, _⟩`. -/
+theorem spendAuthorityOrBreak_pair [DecidableEq G] [NoZeroSMulDivisors F G]
+    (hval : ValidLedger P kv issuance maxActions ledger)
+    {tx : Tx KW F G RHO PSI MHASH MENC MSG SIG P.depth} (htx : tx ∈ ledger)
+    {a : Action KW F G RHO PSI MHASH MENC SIG P.depth} (ha : a ∈ tx.actions)
+    {wV : KW} (hKB : kv.KB wV)
+    (hrecv : a.w.note_old.pkd = P.emb (kv.ivk wV) • a.w.note_old.gd)
+    {Signed : MSG → Prop} (hfresh : ¬ Signed tx.sighash)
+    {b : KeyBindingBreakData kv}
+    (hb : spendAuthorityOrBreak hval htx ha hKB hrecv hfresh = .inr b) :
+    b.w₁ = a.w.kw ∧ b.w₂ = wV := by
+  rw [spendAuthorityOrBreak, spendAuthForgeryOrBreak] at hb
+  split_ifs at hb
+  simp_all only [PSum.inr.injEq]
+  subst hb
+  exact ⟨rfl, rfl⟩
+
+/-- **The Spend Authority key-binding arm fires at announced indices** — the bundled
+event: the ledger is valid, transaction index `t` and action index `i` locate an action
+spending a note addressed to the victim `wV`, the transaction's sighash was never
+signed, and the reduction lands in the key-binding arm. A probability event over this
+structure is its `Nonempty`. Bundling the data and the premisses as named fields keeps
+the arm theorem's event to a single application. -/
+structure SpendAuthorityKBArm [DecidableEq G] [NoZeroSMulDivisors F G]
+    (P : Primitives F G IVK NK RHO PSI MHASH MENC MSG SIG)
+    (kv : KeyBindingInterface KW G IVK NK) (issuance : ℕ → ℕ) (maxActions : ℕ)
+    (ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG P.depth) (t i : ℕ)
+    (wV : KW) (Signed : MSG → Prop) where
+  hval : ValidLedger P kv issuance maxActions ledger
+  tx : Tx KW F G RHO PSI MHASH MENC MSG SIG P.depth
+  htx : ledger[t]? = some tx
+  a : Action KW F G RHO PSI MHASH MENC SIG P.depth
+  ha : tx.actions[i]? = some a
+  hKB : kv.KB wV
+  hrecv : a.w.note_old.pkd = P.emb (kv.ivk wV) • a.w.note_old.gd
+  hfresh : ¬ Signed tx.sighash
+  b : KeyBindingBreakData kv
+  hb : spendAuthorityOrBreak hval (List.mem_of_getElem? htx)
+    (List.mem_of_getElem? ha) hKB hrecv hfresh = .inr b
+
 end Validity
 
 end Zcash.Security.Ledger.Model

--- a/Zcash/Security/Ledger/Spendability.lean
+++ b/Zcash/Security/Ledger/Spendability.lean
@@ -117,7 +117,8 @@ def respendOrBreak [DecidableEq F] [DecidableEq G] [DecidableEq NK] [DecidableEq
 /-- **Persistence.** A transaction valid immediately after `ledger` remains valid when
 appended to any valid extension `ledger'`, given that its nullifiers are still fresh
 and the boundary conjuncts hold for the appended ledger. Anchors persist because prefix
-roots do; satisfaction, signatures, and the action bound are per-transaction. -/
+roots do; satisfaction, the signature rules, the value-balance range, and the action
+bound are per-transaction. -/
 theorem validLedger_append
     (hval' : ValidLedger P kv issuance maxActions ledger')
     (hpre : ledger <+: ledger')
@@ -132,7 +133,7 @@ theorem validLedger_append
     rcases List.mem_append.mp htx with h | h
     · exact Or.inl h
     · exact Or.inr (by simpa using h)
-  refine ⟨?_, ?_, ?_, hcap, ?_, htrans, ?_⟩
+  refine ⟨?_, ?_, ?_, hcap, ?_, ?_, ?_, htrans, ?_⟩
   · intro tx htx a ha
     rcases hmem tx htx with h | rfl
     · exact hval'.satisfied tx h a ha
@@ -178,6 +179,14 @@ theorem validLedger_append
     rcases hmem tx htx with h | rfl
     · exact hval'.sig_verifies tx h a ha
     · exact hvalT.sig_verifies tx hTmem a ha
+  · intro tx htx
+    rcases hmem tx htx with h | rfl
+    · exact hval'.binding_verified tx h
+    · exact hvalT.binding_verified tx hTmem
+  · intro tx htx
+    rcases hmem tx htx with h | rfl
+    · exact hval'.vbalance_bound tx h
+    · exact hvalT.vbalance_bound tx hTmem
   · intro tx htx
     rcases hmem tx htx with h | rfl
     · exact hval'.action_bound tx h

--- a/Zcash/Security/Ledger/Spendability.lean
+++ b/Zcash/Security/Ledger/Spendability.lean
@@ -9,11 +9,11 @@ pin note tuples: two satisfied spends with distinct openings and equal revealed
 nullifiers compute a break — a `NoteCommitBreak` when their derive-inputs coincide (the
 same commitment opened two ways), and otherwise a `NullifierCollision`: two distinct
 note openings whose nullifiers agree. It carries the openings, so `cm` is pinned to a
-real commitment and the collision is a genuine discrete-log relation at the
-instantiation, not a coincidence a free `cm` could fabricate. That reduction — collision
-to a DLR break (deployed), or to an `H^rcm` ±-collision for the Recovery Statement via
-ZIP 2005's Spendability theorem — is nonobvious and not yet formalized; it is planned
-for the stacked capstone PR.
+real commitment and `NontrivialRelation.ofNullifierCollision` reduces the collision to a
+nontrivial discrete-log relation — no fabrication by a free `cm`, and no separate
+distinct-notes premiss (the opening distinctness suffices; see `Nullifier.lean`). For
+the Recovery Statement the analogue is an `H^rcm` ±-collision via ZIP 2005's
+Spendability theorem, which is not formalized here.
 
 Persistence says a transaction valid immediately after `ledger` stays valid when
 appended to any valid extension `ledger'`, under the conditions of nullifier freshness
@@ -49,20 +49,18 @@ variable {ledger ledger' : Ledger KW F G RHO PSI MHASH MENC MSG SIG P.depth}
 variable {T : Tx KW F G RHO PSI MHASH MENC MSG SIG P.depth}
 variable {issuance : ℕ → ℕ} {maxActions : ℕ}
 
-/-- A nullifier-derivation collision, as data: two note openings — each a note with its
-commitment (`open₁`, `open₂`) — whose derive-inputs `(nk, ρ, ψ, cm)` differ (`ne`) but
-whose `deriveNullifier` outputs agree (`eq`).
+/-- A nullifier collision, as data: two *distinct* note openings (`ne`: the
+`(rcm, note)` pairs differ) whose commitments open (`open₁`, `open₂`) and whose
+`deriveNullifier` outputs agree (`eq`).
 
-The openings are what make this self-certifying. They pin each `cm` to a genuine note
-commitment, so at the Orchard instantiation the collision expands to a nontrivial
-discrete-log relation among the nullifier base 𝒦^Orchard, the note-commitment base, and
-the two commitments' hash images. Drop them and `cm` is a free group element: the affine
-`extract` (an x-coordinate) lets `cm₂` be solved to match, so the bare `(nk, ρ, ψ, cm)`
-collision is fabricable and certifies nothing.
-
-Reducing this collision to a nontrivial discrete-log relation (independence of 𝒦^Orchard
-from the note-commitment bases) is nonobvious and not yet formalized; it is planned for
-the stacked capstone PR. -/
+The openings make this self-certifying: they pin each `cm` to a genuine note
+commitment, so `NontrivialRelation.ofNullifierCollision` reduces the collision to a
+nontrivial discrete-log relation among the commitment bases, the nullifier base, and
+the randomness base. The opening distinctness `ne` is exactly what that reduction
+consumes for nontriviality — distinct notes give distinct coefficient vectors, and
+equal notes force distinct randomness — so no separate distinct-notes premiss is
+needed. Drop the openings and `cm` is a free group element the affine `extract` lets
+`cm₂` be solved to match, certifying nothing. -/
 structure NullifierCollision (P : Primitives F G IVK NK RHO PSI MHASH MENC MSG SIG) where
   nk₁ : NK
   rcm₁ : F
@@ -74,7 +72,7 @@ structure NullifierCollision (P : Primitives F G IVK NK RHO PSI MHASH MENC MSG S
   note₂ : Note G RHO PSI
   cm₂ : G
   open₂ : P.noteCommit rcm₂ note₂ = some cm₂
-  ne : (nk₁, note₁.ρ, note₁.ψ, cm₁) ≠ (nk₂, note₂.ρ, note₂.ψ, cm₂)
+  ne : (rcm₁, note₁) ≠ (rcm₂, note₂)
   eq : P.deriveNullifier nk₁ note₁.ρ note₁.ψ cm₁
     = P.deriveNullifier nk₂ note₂.ρ note₂.ψ cm₂
 
@@ -96,7 +94,7 @@ def faerieGoldCore [DecidableEq G] [DecidableEq NK] [DecidableEq RHO] [Decidable
       exact noteCommitBreakOfNe h₁ h₂ (congrArg P.extract hin.2.2.2) hne)
   else
     .inr ⟨kv.nk w₁.kw, w₁.rcm_old, w₁.note_old, w₁.cm_old, h₁.commit_old,
-          kv.nk w₂.kw, w₂.rcm_old, w₂.note_old, w₂.cm_old, h₂.commit_old, hin, by
+          kv.nk w₂.kw, w₂.rcm_old, w₂.note_old, w₂.cm_old, h₂.commit_old, hne, by
       rw [← h₁.nf_old_eq, ← h₂.nf_old_eq]
       exact hnf⟩
 

--- a/Zcash/Security/Ledger/Statement.lean
+++ b/Zcash/Security/Ledger/Statement.lean
@@ -102,6 +102,9 @@ structure Primitives (F G IVK NK RHO PSI MHASH MENC MSG SIG : Type*) where
   /-- Verification of a spend-authorization signature under the randomized key `rk`, over
   a transaction sighash. -/
   spendAuthVerify : G → MSG → SIG → Prop
+  /-- Verification of a transaction's binding signature under the binding verification
+  key, over a transaction sighash. -/
+  bindingVerify : G → MSG → SIG → Prop
 
 /-- The tree depth, read off the Merkle interface. -/
 abbrev Primitives.depth (P : Primitives F G IVK NK RHO PSI MHASH MENC MSG SIG) : ℕ :=

--- a/Zcash/Security/Ledger/Value.lean
+++ b/Zcash/Security/Ledger/Value.lean
@@ -29,8 +29,13 @@ no-overflow bound comes from the statement's value ranges, validity's action cou
 `vBalance` range, and one numeric hypothesis `(maxActions + 1) * valueBound ≤ r`
 (deployed: `(maxActions + 1) · 2^64 ≪ r ≈ 2^254`). The extraction input — `bvk` is a
 known multiple of `R` — is the function-typed named form of RedDSA extractability
-(`extractBsk`/`hextract`), applied to validity's binding-signature conjunct; proving it
-by forking is #22's scope.
+(`extractBsk`/`hextract`), applied to validity's binding-signature conjunct. The total
+form carries no computational content on its own: in a cyclic group every `bvk` is some
+multiple of `R`, so a total `hextract` holds for a choose-the-witness `extractBsk` no one
+can run. It stands in for the forking extractor with a knowledge error — an `extractBsk`
+efficient against a binding-signature forger, delivering the relation only with the
+extractor's success probability. Proving it by forking is #22's scope (#107/#67 track the
+restructuring into the knowledge-error form).
 
 `ValueShape.balanceOrBreak` and `ValueShape.conservationOrBreak` compose
 the premiss into the Balance-value capstones: the shielded pool exceeding the minted
@@ -121,7 +126,9 @@ on failure, compute the nontrivial `(V, R)` relation from the witnessed bundle. 
 no-overflow bound is discharged from the statement's value ranges and validity's
 action-count and `vBalance` range rules; the extraction input applies the named
 RedDSA-extractability form (`extractBsk`/`hextract`) to validity's binding-signature
-conjunct. -/
+conjunct. `hextract` is a placeholder, not a theorem: as a total hypothesis it is
+classically satisfiable, computational only relative to an efficient `extractBsk` (see
+the module doc). -/
 def ValueShape.premissOrBreak {issuance : ℕ → ℕ} {maxActions : ℕ}
     {ledger : Ledger KW (ZMod r) G RHO PSI MHASH MENC MSG SIG P.depth}
     (S : ValueShape P)

--- a/Zcash/Security/Ledger/Value.lean
+++ b/Zcash/Security/Ledger/Value.lean
@@ -1,0 +1,187 @@
+import Mathlib
+import Zcash.Security.Ledger.Balance
+import Zcash.Security.BindingSignature.Balance
+
+-- This lint enforces Mathlib's minimal-hypothesis style, from which we deliberately depart.
+set_option linter.unusedSectionVars false
+
+/-!
+# The value-premiss discharge at the Pedersen shape
+
+Balance-value's per-transaction premiss — the witnessed net value matches the declared
+`vBalance`, or a break of the abstract type `VB` is exhibited — is discharged here
+against the binding-signature layer, with `VB` concretely the nontrivial `(V, R)`
+discrete-log relation.
+
+`ValueShape` is the Pedersen shape of the value commitment over the scalar field
+`ZMod r`: `ValueCommit_rcv(v) = v • V + rcv • R` for fixed independent bases `V` and
+`R` (𝒱^Orchard and ℛ^Orchard at the intended instantiation). The shape is that of the
+deployed construction, but the bases stay abstract — the concrete Pallas
+instantiation (Sinsemilla-derived bases, RedDSA on Pallas) is deferred, per the
+abstract-route plan. On a statement-satisfying transaction the model's
+binding verification key `Tx.bvk` — the sum of the actions' `cv_net`s minus a
+zero-randomness commitment to `vBalance` — is then the binding-signature layer's
+`bindingVK` of the witnessed bundle (`bvk_eq`, via `cv_net_eq`).
+
+`ValueShape.premissOrBreak` produces the premiss: it decides the net-value equation, and on
+failure computes the relation with `NontrivialRelation.ofBundleIntImbalance`. Its
+no-overflow bound comes from the statement's value ranges, validity's action count and
+`vBalance` range, and one numeric hypothesis `(maxActions + 1) * valueBound ≤ r`
+(deployed: `(maxActions + 1) · 2^64 ≪ r ≈ 2^254`). The extraction input — `bvk` is a
+known multiple of `R` — is the function-typed named form of RedDSA extractability
+(`extractBsk`/`hextract`), applied to validity's binding-signature conjunct; proving it
+by forking is #22's scope.
+
+`ValueShape.balanceOrBreak` and `ValueShape.conservationOrBreak` compose
+the premiss into the Balance-value capstones: the shielded pool exceeding the minted
+issuance (or the value ledger failing to balance) computes a nontrivial `(V, R)`
+relation.
+-/
+
+namespace Zcash.Security.Ledger.Model
+
+open Zcash.Security.BindingSignature
+
+variable {r : ℕ} [Fact (Nat.Prime r)]
+variable {G : Type*} [AddCommGroup G] [Module (ZMod r) G]
+variable {IVK NK RHO PSI MHASH MENC MSG SIG : Type*} {KW : Type*} {d : ℕ}
+variable {P : Primitives (ZMod r) G IVK NK RHO PSI MHASH MENC MSG SIG}
+variable {kv : KeyBindingInterface KW G IVK NK}
+
+/-- The Pedersen shape of the value commitment, over the scalar field `ZMod r`:
+`ValueCommit_rcv(v) = v • V + rcv • R` for fixed independent bases `V` and `R`
+(𝒱^Orchard and ℛ^Orchard at the intended instantiation). -/
+structure ValueShape (P : Primitives (ZMod r) G IVK NK RHO PSI MHASH MENC MSG SIG) where
+  V : G
+  R : G
+  commit_eq : ∀ (v : ℤ) (rcv : ZMod r),
+    P.valueCommit v rcv = (v : ZMod r) • V + rcv • R
+
+/-- A transaction's witnessed integer bundle: per action, the net value it releases
+and its commitment randomness. -/
+def txBundle (tx : Tx KW (ZMod r) G RHO PSI MHASH MENC MSG SIG d) : List (ℤ × ZMod r) :=
+  tx.actions.map fun a => ((a.w.note_old.v : ℤ) - a.w.note_new.v, a.w.rcv)
+
+/-- The bundle's value sum is the transaction's witnessed net value. -/
+theorem txBundle_fst_sum (tx : Tx KW (ZMod r) G RHO PSI MHASH MENC MSG SIG d) :
+    ((txBundle tx).map Prod.fst).sum = txNetValue tx := by
+  simp [txBundle, txNetValue, List.map_map, Function.comp_def]
+
+/-- On a statement-satisfying transaction, the model's binding verification key is the
+binding-signature layer's `bindingVK` of the witnessed bundle. -/
+theorem bvk_eq (S : ValueShape P)
+    {tx : Tx KW (ZMod r) G RHO PSI MHASH MENC MSG SIG P.depth}
+    (hsat : ∀ a ∈ tx.actions, ActionSatisfied P kv a.inst a.w) :
+    tx.bvk P
+      = bindingVK S.V S.R (castBundle (txBundle tx)) [] (tx.vBalance : ZMod r) := by
+  have hsum : (tx.actions.map fun a => a.inst.cv_net).sum
+      = ((castBundle (txBundle tx)).map fun p => valueCommit S.V S.R p.1 p.2).sum := by
+    simp only [castBundle, txBundle, List.map_map]
+    refine congrArg List.sum (List.map_congr_left fun a ha => ?_)
+    rw [Function.comp_apply, Function.comp_apply, (hsat a ha).cv_net_eq, S.commit_eq]
+    rfl
+  have hvb : P.valueCommit tx.vBalance 0 = (tx.vBalance : ZMod r) • S.V := by
+    rw [S.commit_eq]
+    simp
+  rw [Tx.bvk, bindingVK, hsum, hvb]
+  simp
+
+/-- The witnessed net value of a satisfied transaction is bounded by the action count
+times the value bound. -/
+theorem txNetValue_natAbs_le
+    {tx : Tx KW (ZMod r) G RHO PSI MHASH MENC MSG SIG P.depth}
+    (hsat : ∀ a ∈ tx.actions, ActionSatisfied P kv a.inst a.w) :
+    (txNetValue tx).natAbs ≤ tx.actions.length * P.valueBound := by
+  suffices h : ∀ L : List (Action KW (ZMod r) G RHO PSI MHASH MENC SIG P.depth),
+      (∀ a ∈ L, ActionSatisfied P kv a.inst a.w) →
+      ((L.map fun x => (x.w.note_old.v : ℤ) - x.w.note_new.v).sum).natAbs
+        ≤ L.length * P.valueBound by
+    exact h tx.actions hsat
+  intro L hL
+  induction L with
+  | nil => simp
+  | cons a t ih =>
+      have h1 : ((a.w.note_old.v : ℤ) - a.w.note_new.v).natAbs ≤ P.valueBound := by
+        have hv1 := (hL a (by simp)).v_old_lt
+        have hv2 := (hL a (by simp)).v_new_lt
+        omega
+      have h2 := ih fun x hx => hL x (by simp [hx])
+      calc (((a :: t).map fun x => (x.w.note_old.v : ℤ) - x.w.note_new.v).sum).natAbs
+          ≤ ((a.w.note_old.v : ℤ) - a.w.note_new.v).natAbs
+            + ((t.map fun x => (x.w.note_old.v : ℤ) - x.w.note_new.v).sum).natAbs := by
+            simp only [List.map_cons, List.sum_cons]
+            exact Int.natAbs_add_le _ _
+        _ ≤ P.valueBound + t.length * P.valueBound := Nat.add_le_add h1 h2
+        _ = (a :: t).length * P.valueBound := by
+            simp only [List.length_cons]
+            ring
+
+/-- **The value-premiss discharge.** Decide the per-transaction net-value equation;
+on failure, compute the nontrivial `(V, R)` relation from the witnessed bundle. The
+no-overflow bound is discharged from the statement's value ranges and validity's
+action-count and `vBalance` range rules; the extraction input applies the named
+RedDSA-extractability form (`extractBsk`/`hextract`) to validity's binding-signature
+conjunct. -/
+def ValueShape.premissOrBreak {issuance : ℕ → ℕ} {maxActions : ℕ}
+    {ledger : Ledger KW (ZMod r) G RHO PSI MHASH MENC MSG SIG P.depth}
+    (S : ValueShape P)
+    (hval : ValidLedger P kv issuance maxActions ledger)
+    (hr : (maxActions + 1) * P.valueBound ≤ r)
+    (extractBsk : G → MSG → SIG → ZMod r)
+    (hextract : ∀ bvk msg sig, P.bindingVerify bvk msg sig
+      → bvk = extractBsk bvk msg sig • S.R)
+    (tx : Tx KW (ZMod r) G RHO PSI MHASH MENC MSG SIG P.depth) (htx : tx ∈ ledger) :
+    (txNetValue tx = tx.vBalance) ⊕' BindingSignature.NontrivialRelation (F := ZMod r) S.V S.R :=
+  if heq : txNetValue tx = tx.vBalance then .inl heq
+  else
+    .inr (NontrivialRelation.ofBundleIntImbalance S.V S.R (txBundle tx) [] tx.vBalance
+      (extractBsk (tx.bvk P) tx.sighash tx.bindingSig)
+      (by
+        simp only [List.map_nil, List.sum_nil, sub_zero, txBundle_fst_sum]
+        exact sub_ne_zero.mpr heq)
+      (by
+        simp only [List.map_nil, List.sum_nil, sub_zero, txBundle_fst_sum]
+        have h1 := txNetValue_natAbs_le (P := P) (kv := kv) (hval.satisfied tx htx)
+        have h2 := hval.vbalance_bound tx htx
+        have hb : tx.actions.length * P.valueBound ≤ maxActions * P.valueBound :=
+          Nat.mul_le_mul_right _ (hval.action_bound tx htx)
+        calc (txNetValue tx - tx.vBalance).natAbs
+            ≤ (txNetValue tx).natAbs + tx.vBalance.natAbs := Int.natAbs_sub_le _ _
+          _ < maxActions * P.valueBound + P.valueBound :=
+              Nat.add_lt_add_of_le_of_lt (le_trans h1 hb) h2
+          _ = (maxActions + 1) * P.valueBound := by ring
+          _ ≤ r := hr)
+      ((bvk_eq S (hval.satisfied tx htx)).symm.trans
+        (hextract _ _ _ (hval.binding_verified tx htx))))
+
+/-- **Value conservation at the Pedersen shape.** The value ledger failing to balance
+computes a nontrivial `(V, R)` relation. -/
+def ValueShape.conservationOrBreak {issuance : ℕ → ℕ} {maxActions : ℕ}
+    {ledger : Ledger KW (ZMod r) G RHO PSI MHASH MENC MSG SIG P.depth}
+    (S : ValueShape P)
+    (hval : ValidLedger P kv issuance maxActions ledger)
+    (hr : (maxActions + 1) * P.valueBound ≤ r)
+    (extractBsk : G → MSG → SIG → ZMod r)
+    (hextract : ∀ bvk msg sig, P.bindingVerify bvk msg sig
+      → bvk = extractBsk bvk msg sig • S.R) (i : ℕ) :
+    (poolValueBalance ledger i + transparentPoolBalance issuance ledger i
+        = issuanceTotal issuance ledger i)
+      ⊕' BindingSignature.NontrivialRelation (F := ZMod r) S.V S.R :=
+  valueConservationOrBreak (S.premissOrBreak hval hr extractBsk hextract) i
+
+/-- **Balance-value at the Pedersen shape.** The shielded pool exceeding the minted
+issuance computes a nontrivial `(V, R)` relation — the Balance-value chain composed,
+with the abstract `VB` instantiated at the shape level. -/
+def ValueShape.balanceOrBreak {issuance : ℕ → ℕ} {maxActions : ℕ}
+    {ledger : Ledger KW (ZMod r) G RHO PSI MHASH MENC MSG SIG P.depth}
+    (S : ValueShape P)
+    (hval : ValidLedger P kv issuance maxActions ledger)
+    (hr : (maxActions + 1) * P.valueBound ≤ r)
+    (extractBsk : G → MSG → SIG → ZMod r)
+    (hextract : ∀ bvk msg sig, P.bindingVerify bvk msg sig
+      → bvk = extractBsk bvk msg sig • S.R) (i : ℕ) :
+    (poolValueBalance ledger i ≤ issuanceTotal issuance ledger i)
+      ⊕' BindingSignature.NontrivialRelation (F := ZMod r) S.V S.R :=
+  balanceValueOrBreak hval (S.premissOrBreak hval hr extractBsk hextract) i
+
+end Zcash.Security.Ledger.Model

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -231,16 +231,20 @@ assert_axioms ivk_eq_of_receivable
 assert_computable spendAuthForgeryOrBreak +choice
 assert_computable spendAuthorityOrBreak +choice
 
-/-! ## Honest-spend completeness
+/-! ## Honest-spend completeness and the Spendability capstone
 
 The honest construction is computable data (the wallet's own algorithm, including the
 authentication data recovered from the defined tree); the two completeness endpoints
-are theorems over it. -/
+are theorems over it. The Spendability capstone is a computed reduction: the
+roadblock branch decides nullifier membership and searches out the revealing action.
+Its `+choice` is the erased-positions tier — choice arrives with proof terms in
+`Prop` positions, never the data path. -/
 
 assert_computable honestTx
 assert_computable HonestAction.withDummySpend
 assert_axioms HonestAction.satisfied
 assert_axioms honestTx_valid
+assert_computable spendabilityOrBreak +choice
 
 /-! ## Probabilistic capstones
 

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -213,7 +213,7 @@ assert_axioms validLedger_append
 /-! ## The nullifier-binding reduction
 
 Computed break reduction: a nullifier collision between distinct notes, over the
-deployed additive derivation shape, computes a nontrivial relation among the
+additive shape of the deployed derivation, computes a nontrivial relation among the
 commitment bases, the nullifier base, and the randomness base — the balance
 argument's terminal. `+choice` is the erased-positions tier: choice arrives with the
 `abel`/`simp` proof terms in the relation's `Prop` fields, never the data path. -/

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -116,8 +116,11 @@ assert_axioms Zcash.Security.toInterface_break_measure_le
 
 /-! ## Ledger-layer break reductions
 
-These data-producing reductions rest on `propext` and `Quot.sound` only — no `Classical.choice`
-even in erased positions, which is the strict (flagless) `assert_computable` tier. -/
+Most of these data-producing reductions rest on `propext` and `Quot.sound` only — no
+`Classical.choice` even in erased positions, the strict (flagless) `assert_computable`
+tier. The exception is `nfOldEqOrBreak`: it decides the `nk`-equality branch on
+`DecidableEq NK`, so choice arrives with its proof terms in erased positions (the
+`+choice` tier). The reduction data is still a direct term of the inputs. -/
 
 assert_computable Collision.upToSign
 assert_computable Merkle.collisionOfWrongLeaf

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -7,6 +7,7 @@ import Zcash.Security.KeyBinding.Probability
 import Zcash.Security.Ledger.Balance
 import Zcash.Security.Ledger.Spendability
 import Zcash.Security.Ledger.SpendAuthority
+import Zcash.Security.Ledger.Completeness
 import Zcash.Security.Common.Birthday
 import Zcash.Security.BindingSignature.Orchard
 import Zcash.Security.BindingSignature.Sapling
@@ -217,6 +218,17 @@ data path. -/
 assert_axioms ivk_eq_of_receivable
 assert_computable spendAuthForgeryOrBreak +choice
 assert_computable spendAuthorityOrBreak +choice
+
+/-! ## Honest-spend completeness
+
+The honest construction is computable data (the wallet's own algorithm, including the
+authentication data recovered from the defined tree); the two completeness endpoints
+are theorems over it. -/
+
+assert_computable honestTx
+assert_computable HonestAction.withDummySpend
+assert_axioms HonestAction.satisfied
+assert_axioms honestTx_valid
 
 /-! ## Binding-signature relation reductions
 

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -9,6 +9,7 @@ import Zcash.Security.Ledger.Spendability
 import Zcash.Security.Ledger.SpendAuthority
 import Zcash.Security.Ledger.Completeness
 import Zcash.Security.Ledger.Capstone
+import Zcash.Security.Ledger.Nullifier
 import Zcash.Security.Common.Birthday
 import Zcash.Security.BindingSignature.Orchard
 import Zcash.Security.BindingSignature.Sapling
@@ -207,6 +208,16 @@ assert_axioms nullifiers_append
 assert_computable faerieGoldCore
 assert_computable respendOrBreak
 assert_axioms validLedger_append
+
+/-! ## The nullifier-binding reduction
+
+Computed break reduction: a nullifier collision between distinct notes, over the
+deployed additive derivation shape, computes a nontrivial relation among the
+commitment bases, the nullifier base, and the randomness base — the balance
+argument's terminal. `+choice` is the erased-positions tier: choice arrives with the
+`abel`/`simp` proof terms in the relation's `Prop` fields, never the data path. -/
+
+assert_computable NontrivialRelation.ofNullifierCollision +choice
 
 /-! ## Spend Authority
 

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -11,6 +11,7 @@ import Zcash.Security.Ledger.Completeness
 import Zcash.Security.Ledger.Capstone
 import Zcash.Security.Ledger.Nullifier
 import Zcash.Security.Ledger.Value
+import Zcash.Security.Ledger.KeyBindingArm
 import Zcash.Security.Common.Birthday
 import Zcash.Security.BindingSignature.Orchard
 import Zcash.Security.BindingSignature.Sapling
@@ -269,6 +270,14 @@ assert_axioms balanceSubset_measure_le
 assert_axioms valueConservation_measure_le
 assert_axioms balanceValue_measure_le
 assert_axioms spendAuthority_measure_le
+
+/-! ## The key-binding arm's ε, discharged
+
+The Balance-subset key-binding arm's probability in the key-binding oracle model:
+`(n + 4)(n + 3)/|RIVK|` for any `n`-query-bounded pair-annotated ledger adversary,
+inherited from the key-binding layer's bound at an unchanged query count. -/
+
+assert_axioms balanceSubset_keyBindingArm_measure_le
 
 /-! ## Binding-signature relation reductions
 

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -10,6 +10,7 @@ import Zcash.Security.Ledger.SpendAuthority
 import Zcash.Security.Ledger.Completeness
 import Zcash.Security.Ledger.Capstone
 import Zcash.Security.Ledger.Nullifier
+import Zcash.Security.Ledger.Value
 import Zcash.Security.Common.Birthday
 import Zcash.Security.BindingSignature.Orchard
 import Zcash.Security.BindingSignature.Sapling
@@ -218,6 +219,19 @@ argument's terminal. `+choice` is the erased-positions tier: choice arrives with
 `abel`/`simp` proof terms in the relation's `Prop` fields, never the data path. -/
 
 assert_computable NontrivialRelation.ofNullifierCollision +choice
+
+/-! ## The value-premiss discharge
+
+Computed reductions at the Pedersen value-commitment shape: the Balance-value
+premiss lands in the binding-signature layer's nontrivial `(V, R)` relation via
+`ofBundleIntImbalance`, with the no-overflow bound discharged from the statement's
+value ranges, validity's action-count and `vBalance` range rules, and the named
+numeric hypothesis `(maxActions + 1) * valueBound ≤ r`. `+choice` is the
+erased-positions tier. -/
+
+assert_computable ValueShape.premissOrBreak +choice
+assert_computable ValueShape.conservationOrBreak +choice
+assert_computable ValueShape.balanceOrBreak +choice
 
 /-! ## Spend Authority
 

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -8,6 +8,7 @@ import Zcash.Security.Ledger.Balance
 import Zcash.Security.Ledger.Spendability
 import Zcash.Security.Ledger.SpendAuthority
 import Zcash.Security.Ledger.Completeness
+import Zcash.Security.Ledger.Capstone
 import Zcash.Security.Common.Birthday
 import Zcash.Security.BindingSignature.Orchard
 import Zcash.Security.BindingSignature.Sapling
@@ -229,6 +230,13 @@ assert_computable honestTx
 assert_computable HonestAction.withDummySpend
 assert_axioms HonestAction.satisfied
 assert_axioms honestTx_valid
+
+/-! ## Probabilistic capstones
+
+The game-level probability statements: pure event algebra over an adversary
+distribution of valid annotated ledgers, with a named ε hypothesis per break arm. -/
+
+assert_axioms balanceSubset_measure_le
 
 /-! ## Binding-signature relation reductions
 

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -237,6 +237,9 @@ The game-level probability statements: pure event algebra over an adversary
 distribution of valid annotated ledgers, with a named ε hypothesis per break arm. -/
 
 assert_axioms balanceSubset_measure_le
+assert_axioms valueConservation_measure_le
+assert_axioms balanceValue_measure_le
+assert_axioms spendAuthority_measure_le
 
 /-! ## Binding-signature relation reductions
 

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -55,7 +55,7 @@ Two commands from `Zcash.Meta.AxiomCheck`, per the breaks-as-computed-data disci
   (`propext` / `Classical.choice` / `Quot.sound`). Both commands reject `sorryAx`.
 -/
 
-open Zcash.Security.KeyBinding Zcash.Security.RandomOracle Zcash.Security.Birthday
+open Zcash.Security.RandomOracle
 open Zcash.Security.Ledger Zcash.Security.Ledger.Model Zcash.Security.BindingSignature
 open Zcash.Meta
 
@@ -222,7 +222,7 @@ commitment bases, the nullifier base, and the randomness base — the balance
 argument's terminal. `+choice` is the erased-positions tier: choice arrives with the
 `abel`/`simp` proof terms in the relation's `Prop` fields, never the data path. -/
 
-assert_computable NontrivialRelation.ofNullifierCollision +choice
+assert_computable Zcash.Security.Ledger.Model.NontrivialRelation.ofNullifierCollision +choice
 
 /-! ## The value-premiss discharge
 
@@ -233,9 +233,9 @@ value ranges, validity's action-count and `vBalance` range rules, and the named
 numeric hypothesis `(maxActions + 1) * valueBound ≤ r`. `+choice` is the
 erased-positions tier. -/
 
-assert_computable ValueShape.premissOrBreak +choice
-assert_computable ValueShape.conservationOrBreak +choice
-assert_computable ValueShape.balanceOrBreak +choice
+assert_computable Zcash.Security.Ledger.Model.ValueShape.premissOrBreak +choice
+assert_computable Zcash.Security.Ledger.Model.ValueShape.conservationOrBreak +choice
+assert_computable Zcash.Security.Ledger.Model.ValueShape.balanceOrBreak +choice
 
 /-! ## Spend Authority
 
@@ -258,31 +258,41 @@ roadblock branch decides nullifier membership and searches out the revealing act
 Its `+choice` is the erased-positions tier — choice arrives with proof terms in
 `Prop` positions, never the data path. -/
 
-assert_computable honestTx
-assert_computable HonestAction.withDummySpend
-assert_axioms HonestAction.satisfied
-assert_axioms honestTx_valid
-assert_computable spendabilityOrBreak +choice
+assert_computable Zcash.Security.Ledger.Model.honestTx
+assert_computable Zcash.Security.Ledger.Model.HonestAction.withDummySpend
+assert_axioms Zcash.Security.Ledger.Model.HonestAction.satisfied
+assert_axioms Zcash.Security.Ledger.Model.honestTx_valid
+assert_computable Zcash.Security.Ledger.Model.spendabilityOrBreak +choice
 
 /-! ## Probabilistic capstones
 
 The game-level probability statements: pure event algebra over an adversary
 distribution of valid annotated ledgers, with a named ε hypothesis per break arm. -/
 
-assert_axioms balanceSubset_measure_le
-assert_axioms valueConservation_measure_le
-assert_axioms balanceValue_measure_le
-assert_axioms spendAuthority_measure_le
+assert_axioms Zcash.Security.Ledger.Model.balanceSubset_measure_le
+assert_axioms Zcash.Security.Ledger.Model.valueConservation_measure_le
+assert_axioms Zcash.Security.Ledger.Model.balanceValue_measure_le
+assert_axioms Zcash.Security.Ledger.Model.spendAuthority_measure_le
 
 /-! ## The key-binding arms' ε, discharged
 
 The Balance-subset and Spend Authority key-binding arms' probability in the
-key-binding oracle model: `(n + 4)(n + 3)/|RIVK|` for any `n`-query-bounded
-pair-annotated ledger adversary, inherited from the key-binding layer's bound at an
-unchanged query count. -/
+key-binding oracle model: `(n + 4)(n + 3)/|RIVK|` for any `n`-query-bounded ledger
+adversary, inherited from the key-binding layer's bound at an unchanged query count.
+The bounded events are the reductions' own; the composite machine recovers the arm's
+witness pair from the adversary's output by an oracle-free computable lookup
+(`kbPairOf` from the ledger for Balance; `kwAt` at the announced indices for Spend
+Authority), identified with the reduction's pair by the localization theorems. -/
 
-assert_axioms balanceSubset_keyBindingArm_measure_le
-assert_axioms spendAuthority_keyBindingArm_measure_le
+assert_computable Zcash.Security.Ledger.Model.BalanceBreak.kbPair
+assert_computable Zcash.Security.Ledger.Model.kbPairOf
+assert_axioms Zcash.Security.Ledger.Model.spendPinnedOrBreak_kbPair
+assert_axioms Zcash.Security.Ledger.Model.allPinnedOrBreak_kbPair
+assert_axioms Zcash.Security.Ledger.Model.balanceSubsetOrBreak_kbPair
+assert_computable Zcash.Security.Ledger.Model.kwAt
+assert_axioms Zcash.Security.Ledger.Model.spendAuthorityOrBreak_pair
+assert_axioms Zcash.Security.Ledger.Model.balanceSubset_keyBindingArm_measure_le
+assert_axioms Zcash.Security.Ledger.Model.spendAuthority_keyBindingArm_measure_le
 
 /-! ## Binding-signature relation reductions
 

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -271,13 +271,15 @@ assert_axioms valueConservation_measure_le
 assert_axioms balanceValue_measure_le
 assert_axioms spendAuthority_measure_le
 
-/-! ## The key-binding arm's ε, discharged
+/-! ## The key-binding arms' ε, discharged
 
-The Balance-subset key-binding arm's probability in the key-binding oracle model:
-`(n + 4)(n + 3)/|RIVK|` for any `n`-query-bounded pair-annotated ledger adversary,
-inherited from the key-binding layer's bound at an unchanged query count. -/
+The Balance-subset and Spend Authority key-binding arms' probability in the
+key-binding oracle model: `(n + 4)(n + 3)/|RIVK|` for any `n`-query-bounded
+pair-annotated ledger adversary, inherited from the key-binding layer's bound at an
+unchanged query count. -/
 
 assert_axioms balanceSubset_keyBindingArm_measure_le
+assert_axioms spendAuthority_keyBindingArm_measure_le
 
 /-! ## Binding-signature relation reductions
 

--- a/book/src/formal-verification/security-definitions.md
+++ b/book/src/formal-verification/security-definitions.md
@@ -69,16 +69,16 @@ flowchart TD
   STMT -. "<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Snark/Soundness/Composition/Bridge.lean'>justified by<br/>the extractor;<br/>hencodes gap</a>" .-> KS["Knowledge soundness:<br/>accepting proof yields<br/>witness or break data"]
   NCBK --> SDLR["Sinsemilla<br/>discrete-log<br/>relation"]
 
-  NDLR --->|"<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Snark/Soundness/AGM/BindingSignature.lean'>independent<br/>hash-to-curve bases</a>"| DL
+  NDLR -->|"<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Snark/Soundness/AGM/BindingSignature.lean'>independent<br/>hash-to-curve bases</a>"| DL
   SDLR -->|"<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Snark/Soundness/AGM/BindingSignature.lean'>independent<br/>hash-to-curve bases</a>"| DL
   KS --->|"<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Snark/Soundness/AGM/Capstone.lean'>AGM heuristic +<br/>independent<br/>hash-to-curve bases</a>"| DL
-  KS --->|"<a target='_blank' href='https://github.com/zcash/ironwood/tree/main/Zcash/Snark/Soundness/Forking'>Fiat–Shamir<br/>heuristic</a>"| ROM
+  KS -->|"<a target='_blank' href='https://github.com/zcash/ironwood/tree/main/Zcash/Snark/Soundness/Forking'>Fiat–Shamir<br/>heuristic</a>"| ROM
   MC --> SDLR
   CUS --->|"<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Security/Common/Birthday.lean'>birthday counting<br/>q(q-1)/r,<br/>no assumption</a>"| ROM
-  NFC --->|"<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Security/Ledger/Spendability.lean'>nullifier base<br/>independent of<br/>commitment bases</a>"| DL
+  NFC -->|"<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Security/Ledger/Nullifier.lean'>distinct-note openings<br/>compute</a>"| SDLR
   SAF --> RDSA["RedDSA unforgeability,<br/>±-randomized keys"]
-  RDSA --->|"re-rand reduction<br/><a target='_blank' href='https://eprint.iacr.org/2015/395'>[FKMSSS2016]</a> +<br/>forking extraction"| DL
-  RDSA --->|"challenge hash<br/>as random oracle"| ROM
+  RDSA -->|"re-rand reduction<br/><a target='_blank' href='https://eprint.iacr.org/2015/395'>[FKMSSS2016]</a> +<br/>forking extraction"| DL
+  RDSA -->|"challenge hash<br/>as random oracle"| ROM
 
   click BAL "https://github.com/zcash/ironwood/blob/main/Zcash/Security/Ledger/Balance.lean" _blank
   click SPEND "https://github.com/zcash/ironwood/blob/main/Zcash/Security/Ledger/Spendability.lean" _blank
@@ -121,13 +121,10 @@ flowchart TD
 </p>
 
 This picture is a deliberate approximation, and is likely to change as the formalization
-proceeds. Some edges are coarser than the eventual argument — for example, the
-`NullifierCollision` edge to discrete log is a named hypothesis whose `PRF^nf` component
-is not yet decomposed, and may not reduce to discrete log alone. The RedDSA node is a
-named hypothesis rather than a terminal assumption: its discharge edge names the
-reduction for security of signatures with re-randomizable keys
-[<a href="https://eprint.iacr.org/2015/395">FKMSSS2016</a>, section 3], adapted
-to the ±-randomized variant, together with forking extraction of the Schnorr witness.
+proceeds. The RedDSA node is a named hypothesis rather than a terminal assumption: its
+discharge edge names the reduction for security of signatures with re-randomizable keys
+[<a href="https://eprint.iacr.org/2015/395">FKMSSS2016</a>, section 3], adapted to the
+±-randomized variant, together with forking extraction of the Schnorr witness.
 
 Every solid arrow reads "rests on"; where an edge carries a label, the label names the
 computed break object flowing along it, or the adversary model or side condition under which
@@ -209,7 +206,7 @@ circuit soundness proof.
 
 <section>
 <div class="grp">Shared foundation · Zcash/Security/Common</div>
-<div class="g"><div class="g-head"><span class="term">collision vocabulary</span><span class="anchor">Security.RandomOracle.Collision · CollisionUpToSign</span></div><div class="def">Layer-A break events for the classical ROM: a <code>Collision</code> is two distinct queries with equal outputs; a <code>CollisionUpToSign</code> (<code>a =± b</code>) is the shape produced by arguments passing through the <code>Extract</code> coordinate extractor, whose fibres are <code>{P, −P}</code>. Both key binding and the nullifier (Faerie-Gold) argument bottom out here.</div></div>
+<div class="g"><div class="g-head"><span class="term">collision vocabulary</span><span class="anchor">Security.RandomOracle.Collision · CollisionUpToSign</span></div><div class="def">Layer-A break events for the classical ROM: a <code>Collision</code> is two distinct queries with equal outputs; a <code>CollisionUpToSign</code> (<code>a =± b</code>) is the shape produced by arguments passing through the <code>Extract</code> coordinate extractor, whose fibres are <code>{P, −P}</code>. Key binding bottoms out here, as does the nullifier (Faerie-Gold) argument for the Recovery Statement; the deployed nullifier argument bottoms out in the Sinsemilla discrete-log relation instead.</div></div>
 <div class="g"><div class="g-head"><span class="term">birthday bound</span><span class="anchor">Security.Birthday.birthday_closed_form</span></div><div class="def">The Layer-C probability: the shifted <code>±</code>-collision event over <code>q</code> uniform oracle outputs has probability at most <code>q(q-1)/|F|</code>, by union-bounding the per-pair fraction <code>2/|F|</code>. Counted in the random-oracle model with no hardness assumption; proven as a probability statement over the uniform oracle table (#73).</div></div>
 </section>
 


### PR DESCRIPTION
This PR carries the completeness direction, the probabilistic layer, and the shape-level discharges of the ledger games — the #72 scope, continued on top of the now-merged #102. fixes #72

- `Model.lean` gains append and saturation lemmas: the leaf list distributes over concatenation, and the transparent pool balance ignores extensions within a prefix, saturates at the ledger's length, and steps by issuance plus `vBalance` across an appended transaction.

- `Completeness.lean` checks that the protocol's intended use actually works. `HonestAction` packages what an honest wallet knows for one Action; from that data alone the module constructs the Action and proves the statement (`satisfied` — the Merkle conjunct is `path_of_root` on the honest authentication data, which exists because the referenced tree is defined). `honestTx` bundles any number of Actions up to the action bound and declares its true summed net value, so honest transactions discharge the Balance game's value premiss; `honestTx_valid` shows appending one preserves validity. Inclusion is required only of nonzero-valued spends, and `HonestAction.withDummySpend` constructs the dummy case — an honest wallet does not need a received note to create an Action. Per-action anchors within one transaction are a documented simplification: deployed Orchard encodes one anchor per transaction (Sapling v4 allowed per-spend anchors), and per-action anchors only widen what the adversary may do.

- `Capstone.lean` is the probabilistic layer. An adversary is an arbitrary `PMF` over valid annotated ledgers (`ValidAnnotated`). Restricting to valid ledgers loses no generality: every bad event requires validity, so conditioning on validity can only increase success probability, and a bound over valid samples implies the bound over bare ledgers. Events are reduction-branch preimages —"the reduction lands in this arm on this sample"— so no choice is needed to extract break data. The composition is pure event algebra: each violation event is contained in the union of its arm events, so its probability is at most the sum of the per-arm probabilities (`measure_mono` plus `measure_union_le`), each bounded by a named ε hypothesis. Instances: Balance-subset (Merkle, note-commitment, and key-binding arms), Balance-value (the value-premiss arm, in conservation and corollary forms), and Spend Authority (forgery and key-binding arms, for a victim key witness and its signing history).

- `Nullifier.lean` is the nullifier-binding reduction deferred from #102. `NullifierShape` is the additive derivation shape of the deployed construction (the [Orchard nullifier design](https://zcash.github.io/orchard/design/nullifiers.html)): derivation is a scalar multiple of the nullifier base `K` plus the commitment point, extracted with the ±-property. Commitments open as coefficient combinations of the fixed commitment bases (for Sinsemilla: `𝒬, 𝒮(0), 𝒮(1), …`) plus a multiple of the randomness base `R`. `NontrivialRelation.ofNullifierCollision` computes a nullifier collision directly into the balance argument's terminal — a nontrivial relation among the commitment bases, `K`, and `R`, under the same independent-hash-to-curve-bases discharge. Nontriviality comes from the shape's two coefficient conditions (distinct notes have distinct coefficient vectors; coefficient vectors never cancel additively), both concrete consequences of the initial `2^n • 𝒬` term. The reduction needs no distinct-notes premiss: the collision's own opening distinctness covers every case (distinct notes use the coefficient difference; equal notes force distinct commitment randomness). It therefore composes directly with the collisions `faerieGoldCore` produces, which hold exactly that inequality at construction.

- `spendabilityOrBreak` (in `Completeness.lean`) is the Spendability capstone at the deterministic layer: the owner of a received note can spend it. Either appending the honest transaction keeps the ledger valid, or the ledger's own data computes the obstruction — an action already spending the owner's exact opening (`Respend`, the case Spend Authority covers), a note-commitment break, or a nullifier collision. The roadblock branch decides nullifier membership, searches out the revealing action, and runs `respendOrBreak` against the owner's satisfied action.

- The security map routes `NullifierCollision` to the Sinsemilla discrete-log relation via the formalized reduction, and drops the caveat about an undecomposed `PRF^nf` component. The reduction needs no PRF assumption: the case that would have needed one —equal notes and randomness under distinct `nk`— cannot arise, because equal openings pin the commitment and the two spends coincide. This matches the Orchard design page's conclusion that Faerie Resistance rests on discrete log alone.

- The model gains the binding-signature side: `Primitives.bindingVerify` (the deployed pool's concrete primitives take the predicate as a parameter, like spend-auth verification), transactions carry their binding signature, `Tx.bvk` is the binding verification key (`∑ cv_net − ValueCommit_0(vBalance)`), and `ValidLedger` gains the consensus binding-signature rule and the `valueBalance` range rule (reusing `valueBound`, so no new game parameter). The validity constructors establish both — persistence per-transaction, the honest constructors from two wallet-checkable boundary hypotheses. `Value.lean` then discharges Balance-value's per-transaction premiss at the Pedersen shape. `ValueShape` is the shape `valueCommit v rcv = v • V + rcv • R` over abstract fixed bases — 𝒱 and ℛ at the intended instantiation; the concrete Pallas instantiation, with Sinsemilla-derived bases and RedDSA on Pallas, is deferred per the abstract-route plan. `ValueShape.premissOrBreak` decides the net-value equation; on failure it computes the binding-signature layer's nontrivial `(V, R)` relation via `ofBundleIntImbalance`. The no-overflow bound comes from the statement's value ranges, validity's action-count and `vBalance` range rules, and one numeric hypothesis `(maxActions + 1) * valueBound ≤ r`. The extraction input is the function-typed named form of RedDSA extractability applied to the new conjunct — a placeholder: the total form is classically satisfiable, so it has computational content only relative to an efficient extractor (#22 tracks the forking extractor-with-knowledge-error form). `ValueShape.balanceOrBreak` and `ValueShape.conservationOrBreak` compose the premiss into the Balance-value capstones, with the abstract `VB` instantiated at the shape level. Shape members drop from their base names what the namespace already says, so no base name collides with the abstract capstones they instantiate.

- `KeyBindingArm.lean` bounds the key-binding arms in the key-binding oracle model at the reductions' own events: `(n + 4)(n + 3)/|RIVK|` for any `n`-query-bounded ledger adversary, via `toInterface_break_measure_le` at an unchanged query count. The sampling is the named `kbExperiment` (do-notation, shared with the key-binding layer's bound; the oracle-model types share a universe because `PMF`'s monad instance is single-universe). The adversary outputs a ledger; the arm's witness pair is an oracle-free function of it (`kbPairOf`, the `findPair` duplicate's key witnesses, identified with the reduction's pair by `balanceSubsetOrBreak_kbPair`), so the Balance event is simply "the reduction lands in the key-binding arm". Spend Authority's selection criterion includes the undecidable `Signed`, so its adversary announces a transaction and action index — pointing at its own break — and the machine derives the pair from the indices (`kwAt`, `spendAuthorityOrBreak_pair`); its event is the bundled `SpendAuthorityKBArm`. The pair-recovery functions are censused as computable at the strict flagless tier. What remains for the capstones' ε_kb: the adversary here is an oracle machine rather than the capstones' `PMF` over valid annotated ledgers; that bridge is tracked in #107.

Full build green.

Filed using AI (Claude Fable 5).




