### PR TITLE
Enforce the csimp-census and native-opt-in trust rules

### DIFF
--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -75,6 +75,12 @@ jobs:
       # native_decide axiom tracking (lean4#7463).
       - name: Verify csimp lemmas are axiom-censused
         run: scripts/check_csimp_census.sh
+      # Executing a check through a locally compiled precompileModules dylib is a
+      # coarse-grained compiler-trust event with no axiom trace, so it must be an
+      # explicit opt-in: no module reaching a lane module by imports may contain an
+      # evaluation-based check without an entry in the script's opt-in list.
+      - name: Verify native-executing checks are opt-in
+        run: python3 scripts/check_native_optin.py
           diff Stamp.lean <(./stamp.sh) \
             || { echo "::error::Stamp.lean is stale; regenerate with ./stamp.sh > Stamp.lean"; exit 1; }
       # Installs the toolchain from lean-toolchain, fetches the Mathlib olean

--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -70,6 +70,11 @@ jobs:
           diff <(ls *.json | sort) <(awk '{print $2}' SHA256SUMS | sort) \
             || { echo "::error::SHA256SUMS must list exactly the committed *.json fixtures"; exit 1; }
           sha256sum -c SHA256SUMS
+      # Every @[csimp] replacement lemma must have its own assert_axioms entry in
+      # Zcash/TrustBoundary.lean: csimp-proof axioms are not propagated into downstream
+      # native_decide axiom tracking (lean4#7463).
+      - name: Verify csimp lemmas are axiom-censused
+        run: scripts/check_csimp_census.sh
           diff Stamp.lean <(./stamp.sh) \
             || { echo "::error::Stamp.lean is stale; regenerate with ./stamp.sh > Stamp.lean"; exit 1; }
       # Installs the toolchain from lean-toolchain, fetches the Mathlib olean

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -1,6 +1,7 @@
 import Zcash.Circuits.Action.RealBases
 import Zcash.Security.Ledger.Bridge
 import Zcash.Security.Ledger.SinsemillaDLR
+import Zcash.Arithmetic.FastMsm
 import Zcash.Security.KeyBinding.Instance
 import Zcash.Security.KeyBinding.Probability
 import Zcash.Security.Ledger.Balance
@@ -874,3 +875,14 @@ assert_axioms Zcash.Security.Ledger.Bridge.breakCoeffs_nontrivial
 assert_axioms Zcash.Security.Ledger.Bridge.classify_query_inr +native
 assert_axioms Zcash.Security.Ledger.Bridge.classifyRelation_isSome_iff +native
 assert_axioms Zcash.Security.Ledger.Bridge.classifyRelation_site +native
+
+/-! ## `@[csimp]` replacement lemmas
+
+Every `@[csimp]` lemma gets an axiom check here. The compiler applies the
+substitution in all downstream compiled code, but the axioms of the lemma's own
+proof are not propagated into downstream `native_decide` axiom tracking (
+[lean4#7463](https://github.com/leanprover/lean4/issues/7463)), so a csimp lemma
+whose proof smuggled `sorryAx` or a project axiom would be invisible to every
+consumer's census entry. Checking the lemma itself closes that hole. -/
+
+assert_axioms Zcash.Arithmetic.Msm.evalNat_eq_evalNatFast

--- a/_typos.toml
+++ b/_typos.toml
@@ -26,6 +26,7 @@ extend-ignore-identifiers-re = [
 ]
 
 [default.extend-words]
+optin = "optin" # scripts/check_native_optin.py
 advices = "advices"
 thr = "thr"  # threshold identifiers (`thr`, `thr1`, `thr4`) in Composition/Completeness
 hsi = "hsi"  # hypothesis identifiers (`hsiN`) in Verifier/Assemble

--- a/book/src/formal-verification.md
+++ b/book/src/formal-verification.md
@@ -72,6 +72,16 @@ axiom: CompElliptic's curve point-count, a closed computational fact discharged 
 soundness (Pallas). The `+native` flag on the corresponding build-time checks records
 exactly which endpoints carry it.
 
+**`@[csimp]` replacement lemmas** get their own `assert_axioms` entries in
+`Zcash/TrustBoundary.lean`, enforced by `scripts/check_csimp_census.sh` in CI: the compiler
+applies a csimp substitution in all downstream compiled code, but the axioms of the lemma's
+own proof are not propagated into downstream `native_decide` axiom tracking (
+[lean4#7463](https://github.com/leanprover/lean4/issues/7463)), so the check must sit on the
+lemma itself. The underlying mechanism study — what `native_decide`, the interpreter, and
+precompiled native code actually trust — is
+[`design/lean-native-trust-research.md`](https://github.com/daira/CompElliptic/blob/main/design/lean-native-trust-research.md)
+in the CompElliptic repository.
+
 **Concrete, closed facts with no free variables** may additionally use `native_decide`
 (which discharges a goal by running compiled native code, adding a compiler-trust axiom) and
 the kernel's GMP-backed bignum arithmetic. The principal such fact in this repository is the

--- a/book/src/formal-verification.md
+++ b/book/src/formal-verification.md
@@ -82,6 +82,15 @@ precompiled native code actually trust — is
 [`design/lean-native-trust-research.md`](https://github.com/daira/CompElliptic/blob/main/design/lean-native-trust-research.md)
 in the CompElliptic repository.
 
+**Native-executing checks are opt-in.** Executing a check through locally compiled native
+code (a `precompileModules` dylib — ours, or the CompElliptic pin's) trusts the C emitter,
+the local C toolchain, and the loader, coarse-grained and with no axiom trace. Loading a
+lane's dylib is inseparable from elaborating modules that import it, so the enforced
+invariant sits at the level of checks: no module whose import closure reaches a lane module
+may contain an evaluation-based check (`#eval`, `#guard`, `native_decide`) unless explicitly
+opted in, enforced by `scripts/check_native_optin.py` in CI. Appendix C of the research
+document linked above records the observed Lake behaviour behind this rule.
+
 **Concrete, closed facts with no free variables** may additionally use `native_decide`
 (which discharges a goal by running compiled native code, adding a compiler-trust axiom) and
 the kernel's GMP-backed bignum arithmetic. The principal such fact in this repository is the

--- a/scripts/check_csimp_census.sh
+++ b/scripts/check_csimp_census.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Check that every `@[csimp]` declaration in the library is covered by an
+# `assert_axioms` entry in Zcash/TrustBoundary.lean. The compiler applies a
+# csimp substitution in all downstream compiled code, but the axioms of the lemma's
+# own proof are not propagated into downstream `native_decide` axiom tracking (
+# lean4#7463), so a csimp lemma whose axioms go unchecked would be an
+# axiom-smuggling channel.
+#
+# Robustness: every line containing "csimp" is scanned. Documentation must quote
+# mentions as exactly `@[csimp]` (backtick-quoted); that exact string is removed
+# before testing, so any remaining attribute syntax (`@[..., csimp, ...]` or
+# `attribute [csimp] name`) is treated as real and must name its declaration on
+# the same line. Matching against the census is by the declaration's final name
+# component.
+#
+# Scope: this guards against accidental omissions, NOT adversarial code. Run from
+# the repository root; exits non-zero on violation.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# Every "csimp" line in the library (the census file itself included: a csimp
+# declared there is enforced like any other, and its comments follow the same
+# quoting rule).
+matches=$(grep -rn "csimp" Zcash/ --include="*.lean" || true)
+
+status=0
+count=0
+while IFS=: read -r file lineno line; do
+  [[ -z "$file" ]] && continue
+  stripped=${line//'`@[csimp]`'/}
+  if ! printf '%s' "$stripped" | grep -qE '@\[[^]]*\bcsimp\b|attribute[[:space:]]*\[[^]]*\bcsimp\b'; then
+    continue  # only quoted documentation mentions on this line
+  fi
+  name=$(printf '%s' "$stripped" | sed -nE "s/.*(theorem|def)[[:space:]]+([A-Za-z0-9_'.]+).*/\2/p")
+  if [[ -z "$name" ]]; then
+    name=$(printf '%s' "$stripped" | sed -nE "s/.*attribute[[:space:]]*\[[^]]*csimp[^]]*\][[:space:]]+([A-Za-z0-9_'.]+).*/\1/p")
+  fi
+  if [[ -z "$name" ]]; then
+    echo "VIOLATION: $file:$lineno: csimp attribute syntax must name its declaration on the same line (write \`@[csimp] theorem <name>\`), and documentation mentions must be quoted as exactly \`@[csimp]\`" >&2
+    status=1
+    continue
+  fi
+  count=$((count + 1))
+  if ! grep -qE "^assert_axioms .*\.${name}( |\$)|^assert_axioms ${name}( |\$)" Zcash/TrustBoundary.lean; then
+    echo "VIOLATION: csimp declaration ${name} ($file:$lineno) has no assert_axioms entry in Zcash/TrustBoundary.lean" >&2
+    status=1
+  fi
+done <<< "$matches"
+
+if [[ $status -eq 0 ]]; then
+  echo "csimp census: ${count} csimp declaration(s), all covered."
+fi
+exit $status

--- a/scripts/check_native_optin.py
+++ b/scripts/check_native_optin.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Check that native-executing checks are opt-in.
+
+Elaborating a module that (transitively) imports a `precompileModules` lane module
+loads the lane's locally compiled dylib, and the interpreter then dispatches calls
+into it for any evaluation run during that module's elaboration. Loading is
+unavoidable for the lane's own proof modules, so the enforced invariant is one
+level up: no module whose import closure reaches a lane module may contain an
+evaluation-based check (`#eval`, `#guard`, `native_decide`) unless it is on the
+explicit opt-in list below. A check that executes locally compiled native code
+trusts the C emitter, the local C toolchain, and the loader, coarse-grained and
+with no axiom trace — so it must be a documented decision, never ambient.
+
+Scope: textual, non-adversarial (comments and strings are stripped heuristically;
+crafted code could evade this). The local lane is parsed from lakefile.toml; the
+pin lane is an explicit mirror (see PIN_LANE). Run from the repository root;
+exits non-zero on violation.
+"""
+import re, sys
+from pathlib import Path
+
+def parse_local_lane():
+    """The local lane, parsed from lakefile.toml (the single source of truth):
+    every lean_lib with precompileModules = true contributes its globs. A glob
+    ending in ".+" is a prefix entry. Parse failures are violations, not skips.
+    (A hand-rolled block parse rather than tomllib, which needs python 3.11+.)"""
+    text = Path("lakefile.toml").read_text()
+    lane = []
+    for block in re.split(r"(?m)^\[\[lean_lib\]\]", text)[1:]:
+        block = re.split(r"(?m)^\[", block)[0]  # stop at the next table header
+        if not re.search(r"(?m)^precompileModules\s*=\s*true", block):
+            continue
+        globs_m = re.search(r"(?m)^globs\s*=\s*\[(.*?)\]", block, re.S)
+        globs = re.findall(r'"([^"]+)"', globs_m.group(1)) if globs_m else []
+        if not globs:
+            name_m = re.search(r'(?m)^name\s*=\s*"([^"]+)"', block)
+            print(f"ERROR: cannot determine the globs of precompileModules "
+                  f"library {name_m.group(1) if name_m else '?'}; extend "
+                  f"parse_local_lane", file=sys.stderr)
+            sys.exit(2)
+        for g in globs:
+            lane.append(("prefix", g[:-2]) if g.endswith(".+") else ("one", g))
+    if not lane:
+        print("ERROR: no precompileModules library found in lakefile.toml; "
+              "if the lane was removed, retire this script", file=sys.stderr)
+        sys.exit(2)
+    return lane
+
+# The CompElliptic pin's lane modules: importing them loads the pin's dylib.
+# Not derivable from this repository's lakefile — mirror of the pin's
+# precompileModules globs; re-check whenever the CompElliptic pin is bumped
+# (the pin's scripts/check_native_optin.py --print-lane prints them).
+PIN_LANE = [
+    ("one", "FastFieldNative"),
+    ("one", "CompElliptic.Vendor.CompPoly.Montgomery.Native64x8Defs"),
+    ("one", "CompElliptic.Curves.Pasta.Fast.ProjectiveMontDefs"),
+]
+
+LANE_ENTRIES = parse_local_lane() + PIN_LANE
+
+def is_lane(mod: str) -> bool:
+    return any(mod == name or (kind == "prefix" and mod.startswith(name + "."))
+               for kind, name in LANE_ENTRIES)
+# Modules allowed to contain evaluation-based checks despite reaching a lane
+# module. Add a module here only with a comment saying which checks it runs and
+# why native execution is intended.
+OPT_IN = set()
+
+EVAL_TOKENS = re.compile(r"#eval\b|#guard\b|\bnative_decide\b|\bdecide\s*\+\s*native\b")
+
+def module_name(path: Path) -> str:
+    return ".".join(path.with_suffix("").parts)
+
+def strip_code(text: str) -> str:
+    # Remove block comments (with nesting), line comments, and string literals.
+    out, i, depth, n = [], 0, 0, len(text)
+    while i < n:
+        two = text[i:i+2]
+        if two == "/-":
+            depth += 1; i += 2; continue
+        if depth > 0:
+            if two == "-/":
+                depth -= 1; i += 2
+            else:
+                i += 1
+            continue
+        if two == "--":
+            j = text.find("\n", i)
+            i = n if j == -1 else j
+            continue
+        if text[i] == '"':
+            j = i + 1
+            while j < n and text[j] != '"':
+                j += 2 if text[j] == "\\" else 1
+            i = j + 1
+            continue
+        out.append(text[i]); i += 1
+    return "".join(out)
+
+files = sorted(Path("Zcash").rglob("*.lean")) + [p for p in [Path("Zcash.lean")] if p.exists()]
+imports = {}
+for f in files:
+    mods = re.findall(r"^import\s+([A-Za-z0-9_.]+)", f.read_text(), re.M)
+    imports[module_name(f)] = set(mods)
+
+# Modules whose import closure reaches the lane.
+reaches = set()
+changed = True
+while changed:
+    changed = False
+    for m, deps in imports.items():
+        if m not in reaches and any(is_lane(d) or d in reaches for d in deps):
+            reaches.add(m); changed = True
+
+status = 0
+for f in files:
+    m = module_name(f)
+    if m not in reaches or is_lane(m) or m in OPT_IN:
+        continue
+    code = strip_code(f.read_text())
+    hits = sorted(set(EVAL_TOKENS.findall(code)))
+    if hits:
+        print(f"VIOLATION: {f} reaches a precompiled lane module and contains "
+              f"evaluation-based check(s) {hits}; native-executing checks must be "
+              f"opt-in — add the module to OPT_IN in this script with a rationale, "
+              f"or move the check out of the lane's import cone", file=sys.stderr)
+        status = 1
+
+in_cone = sorted(m for m in reaches if not is_lane(m) and m in imports)
+print(f"native opt-in: {len(in_cone)} module(s) in the lane import cone, "
+      f"{len(OPT_IN)} opted in, no ambient native-executing checks"
+      if status == 0 else "native opt-in: violations found", file=sys.stdout)
+sys.exit(status)


### PR DESCRIPTION
Ports the two trust-enforcement rules adopted in CompElliptic (daira/CompElliptic#16, daira/CompElliptic#17) to this repository:

- **csimp census**: every `@[csimp]` replacement lemma must carry its own `assert_axioms` entry in `Zcash/TrustBoundary.lean`, because the axioms of a csimp proof are not propagated into downstream `native_decide` axiom tracking ([lean4#7463](https://github.com/leanprover/lean4/issues/7463)). The one existing csimp lemma (`Zcash.Arithmetic.Msm.evalNat_eq_evalNatFast`) is now censused at the standard tier; `scripts/check_csimp_census.sh` enforces the rule in CI.
- **native opt-in**: executing a check through a locally compiled `precompileModules` dylib (ours or the CompElliptic pin's) is a coarse-grained compiler-trust event with no axiom trace, and loading is inseparable from elaborating lane-importing modules — so the enforced invariant sits at the level of checks: no module whose import closure reaches a lane module may contain an evaluation-based check (`#eval`, `#guard`, `native_decide`) without an explicit opt-in entry. `scripts/check_native_optin.py` enforces this in CI; the local lane is parsed from `lakefile.toml`, the pin's lane is an explicit mirror re-checked on pin bumps. Currently one module in the lane import cone and no ambient checks. If #99's VK-pin checks rely on native compilation, they will need to be added to the opt-in list, with rationale.

The book's formal-verification page documents both rules; the underlying mechanism study is [`design/lean-native-trust-research.md`](https://github.com/daira/CompElliptic/blob/main/design/lean-native-trust-research.md) in the CompElliptic repository. Both guards share the non-adversarial scope of the existing fixture checks. Full `lake build Zcash` green at the census commit; the guard commits are script/CI/book only.

🤖 Claude Fable 5