### PR TITLE
fv: require fully-qualified names and native provenance in the trust census

### DIFF
--- a/Zcash/Meta/AxiomCheck.lean
+++ b/Zcash/Meta/AxiomCheck.lean
@@ -12,6 +12,11 @@ declared tier (a `sorry`, an unexpected axiom, or `native_decide` where none was
 
 The `#guard_msgs`-pinned form remains the right tool when the *exact* axiom set is the claim.
 
+Both commands require their argument to be written fully qualified (`checkFullyQualified`):
+an unqualified name resolves through the census file's `open`s, so a same-base-name cousin in
+an opened namespace can silently capture an entry meant for a declaration that is not in scope
+at all — the assertion then reads as covering one theorem while checking another.
+
 This command is also used in CompElliptic (`CompElliptic/Meta/AxiomCheck.lean`); changes here
 should be reflected there and vice versa.
 -/
@@ -29,19 +34,75 @@ the check stable across the toolchain-dependent axiom naming. -/
 def isNativeDecideAxiom (n : Name) : Bool :=
   n.components.any (· == `native_decide)
 
+/-- Assertion names must be written fully qualified. Resolution through `open`s is
+context-dependent: a same-base-name cousin in an opened namespace can silently capture an
+entry meant for a declaration that is not even in scope, so the assertion reads as covering
+one theorem while checking another. Requiring the written name to equal the resolved
+constant's full name (an optional `_root_.` prefix is accepted) makes every entry
+independent of the file's `open`s and turns the wrong-cousin case into a loud error. -/
+def checkFullyQualified (n : Ident) (resolved : Name) : CommandElabM Unit := do
+  let written := n.getId
+  unless written == resolved || written == rootNamespace ++ resolved do
+    throwError "{n} is not written fully qualified: it resolves to '{resolved}'. \
+      Write the full name so the entry does not depend on this file's `open`s."
+
+/-- The declaration a `native_decide` axiom certifies: the axiom name's components strictly
+before its first `_native` / `native_decide` component
+(e.g. `Foo.bar._native.native_decide.ax_1_1` is owned by `Foo.bar`). -/
+def nativeAxiomOwner (ax : Name) : Name :=
+  (ax.components.takeWhile fun c => c != `_native && c != `native_decide).foldl
+    Name.append Name.anonymous
+
+/-- Render a list of owners as the text to write inside `+native(...)`. -/
+def ownersText (owners : List Name) : String :=
+  ", ".intercalate (owners.map toString)
+
+/-- `+native` must name the owning declaration(s) of exactly the `native_decide` axioms the
+entry actually reaches, fully qualified. A bare `+native` would permit a `native_decide`
+axiom smuggled in by *any* declaration entering the dependency cone; naming the owners makes
+the census state precisely which native certificates are trusted, and a new native axiom —
+or a stale annotation — fails the build with the list to write. -/
+def checkNativeAllowance (n : Ident) (axs : Array Name) (allowed : Option (Array Name)) :
+    CommandElabM Unit := do
+  let owners := (axs.filter isNativeDecideAxiom |>.map nativeAxiomOwner).toList.eraseDups
+  match allowed with
+  | none =>
+    unless owners.isEmpty do
+      throwError "{n} depends on native_decide axiom(s); name their owning declaration(s): \
+        write '+native({ownersText owners})'"
+  | some allowedArr =>
+    let allowedL := allowedArr.toList.eraseDups
+    if owners.isEmpty then
+      throwError "{n} reaches no native_decide axiom; drop the '+native(...)' flag"
+    unless owners.all allowedL.contains && allowedL.all owners.contains do
+      throwError "{n}: '+native' names {allowedL} but the native_decide axiom(s) present \
+        are owned by {owners}; write '+native({ownersText owners})'"
+
+/-- The `+native(A, B)` flag: the parenthesized, comma-separated owner list is required. -/
+syntax nativeFlag := "+native" "(" ident,+ ")"
+
+/-- Extract the annotation list from an optional `+native(A, B)` flag: `none` when the flag
+is absent, `some names` with the parenthesized list otherwise. -/
+def nativeAnnotation (native : Option (TSyntax ``nativeFlag)) : Option (Array Name) :=
+  native.map fun stx => stx.raw[2].getSepArgs.map (·.getId)
+
 /--
 `assert_axioms foo` fails the build unless `foo` depends only on the standard axioms
 (`propext`, `Classical.choice`, `Quot.sound`) — in particular, no `sorry` and no `native_decide`.
 
-`assert_axioms foo +native` additionally permits `native_decide` compiler-trust axioms, whose exact
-names are toolchain-dependent. Any other axiom (including `sorryAx`) is still rejected.
+`assert_axioms foo +native(D₁, ...)` additionally permits `native_decide` compiler-trust axioms —
+exactly those owned by the named declarations, written fully qualified. The axiom names' tails are
+toolchain-dependent, so entries name the owning declarations rather than the axioms themselves.
+Any other axiom (including `sorryAx`) is still rejected, as is a stale or incomplete list.
 -/
-elab "assert_axioms " n:ident native:("+native")? : command => do
+elab "assert_axioms " n:ident native:(nativeFlag)? : command => do
   let name ← liftCoreM <| realizeGlobalConstNoOverloadWithInfo n
+  checkFullyQualified n name
   let axs ← collectAxioms name
-  let allowNative := native.isSome
+  let allowed := nativeAnnotation native
+  checkNativeAllowance n axs allowed
   let unexpected := axs.filter fun ax =>
-    !standardAxioms.contains ax && !(allowNative && isNativeDecideAxiom ax)
+    !standardAxioms.contains ax && !(allowed.isSome && isNativeDecideAxiom ax)
   unless unexpected.isEmpty do
     throwError "{n} depends on unexpected axiom(s): {unexpected.toList}"
 
@@ -54,15 +115,16 @@ in erased positions.
 
 `assert_computable foo +choice` additionally permits `Classical.choice`. Together with the
 plain-`def` check this asserts choice enters only through erased `Prop` fields: had it touched the
-data, the definition could not have compiled as a plain `def`. `+native` likewise permits
-`native_decide` compiler-trust axioms.
+data, the definition could not have compiled as a plain `def`. `+native(D₁, ...)` likewise permits
+the named declarations' `native_decide` compiler-trust axioms.
 
 The plain-`def` check guards a gap in "computability is compiler-enforced": marking a reduction
 `noncomputable` later would still build, silently voiding the convention; this assertion catches
 it.
 -/
-elab "assert_computable " n:ident choice:("+choice")? native:("+native")? : command => do
+elab "assert_computable " n:ident choice:("+choice")? native:(nativeFlag)? : command => do
   let name ← liftCoreM <| realizeGlobalConstNoOverloadWithInfo n
+  checkFullyQualified n name
   let env ← getEnv
   let info ← liftCoreM <| getConstInfo name
   unless info matches .defnInfo _ do
@@ -71,11 +133,12 @@ elab "assert_computable " n:ident choice:("+choice")? native:("+native")? : comm
     throwError "{n} is marked noncomputable"
   let axs ← collectAxioms name
   let allowChoice := choice.isSome
-  let allowNative := native.isSome
+  let allowed := nativeAnnotation native
+  checkNativeAllowance n axs allowed
   let unexpected := axs.filter fun ax =>
     !(ax == ``propext || ax == ``Quot.sound
       || (allowChoice && ax == ``Classical.choice)
-      || (allowNative && isNativeDecideAxiom ax))
+      || (allowed.isSome && isNativeDecideAxiom ax))
   unless unexpected.isEmpty do
     throwError "{n} depends on unexpected axiom(s): {unexpected.toList}"
 

--- a/Zcash/Security/Ledger/BridgeTests.lean
+++ b/Zcash/Security/Ledger/BridgeTests.lean
@@ -222,14 +222,57 @@ assert_axioms Zcash.Security.Ledger.BridgeTests.enable_output_disabled_forces_ze
 -- The refinements instantiated at the deployed Pallas bases sit one tier up: their proofs
 -- consume `native_decide` certificates — the fixed-base window tables and CompElliptic's
 -- Pallas point count (`pallas_natCard`) — so `+native` is the whole of the extra budget.
-assert_axioms Zcash.Security.Ledger.BridgeTests.alpha_scaling +native
-assert_axioms Zcash.Security.Ledger.BridgeTests.value_commit_positive_scaling +native
-assert_axioms Zcash.Security.Ledger.BridgeTests.value_commit_negative_scaling +native
-assert_axioms Zcash.Security.Ledger.BridgeTests.or_break_iff_guarded_smoke +native
-assert_axioms Zcash.Security.Ledger.BridgeTests.path_iff_guarded_smoke +native
-assert_axioms Zcash.Security.Ledger.Bridge.guardedPath_of_exact +native
-assert_axioms Zcash.Security.Ledger.BridgeTests.spec_post_bridge_smoke +native
-assert_axioms Zcash.Security.Ledger.BridgeTests.circuit_soundness_bridge_smoke +native
+assert_axioms Zcash.Security.Ledger.BridgeTests.alpha_scaling +native(
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt,
+  Zcash.Circuits.Ecc.MulFixed.Certs.spendAuthGCert_check)
+assert_axioms Zcash.Security.Ledger.BridgeTests.value_commit_positive_scaling +native(
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitVCert_check)
+assert_axioms Zcash.Security.Ledger.BridgeTests.value_commit_negative_scaling +native(
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitVCert_check)
+assert_axioms Zcash.Security.Ledger.BridgeTests.or_break_iff_guarded_smoke +native(
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt,
+  Zcash.Circuits.Ecc.MulFixed.Certs.commitIvkRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.noteCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.nullifierKCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.spendAuthGCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitVCert_check)
+assert_axioms Zcash.Security.Ledger.BridgeTests.path_iff_guarded_smoke
+assert_axioms Zcash.Security.Ledger.Bridge.guardedPath_of_exact +native(
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt,
+  Zcash.Circuits.Ecc.MulFixed.Certs.commitIvkRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.noteCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.nullifierKCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.spendAuthGCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitVCert_check)
+assert_axioms Zcash.Security.Ledger.BridgeTests.spec_post_bridge_smoke +native(
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt,
+  Zcash.Security.Concrete.PallasGroup.pallas_base_card_lt_scalar_card,
+  Zcash.Security.Ledger.Pool.unc_thirteen_not_isSquare,
+  Zcash.Circuits.Ecc.MulFixed.Certs.commitIvkRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.noteCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.nullifierKCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.spendAuthGCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitVCert_check)
+assert_axioms Zcash.Security.Ledger.BridgeTests.circuit_soundness_bridge_smoke +native(
+  CompElliptic.Curves.Pasta.Pallas.neg_five_not_isCube,
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt,
+  Zcash.Circuits.Ecc.MulFixed.windowScalar_ne_zero,
+  Zcash.Security.Concrete.PallasGroup.pallas_base_card_lt_scalar_card,
+  Zcash.Security.Ledger.Pool.unc_thirteen_not_isSquare,
+  Zcash.Circuits.Ecc.MulFixed.Certs.commitIvkRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.noteCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.nullifierKCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.spendAuthGCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitVCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Short.windowScalar_ne_zero)
 
 -- The onward reduction from classified break data to the games-facing
 -- discrete-log-relation object is likewise a computation: the coefficients are a
@@ -240,7 +283,21 @@ assert_computable Zcash.Security.Ledger.Bridge.breakCoeffs +choice
 -- computable per the breaks-as-computed-data convention.  Their erased `Prop` fields
 -- additionally carry the deployed base points' on-curve certificates, which are
 -- `native_decide` checks, so they sit one tier up at `+choice +native`.
-assert_computable Zcash.Security.Ledger.Bridge.relationOfBreakData +choice +native
-assert_computable Zcash.Security.Ledger.Bridge.classifyRelation +choice +native
+assert_computable Zcash.Security.Ledger.Bridge.relationOfBreakData +choice +native(
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt,
+  Zcash.Circuits.Ecc.MulFixed.Certs.commitIvkRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.noteCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.nullifierKCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.spendAuthGCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitVCert_check)
+assert_computable Zcash.Security.Ledger.Bridge.classifyRelation +choice +native(
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt,
+  Zcash.Circuits.Ecc.MulFixed.Certs.commitIvkRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.noteCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.nullifierKCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.spendAuthGCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitVCert_check)
 
 end Zcash.Security.Ledger.BridgeTests

--- a/Zcash/Security/Ledger/BridgeTests.lean
+++ b/Zcash/Security/Ledger/BridgeTests.lean
@@ -203,44 +203,44 @@ open Zcash.Meta
 -- field-arithmetic instances.  The plain-`def` check is what certifies that
 -- choice stays erased: had it touched the data path, the definition could not
 -- have compiled (`Zcash.Meta.AxiomCheck` documents this convention).
-assert_computable classifyMerkle +choice
-assert_computable classifyAction +choice
+assert_computable Zcash.Security.Ledger.Bridge.classifyMerkle +choice
+assert_computable Zcash.Security.Ledger.Bridge.classifyAction +choice
 
-assert_axioms value_positive
-assert_axioms value_negative
-assert_axioms value_equal
-assert_axioms zero_encodings_distinct
-assert_axioms zero_encodings_decode_equal
-assert_axioms dummy_spend_merkle_vacuous
-assert_axioms path_layers_defined
-assert_axioms cross_address_flag_zero
-assert_axioms cross_address_flag_one
-assert_axioms cross_address_flag_arbitrary_nonzero
-assert_axioms enable_spend_disabled_forces_zero
-assert_axioms enable_output_disabled_forces_zero
+assert_axioms Zcash.Security.Ledger.BridgeTests.value_positive
+assert_axioms Zcash.Security.Ledger.BridgeTests.value_negative
+assert_axioms Zcash.Security.Ledger.BridgeTests.value_equal
+assert_axioms Zcash.Security.Ledger.BridgeTests.zero_encodings_distinct
+assert_axioms Zcash.Security.Ledger.BridgeTests.zero_encodings_decode_equal
+assert_axioms Zcash.Security.Ledger.BridgeTests.dummy_spend_merkle_vacuous
+assert_axioms Zcash.Security.Ledger.BridgeTests.path_layers_defined
+assert_axioms Zcash.Security.Ledger.BridgeTests.cross_address_flag_zero
+assert_axioms Zcash.Security.Ledger.BridgeTests.cross_address_flag_one
+assert_axioms Zcash.Security.Ledger.BridgeTests.cross_address_flag_arbitrary_nonzero
+assert_axioms Zcash.Security.Ledger.BridgeTests.enable_spend_disabled_forces_zero
+assert_axioms Zcash.Security.Ledger.BridgeTests.enable_output_disabled_forces_zero
 
 -- The refinements instantiated at the deployed Pallas bases sit one tier up: their proofs
 -- consume `native_decide` certificates — the fixed-base window tables and CompElliptic's
 -- Pallas point count (`pallas_natCard`) — so `+native` is the whole of the extra budget.
-assert_axioms alpha_scaling +native
-assert_axioms value_commit_positive_scaling +native
-assert_axioms value_commit_negative_scaling +native
-assert_axioms or_break_iff_guarded_smoke +native
-assert_axioms path_iff_guarded_smoke +native
-assert_axioms guardedPath_of_exact +native
-assert_axioms spec_post_bridge_smoke +native
-assert_axioms circuit_soundness_bridge_smoke +native
+assert_axioms Zcash.Security.Ledger.BridgeTests.alpha_scaling +native
+assert_axioms Zcash.Security.Ledger.BridgeTests.value_commit_positive_scaling +native
+assert_axioms Zcash.Security.Ledger.BridgeTests.value_commit_negative_scaling +native
+assert_axioms Zcash.Security.Ledger.BridgeTests.or_break_iff_guarded_smoke +native
+assert_axioms Zcash.Security.Ledger.BridgeTests.path_iff_guarded_smoke +native
+assert_axioms Zcash.Security.Ledger.Bridge.guardedPath_of_exact +native
+assert_axioms Zcash.Security.Ledger.BridgeTests.spec_post_bridge_smoke +native
+assert_axioms Zcash.Security.Ledger.BridgeTests.circuit_soundness_bridge_smoke +native
 
 -- The onward reduction from classified break data to the games-facing
 -- discrete-log-relation object is likewise a computation: the coefficients are a
 -- plain compiled `def` over the break datum, with the relation and nontriviality
 -- facts in erased `Prop` fields (same `+choice` reading as the classifier above).
-assert_computable breakCoeffs +choice
+assert_computable Zcash.Security.Ledger.Bridge.breakCoeffs +choice
 -- `relationOfBreakData` and `classifyRelation` are likewise plain compiled `def`s, asserted
 -- computable per the breaks-as-computed-data convention.  Their erased `Prop` fields
 -- additionally carry the deployed base points' on-curve certificates, which are
 -- `native_decide` checks, so they sit one tier up at `+choice +native`.
-assert_computable relationOfBreakData +choice +native
-assert_computable classifyRelation +choice +native
+assert_computable Zcash.Security.Ledger.Bridge.relationOfBreakData +choice +native
+assert_computable Zcash.Security.Ledger.Bridge.classifyRelation +choice +native
 
 end Zcash.Security.Ledger.BridgeTests

--- a/Zcash/Security/Ledger/Pool.lean
+++ b/Zcash/Security/Ledger/Pool.lean
@@ -111,7 +111,7 @@ def extract (P : PallasGroup) : Fp := (PallasGroup.toPoint P).x
   simp [extract]
 
 /-- `13` is a quadratic non-residue in the Pallas base field, so it is not a square. -/
-private theorem unc_thirteen_not_isSquare : ¬ IsSquare (13 : Fp) := by
+theorem unc_thirteen_not_isSquare : ¬ IsSquare (13 : Fp) := by
   have h : ¬ IsSquare ((13 : ℕ) : Fp) :=
     Zcash.Circuits.Ecc.MulFixed.Cert.Chain.checkNonSquare_sound (by native_decide)
   simpa using h

--- a/Zcash/Snark/Fixtures/MultiAction/TrustBoundary.lean
+++ b/Zcash/Snark/Fixtures/MultiAction/TrustBoundary.lean
@@ -28,71 +28,69 @@ functions it ranges over; see the single-action sibling for why this is the fixt
 surface.
 -/
 
-open Zcash.Snark Zcash.Snark.Fixture2
-
-assert_axioms capturedPointCoordinatesValid_eq_true +native
-assert_axioms capturedInit_startsWith_vkTranscriptRepr +native
-assert_axioms fingerprint_matches +native
-assert_axioms capturedMsm_eval_eq_zero +native
-assert_axioms assembledMsm_eval_eq_zero +native
+assert_axioms Zcash.Snark.Fixture2.capturedPointCoordinatesValid_eq_true +native
+assert_axioms Zcash.Snark.Fixture2.capturedInit_startsWith_vkTranscriptRepr +native
+assert_axioms Zcash.Snark.Fixture2.fingerprint_matches +native
+assert_axioms Zcash.Snark.Fixture2.capturedMsm_eval_eq_zero +native
+assert_axioms Zcash.Snark.Fixture2.assembledMsm_eval_eq_zero +native
 assert_axioms Zcash.Arithmetic.Msm.evalNat
-assert_axioms assemble
+assert_axioms Zcash.Snark.assemble
 -- The captured key's degree budget: one literal (`20470`) dominates every constraint family,
 -- so the `x`-squeeze schedule's `epsilonX` is the concrete `20470 / |𝔽|` at this key.
-assert_axioms vk_gates_degree_le +native
-assert_axioms vk_chunk_width_le +native
-assert_axioms vk_lookup_input_degree_le +native
-assert_axioms vk_lookup_table_degree_le +native
-assert_axioms vk_quotient_tail_le +native
-assert_axioms vk_n_pred_le +native
-assert_axioms shape_k_pred_le +native
+assert_axioms Zcash.Snark.Fixture2.vk_gates_degree_le +native
+assert_axioms Zcash.Snark.Fixture2.vk_chunk_width_le +native
+assert_axioms Zcash.Snark.Fixture2.vk_lookup_input_degree_le +native
+assert_axioms Zcash.Snark.Fixture2.vk_lookup_table_degree_le +native
+assert_axioms Zcash.Snark.Fixture2.vk_quotient_tail_le +native
+assert_axioms Zcash.Snark.Fixture2.vk_n_pred_le +native
+assert_axioms Zcash.Snark.Fixture2.shape_k_pred_le +native
 -- The captured key's static checks: the query layouts cover the shape's counts, `ω` has order
 -- dividing `n`, and `n` does not vanish in `𝔽` — packaged for any family carrying the
 -- captured non-group profile. Literal equality of fixed Vesta commitments is intentionally absent.
-assert_axioms capturedVerifierKeyProfile_vk
-assert_axioms vk_advice_layout_length +native
-assert_axioms vk_instance_layout_length +native
-assert_axioms vk_fixed_layout_length +native
-assert_axioms vk_omega_order +native
-assert_axioms vk_n_cast_ne_zero +native
-assert_axioms deployedConstraintStaticChecks_of_captured +native
+assert_axioms Zcash.Snark.Fixture2.capturedVerifierKeyProfile_vk
+assert_axioms Zcash.Snark.Fixture2.vk_advice_layout_length +native
+assert_axioms Zcash.Snark.Fixture2.vk_instance_layout_length +native
+assert_axioms Zcash.Snark.Fixture2.vk_fixed_layout_length +native
+assert_axioms Zcash.Snark.Fixture2.vk_omega_order +native
+assert_axioms Zcash.Snark.Fixture2.vk_n_cast_ne_zero +native
+assert_axioms Zcash.Snark.Fixture2.deployedConstraintStaticChecks_of_captured +native
 -- The `x`-squeeze schedule at the captured key: the degree caps are discharged, so `epsilonX` is
 -- the concrete `20470 / |𝔽|`; exact leave-one-`x` invariance follows from the family's
 -- fresh-query constraint trace.
-assert_axioms deployedConstraintXSqueezeSchedule_captured +native
+assert_axioms Zcash.Snark.Fixture2.deployedConstraintXSqueezeSchedule_captured +native
 -- The deployed compressed-identity extraction bound at the captured key: the rewind-free
 -- capstone with the static checks and degree caps discharged, so the bad-`x` term is the concrete
 -- `(Q + 1) · 20470 / |𝔽|` and the multiopen term is the additive root budget.  Semantic
 -- circuit satisfaction additionally uses the four-budget promotion in the core trust census.
-assert_axioms orchard_deployed_knowledge_error_captured +native
+assert_axioms Zcash.Snark.Fixture2.orchard_deployed_knowledge_error_captured +native
 -- The same bound on the interpolation-free route: the deployed constraint family is built by
 -- `ofCovered` from the two fresh-query traces, with no field-capacity premise or interpolation.
-assert_axioms orchard_deployed_knowledge_error_captured_direct +native
+assert_axioms Zcash.Snark.Fixture2.orchard_deployed_knowledge_error_captured_direct +native
 
 -- The instance-commitment derivation: the two captured claims, plus the data and functions they
 -- range over. The latter are flagless — they are ordinary definitions, so compiler trust must not
 -- reach them; only the two claims about them may spend it.
-assert_axioms instance_commitments_derived +native
-assert_axioms capturedPublicInstances_within_lagrange +native
-assert_axioms capturedUrsGLagrange
-assert_axioms capturedPublicInstances
-assert_axioms commitLagrange
-assert_axioms derivedInstanceCommitment
+assert_axioms Zcash.Snark.Fixture2.instance_commitments_derived +native
+assert_axioms Zcash.Snark.Fixture2.capturedPublicInstances_within_lagrange +native
+assert_axioms Zcash.Snark.Fixture2.capturedUrsGLagrange
+assert_axioms Zcash.Snark.Fixture2.capturedPublicInstances
+assert_axioms Zcash.Snark.Fixture2.commitLagrange
+assert_axioms Zcash.Snark.Fixture2.derivedInstanceCommitment
 
 -- `whitespace := lax` collapses all whitespace, so the pin is insensitive to how
 -- `#print axioms` line-wraps the list (a formatting artifact of the axiom-name lengths).
-/-- info: 'Zcash.Snark.Fixture2.fingerprint_matches' depends on axioms: [propext, Classical.choice, Quot.sound, fingerprint_matches._native.native_decide.ax_1_1] -/
+/-- info: 'Zcash.Snark.Fixture2.fingerprint_matches' depends on axioms: [propext, Classical.choice, Quot.sound, Zcash.Snark.Fixture2.fingerprint_matches._native.native_decide.ax_1_1] -/
 #guard_msgs (whitespace := lax) in
-#print axioms fingerprint_matches
+#print axioms Zcash.Snark.Fixture2.fingerprint_matches
 
-/-- info: 'Zcash.Snark.Fixture2.capturedMsm_eval_eq_zero' depends on axioms: [propext, Classical.choice, Quot.sound, capturedMsm_eval_eq_zero._native.native_decide.ax_1_1] -/
+/-- info: 'Zcash.Snark.Fixture2.capturedMsm_eval_eq_zero' depends on axioms: [propext, Classical.choice, Quot.sound, Zcash.Snark.Fixture2.capturedMsm_eval_eq_zero._native.native_decide.ax_1_1] -/
 #guard_msgs (whitespace := lax) in
-#print axioms capturedMsm_eval_eq_zero
+#print axioms Zcash.Snark.Fixture2.capturedMsm_eval_eq_zero
 
-/-- info: 'Zcash.Snark.Fixture2.instance_commitments_derived' depends on axioms: [propext, Classical.choice, Quot.sound, instance_commitments_derived._native.native_decide.ax_1_1] -/
+/-- info: 'Zcash.Snark.Fixture2.instance_commitments_derived' depends on axioms: [propext, Classical.choice, Quot.sound, Zcash.Snark.Fixture2.instance_commitments_derived._native.native_decide.ax_1_1] -/
 #guard_msgs (whitespace := lax) in
-#print axioms instance_commitments_derived
+#print axioms Zcash.Snark.Fixture2.instance_commitments_derived
 
-/-- info: 'Zcash.Snark.Fixture2.capturedPublicInstances_within_lagrange' depends on axioms: [propext, Classical.choice, Quot.sound, capturedPublicInstances_within_lagrange._native.native_decide.ax_1_1] -/
+/-- info: 'Zcash.Snark.Fixture2.capturedPublicInstances_within_lagrange' depends on axioms: [propext, Classical.choice, Quot.sound, Zcash.Snark.Fixture2.capturedPublicInstances_within_lagrange._native.native_decide.ax_1_1] -/
 #guard_msgs (whitespace := lax) in
-#print axioms capturedPublicInstances_within_lagrange
+#print axioms Zcash.Snark.Fixture2.capturedPublicInstances_within_lagrange

--- a/Zcash/Snark/Fixtures/MultiAction/TrustBoundary.lean
+++ b/Zcash/Snark/Fixtures/MultiAction/TrustBoundary.lean
@@ -28,50 +28,107 @@ functions it ranges over; see the single-action sibling for why this is the fixt
 surface.
 -/
 
-assert_axioms Zcash.Snark.Fixture2.capturedPointCoordinatesValid_eq_true +native
-assert_axioms Zcash.Snark.Fixture2.capturedInit_startsWith_vkTranscriptRepr +native
-assert_axioms Zcash.Snark.Fixture2.fingerprint_matches +native
-assert_axioms Zcash.Snark.Fixture2.capturedMsm_eval_eq_zero +native
-assert_axioms Zcash.Snark.Fixture2.assembledMsm_eval_eq_zero +native
+assert_axioms Zcash.Snark.Fixture2.capturedPointCoordinatesValid_eq_true +native(
+  Zcash.Snark.Fixture2.capturedPointCoordinatesValid_eq_true)
+assert_axioms Zcash.Snark.Fixture2.capturedInit_startsWith_vkTranscriptRepr +native(
+  Zcash.Snark.Fixture2.capturedInit_startsWith_vkTranscriptRepr)
+assert_axioms Zcash.Snark.Fixture2.fingerprint_matches +native(
+  Zcash.Snark.Fixture2.fingerprint_matches)
+assert_axioms Zcash.Snark.Fixture2.capturedMsm_eval_eq_zero +native(
+  Zcash.Snark.Fixture2.capturedMsm_eval_eq_zero)
+assert_axioms Zcash.Snark.Fixture2.assembledMsm_eval_eq_zero +native(
+  Zcash.Snark.Fixture2.capturedMsm_eval_eq_zero,
+  Zcash.Snark.Fixture2.fingerprint_matches)
 assert_axioms Zcash.Arithmetic.Msm.evalNat
 assert_axioms Zcash.Snark.assemble
 -- The captured key's degree budget: one literal (`20470`) dominates every constraint family,
 -- so the `x`-squeeze schedule's `epsilonX` is the concrete `20470 / |𝔽|` at this key.
-assert_axioms Zcash.Snark.Fixture2.vk_gates_degree_le +native
-assert_axioms Zcash.Snark.Fixture2.vk_chunk_width_le +native
-assert_axioms Zcash.Snark.Fixture2.vk_lookup_input_degree_le +native
-assert_axioms Zcash.Snark.Fixture2.vk_lookup_table_degree_le +native
-assert_axioms Zcash.Snark.Fixture2.vk_quotient_tail_le +native
-assert_axioms Zcash.Snark.Fixture2.vk_n_pred_le +native
-assert_axioms Zcash.Snark.Fixture2.shape_k_pred_le +native
+assert_axioms Zcash.Snark.Fixture2.vk_gates_degree_le +native(
+  Zcash.Snark.Fixture2.vk_gates_degree_le)
+assert_axioms Zcash.Snark.Fixture2.vk_chunk_width_le +native(
+  Zcash.Snark.Fixture2.vk_chunk_width_le)
+assert_axioms Zcash.Snark.Fixture2.vk_lookup_input_degree_le +native(
+  Zcash.Snark.Fixture2.vk_lookup_input_degree_le)
+assert_axioms Zcash.Snark.Fixture2.vk_lookup_table_degree_le +native(
+  Zcash.Snark.Fixture2.vk_lookup_table_degree_le)
+assert_axioms Zcash.Snark.Fixture2.vk_quotient_tail_le +native(
+  Zcash.Snark.Fixture2.vk_quotient_tail_le)
+assert_axioms Zcash.Snark.Fixture2.vk_n_pred_le +native(Zcash.Snark.Fixture2.vk_n_pred_le)
+assert_axioms Zcash.Snark.Fixture2.shape_k_pred_le +native(Zcash.Snark.Fixture2.shape_k_pred_le)
 -- The captured key's static checks: the query layouts cover the shape's counts, `ω` has order
 -- dividing `n`, and `n` does not vanish in `𝔽` — packaged for any family carrying the
 -- captured non-group profile. Literal equality of fixed Vesta commitments is intentionally absent.
 assert_axioms Zcash.Snark.Fixture2.capturedVerifierKeyProfile_vk
-assert_axioms Zcash.Snark.Fixture2.vk_advice_layout_length +native
-assert_axioms Zcash.Snark.Fixture2.vk_instance_layout_length +native
-assert_axioms Zcash.Snark.Fixture2.vk_fixed_layout_length +native
-assert_axioms Zcash.Snark.Fixture2.vk_omega_order +native
-assert_axioms Zcash.Snark.Fixture2.vk_n_cast_ne_zero +native
-assert_axioms Zcash.Snark.Fixture2.deployedConstraintStaticChecks_of_captured +native
+assert_axioms Zcash.Snark.Fixture2.vk_advice_layout_length +native(
+  Zcash.Snark.Fixture2.vk_advice_layout_length)
+assert_axioms Zcash.Snark.Fixture2.vk_instance_layout_length +native(
+  Zcash.Snark.Fixture2.vk_instance_layout_length)
+assert_axioms Zcash.Snark.Fixture2.vk_fixed_layout_length +native(
+  Zcash.Snark.Fixture2.vk_fixed_layout_length)
+assert_axioms Zcash.Snark.Fixture2.vk_omega_order +native(Zcash.Snark.Fixture2.vk_omega_order)
+assert_axioms Zcash.Snark.Fixture2.vk_n_cast_ne_zero +native(
+  Zcash.Snark.Fixture2.vk_n_cast_ne_zero)
+assert_axioms Zcash.Snark.Fixture2.deployedConstraintStaticChecks_of_captured +native(
+  Zcash.Snark.Fixture2.vk_advice_layout_length,
+  Zcash.Snark.Fixture2.vk_fixed_layout_length,
+  Zcash.Snark.Fixture2.vk_instance_layout_length,
+  Zcash.Snark.Fixture2.vk_n_cast_ne_zero,
+  Zcash.Snark.Fixture2.vk_omega_order,
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
 -- The `x`-squeeze schedule at the captured key: the degree caps are discharged, so `epsilonX` is
 -- the concrete `20470 / |𝔽|`; exact leave-one-`x` invariance follows from the family's
 -- fresh-query constraint trace.
-assert_axioms Zcash.Snark.Fixture2.deployedConstraintXSqueezeSchedule_captured +native
+assert_axioms Zcash.Snark.Fixture2.deployedConstraintXSqueezeSchedule_captured +native(
+  Zcash.Snark.Fixture2.shape_k_pred_le,
+  Zcash.Snark.Fixture2.vk_chunk_width_le,
+  Zcash.Snark.Fixture2.vk_gates_degree_le,
+  Zcash.Snark.Fixture2.vk_lookup_input_degree_le,
+  Zcash.Snark.Fixture2.vk_lookup_table_degree_le,
+  Zcash.Snark.Fixture2.vk_n_pred_le,
+  Zcash.Snark.Fixture2.vk_quotient_tail_le,
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
 -- The deployed compressed-identity extraction bound at the captured key: the rewind-free
 -- capstone with the static checks and degree caps discharged, so the bad-`x` term is the concrete
 -- `(Q + 1) · 20470 / |𝔽|` and the multiopen term is the additive root budget.  Semantic
 -- circuit satisfaction additionally uses the four-budget promotion in the core trust census.
-assert_axioms Zcash.Snark.Fixture2.orchard_deployed_knowledge_error_captured +native
+assert_axioms Zcash.Snark.Fixture2.orchard_deployed_knowledge_error_captured +native(
+  Zcash.Snark.Fixture2.shape_k_pred_le,
+  Zcash.Snark.Fixture2.vk_advice_layout_length,
+  Zcash.Snark.Fixture2.vk_chunk_width_le,
+  Zcash.Snark.Fixture2.vk_fixed_layout_length,
+  Zcash.Snark.Fixture2.vk_gates_degree_le,
+  Zcash.Snark.Fixture2.vk_instance_layout_length,
+  Zcash.Snark.Fixture2.vk_lookup_input_degree_le,
+  Zcash.Snark.Fixture2.vk_lookup_table_degree_le,
+  Zcash.Snark.Fixture2.vk_n_cast_ne_zero,
+  Zcash.Snark.Fixture2.vk_n_pred_le,
+  Zcash.Snark.Fixture2.vk_omega_order,
+  Zcash.Snark.Fixture2.vk_quotient_tail_le,
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
 -- The same bound on the interpolation-free route: the deployed constraint family is built by
 -- `ofCovered` from the two fresh-query traces, with no field-capacity premise or interpolation.
-assert_axioms Zcash.Snark.Fixture2.orchard_deployed_knowledge_error_captured_direct +native
+assert_axioms Zcash.Snark.Fixture2.orchard_deployed_knowledge_error_captured_direct +native(
+  Zcash.Snark.Fixture2.shape_k_pred_le,
+  Zcash.Snark.Fixture2.vk_advice_layout_length,
+  Zcash.Snark.Fixture2.vk_chunk_width_le,
+  Zcash.Snark.Fixture2.vk_fixed_layout_length,
+  Zcash.Snark.Fixture2.vk_gates_degree_le,
+  Zcash.Snark.Fixture2.vk_instance_layout_length,
+  Zcash.Snark.Fixture2.vk_lookup_input_degree_le,
+  Zcash.Snark.Fixture2.vk_lookup_table_degree_le,
+  Zcash.Snark.Fixture2.vk_n_cast_ne_zero,
+  Zcash.Snark.Fixture2.vk_n_pred_le,
+  Zcash.Snark.Fixture2.vk_omega_order,
+  Zcash.Snark.Fixture2.vk_quotient_tail_le,
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
 
 -- The instance-commitment derivation: the two captured claims, plus the data and functions they
 -- range over. The latter are flagless — they are ordinary definitions, so compiler trust must not
 -- reach them; only the two claims about them may spend it.
-assert_axioms Zcash.Snark.Fixture2.instance_commitments_derived +native
-assert_axioms Zcash.Snark.Fixture2.capturedPublicInstances_within_lagrange +native
+assert_axioms Zcash.Snark.Fixture2.instance_commitments_derived +native(
+  Zcash.Snark.Fixture2.instance_commitments_derived)
+assert_axioms Zcash.Snark.Fixture2.capturedPublicInstances_within_lagrange +native(
+  Zcash.Snark.Fixture2.capturedPublicInstances_within_lagrange)
 assert_axioms Zcash.Snark.Fixture2.capturedUrsGLagrange
 assert_axioms Zcash.Snark.Fixture2.capturedPublicInstances
 assert_axioms Zcash.Snark.Fixture2.commitLagrange

--- a/Zcash/Snark/Fixtures/SingleAction/TrustBoundary.lean
+++ b/Zcash/Snark/Fixtures/SingleAction/TrustBoundary.lean
@@ -34,43 +34,41 @@ captured points. The derivation's supporting data and functions (`capturedUrsGLa
 `native_decide` claims cannot be narrowed by quietly widening what they range over.
 -/
 
-open Zcash.Snark Zcash.Snark.Fixture
-
 -- Every captured fixture and the verifier assembly it runs are bounded at the standard tier — no
 -- `sorry`, no unexpected axiom (whole dependency graph). The `native_decide` fixtures carry the
 -- compiler-trust axiom, permitted by `+native` and pinned exactly by the `#print axioms` guards below.
-assert_axioms fingerprint_matches +native
-assert_axioms capturedPointCoordinatesValid_eq_true +native
-assert_axioms capturedInit_startsWith_vkTranscriptRepr +native
-assert_axioms capturedMsm_eval_eq_zero +native
-assert_axioms assembledMsm_eval_eq_zero +native
+assert_axioms Zcash.Snark.Fixture.fingerprint_matches +native
+assert_axioms Zcash.Snark.Fixture.capturedPointCoordinatesValid_eq_true +native
+assert_axioms Zcash.Snark.Fixture.capturedInit_startsWith_vkTranscriptRepr +native
+assert_axioms Zcash.Snark.Fixture.capturedMsm_eval_eq_zero +native
+assert_axioms Zcash.Snark.Fixture.assembledMsm_eval_eq_zero +native
 assert_axioms Zcash.Arithmetic.Msm.evalNat
-assert_axioms assemble
+assert_axioms Zcash.Snark.assemble
 
 -- The instance-commitment derivation: the two captured claims, plus the data and functions they
 -- range over. The latter are flagless — they are ordinary definitions, so compiler trust must not
 -- reach them; only the two claims about them may spend it.
-assert_axioms instance_commitments_derived +native
-assert_axioms capturedPublicInstances_within_lagrange +native
-assert_axioms capturedUrsGLagrange
-assert_axioms capturedPublicInstances
-assert_axioms commitLagrange
-assert_axioms derivedInstanceCommitment
+assert_axioms Zcash.Snark.Fixture.instance_commitments_derived +native
+assert_axioms Zcash.Snark.Fixture.capturedPublicInstances_within_lagrange +native
+assert_axioms Zcash.Snark.Fixture.capturedUrsGLagrange
+assert_axioms Zcash.Snark.Fixture.capturedPublicInstances
+assert_axioms Zcash.Snark.Fixture.commitLagrange
+assert_axioms Zcash.Snark.Fixture.derivedInstanceCommitment
 
 -- `whitespace := lax` collapses all whitespace, so the pin is insensitive to how
 -- `#print axioms` line-wraps the list (a formatting artifact of the axiom-name lengths).
-/-- info: 'Zcash.Snark.Fixture.fingerprint_matches' depends on axioms: [propext, Classical.choice, Quot.sound, fingerprint_matches._native.native_decide.ax_1_1] -/
+/-- info: 'Zcash.Snark.Fixture.fingerprint_matches' depends on axioms: [propext, Classical.choice, Quot.sound, Zcash.Snark.Fixture.fingerprint_matches._native.native_decide.ax_1_1] -/
 #guard_msgs (whitespace := lax) in
-#print axioms fingerprint_matches
+#print axioms Zcash.Snark.Fixture.fingerprint_matches
 
-/-- info: 'Zcash.Snark.Fixture.capturedMsm_eval_eq_zero' depends on axioms: [propext, Classical.choice, Quot.sound, capturedMsm_eval_eq_zero._native.native_decide.ax_1_1] -/
+/-- info: 'Zcash.Snark.Fixture.capturedMsm_eval_eq_zero' depends on axioms: [propext, Classical.choice, Quot.sound, Zcash.Snark.Fixture.capturedMsm_eval_eq_zero._native.native_decide.ax_1_1] -/
 #guard_msgs (whitespace := lax) in
-#print axioms capturedMsm_eval_eq_zero
+#print axioms Zcash.Snark.Fixture.capturedMsm_eval_eq_zero
 
-/-- info: 'Zcash.Snark.Fixture.instance_commitments_derived' depends on axioms: [propext, Classical.choice, Quot.sound, instance_commitments_derived._native.native_decide.ax_1_1] -/
+/-- info: 'Zcash.Snark.Fixture.instance_commitments_derived' depends on axioms: [propext, Classical.choice, Quot.sound, Zcash.Snark.Fixture.instance_commitments_derived._native.native_decide.ax_1_1] -/
 #guard_msgs (whitespace := lax) in
-#print axioms instance_commitments_derived
+#print axioms Zcash.Snark.Fixture.instance_commitments_derived
 
-/-- info: 'Zcash.Snark.Fixture.capturedPublicInstances_within_lagrange' depends on axioms: [propext, Classical.choice, Quot.sound, capturedPublicInstances_within_lagrange._native.native_decide.ax_1_1] -/
+/-- info: 'Zcash.Snark.Fixture.capturedPublicInstances_within_lagrange' depends on axioms: [propext, Classical.choice, Quot.sound, Zcash.Snark.Fixture.capturedPublicInstances_within_lagrange._native.native_decide.ax_1_1] -/
 #guard_msgs (whitespace := lax) in
-#print axioms capturedPublicInstances_within_lagrange
+#print axioms Zcash.Snark.Fixture.capturedPublicInstances_within_lagrange

--- a/Zcash/Snark/Fixtures/SingleAction/TrustBoundary.lean
+++ b/Zcash/Snark/Fixtures/SingleAction/TrustBoundary.lean
@@ -37,19 +37,27 @@ captured points. The derivation's supporting data and functions (`capturedUrsGLa
 -- Every captured fixture and the verifier assembly it runs are bounded at the standard tier — no
 -- `sorry`, no unexpected axiom (whole dependency graph). The `native_decide` fixtures carry the
 -- compiler-trust axiom, permitted by `+native` and pinned exactly by the `#print axioms` guards below.
-assert_axioms Zcash.Snark.Fixture.fingerprint_matches +native
-assert_axioms Zcash.Snark.Fixture.capturedPointCoordinatesValid_eq_true +native
-assert_axioms Zcash.Snark.Fixture.capturedInit_startsWith_vkTranscriptRepr +native
-assert_axioms Zcash.Snark.Fixture.capturedMsm_eval_eq_zero +native
-assert_axioms Zcash.Snark.Fixture.assembledMsm_eval_eq_zero +native
+assert_axioms Zcash.Snark.Fixture.fingerprint_matches +native(
+  Zcash.Snark.Fixture.fingerprint_matches)
+assert_axioms Zcash.Snark.Fixture.capturedPointCoordinatesValid_eq_true +native(
+  Zcash.Snark.Fixture.capturedPointCoordinatesValid_eq_true)
+assert_axioms Zcash.Snark.Fixture.capturedInit_startsWith_vkTranscriptRepr +native(
+  Zcash.Snark.Fixture.capturedInit_startsWith_vkTranscriptRepr)
+assert_axioms Zcash.Snark.Fixture.capturedMsm_eval_eq_zero +native(
+  Zcash.Snark.Fixture.capturedMsm_eval_eq_zero)
+assert_axioms Zcash.Snark.Fixture.assembledMsm_eval_eq_zero +native(
+  Zcash.Snark.Fixture.capturedMsm_eval_eq_zero,
+  Zcash.Snark.Fixture.fingerprint_matches)
 assert_axioms Zcash.Arithmetic.Msm.evalNat
 assert_axioms Zcash.Snark.assemble
 
 -- The instance-commitment derivation: the two captured claims, plus the data and functions they
 -- range over. The latter are flagless — they are ordinary definitions, so compiler trust must not
 -- reach them; only the two claims about them may spend it.
-assert_axioms Zcash.Snark.Fixture.instance_commitments_derived +native
-assert_axioms Zcash.Snark.Fixture.capturedPublicInstances_within_lagrange +native
+assert_axioms Zcash.Snark.Fixture.instance_commitments_derived +native(
+  Zcash.Snark.Fixture.instance_commitments_derived)
+assert_axioms Zcash.Snark.Fixture.capturedPublicInstances_within_lagrange +native(
+  Zcash.Snark.Fixture.capturedPublicInstances_within_lagrange)
 assert_axioms Zcash.Snark.Fixture.capturedUrsGLagrange
 assert_axioms Zcash.Snark.Fixture.capturedPublicInstances
 assert_axioms Zcash.Snark.Fixture.commitLagrange

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -337,7 +337,8 @@ assert_computable Zcash.Snark.NontrivialDLRelation.ofIpaOpenings +choice
 assert_axioms Zcash.Snark.deployedAccepts_verifierEq
 assert_axioms Zcash.Snark.orchard_verifier_deployed_opening_of_forked
 assert_axioms Zcash.Snark.orchard_verifier_deployed_constraint_of_forked
-assert_axioms Zcash.Snark.orchard_verifier_vesta_constraint_of_forked +native
+assert_axioms Zcash.Snark.orchard_verifier_vesta_constraint_of_forked +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
 
 /-! ### Deployed binding-reduction breaks
 
@@ -350,7 +351,8 @@ assert_computable Zcash.Snark.NontrivialRelation.ofFoldedGens +choice
 assert_computable Zcash.Snark.NontrivialRelation.ofLeafPeel +choice
 assert_computable Zcash.Snark.NontrivialRelation.ofDeployedTree +choice
 assert_computable Zcash.Snark.NontrivialRelation.ofUnopenedFork +choice
-assert_computable Zcash.Snark.NontrivialRelation.ofUnopenedForkVesta +choice +native
+assert_computable Zcash.Snark.NontrivialRelation.ofUnopenedForkVesta +choice +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
 assert_computable Zcash.Snark.ipa_extractV +choice
 assert_computable Zcash.Snark.ipaRelation_extract +choice
 assert_computable Zcash.Snark.produceDeployed +choice
@@ -375,23 +377,34 @@ assert_computable Zcash.Snark.finForallOrRelationWitness +choice
 assert_computable Zcash.Snark.constructIntermediateSets_comm_route +choice
 assert_computable Zcash.Snark.deployed_slot_route_of_checks +choice
 assert_computable Zcash.Snark.deployedRouteSelectorOfSpecs +choice
-assert_computable Zcash.Snark.deployedConstraintQuotientAgreementOrRelation +choice +native
-assert_computable Zcash.Snark.deployedConstraintQuotientFinder +choice +native
+assert_computable Zcash.Snark.deployedConstraintQuotientAgreementOrRelation +choice +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_computable Zcash.Snark.deployedConstraintQuotientFinder +choice +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
 assert_computable Zcash.Snark.decodedQuotientEqReassembledOrRelationWitness +choice
 assert_computable Zcash.Snark.DeployedAlgebraicDecode.quotientEvalEqCommittedPreXOrRelationWitness +choice
-assert_computable Zcash.Snark.x4BatchCommitments +choice +native
-assert_computable Zcash.Snark.deployedSetMemberCommitments +choice +native
-assert_computable Zcash.Snark.deployedX4AlgebraicBatchOrRelation +choice +native
-assert_computable Zcash.Snark.deployedX1AlgebraicBatchWithSourceOrRelation +choice +native
-assert_computable Zcash.Snark.deployedX1BatchOfCoveredWithSourceOrRelation +choice +native
-assert_computable Zcash.Snark.deployedX4ColumnRepresentationsOfCovered +choice +native
-assert_computable Zcash.Snark.deployedX4BatchOfCoveredOrRelation +choice +native
-assert_computable Zcash.Snark.deployedRootOutcomeOfCovered +choice +native
-assert_computable Zcash.Snark.ComputedDeployedRootFSFamily.ofCovered +choice +native
-assert_computable Zcash.Snark.ComputedDeployedConstraintFSFamily.ofCovered +choice +native
-assert_computable Zcash.Snark.ComputedDeployedRootFSFamily.deployedRelationFinder +choice +native
-assert_computable Zcash.Snark.deployedConstraintFinderOfOutcome +choice +native
-assert_computable Zcash.Snark.deployedConstraintRelationFinder +choice +native
+assert_computable Zcash.Snark.x4BatchCommitments +choice
+assert_computable Zcash.Snark.deployedSetMemberCommitments +choice
+assert_computable Zcash.Snark.deployedX4AlgebraicBatchOrRelation +choice
+assert_computable Zcash.Snark.deployedX1AlgebraicBatchWithSourceOrRelation +choice
+assert_computable Zcash.Snark.deployedX1BatchOfCoveredWithSourceOrRelation +choice +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_computable Zcash.Snark.deployedX4ColumnRepresentationsOfCovered +choice +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_computable Zcash.Snark.deployedX4BatchOfCoveredOrRelation +choice +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_computable Zcash.Snark.deployedRootOutcomeOfCovered +choice +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_computable Zcash.Snark.ComputedDeployedRootFSFamily.ofCovered +choice +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_computable Zcash.Snark.ComputedDeployedConstraintFSFamily.ofCovered +choice +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_computable Zcash.Snark.ComputedDeployedRootFSFamily.deployedRelationFinder +choice +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_computable Zcash.Snark.deployedConstraintFinderOfOutcome +choice +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_computable Zcash.Snark.deployedConstraintRelationFinder +choice +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
 assert_computable Zcash.Snark.relationOfFoldGensWitness +choice
 assert_computable Zcash.Snark.deployedLeafPeelWitness +choice
 assert_computable Zcash.Snark.deployedToAcceptVWitness +choice
@@ -411,44 +424,75 @@ assert_computable Zcash.Snark.deployedAlgebraicRelationFinder +choice
 assert_axioms Zcash.Snark.deployedAlgebraicRelationFinder_isSome_iff
 assert_computable Zcash.Snark.deployedAlgebraicRelation +choice
 assert_computable Zcash.Snark.deployedAlgebraicRelationWitness +choice
-assert_axioms Zcash.Snark.orchardDeployedAlgebraicForkingProgrammed +native
-assert_axioms Zcash.Snark.orchardDeployedRelationSet +native
-assert_axioms Zcash.Snark.OrchardUniformURSIdentification +native
+assert_axioms Zcash.Snark.orchardDeployedAlgebraicForkingProgrammed +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.orchardDeployedRelationSet +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.OrchardUniformURSIdentification +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
 assert_axioms Zcash.Snark.orchardGeneratorROSetup
 assert_axioms Zcash.Snark.orchardGeneratorROBasis
-assert_axioms Zcash.Snark.orchard_uniformURSIdentification_of_generatorRO +native
+assert_axioms Zcash.Snark.orchard_uniformURSIdentification_of_generatorRO +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
 assert_axioms Zcash.Snark.recursiveAlgebraicForkFrom
 assert_axioms Zcash.Snark.recursiveAlgebraicForkFrom_realizes
-assert_axioms Zcash.Snark.algebraicForkCertAttempt +native
-assert_axioms Zcash.Snark.algebraicForkCertAttempt_valid +native
-assert_axioms Zcash.Snark.computedDeployedAlgebraicInstance +native
-assert_axioms Zcash.Snark.computedAlgebraicInstanceFailure_measure_le +native
+assert_axioms Zcash.Snark.algebraicForkCertAttempt +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.algebraicForkCertAttempt_valid +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.computedDeployedAlgebraicInstance +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.computedAlgebraicInstanceFailure_measure_le +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
 assert_axioms Zcash.Snark.AlgebraicRelationWitness.augment
 assert_axioms Zcash.Snark.DeployedAlgebraicForkingInstance.runRelation
 assert_axioms Zcash.Snark.DeployedAlgebraicForkingInstance.runRelation_isSome_of_mismatch
-assert_computable Zcash.Snark.DeployedAlgebraicForkingInstance.runToSnark +choice +native
-assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.relationFinder +native
-assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.relationFinder_isSome_of_bindingWin +native
-assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.snarkRelationFinder +native
-assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.snarkRelation_prob_le_of_textbookDL +native
-assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.acceptExtractionFailure_measure_le +native
-assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.snarkNonRelationFailure +native
-assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.snarkNonRelationFailure_measure_le +native
-assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.snarkFailure_prob_le_of_textbookDL +native
-assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.snarkFailure_prob_le_of_textbookDL_full +native
-assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.snarkFailure_prob_le_of_uniformURS_textbookDL +native
-assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.snarkFailure_prob_le_of_generatorRO_textbookDL +native
-assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.binding_prob_le_of_textbookDL +native
-assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.binding_prob_le_of_uniformURS_textbookDL +native
-assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.binding_prob_le_of_generatorRO_textbookDL +native
-assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.ReductionEfficient +native
-assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.reductionEfficient_exists +native
-assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.instanceAttempt_runs_eq +native
-assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.reductionEfficient_exponential +native
-assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.DiscreteLogRelationHardFor +native
-assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.knowledgeSoundness_under_DL +native
-assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.binding_under_DL +native
-assert_axioms Zcash.Snark.bindingWin_unbounded_measure_le +native
+assert_computable Zcash.Snark.DeployedAlgebraicForkingInstance.runToSnark +choice +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.relationFinder +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.relationFinder_isSome_of_bindingWin +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.snarkRelationFinder +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.snarkRelation_prob_le_of_textbookDL +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.acceptExtractionFailure_measure_le +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.snarkNonRelationFailure +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.snarkNonRelationFailure_measure_le +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.snarkFailure_prob_le_of_textbookDL +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.snarkFailure_prob_le_of_textbookDL_full +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.snarkFailure_prob_le_of_uniformURS_textbookDL +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.snarkFailure_prob_le_of_generatorRO_textbookDL +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.binding_prob_le_of_textbookDL +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.binding_prob_le_of_uniformURS_textbookDL +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.binding_prob_le_of_generatorRO_textbookDL +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.ReductionEfficient +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.reductionEfficient_exists +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.instanceAttempt_runs_eq +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.reductionEfficient_exponential +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.DiscreteLogRelationHardFor +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.knowledgeSoundness_under_DL +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.binding_under_DL +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.bindingWin_unbounded_measure_le +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
 assert_axioms Zcash.Snark.queryCharge
 assert_axioms Zcash.Snark.queryCharge_sum_mul_le
 assert_axioms Zcash.Snark.le_queryCharge_of_mem_queries
@@ -476,52 +520,80 @@ assert_axioms Zcash.Snark.sum_card_scanRank_erase_lt_le
 assert_axioms Zcash.Snark.OracleComp.restrictSum
 assert_axioms Zcash.Snark.fsWinsFull_restrictSum_le
 assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyRand.determinize
-assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyRand.binding_prob_le_of_textbookDL_rand +native
-assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyRand.snarkFailure_prob_le_of_textbookDL_rand +native
-assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.snarkFailureEvent +native
-assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyRand.foldedRelationFinder +native
-assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyRand.binding_prob_le_of_foldedTextbookDL_rand +native
-assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyRand.foldedSnarkRelationFinder +native
-assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyRand.snarkFailure_prob_le_of_foldedTextbookDL_rand +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyRand.binding_prob_le_of_textbookDL_rand +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyRand.snarkFailure_prob_le_of_textbookDL_rand +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.snarkFailureEvent +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyRand.foldedRelationFinder +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyRand.binding_prob_le_of_foldedTextbookDL_rand +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyRand.foldedSnarkRelationFinder +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyRand.snarkFailure_prob_le_of_foldedTextbookDL_rand +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
 assert_computable Zcash.Snark.ComputedAlgebraicFSFamilyUnbounded.globalReachSet +choice
 assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnbounded.reachSet_subset_globalReachSet
 assert_computable Zcash.Snark.ComputedAlgebraicFSFamilyUnbounded.splitFamilyRand +choice
 assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnbounded.run_splitFamilyRand_adversary
-assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnbounded.binding_prob_le_of_unbounded_foldedTextbookDL +native
-assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnbounded.snarkFailure_prob_le_of_unbounded_foldedTextbookDL +native
-assert_axioms Zcash.Snark.uniformURS_basis_transfer +native
-assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnbounded.snarkFailureEventUnbounded +native
-assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnbounded.snarkFailure_prob_le_of_unbounded_uniformURS_textbookDL +native
-assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnbounded.snarkFailure_prob_le_of_unbounded_generatorRO_textbookDL +native
-assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnbounded.bindingEventUnbounded +native
-assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnbounded.binding_prob_le_of_unbounded_uniformURS_textbookDL +native
-assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnbounded.binding_prob_le_of_unbounded_generatorRO_textbookDL +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnbounded.binding_prob_le_of_unbounded_foldedTextbookDL +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnbounded.snarkFailure_prob_le_of_unbounded_foldedTextbookDL +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.uniformURS_basis_transfer +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnbounded.snarkFailureEventUnbounded +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnbounded.snarkFailure_prob_le_of_unbounded_uniformURS_textbookDL +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnbounded.snarkFailure_prob_le_of_unbounded_generatorRO_textbookDL +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnbounded.bindingEventUnbounded +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnbounded.binding_prob_le_of_unbounded_uniformURS_textbookDL +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnbounded.binding_prob_le_of_unbounded_generatorRO_textbookDL +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
 assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnboundedRand.determinize
 assert_computable Zcash.Snark.ComputedAlgebraicFSFamilyUnboundedRand.globalReachSet +choice
 assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnboundedRand.reachSet_subset_globalReachSet
 assert_computable Zcash.Snark.ComputedAlgebraicFSFamilyUnboundedRand.splitFamilyRand +choice
 assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnboundedRand.run_splitFamilyRand_adversary
-assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnboundedRand.binding_prob_le_of_unboundedRand_foldedTextbookDL +native
-assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnboundedRand.snarkFailure_prob_le_of_unboundedRand_foldedTextbookDL +native
-assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnboundedRand.snarkFailureEventUnboundedRand +native
-assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnboundedRand.snarkFailure_prob_le_of_unboundedRand_uniformURS_textbookDL +native
-assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnboundedRand.snarkFailure_prob_le_of_unboundedRand_generatorRO_textbookDL +native
-assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnboundedRand.bindingEventUnboundedRand +native
-assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnboundedRand.binding_prob_le_of_unboundedRand_uniformURS_textbookDL +native
-assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnboundedRand.binding_prob_le_of_unboundedRand_generatorRO_textbookDL +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnboundedRand.binding_prob_le_of_unboundedRand_foldedTextbookDL +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnboundedRand.snarkFailure_prob_le_of_unboundedRand_foldedTextbookDL +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnboundedRand.snarkFailureEventUnboundedRand +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnboundedRand.snarkFailure_prob_le_of_unboundedRand_uniformURS_textbookDL +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnboundedRand.snarkFailure_prob_le_of_unboundedRand_generatorRO_textbookDL +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnboundedRand.bindingEventUnboundedRand +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnboundedRand.binding_prob_le_of_unboundedRand_uniformURS_textbookDL +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnboundedRand.binding_prob_le_of_unboundedRand_generatorRO_textbookDL +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
 assert_axioms Zcash.Snark.recursiveAlgebraicForkFrom_node_runs_le
 assert_axioms Zcash.Snark.recursiveAlgebraicFork_sum_runs_le_unconditional
 assert_axioms Zcash.Snark.recursiveAlgebraicFork_oracle_tape_sum_runs_le_unconditional
 assert_axioms Zcash.Snark.recursiveAlgebraicForkFrom_sum_runs_le_of_forkSpread
 assert_axioms Zcash.Snark.recursiveAlgebraicFork_sum_runs_le_of_forkSpread
-assert_axioms Zcash.Snark.AlgebraicPoint.point_eq_components +native
-assert_axioms Zcash.Snark.Msm.eval_repr +native
-assert_axioms Zcash.Snark.RepresentedMultiopen.ofCoveredList +native
-assert_axioms Zcash.Snark.AlgebraicWfProof.ofRepresented +native
+assert_axioms Zcash.Snark.AlgebraicPoint.point_eq_components +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.Msm.eval_repr +native(CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.RepresentedMultiopen.ofCoveredList +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.AlgebraicWfProof.ofRepresented +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
 assert_axioms Zcash.Snark.assembleQueries_points_mem
 assert_axioms Zcash.Snark.constructIntermediateSets_ref_mem
 assert_axioms Zcash.Snark.multiopenMsm_points_mem
-assert_axioms Zcash.Snark.AlgebraicWfProof.ofStandard +native
+assert_axioms Zcash.Snark.AlgebraicWfProof.ofStandard +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
 assert_axioms Zcash.Snark.OracleComp.reachSet
 assert_axioms Zcash.Snark.OracleComp.run_congr_reachSet
 assert_axioms Zcash.Snark.OracleComp.restrictTo
@@ -543,14 +615,22 @@ assert_axioms Zcash.Snark.programmedRelSetWithCoins_card
 assert_axioms Zcash.Snark.programmedRelSetWithCoins_subset_win_union_miss
 assert_axioms Zcash.Snark.missSetWithCoins_card_le
 assert_axioms Zcash.Snark.relationWithCoins_prob_le_of_textbookDL
-assert_axioms Zcash.Snark.orchard_relation_prob_le_of_textbookDL +native
-assert_axioms Zcash.Snark.commitment_binding_prob_le_of_textbookDL +native
-assert_axioms Zcash.Snark.orchard_deployed_relation_prob_le_of_textbookDL +native
-assert_axioms Zcash.Snark.orchard_deployed_relation_set_eq_relSet +native
-assert_axioms Zcash.Snark.orchard_deployed_relation_event_prob_le_of_textbookDL +native
-assert_axioms Zcash.Snark.orchard_deployed_relation_prob_eq_of_uniformURS +native
-assert_axioms Zcash.Snark.orchard_deployed_relation_prob_le_of_uniformURS_textbookDL +native
-assert_axioms Zcash.Snark.orchard_deployed_relation_prob_le_of_generatorRO_textbookDL +native
+assert_axioms Zcash.Snark.orchard_relation_prob_le_of_textbookDL +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.commitment_binding_prob_le_of_textbookDL +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.orchard_deployed_relation_prob_le_of_textbookDL +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.orchard_deployed_relation_set_eq_relSet +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.orchard_deployed_relation_event_prob_le_of_textbookDL +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.orchard_deployed_relation_prob_eq_of_uniformURS +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.orchard_deployed_relation_prob_le_of_uniformURS_textbookDL +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.orchard_deployed_relation_prob_le_of_generatorRO_textbookDL +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
 
 /-! ### Fork-tree knowledge error
 
@@ -583,11 +663,16 @@ below through explicit `PSum` outcomes and computable finders. Theorems througho
 -- extraction). Discharging `hExtract` — coupling the AGM family's coin measure to the multiopen
 -- budget below — is the remaining reconciliation. This stack is not consumed by the rewind-free
 -- constraint capstone below.
-assert_axioms Zcash.Snark.ipaRelation_deployed_of_instance +native
-assert_axioms Zcash.Snark.snarkExtraction_prob_le_of_generatorRO_textbookDL +native
-assert_axioms Zcash.Snark.instanceAttempt_provenance +native
-assert_axioms Zcash.Snark.ipaRelation_deployed_of_openings_agree +native
-assert_axioms Zcash.Snark.shift_eq_zero_of_openings_agree +native
+assert_axioms Zcash.Snark.ipaRelation_deployed_of_instance +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.snarkExtraction_prob_le_of_generatorRO_textbookDL +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.instanceAttempt_provenance +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.ipaRelation_deployed_of_openings_agree +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.shift_eq_zero_of_openings_agree +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
 
 -- The decode layer (`Soundness.Multiopen.Decode`/`Deployed`): the Vandermonde recovery of the
 -- column witnesses, the deployed x4 collapse proved to be a flat power batch, and the two-level
@@ -659,7 +744,8 @@ assert_axioms Zcash.Snark.exists_accepting_good_challenge
 assert_axioms Zcash.Snark.exists_accepting_good_challenge_quotient
 -- The deployed Vesta capstone family: the decoded-column rungs and the terminal, alongside the
 -- derived capstone already pinned below.
-assert_axioms Zcash.Snark.orchard_verifier_vesta_decoded_constraint_of_forked_x4 +native
+assert_axioms Zcash.Snark.orchard_verifier_vesta_decoded_constraint_of_forked_x4 +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
 
 -- Deterministic verifier routing used by the rewind-free deployed constraint decoder.
 assert_axioms Zcash.Snark.vanishing_query_mem_assembleQueries
@@ -779,15 +865,21 @@ assert_axioms Zcash.Snark.hgood_of_good_challenge
 -- The UNCONDITIONAL decomposition: `hExtract` removed, the residual quantified as the
 -- clean-but-not-extracted measure term (bounded by the multiopen budget under the coupling
 -- documented in `Composition.Decomposition`, not assumed here).
-assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.snarkExtractionFailureEvent_subset_union +native
-assert_axioms Zcash.Snark.snarkExtraction_prob_le_of_generatorRO_textbookDL_decomposed +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.snarkExtractionFailureEvent_subset_union +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.snarkExtraction_prob_le_of_generatorRO_textbookDL_decomposed +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
 -- Product-measure lifting, now used by the direct pinned-root composition.
 assert_axioms Zcash.Snark.independentProductPMF_fiber_bound
 -- Acceptance through `assemble?`, isolated from the historical completeness ladder.
-assert_axioms Zcash.Snark.fullAlgebraicAcceptDeployed +native
-assert_axioms Zcash.Snark.fullAlgebraicAccept_of_deployed +native
-assert_axioms Zcash.Snark.snarkExtractionFailureEventDeployed +native
-assert_axioms Zcash.Snark.snarkExtractionFailureEventDeployed_subset_union +native
+assert_axioms Zcash.Snark.fullAlgebraicAcceptDeployed +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.fullAlgebraicAccept_of_deployed +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.snarkExtractionFailureEventDeployed +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.snarkExtractionFailureEventDeployed_subset_union +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
 
 -- Rewind-free AGM unbatching and its direct additive root pricing.
 assert_axioms Zcash.Snark.algebraicBatchErrorPolynomial_eval
@@ -803,25 +895,35 @@ assert_axioms Zcash.Snark.xEscTable_measure_le
 assert_axioms Zcash.Snark.xEscAtPoint_measure_le
 assert_axioms Zcash.Snark.PinnedRootEvent.landing_measure_le
 assert_axioms Zcash.Snark.PinnedRootFamily.landing_measure_le
-assert_axioms Zcash.Snark.deployedRootBad_measure_le +native
+assert_axioms Zcash.Snark.deployedRootBad_measure_le +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
 -- The shape-only root budget is monotone, so its consensus-maximum specialization bounds every
 -- smaller captured Orchard bundle rather than only the exact endpoint shape.
 assert_axioms Zcash.Snark.algebraicRootBudget_mono
-assert_axioms Zcash.Snark.DeployedRootPrefixDetermined +native
-assert_axioms Zcash.Snark.DeployedRootSqueezeInvariance +native
-assert_axioms Zcash.Snark.deployedRootSqueezeInvariance_of_prefixDetermined +native
-assert_axioms Zcash.Snark.DeployedRootOnlineTrace.toSqueezeInvariance +native
-assert_axioms Zcash.Snark.ComputedDeployedRootFSFamily.pinned +native
-assert_axioms Zcash.Snark.DeployedConstraintXOnlineTrace.toPinning +native
-assert_axioms Zcash.Snark.ComputedDeployedConstraintFSFamily.pinnedX +native
+assert_axioms Zcash.Snark.DeployedRootPrefixDetermined +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.DeployedRootSqueezeInvariance +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.deployedRootSqueezeInvariance_of_prefixDetermined +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.DeployedRootOnlineTrace.toSqueezeInvariance +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.ComputedDeployedRootFSFamily.pinned +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.DeployedConstraintXOnlineTrace.toPinning +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.ComputedDeployedConstraintFSFamily.pinnedX +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
 assert_axioms Zcash.Snark.tableReadingPinnedRootEvent
 assert_axioms Zcash.Snark.tableReadingPinnedRootEvent_landing_measure_le
 assert_axioms Zcash.Snark.deployedRootEventBudget_sum_le
-assert_axioms Zcash.Snark.badX_le_via_squeeze_prefixed +native
+assert_axioms Zcash.Snark.badX_le_via_squeeze_prefixed +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
 -- Squeeze-point toolkit: prefix-determinism makes the `x` point stable under self-reprogramming.
 -- This is not the live constraint schedule's chronology discharge: point stability alone does not
 -- prove that the bad set was fixed before `x`.
-assert_axioms Zcash.Snark.hstab_of_xPrefixDetermined +native
+assert_axioms Zcash.Snark.hstab_of_xPrefixDetermined +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
 -- Prefix injectivity at the multiopen squeeze points (`Forking.Adversary.PreIpa`): each point
 -- pins every field absorbed before it — the toolkit for the deployed squeeze-invariance
 -- schedules, which need each root-set datum emitted strictly before its own squeeze.
@@ -841,65 +943,106 @@ assert_axioms Zcash.Snark.natDegree_combineConstraints_le
 -- pinning from its query log. The lower-level direct-pinning constructor remains generic plumbing;
 -- it is not a standalone captured-capstone premise.
 assert_axioms Zcash.Snark.natDegree_committedPreXConstraintDifference_le
-assert_axioms Zcash.Snark.natDegree_deployedConstraintDifferenceOfRoot_le +native
-assert_axioms Zcash.Snark.deployedConstraintDifference_witness_congr +native
-assert_axioms Zcash.Snark.deployedConstraintXBadSet_measure_le +native
-assert_axioms Zcash.Snark.DeployedConstraintXPrefixDetermined +native
-assert_axioms Zcash.Snark.deployedConstraintXPinning_of_prefixDetermined +native
-assert_axioms Zcash.Snark.deployedConstraintXSqueezeSchedule_of_pinned +native
-assert_axioms Zcash.Snark.deployedConstraintXSqueezeSchedule_of_prefixDetermined +native
+assert_axioms Zcash.Snark.natDegree_deployedConstraintDifferenceOfRoot_le +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.deployedConstraintDifference_witness_congr +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.deployedConstraintXBadSet_measure_le +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.DeployedConstraintXPrefixDetermined +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.deployedConstraintXPinning_of_prefixDetermined +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.deployedConstraintXSqueezeSchedule_of_pinned +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.deployedConstraintXSqueezeSchedule_of_prefixDetermined +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
 -- The pinned-root witness family (`AGM.PinnedRootWitness`): the zero data over the degenerate
 -- shape, whose assembled multiopen commitment is the zero point for every basis and record.
-assert_axioms Zcash.Snark.multiopenCommitment_witness_zero +native
-assert_axioms Zcash.Snark.witnessProof +native
-assert_axioms Zcash.Snark.witnessFamily +native
+assert_axioms Zcash.Snark.multiopenCommitment_witness_zero +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.witnessProof +native(CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.witnessFamily +native(CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
 -- The actual strict-prefix property is satisfiable: the constant family's root sets are empty
 -- except at `x₃`, whose point set consumes only earlier answers.  It is packaged as an inhabitant
 -- of `ComputedDeployedRootFSFamily`; the weaker invariance theorem is a corollary.
-assert_axioms Zcash.Snark.witnessFamily_reads_update +native
-assert_axioms Zcash.Snark.deployedRootBad_witness +native
+assert_axioms Zcash.Snark.witnessFamily_reads_update +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.deployedRootBad_witness +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
 assert_axioms Zcash.Snark.deployedAllPts_x3_blind
 assert_axioms Zcash.Snark.deployedAllPts_congr_preMultiopen
-assert_axioms Zcash.Snark.deployedRootPrefixDetermined_witness +native
-assert_axioms Zcash.Snark.witnessOnlineMemberFamily +native
-assert_axioms Zcash.Snark.witnessDeployedRootFamily +native
-assert_axioms Zcash.Snark.deployedRootSqueezeInvariance_witness +native
+assert_axioms Zcash.Snark.deployedRootPrefixDetermined_witness +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.witnessOnlineMemberFamily +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.witnessDeployedRootFamily +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.deployedRootSqueezeInvariance_witness +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
 -- The satisfiability witness is itself an executable five-query stage, not a classical
 -- enumeration of the finite oracle domain.
-assert_computable Zcash.Snark.witnessOutcome +choice +native
-assert_computable Zcash.Snark.witnessOnlineMemberFamily +choice +native
-assert_computable Zcash.Snark.witnessRootStage +choice +native
-assert_computable Zcash.Snark.witnessRootTrace +choice +native
-assert_computable Zcash.Snark.witnessDeployedRootFamily +choice +native
+assert_computable Zcash.Snark.witnessOutcome +choice +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_computable Zcash.Snark.witnessOnlineMemberFamily +choice +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_computable Zcash.Snark.witnessRootStage +choice +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_computable Zcash.Snark.witnessRootTrace +choice +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_computable Zcash.Snark.witnessDeployedRootFamily +choice +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
 -- The direct route (`AGM.DirectX4Columns`): the `x₄` columns are read off the online coverage —
 -- a column below the pair count is its set's `x₁` power sum, the last is the prover's `q′` — so
 -- the batch-or-relation decision needs no offline interpolation and no field-capacity premise.
 assert_axioms Zcash.Snark.x4BatchCommitments_eq_memberPowerSum
-assert_axioms Zcash.Snark.aggregate_opens_deployedCommitment +native
-assert_axioms Zcash.Snark.snarkExtractionDeployed_prob_le_via_wrapped_pinned_roots +native
-assert_axioms Zcash.Snark.ComputedDeployedRootFSFamily.deployedRelation_prob_le_of_generatorRO_textbookDL +native
-assert_axioms Zcash.Snark.deployedRootFailure_subset_landing +native
-assert_axioms Zcash.Snark.deployedDecodeFailure_subset_union +native
-assert_axioms Zcash.Snark.deployedNonRelationFailure_prob_le_of_generatorRO +native
-assert_axioms Zcash.Snark.snarkExtractionDeployed_prob_le_via_deployed_roots +native
+assert_axioms Zcash.Snark.aggregate_opens_deployedCommitment +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.snarkExtractionDeployed_prob_le_via_wrapped_pinned_roots +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.ComputedDeployedRootFSFamily.deployedRelation_prob_le_of_generatorRO_textbookDL +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.deployedRootFailure_subset_landing +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.deployedDecodeFailure_subset_union +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.deployedNonRelationFailure_prob_le_of_generatorRO +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.snarkExtractionDeployed_prob_le_via_deployed_roots +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
 
 -- Online-source constraint composition.  All disagreement branches retain concrete relation
 -- coefficients and are charged through the same single-instance textbook-DLOG finder.
-assert_axioms Zcash.Snark.deployedConstraint_memberPoly_eq_online +native
-assert_axioms Zcash.Snark.deployedOnlineConstraintOutcomeOfDecode +native
-assert_axioms Zcash.Snark.deployedConstraintFailure_subset_union +native
-assert_axioms Zcash.Snark.deployedConstraintRelation_prob_le_of_generatorRO_textbookDL +native
-assert_axioms Zcash.Snark.snarkConstraintsDeployed_prob_le_via_deployed_roots +native
-assert_axioms Zcash.Snark.snarkConstraintsDeployed_prob_le_of_online_outcome +native
-assert_axioms Zcash.Snark.deployedConstraintUpgradeContained_of_root +native
-assert_axioms Zcash.Snark.deployedConstraintOutcomeOfRoot_relation_eq_online +native
-assert_axioms Zcash.Snark.deployedConstraintDecodedOfRoot +native
-assert_axioms Zcash.Snark.deployedConstraintBadX_subset_landing +native
-assert_axioms Zcash.Snark.deployedConstraintBadX_prob_le +native
-assert_axioms Zcash.Snark.snarkConstraintsDeployed_prob_le_of_root_schedule +native
-assert_axioms Zcash.Snark.DeployedConstraintSemanticUpgradeContained +native
-assert_axioms Zcash.Snark.deployedConstraintSemanticFailure_subset_union +native
-assert_axioms Zcash.Snark.snarkConstraintsSemanticDeployed_prob_le_of_root_schedule +native
+assert_axioms Zcash.Snark.deployedConstraint_memberPoly_eq_online +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.deployedOnlineConstraintOutcomeOfDecode +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.deployedConstraintFailure_subset_union +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.deployedConstraintRelation_prob_le_of_generatorRO_textbookDL +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.snarkConstraintsDeployed_prob_le_via_deployed_roots +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.snarkConstraintsDeployed_prob_le_of_online_outcome +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.deployedConstraintUpgradeContained_of_root +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.deployedConstraintOutcomeOfRoot_relation_eq_online +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.deployedConstraintDecodedOfRoot +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.deployedConstraintBadX_subset_landing +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.deployedConstraintBadX_prob_le +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.snarkConstraintsDeployed_prob_le_of_root_schedule +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.DeployedConstraintSemanticUpgradeContained +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.deployedConstraintSemanticFailure_subset_union +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.snarkConstraintsSemanticDeployed_prob_le_of_root_schedule +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
 
 /-! ## The Action circuit — the halo2-native soundness trust surface
 
@@ -910,9 +1053,27 @@ exactly that budget for the generic soundness theorems and for the fully-instant
 bundle — a `sorry` or any further axiom reached anywhere in the Action stack fails the build
 here. -/
 
-assert_axioms Zcash.Circuits.Action.Circuit.soundness +native
-assert_axioms Zcash.Circuits.Action.Circuit.soundnessPost +native
-assert_axioms Zcash.Circuits.Action.orchardActionCircuit +native
+assert_axioms Zcash.Circuits.Action.Circuit.soundness +native(
+  CompElliptic.Curves.Pasta.Pallas.neg_five_not_isCube,
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt,
+  Zcash.Circuits.Ecc.MulFixed.windowScalar_ne_zero,
+  Zcash.Circuits.Ecc.MulFixed.Short.windowScalar_ne_zero)
+assert_axioms Zcash.Circuits.Action.Circuit.soundnessPost +native(
+  CompElliptic.Curves.Pasta.Pallas.neg_five_not_isCube,
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt,
+  Zcash.Circuits.Ecc.MulFixed.windowScalar_ne_zero,
+  Zcash.Circuits.Ecc.MulFixed.Short.windowScalar_ne_zero)
+assert_axioms Zcash.Circuits.Action.orchardActionCircuit +native(
+  CompElliptic.Curves.Pasta.Pallas.neg_five_not_isCube,
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt,
+  Zcash.Circuits.Ecc.MulFixed.windowScalar_ne_zero,
+  Zcash.Circuits.Ecc.MulFixed.Certs.commitIvkRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.noteCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.nullifierKCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.spendAuthGCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitVCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Short.windowScalar_ne_zero)
 
 /-! ## The circuit → ledger bridge — exported refinement theorems
 
@@ -924,11 +1085,53 @@ of the witness is defined. `actionBreak_iff_classify_isSome` packages both direc
 consumer-boundary equivalence. Same budget as the circuit layer above: standard tier plus
 `native_decide` certificates (including the Pallas point-count witness). -/
 
-assert_axioms Zcash.Security.Ledger.Bridge.specPost_to_ledger +native
-assert_axioms Zcash.Security.Ledger.Bridge.circuit_soundness_to_ledger +native
-assert_axioms Zcash.Security.Ledger.Bridge.actionBreak_of_classify +native
-assert_axioms Zcash.Security.Ledger.Bridge.classify_none_defined +native
-assert_axioms Zcash.Security.Ledger.Bridge.actionBreak_iff_classify_isSome +native
+assert_axioms Zcash.Security.Ledger.Bridge.specPost_to_ledger +native(
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt,
+  Zcash.Security.Concrete.PallasGroup.pallas_base_card_lt_scalar_card,
+  Zcash.Security.Ledger.Pool.unc_thirteen_not_isSquare,
+  Zcash.Circuits.Ecc.MulFixed.Certs.commitIvkRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.noteCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.nullifierKCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.spendAuthGCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitVCert_check)
+assert_axioms Zcash.Security.Ledger.Bridge.circuit_soundness_to_ledger +native(
+  CompElliptic.Curves.Pasta.Pallas.neg_five_not_isCube,
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt,
+  Zcash.Circuits.Ecc.MulFixed.windowScalar_ne_zero,
+  Zcash.Security.Concrete.PallasGroup.pallas_base_card_lt_scalar_card,
+  Zcash.Security.Ledger.Pool.unc_thirteen_not_isSquare,
+  Zcash.Circuits.Ecc.MulFixed.Certs.commitIvkRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.noteCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.nullifierKCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.spendAuthGCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitVCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Short.windowScalar_ne_zero)
+assert_axioms Zcash.Security.Ledger.Bridge.actionBreak_of_classify +native(
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt,
+  Zcash.Circuits.Ecc.MulFixed.Certs.commitIvkRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.noteCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.nullifierKCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.spendAuthGCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitVCert_check)
+assert_axioms Zcash.Security.Ledger.Bridge.classify_none_defined +native(
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt,
+  Zcash.Circuits.Ecc.MulFixed.Certs.commitIvkRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.noteCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.nullifierKCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.spendAuthGCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitVCert_check)
+assert_axioms Zcash.Security.Ledger.Bridge.actionBreak_iff_classify_isSome +native(
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt,
+  Zcash.Circuits.Ecc.MulFixed.Certs.commitIvkRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.noteCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.nullifierKCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.spendAuthGCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitVCert_check)
 
 /-! ## The Sinsemilla discrete-log-relation reduction
 
@@ -951,14 +1154,50 @@ is the same witness the circuit layer above carries, reaching this file through 
 scalar action rather than a certificate check. -/
 
 assert_computable Zcash.Security.Ledger.Bridge.breakCoeffs +choice
-assert_computable Zcash.Security.Ledger.Bridge.relationOfBreakData +choice +native
-assert_computable Zcash.Security.Ledger.Bridge.classifyRelation +choice +native
+assert_computable Zcash.Security.Ledger.Bridge.relationOfBreakData +choice +native(
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt,
+  Zcash.Circuits.Ecc.MulFixed.Certs.commitIvkRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.noteCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.nullifierKCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.spendAuthGCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitVCert_check)
+assert_computable Zcash.Security.Ledger.Bridge.classifyRelation +choice +native(
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt,
+  Zcash.Circuits.Ecc.MulFixed.Certs.commitIvkRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.noteCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.nullifierKCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.spendAuthGCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitVCert_check)
 assert_axioms Zcash.Security.Ledger.Bridge.ofPoint_hashToPoint
-assert_axioms Zcash.Security.Ledger.Bridge.breakCoeffs_relation +native
+assert_axioms Zcash.Security.Ledger.Bridge.breakCoeffs_relation +native(
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt)
 assert_axioms Zcash.Security.Ledger.Bridge.breakCoeffs_nontrivial
-assert_axioms Zcash.Security.Ledger.Bridge.classify_query_inr +native
-assert_axioms Zcash.Security.Ledger.Bridge.classifyRelation_isSome_iff +native
-assert_axioms Zcash.Security.Ledger.Bridge.classifyRelation_site +native
+assert_axioms Zcash.Security.Ledger.Bridge.classify_query_inr +native(
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt,
+  Zcash.Circuits.Ecc.MulFixed.Certs.commitIvkRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.noteCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.nullifierKCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.spendAuthGCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitVCert_check)
+assert_axioms Zcash.Security.Ledger.Bridge.classifyRelation_isSome_iff +native(
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt,
+  Zcash.Circuits.Ecc.MulFixed.Certs.commitIvkRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.noteCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.nullifierKCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.spendAuthGCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitVCert_check)
+assert_axioms Zcash.Security.Ledger.Bridge.classifyRelation_site +native(
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt,
+  Zcash.Circuits.Ecc.MulFixed.Certs.commitIvkRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.noteCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.nullifierKCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.spendAuthGCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitVCert_check)
 
 /-! ## `@[csimp]` replacement lemmas
 

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -59,10 +59,6 @@ Two commands from `Zcash.Meta.AxiomCheck`, per the breaks-as-computed-data disci
   (`propext` / `Classical.choice` / `Quot.sound`). Both commands reject `sorryAx`.
 -/
 
-open Zcash.Security.RandomOracle
-open Zcash.Security.Ledger Zcash.Security.Ledger.Model Zcash.Security.BindingSignature
-open Zcash.Meta
-
 /-! ## Key binding — computed break reductions -/
 
 assert_computable Zcash.Security.RandomOracle.CollisionUpToSign.ofOpeningBreak +choice
@@ -126,9 +122,9 @@ tier. The exception is `nfOldEqOrBreak`: it decides the `nk`-equality branch on
 `DecidableEq NK`, so choice arrives with its proof terms in erased positions (the
 `+choice` tier). The reduction data is still a direct term of the inputs. -/
 
-assert_computable Collision.upToSign
-assert_computable Merkle.collisionOfWrongLeaf
-assert_computable noteCommitBreakOfNe
+assert_computable Zcash.Security.RandomOracle.Collision.upToSign
+assert_computable Zcash.Security.Ledger.Merkle.collisionOfWrongLeaf
+assert_computable Zcash.Security.Ledger.noteCommitBreakOfNe
 assert_computable Zcash.Security.Ledger.nfOldEqOrBreak +choice
 
 /-! ## Statement-layer pinning theorems
@@ -136,35 +132,35 @@ assert_computable Zcash.Security.Ledger.nfOldEqOrBreak +choice
 The statement layer's exported pinning guarantees: an address `(g_d, pk_d)` determines
 `ivk`, and hence `nk` is determined up to an exhibited key-binding break. -/
 
-assert_axioms ivk_pinned
-assert_axioms nk_eq_or_break
+assert_axioms Zcash.Security.Ledger.ivk_pinned
+assert_axioms Zcash.Security.Ledger.nk_eq_or_break
 
 /-! ## Ledger model
 
 The ledger-model definitions are plain computable data over public ledger contents; the
 theorems are deterministic list facts. -/
 
-assert_computable posVal
-assert_computable Merkle.subRoot
-assert_computable Merkle.authChildren
-assert_axioms Merkle.Path.compress_isSome
-assert_axioms Merkle.path_of_root
-assert_computable leafList
-assert_computable leafFun
-assert_computable rootAfter
-assert_computable nullifiers
-assert_computable transparentPoolBalance
-assert_computable outputActions
-assert_computable outputOpenings
-assert_computable positionedOutputs
-assert_computable nonZeroSpends
-assert_computable poolValueBalance
-assert_axioms posVal_lt
-assert_axioms rootAfter_prefix
-assert_axioms output_rho_eq_nullifiers
-assert_axioms output_rho_nodup
-assert_axioms leafList_eq_map
-assert_axioms outputOpenings_length
+assert_computable Zcash.Security.Ledger.Model.posVal
+assert_computable Zcash.Security.Ledger.Merkle.subRoot
+assert_computable Zcash.Security.Ledger.Merkle.authChildren
+assert_axioms Zcash.Security.Ledger.Merkle.Path.compress_isSome
+assert_axioms Zcash.Security.Ledger.Merkle.path_of_root
+assert_computable Zcash.Security.Ledger.Model.leafList
+assert_computable Zcash.Security.Ledger.Model.leafFun
+assert_computable Zcash.Security.Ledger.Model.rootAfter
+assert_computable Zcash.Security.Ledger.Model.nullifiers
+assert_computable Zcash.Security.Ledger.Model.transparentPoolBalance
+assert_computable Zcash.Security.Ledger.Model.outputActions
+assert_computable Zcash.Security.Ledger.Model.outputOpenings
+assert_computable Zcash.Security.Ledger.Model.positionedOutputs
+assert_computable Zcash.Security.Ledger.Model.nonZeroSpends
+assert_computable Zcash.Security.Ledger.Model.poolValueBalance
+assert_axioms Zcash.Security.Ledger.Model.posVal_lt
+assert_axioms Zcash.Security.Ledger.Model.rootAfter_prefix
+assert_axioms Zcash.Security.Ledger.Model.output_rho_eq_nullifiers
+assert_axioms Zcash.Security.Ledger.Model.output_rho_nodup
+assert_axioms Zcash.Security.Ledger.Model.leafList_eq_map
+assert_axioms Zcash.Security.Ledger.Model.outputOpenings_length
 
 /-! ## Balance-subset
 
@@ -174,38 +170,38 @@ anchor search (`Nat.find`, itself axiom-free) keep the branch decisions decidabl
 through Mathlib proof terms in `Prop` positions (e.g. `List.getD_eq_getElem`'s proof),
 never the data path. -/
 
-assert_computable findPair
-assert_axioms findPair_spec
-assert_axioms findPair_none
-assert_axioms flatMap_sublist
-assert_axioms outputActions_prefix
-assert_axioms nullifiers_prefix
-assert_axioms take_prefix_take
-assert_axioms spendActions_map_nf_sublist
-assert_axioms length_leafList
-assert_axioms length_positionedOutputs
-assert_axioms positionedOutputs_getElem
-assert_computable noteCommitBreakOfOutputNe
-assert_axioms satisfied_of_spendMem
-assert_axioms anchor_of_spendMem
-assert_computable spendPinnedOrBreak +choice
-assert_computable allPinnedOrBreak +choice
-assert_computable balanceSubsetOrBreak +choice
+assert_computable Zcash.Security.Ledger.Model.findPair
+assert_axioms Zcash.Security.Ledger.Model.findPair_spec
+assert_axioms Zcash.Security.Ledger.Model.findPair_none
+assert_axioms Zcash.Security.Ledger.Model.flatMap_sublist
+assert_axioms Zcash.Security.Ledger.Model.outputActions_prefix
+assert_axioms Zcash.Security.Ledger.Model.nullifiers_prefix
+assert_axioms Zcash.Security.Ledger.Model.take_prefix_take
+assert_axioms Zcash.Security.Ledger.Model.spendActions_map_nf_sublist
+assert_axioms Zcash.Security.Ledger.Model.length_leafList
+assert_axioms Zcash.Security.Ledger.Model.length_positionedOutputs
+assert_axioms Zcash.Security.Ledger.Model.positionedOutputs_getElem
+assert_computable Zcash.Security.Ledger.Model.noteCommitBreakOfOutputNe
+assert_axioms Zcash.Security.Ledger.Model.satisfied_of_spendMem
+assert_axioms Zcash.Security.Ledger.Model.anchor_of_spendMem
+assert_computable Zcash.Security.Ledger.Model.spendPinnedOrBreak +choice
+assert_computable Zcash.Security.Ledger.Model.allPinnedOrBreak +choice
+assert_computable Zcash.Security.Ledger.Model.balanceSubsetOrBreak +choice
 
 /-! ## Balance-value (conservation form)
 
 `+choice` on the two endpoints is again the erased-positions tier: choice arrives with
 the `ring`/`omega` proof terms in their `Prop` fields, never the data path. -/
 
-assert_computable txNetValue
-assert_computable issuanceTotal
-assert_axioms transparentPoolBalance_eq
-assert_axioms positionedOutputs_value_sum
-assert_axioms nonZeroSpends_value_sum
-assert_axioms poolValueBalance_eq_neg
-assert_computable allValueOrBreak
-assert_computable valueConservationOrBreak +choice
-assert_computable balanceValueOrBreak +choice
+assert_computable Zcash.Security.Ledger.Model.txNetValue
+assert_computable Zcash.Security.Ledger.Model.issuanceTotal
+assert_axioms Zcash.Security.Ledger.Model.transparentPoolBalance_eq
+assert_axioms Zcash.Security.Ledger.Model.positionedOutputs_value_sum
+assert_axioms Zcash.Security.Ledger.Model.nonZeroSpends_value_sum
+assert_axioms Zcash.Security.Ledger.Model.poolValueBalance_eq_neg
+assert_computable Zcash.Security.Ledger.Model.allValueOrBreak
+assert_computable Zcash.Security.Ledger.Model.valueConservationOrBreak +choice
+assert_computable Zcash.Security.Ledger.Model.balanceValueOrBreak +choice
 
 /-! ## Spendability
 
@@ -213,10 +209,10 @@ The Faerie-Gold core and the roadblock inversion are computable reductions at th
 flagless tier; the nullifier split and the persistence theorem are deterministic list
 facts. -/
 
-assert_axioms nullifiers_append
-assert_computable faerieGoldCore
-assert_computable respendOrBreak
-assert_axioms validLedger_append
+assert_axioms Zcash.Security.Ledger.Model.nullifiers_append
+assert_computable Zcash.Security.Ledger.Model.faerieGoldCore
+assert_computable Zcash.Security.Ledger.Model.respendOrBreak
+assert_axioms Zcash.Security.Ledger.Model.validLedger_append
 
 /-! ## The nullifier-binding reduction
 
@@ -249,9 +245,9 @@ reductions is the erased-positions tier: choice arrives with `smul_eq_zero`'s Ma
 proof inside the receivability pinning, consumed only in `Prop` positions — never the
 data path. -/
 
-assert_axioms ivk_eq_of_receivable
-assert_computable spendAuthForgeryOrBreak +choice
-assert_computable spendAuthorityOrBreak +choice
+assert_axioms Zcash.Security.Ledger.Model.ivk_eq_of_receivable
+assert_computable Zcash.Security.Ledger.Model.spendAuthForgeryOrBreak +choice
+assert_computable Zcash.Security.Ledger.Model.spendAuthorityOrBreak +choice
 
 /-! ## Honest-spend completeness and the Spendability capstone
 
@@ -305,11 +301,11 @@ only through erased `Prop` certificate fields (the arithmetic side proofs); the 
 coefficients themselves are direct terms of the inputs, and the plain-`def` check means the data
 cannot have been conjured from mere propositional existence. -/
 
-assert_computable NontrivialRelation.ofImbalance +choice
-assert_computable NontrivialRelation.ofBundleModImbalance +choice
-assert_computable NontrivialRelation.ofBundleIntImbalance +choice
-assert_computable NontrivialRelation.ofOrchardImbalance +choice
-assert_computable NontrivialRelation.ofSaplingImbalance +choice
+assert_computable Zcash.Security.BindingSignature.NontrivialRelation.ofImbalance +choice
+assert_computable Zcash.Security.BindingSignature.NontrivialRelation.ofBundleModImbalance +choice
+assert_computable Zcash.Security.BindingSignature.NontrivialRelation.ofBundleIntImbalance +choice
+assert_computable Zcash.Security.BindingSignature.NontrivialRelation.ofOrchardImbalance +choice
+assert_computable Zcash.Security.BindingSignature.NontrivialRelation.ofSaplingImbalance +choice
 
 /-!
 ## SNARK soundness stack
@@ -331,19 +327,17 @@ through the `Zcash.Meta.AxiomCheck` macros rather than the older `assert_no_sorr
   `Quot.sound`), with `+native` on the Vesta-instantiated endpoints.
 -/
 
-open Zcash.Snark
-
 /-! ### Binding reductions from IPA/CommitFold collisions -/
 
-assert_computable NontrivialDLRelation.ofCollision +choice
-assert_computable NontrivialDLRelation.ofIpaOpenings +choice
+assert_computable Zcash.Snark.NontrivialDLRelation.ofCollision +choice
+assert_computable Zcash.Snark.NontrivialDLRelation.ofIpaOpenings +choice
 
 /-! ### Verifier-soundness capstones -/
 
-assert_axioms deployedAccepts_verifierEq
-assert_axioms orchard_verifier_deployed_opening_of_forked
-assert_axioms orchard_verifier_deployed_constraint_of_forked
-assert_axioms orchard_verifier_vesta_constraint_of_forked +native
+assert_axioms Zcash.Snark.deployedAccepts_verifierEq
+assert_axioms Zcash.Snark.orchard_verifier_deployed_opening_of_forked
+assert_axioms Zcash.Snark.orchard_verifier_deployed_constraint_of_forked
+assert_axioms Zcash.Snark.orchard_verifier_vesta_constraint_of_forked +native
 
 /-! ### Deployed binding-reduction breaks
 
@@ -351,17 +345,17 @@ The binding reductions return computed data (plain `def`s); the same treatment c
 reductions `ipa_extractV`, `ipaRelation_extract`, `produceDeployed`, `deployed_forking_tree`, and
 `deployed_forking_relation`, each computing its witness from an explicit certificate. -/
 
-assert_computable NontrivialRelation.ofCombinationCollision +choice
-assert_computable NontrivialRelation.ofFoldedGens +choice
-assert_computable NontrivialRelation.ofLeafPeel +choice
-assert_computable NontrivialRelation.ofDeployedTree +choice
-assert_computable NontrivialRelation.ofUnopenedFork +choice
-assert_computable NontrivialRelation.ofUnopenedForkVesta +choice +native
-assert_computable ipa_extractV +choice
-assert_computable ipaRelation_extract +choice
-assert_computable produceDeployed +choice
-assert_computable deployed_forking_tree +choice
-assert_computable deployed_forking_relation +choice
+assert_computable Zcash.Snark.NontrivialRelation.ofCombinationCollision +choice
+assert_computable Zcash.Snark.NontrivialRelation.ofFoldedGens +choice
+assert_computable Zcash.Snark.NontrivialRelation.ofLeafPeel +choice
+assert_computable Zcash.Snark.NontrivialRelation.ofDeployedTree +choice
+assert_computable Zcash.Snark.NontrivialRelation.ofUnopenedFork +choice
+assert_computable Zcash.Snark.NontrivialRelation.ofUnopenedForkVesta +choice +native
+assert_computable Zcash.Snark.ipa_extractV +choice
+assert_computable Zcash.Snark.ipaRelation_extract +choice
+assert_computable Zcash.Snark.produceDeployed +choice
+assert_computable Zcash.Snark.deployed_forking_tree +choice
+assert_computable Zcash.Snark.deployed_forking_relation +choice
 
 /-! ### AGM / Fiat–Shamir soundness
 
@@ -369,194 +363,194 @@ The AGM kernels compute representations, openings, relations, certificates, and 
 as data (`assert_computable`); the probability layer, the knowledge-soundness and binding endpoints,
 and the run-time bounds are theorems (`assert_axioms`). -/
 
-assert_computable discreteLogOfBasis_of_relation +choice
-assert_computable discreteLogOfChallenge_of_relation +choice
-assert_computable programmedExtractOrMiss +choice
-assert_computable AugmentedRelationWitness.toAlgebraicRelationWitness +choice
-assert_computable relationWitnessOfCollision +choice
-assert_computable discreteLogOfAugmentedRelationAtChallenge +choice
-assert_computable separateOrRelationWitness +choice
-assert_computable algebraicPowerBatchWithSourceOrRelation +choice
-assert_computable finForallOrRelationWitness +choice
-assert_computable constructIntermediateSets_comm_route +choice
-assert_computable deployed_slot_route_of_checks +choice
-assert_computable deployedRouteSelectorOfSpecs +choice
-assert_computable deployedConstraintQuotientAgreementOrRelation +choice +native
-assert_computable deployedConstraintQuotientFinder +choice +native
-assert_computable decodedQuotientEqReassembledOrRelationWitness +choice
-assert_computable DeployedAlgebraicDecode.quotientEvalEqCommittedPreXOrRelationWitness +choice
-assert_computable x4BatchCommitments +choice +native
-assert_computable deployedSetMemberCommitments +choice +native
-assert_computable deployedX4AlgebraicBatchOrRelation +choice +native
-assert_computable deployedX1AlgebraicBatchWithSourceOrRelation +choice +native
-assert_computable deployedX1BatchOfCoveredWithSourceOrRelation +choice +native
-assert_computable deployedX4ColumnRepresentationsOfCovered +choice +native
-assert_computable deployedX4BatchOfCoveredOrRelation +choice +native
-assert_computable deployedRootOutcomeOfCovered +choice +native
-assert_computable ComputedDeployedRootFSFamily.ofCovered +choice +native
-assert_computable ComputedDeployedConstraintFSFamily.ofCovered +choice +native
-assert_computable ComputedDeployedRootFSFamily.deployedRelationFinder +choice +native
-assert_computable deployedConstraintFinderOfOutcome +choice +native
-assert_computable deployedConstraintRelationFinder +choice +native
-assert_computable relationOfFoldGensWitness +choice
-assert_computable deployedLeafPeelWitness +choice
-assert_computable deployedToAcceptVWitness +choice
-assert_computable algebraicRelationOfDeployedAccept +choice
-assert_axioms AlgebraicProver.toProver
-assert_axioms AlgebraicDForkCert.toDForkCert
-assert_axioms algebraicProverAccept_forkValid
-assert_computable deployedAlgebraicForkingRelation +choice
-assert_axioms deployed_forking_relation_shifted
-assert_axioms deployedAlgebraicForkingRelation_shifted
-assert_computable deployedAlgebraicForkingProgrammed +choice
-assert_axioms DeployedAlgebraicForkingInstance.run
-assert_axioms DeployedAlgebraicForkingInstance.ProducesRelation
-assert_axioms deployedAlgebraicRelationProduced
-assert_axioms deployedAlgebraicRelationEvent
-assert_computable deployedAlgebraicRelationFinder +choice
-assert_axioms deployedAlgebraicRelationFinder_isSome_iff
-assert_computable deployedAlgebraicRelation +choice
-assert_computable deployedAlgebraicRelationWitness +choice
-assert_axioms orchardDeployedAlgebraicForkingProgrammed +native
-assert_axioms orchardDeployedRelationSet +native
-assert_axioms OrchardUniformURSIdentification +native
-assert_axioms orchardGeneratorROSetup
-assert_axioms orchardGeneratorROBasis
-assert_axioms orchard_uniformURSIdentification_of_generatorRO +native
-assert_axioms recursiveAlgebraicForkFrom
-assert_axioms recursiveAlgebraicForkFrom_realizes
-assert_axioms algebraicForkCertAttempt +native
-assert_axioms algebraicForkCertAttempt_valid +native
-assert_axioms computedDeployedAlgebraicInstance +native
-assert_axioms computedAlgebraicInstanceFailure_measure_le +native
-assert_axioms AlgebraicRelationWitness.augment
-assert_axioms DeployedAlgebraicForkingInstance.runRelation
-assert_axioms DeployedAlgebraicForkingInstance.runRelation_isSome_of_mismatch
-assert_computable DeployedAlgebraicForkingInstance.runToSnark +choice +native
-assert_axioms ComputedAlgebraicFSFamily.relationFinder +native
-assert_axioms ComputedAlgebraicFSFamily.relationFinder_isSome_of_bindingWin +native
-assert_axioms ComputedAlgebraicFSFamily.snarkRelationFinder +native
-assert_axioms ComputedAlgebraicFSFamily.snarkRelation_prob_le_of_textbookDL +native
-assert_axioms ComputedAlgebraicFSFamily.acceptExtractionFailure_measure_le +native
-assert_axioms ComputedAlgebraicFSFamily.snarkNonRelationFailure +native
-assert_axioms ComputedAlgebraicFSFamily.snarkNonRelationFailure_measure_le +native
-assert_axioms ComputedAlgebraicFSFamily.snarkFailure_prob_le_of_textbookDL +native
-assert_axioms ComputedAlgebraicFSFamily.snarkFailure_prob_le_of_textbookDL_full +native
-assert_axioms ComputedAlgebraicFSFamily.snarkFailure_prob_le_of_uniformURS_textbookDL +native
-assert_axioms ComputedAlgebraicFSFamily.snarkFailure_prob_le_of_generatorRO_textbookDL +native
-assert_axioms ComputedAlgebraicFSFamily.binding_prob_le_of_textbookDL +native
-assert_axioms ComputedAlgebraicFSFamily.binding_prob_le_of_uniformURS_textbookDL +native
-assert_axioms ComputedAlgebraicFSFamily.binding_prob_le_of_generatorRO_textbookDL +native
-assert_axioms ComputedAlgebraicFSFamily.ReductionEfficient +native
-assert_axioms ComputedAlgebraicFSFamily.reductionEfficient_exists +native
-assert_axioms ComputedAlgebraicFSFamily.instanceAttempt_runs_eq +native
-assert_axioms ComputedAlgebraicFSFamily.reductionEfficient_exponential +native
-assert_axioms ComputedAlgebraicFSFamily.DiscreteLogRelationHardFor +native
-assert_axioms ComputedAlgebraicFSFamily.knowledgeSoundness_under_DL +native
-assert_axioms ComputedAlgebraicFSFamily.binding_under_DL +native
-assert_axioms bindingWin_unbounded_measure_le +native
-assert_axioms queryCharge
-assert_axioms queryCharge_sum_mul_le
-assert_axioms le_queryCharge_of_mem_queries
-assert_axioms mem_queries_dedup
-assert_axioms applyUpdates_apply_mem_nodup
-assert_axioms queryCharge_sum_mul_le_table_budget
-assert_axioms steeredCharge_context_sum_mul_le
-assert_axioms steeredCharge_context_sum_mul_le_table_budget
-assert_axioms steeredCharge_sum_mul_le
-assert_axioms scanCandidate_self
-assert_axioms self_mem_goodChallenges_iff
-assert_axioms scanRank_insert_erase
-assert_axioms scanRank_insert_eq_filter
-assert_axioms goodChallengesAt
-assert_axioms OracleComp.queries_queryList
-assert_axioms recursiveAlgebraicForkFrom_node_runs_le_gated
-assert_axioms OracleComp.queries_bind
-assert_axioms OracleComp.mem_queries_completing
-assert_axioms scanCandidateAt
-assert_axioms scanCandidateAt_fork
-assert_axioms scanCandidateAt_update
-assert_axioms goodChallengesAt_fork
-assert_axioms goodChallengesAt_update
-assert_axioms sum_card_scanRank_erase_lt_le
-assert_axioms OracleComp.restrictSum
-assert_axioms fsWinsFull_restrictSum_le
-assert_axioms ComputedAlgebraicFSFamilyRand.determinize
-assert_axioms ComputedAlgebraicFSFamilyRand.binding_prob_le_of_textbookDL_rand +native
-assert_axioms ComputedAlgebraicFSFamilyRand.snarkFailure_prob_le_of_textbookDL_rand +native
-assert_axioms ComputedAlgebraicFSFamily.snarkFailureEvent +native
-assert_axioms ComputedAlgebraicFSFamilyRand.foldedRelationFinder +native
-assert_axioms ComputedAlgebraicFSFamilyRand.binding_prob_le_of_foldedTextbookDL_rand +native
-assert_axioms ComputedAlgebraicFSFamilyRand.foldedSnarkRelationFinder +native
-assert_axioms ComputedAlgebraicFSFamilyRand.snarkFailure_prob_le_of_foldedTextbookDL_rand +native
-assert_computable ComputedAlgebraicFSFamilyUnbounded.globalReachSet +choice
-assert_axioms ComputedAlgebraicFSFamilyUnbounded.reachSet_subset_globalReachSet
-assert_computable ComputedAlgebraicFSFamilyUnbounded.splitFamilyRand +choice
-assert_axioms ComputedAlgebraicFSFamilyUnbounded.run_splitFamilyRand_adversary
-assert_axioms ComputedAlgebraicFSFamilyUnbounded.binding_prob_le_of_unbounded_foldedTextbookDL +native
-assert_axioms ComputedAlgebraicFSFamilyUnbounded.snarkFailure_prob_le_of_unbounded_foldedTextbookDL +native
-assert_axioms uniformURS_basis_transfer +native
-assert_axioms ComputedAlgebraicFSFamilyUnbounded.snarkFailureEventUnbounded +native
-assert_axioms ComputedAlgebraicFSFamilyUnbounded.snarkFailure_prob_le_of_unbounded_uniformURS_textbookDL +native
-assert_axioms ComputedAlgebraicFSFamilyUnbounded.snarkFailure_prob_le_of_unbounded_generatorRO_textbookDL +native
-assert_axioms ComputedAlgebraicFSFamilyUnbounded.bindingEventUnbounded +native
-assert_axioms ComputedAlgebraicFSFamilyUnbounded.binding_prob_le_of_unbounded_uniformURS_textbookDL +native
-assert_axioms ComputedAlgebraicFSFamilyUnbounded.binding_prob_le_of_unbounded_generatorRO_textbookDL +native
-assert_axioms ComputedAlgebraicFSFamilyUnboundedRand.determinize
-assert_computable ComputedAlgebraicFSFamilyUnboundedRand.globalReachSet +choice
-assert_axioms ComputedAlgebraicFSFamilyUnboundedRand.reachSet_subset_globalReachSet
-assert_computable ComputedAlgebraicFSFamilyUnboundedRand.splitFamilyRand +choice
-assert_axioms ComputedAlgebraicFSFamilyUnboundedRand.run_splitFamilyRand_adversary
-assert_axioms ComputedAlgebraicFSFamilyUnboundedRand.binding_prob_le_of_unboundedRand_foldedTextbookDL +native
-assert_axioms ComputedAlgebraicFSFamilyUnboundedRand.snarkFailure_prob_le_of_unboundedRand_foldedTextbookDL +native
-assert_axioms ComputedAlgebraicFSFamilyUnboundedRand.snarkFailureEventUnboundedRand +native
-assert_axioms ComputedAlgebraicFSFamilyUnboundedRand.snarkFailure_prob_le_of_unboundedRand_uniformURS_textbookDL +native
-assert_axioms ComputedAlgebraicFSFamilyUnboundedRand.snarkFailure_prob_le_of_unboundedRand_generatorRO_textbookDL +native
-assert_axioms ComputedAlgebraicFSFamilyUnboundedRand.bindingEventUnboundedRand +native
-assert_axioms ComputedAlgebraicFSFamilyUnboundedRand.binding_prob_le_of_unboundedRand_uniformURS_textbookDL +native
-assert_axioms ComputedAlgebraicFSFamilyUnboundedRand.binding_prob_le_of_unboundedRand_generatorRO_textbookDL +native
-assert_axioms recursiveAlgebraicForkFrom_node_runs_le
-assert_axioms recursiveAlgebraicFork_sum_runs_le_unconditional
-assert_axioms recursiveAlgebraicFork_oracle_tape_sum_runs_le_unconditional
-assert_axioms recursiveAlgebraicForkFrom_sum_runs_le_of_forkSpread
-assert_axioms recursiveAlgebraicFork_sum_runs_le_of_forkSpread
-assert_axioms AlgebraicPoint.point_eq_components +native
-assert_axioms Msm.eval_repr +native
-assert_axioms RepresentedMultiopen.ofCoveredList +native
-assert_axioms AlgebraicWfProof.ofRepresented +native
-assert_axioms assembleQueries_points_mem
-assert_axioms constructIntermediateSets_ref_mem
-assert_axioms multiopenMsm_points_mem
-assert_axioms AlgebraicWfProof.ofStandard +native
-assert_axioms OracleComp.reachSet
-assert_axioms OracleComp.run_congr_reachSet
-assert_axioms OracleComp.restrictTo
-assert_axioms OracleComp.splitDomain
-assert_axioms finite_domain_restriction
-assert_axioms fsWinsFull_mapDomain_measure_eq
-assert_axioms fsWinsFull_splitDomain
-assert_axioms fsWinsFull_unbounded_measure_le
-assert_axioms truncateTranscript
+assert_computable Zcash.Snark.discreteLogOfBasis_of_relation +choice
+assert_computable Zcash.Snark.discreteLogOfChallenge_of_relation +choice
+assert_computable Zcash.Snark.programmedExtractOrMiss +choice
+assert_computable Zcash.Snark.AugmentedRelationWitness.toAlgebraicRelationWitness +choice
+assert_computable Zcash.Snark.relationWitnessOfCollision +choice
+assert_computable Zcash.Snark.discreteLogOfAugmentedRelationAtChallenge +choice
+assert_computable Zcash.Snark.separateOrRelationWitness +choice
+assert_computable Zcash.Snark.algebraicPowerBatchWithSourceOrRelation +choice
+assert_computable Zcash.Snark.finForallOrRelationWitness +choice
+assert_computable Zcash.Snark.constructIntermediateSets_comm_route +choice
+assert_computable Zcash.Snark.deployed_slot_route_of_checks +choice
+assert_computable Zcash.Snark.deployedRouteSelectorOfSpecs +choice
+assert_computable Zcash.Snark.deployedConstraintQuotientAgreementOrRelation +choice +native
+assert_computable Zcash.Snark.deployedConstraintQuotientFinder +choice +native
+assert_computable Zcash.Snark.decodedQuotientEqReassembledOrRelationWitness +choice
+assert_computable Zcash.Snark.DeployedAlgebraicDecode.quotientEvalEqCommittedPreXOrRelationWitness +choice
+assert_computable Zcash.Snark.x4BatchCommitments +choice +native
+assert_computable Zcash.Snark.deployedSetMemberCommitments +choice +native
+assert_computable Zcash.Snark.deployedX4AlgebraicBatchOrRelation +choice +native
+assert_computable Zcash.Snark.deployedX1AlgebraicBatchWithSourceOrRelation +choice +native
+assert_computable Zcash.Snark.deployedX1BatchOfCoveredWithSourceOrRelation +choice +native
+assert_computable Zcash.Snark.deployedX4ColumnRepresentationsOfCovered +choice +native
+assert_computable Zcash.Snark.deployedX4BatchOfCoveredOrRelation +choice +native
+assert_computable Zcash.Snark.deployedRootOutcomeOfCovered +choice +native
+assert_computable Zcash.Snark.ComputedDeployedRootFSFamily.ofCovered +choice +native
+assert_computable Zcash.Snark.ComputedDeployedConstraintFSFamily.ofCovered +choice +native
+assert_computable Zcash.Snark.ComputedDeployedRootFSFamily.deployedRelationFinder +choice +native
+assert_computable Zcash.Snark.deployedConstraintFinderOfOutcome +choice +native
+assert_computable Zcash.Snark.deployedConstraintRelationFinder +choice +native
+assert_computable Zcash.Snark.relationOfFoldGensWitness +choice
+assert_computable Zcash.Snark.deployedLeafPeelWitness +choice
+assert_computable Zcash.Snark.deployedToAcceptVWitness +choice
+assert_computable Zcash.Snark.algebraicRelationOfDeployedAccept +choice
+assert_axioms Zcash.Snark.AlgebraicProver.toProver
+assert_axioms Zcash.Snark.AlgebraicDForkCert.toDForkCert
+assert_axioms Zcash.Snark.algebraicProverAccept_forkValid
+assert_computable Zcash.Snark.deployedAlgebraicForkingRelation +choice
+assert_axioms Zcash.Snark.deployed_forking_relation_shifted
+assert_axioms Zcash.Snark.deployedAlgebraicForkingRelation_shifted
+assert_computable Zcash.Snark.deployedAlgebraicForkingProgrammed +choice
+assert_axioms Zcash.Snark.DeployedAlgebraicForkingInstance.run
+assert_axioms Zcash.Snark.DeployedAlgebraicForkingInstance.ProducesRelation
+assert_axioms Zcash.Snark.deployedAlgebraicRelationProduced
+assert_axioms Zcash.Snark.deployedAlgebraicRelationEvent
+assert_computable Zcash.Snark.deployedAlgebraicRelationFinder +choice
+assert_axioms Zcash.Snark.deployedAlgebraicRelationFinder_isSome_iff
+assert_computable Zcash.Snark.deployedAlgebraicRelation +choice
+assert_computable Zcash.Snark.deployedAlgebraicRelationWitness +choice
+assert_axioms Zcash.Snark.orchardDeployedAlgebraicForkingProgrammed +native
+assert_axioms Zcash.Snark.orchardDeployedRelationSet +native
+assert_axioms Zcash.Snark.OrchardUniformURSIdentification +native
+assert_axioms Zcash.Snark.orchardGeneratorROSetup
+assert_axioms Zcash.Snark.orchardGeneratorROBasis
+assert_axioms Zcash.Snark.orchard_uniformURSIdentification_of_generatorRO +native
+assert_axioms Zcash.Snark.recursiveAlgebraicForkFrom
+assert_axioms Zcash.Snark.recursiveAlgebraicForkFrom_realizes
+assert_axioms Zcash.Snark.algebraicForkCertAttempt +native
+assert_axioms Zcash.Snark.algebraicForkCertAttempt_valid +native
+assert_axioms Zcash.Snark.computedDeployedAlgebraicInstance +native
+assert_axioms Zcash.Snark.computedAlgebraicInstanceFailure_measure_le +native
+assert_axioms Zcash.Snark.AlgebraicRelationWitness.augment
+assert_axioms Zcash.Snark.DeployedAlgebraicForkingInstance.runRelation
+assert_axioms Zcash.Snark.DeployedAlgebraicForkingInstance.runRelation_isSome_of_mismatch
+assert_computable Zcash.Snark.DeployedAlgebraicForkingInstance.runToSnark +choice +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.relationFinder +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.relationFinder_isSome_of_bindingWin +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.snarkRelationFinder +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.snarkRelation_prob_le_of_textbookDL +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.acceptExtractionFailure_measure_le +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.snarkNonRelationFailure +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.snarkNonRelationFailure_measure_le +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.snarkFailure_prob_le_of_textbookDL +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.snarkFailure_prob_le_of_textbookDL_full +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.snarkFailure_prob_le_of_uniformURS_textbookDL +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.snarkFailure_prob_le_of_generatorRO_textbookDL +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.binding_prob_le_of_textbookDL +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.binding_prob_le_of_uniformURS_textbookDL +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.binding_prob_le_of_generatorRO_textbookDL +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.ReductionEfficient +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.reductionEfficient_exists +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.instanceAttempt_runs_eq +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.reductionEfficient_exponential +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.DiscreteLogRelationHardFor +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.knowledgeSoundness_under_DL +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.binding_under_DL +native
+assert_axioms Zcash.Snark.bindingWin_unbounded_measure_le +native
+assert_axioms Zcash.Snark.queryCharge
+assert_axioms Zcash.Snark.queryCharge_sum_mul_le
+assert_axioms Zcash.Snark.le_queryCharge_of_mem_queries
+assert_axioms Zcash.Snark.mem_queries_dedup
+assert_axioms Zcash.Snark.applyUpdates_apply_mem_nodup
+assert_axioms Zcash.Snark.queryCharge_sum_mul_le_table_budget
+assert_axioms Zcash.Snark.steeredCharge_context_sum_mul_le
+assert_axioms Zcash.Snark.steeredCharge_context_sum_mul_le_table_budget
+assert_axioms Zcash.Snark.steeredCharge_sum_mul_le
+assert_axioms Zcash.Snark.scanCandidate_self
+assert_axioms Zcash.Snark.self_mem_goodChallenges_iff
+assert_axioms Zcash.Snark.scanRank_insert_erase
+assert_axioms Zcash.Snark.scanRank_insert_eq_filter
+assert_axioms Zcash.Snark.goodChallengesAt
+assert_axioms Zcash.Snark.OracleComp.queries_queryList
+assert_axioms Zcash.Snark.recursiveAlgebraicForkFrom_node_runs_le_gated
+assert_axioms Zcash.Snark.OracleComp.queries_bind
+assert_axioms Zcash.Snark.OracleComp.mem_queries_completing
+assert_axioms Zcash.Snark.scanCandidateAt
+assert_axioms Zcash.Snark.scanCandidateAt_fork
+assert_axioms Zcash.Snark.scanCandidateAt_update
+assert_axioms Zcash.Snark.goodChallengesAt_fork
+assert_axioms Zcash.Snark.goodChallengesAt_update
+assert_axioms Zcash.Snark.sum_card_scanRank_erase_lt_le
+assert_axioms Zcash.Snark.OracleComp.restrictSum
+assert_axioms Zcash.Snark.fsWinsFull_restrictSum_le
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyRand.determinize
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyRand.binding_prob_le_of_textbookDL_rand +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyRand.snarkFailure_prob_le_of_textbookDL_rand +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.snarkFailureEvent +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyRand.foldedRelationFinder +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyRand.binding_prob_le_of_foldedTextbookDL_rand +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyRand.foldedSnarkRelationFinder +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyRand.snarkFailure_prob_le_of_foldedTextbookDL_rand +native
+assert_computable Zcash.Snark.ComputedAlgebraicFSFamilyUnbounded.globalReachSet +choice
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnbounded.reachSet_subset_globalReachSet
+assert_computable Zcash.Snark.ComputedAlgebraicFSFamilyUnbounded.splitFamilyRand +choice
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnbounded.run_splitFamilyRand_adversary
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnbounded.binding_prob_le_of_unbounded_foldedTextbookDL +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnbounded.snarkFailure_prob_le_of_unbounded_foldedTextbookDL +native
+assert_axioms Zcash.Snark.uniformURS_basis_transfer +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnbounded.snarkFailureEventUnbounded +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnbounded.snarkFailure_prob_le_of_unbounded_uniformURS_textbookDL +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnbounded.snarkFailure_prob_le_of_unbounded_generatorRO_textbookDL +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnbounded.bindingEventUnbounded +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnbounded.binding_prob_le_of_unbounded_uniformURS_textbookDL +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnbounded.binding_prob_le_of_unbounded_generatorRO_textbookDL +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnboundedRand.determinize
+assert_computable Zcash.Snark.ComputedAlgebraicFSFamilyUnboundedRand.globalReachSet +choice
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnboundedRand.reachSet_subset_globalReachSet
+assert_computable Zcash.Snark.ComputedAlgebraicFSFamilyUnboundedRand.splitFamilyRand +choice
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnboundedRand.run_splitFamilyRand_adversary
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnboundedRand.binding_prob_le_of_unboundedRand_foldedTextbookDL +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnboundedRand.snarkFailure_prob_le_of_unboundedRand_foldedTextbookDL +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnboundedRand.snarkFailureEventUnboundedRand +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnboundedRand.snarkFailure_prob_le_of_unboundedRand_uniformURS_textbookDL +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnboundedRand.snarkFailure_prob_le_of_unboundedRand_generatorRO_textbookDL +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnboundedRand.bindingEventUnboundedRand +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnboundedRand.binding_prob_le_of_unboundedRand_uniformURS_textbookDL +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamilyUnboundedRand.binding_prob_le_of_unboundedRand_generatorRO_textbookDL +native
+assert_axioms Zcash.Snark.recursiveAlgebraicForkFrom_node_runs_le
+assert_axioms Zcash.Snark.recursiveAlgebraicFork_sum_runs_le_unconditional
+assert_axioms Zcash.Snark.recursiveAlgebraicFork_oracle_tape_sum_runs_le_unconditional
+assert_axioms Zcash.Snark.recursiveAlgebraicForkFrom_sum_runs_le_of_forkSpread
+assert_axioms Zcash.Snark.recursiveAlgebraicFork_sum_runs_le_of_forkSpread
+assert_axioms Zcash.Snark.AlgebraicPoint.point_eq_components +native
+assert_axioms Zcash.Snark.Msm.eval_repr +native
+assert_axioms Zcash.Snark.RepresentedMultiopen.ofCoveredList +native
+assert_axioms Zcash.Snark.AlgebraicWfProof.ofRepresented +native
+assert_axioms Zcash.Snark.assembleQueries_points_mem
+assert_axioms Zcash.Snark.constructIntermediateSets_ref_mem
+assert_axioms Zcash.Snark.multiopenMsm_points_mem
+assert_axioms Zcash.Snark.AlgebraicWfProof.ofStandard +native
+assert_axioms Zcash.Snark.OracleComp.reachSet
+assert_axioms Zcash.Snark.OracleComp.run_congr_reachSet
+assert_axioms Zcash.Snark.OracleComp.restrictTo
+assert_axioms Zcash.Snark.OracleComp.splitDomain
+assert_axioms Zcash.Snark.finite_domain_restriction
+assert_axioms Zcash.Snark.fsWinsFull_mapDomain_measure_eq
+assert_axioms Zcash.Snark.fsWinsFull_splitDomain
+assert_axioms Zcash.Snark.fsWinsFull_unbounded_measure_le
+assert_axioms Zcash.Snark.truncateTranscript
 assert_computable Zcash.Security.BindingSignature.NontrivialRelation.toAlgebraicRelationWitness +choice
 assert_computable Zcash.Security.BindingSignature.NontrivialRelation.toDiscreteLog +choice
 assert_axioms Zcash.Security.BindingSignature.orchardImbalanceToDiscreteLog
 assert_axioms Zcash.Security.BindingSignature.saplingImbalanceToDiscreteLog
-assert_axioms programmedRelSet_card
-assert_axioms programmedRelSet_subset_win_union_miss
-assert_axioms missSet_card_le
-assert_axioms relation_prob_le_of_textbookDL
-assert_axioms programmedRelSetWithCoins_card
-assert_axioms programmedRelSetWithCoins_subset_win_union_miss
-assert_axioms missSetWithCoins_card_le
-assert_axioms relationWithCoins_prob_le_of_textbookDL
-assert_axioms orchard_relation_prob_le_of_textbookDL +native
-assert_axioms commitment_binding_prob_le_of_textbookDL +native
-assert_axioms orchard_deployed_relation_prob_le_of_textbookDL +native
-assert_axioms orchard_deployed_relation_set_eq_relSet +native
-assert_axioms orchard_deployed_relation_event_prob_le_of_textbookDL +native
-assert_axioms orchard_deployed_relation_prob_eq_of_uniformURS +native
-assert_axioms orchard_deployed_relation_prob_le_of_uniformURS_textbookDL +native
-assert_axioms orchard_deployed_relation_prob_le_of_generatorRO_textbookDL +native
+assert_axioms Zcash.Snark.programmedRelSet_card
+assert_axioms Zcash.Snark.programmedRelSet_subset_win_union_miss
+assert_axioms Zcash.Snark.missSet_card_le
+assert_axioms Zcash.Snark.relation_prob_le_of_textbookDL
+assert_axioms Zcash.Snark.programmedRelSetWithCoins_card
+assert_axioms Zcash.Snark.programmedRelSetWithCoins_subset_win_union_miss
+assert_axioms Zcash.Snark.missSetWithCoins_card_le
+assert_axioms Zcash.Snark.relationWithCoins_prob_le_of_textbookDL
+assert_axioms Zcash.Snark.orchard_relation_prob_le_of_textbookDL +native
+assert_axioms Zcash.Snark.commitment_binding_prob_le_of_textbookDL +native
+assert_axioms Zcash.Snark.orchard_deployed_relation_prob_le_of_textbookDL +native
+assert_axioms Zcash.Snark.orchard_deployed_relation_set_eq_relSet +native
+assert_axioms Zcash.Snark.orchard_deployed_relation_event_prob_le_of_textbookDL +native
+assert_axioms Zcash.Snark.orchard_deployed_relation_prob_eq_of_uniformURS +native
+assert_axioms Zcash.Snark.orchard_deployed_relation_prob_le_of_uniformURS_textbookDL +native
+assert_axioms Zcash.Snark.orchard_deployed_relation_prob_le_of_generatorRO_textbookDL +native
 
 /-! ### Fork-tree knowledge error
 
@@ -564,11 +558,11 @@ The closed form of the fork-tree knowledge error and its evaluation over the dep
 parameters. All theorems, so `assert_axioms`: the arithmetic runs on `Nat`/`ℝ≥0∞` and the deployed
 field cardinality comes from `ZMod.card`, so no compiler trust enters here. -/
 
-assert_axioms kerr_mul_card
-assert_axioms kerr_eq
-assert_axioms kerr_div_card
-assert_axioms deployed_forking_knowledge_error
-assert_axioms deployed_forking_knowledge_error_captured
+assert_axioms Zcash.Snark.kerr_mul_card
+assert_axioms Zcash.Snark.kerr_eq
+assert_axioms Zcash.Snark.kerr_div_card
+assert_axioms Zcash.Snark.deployed_forking_knowledge_error
+assert_axioms Zcash.Snark.deployed_forking_knowledge_error_captured
 
 /-! ### Multiopen decode and forking composition
 
@@ -589,323 +583,323 @@ below through explicit `PSum` outcomes and computable finders. Theorems througho
 -- extraction). Discharging `hExtract` — coupling the AGM family's coin measure to the multiopen
 -- budget below — is the remaining reconciliation. This stack is not consumed by the rewind-free
 -- constraint capstone below.
-assert_axioms ipaRelation_deployed_of_instance +native
-assert_axioms snarkExtraction_prob_le_of_generatorRO_textbookDL +native
-assert_axioms instanceAttempt_provenance +native
-assert_axioms ipaRelation_deployed_of_openings_agree +native
-assert_axioms shift_eq_zero_of_openings_agree +native
+assert_axioms Zcash.Snark.ipaRelation_deployed_of_instance +native
+assert_axioms Zcash.Snark.snarkExtraction_prob_le_of_generatorRO_textbookDL +native
+assert_axioms Zcash.Snark.instanceAttempt_provenance +native
+assert_axioms Zcash.Snark.ipaRelation_deployed_of_openings_agree +native
+assert_axioms Zcash.Snark.shift_eq_zero_of_openings_agree +native
 
 -- The decode layer (`Soundness.Multiopen.Decode`/`Deployed`): the Vandermonde recovery of the
 -- column witnesses, the deployed x4 collapse proved to be a flat power batch, and the two-level
 -- binding of the extracted witness to the member commitments.
-assert_axioms decodedColumnFamily_of_batch_openings
-assert_axioms deployedCommitment_x4_batch
-assert_axioms multiopenValue_x4_batch
-assert_axioms member_binding_of_x1_samples
-assert_axioms node_binding_of_samples
+assert_axioms Zcash.Snark.decodedColumnFamily_of_batch_openings
+assert_axioms Zcash.Snark.deployedCommitment_x4_batch
+assert_axioms Zcash.Snark.multiopenValue_x4_batch
+assert_axioms Zcash.Snark.member_binding_of_x1_samples
+assert_axioms Zcash.Snark.node_binding_of_samples
 -- The multiopen support modules, pinned directly rather than transitively through the capstones
 -- above. `Opened` holds the rewind accept events and the three `Classical.choose` witness
 -- extractors; `RPoly` the interpolation/power-form algebra; `Compat` the Msm-evaluation and
 -- two-openings binding lemmas; `Claimed` the counting cores; `ValueCheckDeployed` the deployed
 -- point sets. A stray axiom here would surface at a capstone, but only these pins name the
 -- declaration that introduced it.
-assert_axioms vandermonde_decode_map
-assert_axioms vandermonde_reconstruct_map
-assert_axioms openedColumnDecode
-assert_axioms openedDecodedCols
-assert_axioms openedDecodedCols_eval_x3
-assert_axioms openedDecodedCols_top_eval_x3
-assert_axioms openedX4Batch_of_witnessFamily
-assert_axioms OpenedX4Accept
-assert_axioms OpenedX3Accept
-assert_axioms OpenedX2Accept
-assert_axioms openedX4Rewind_of_x4Prob
-assert_axioms openedX4Rewind_of_x4Prob_forked
-assert_axioms opened_constraint_of_relation_and_batch
-assert_axioms x1DecodeComp
-assert_axioms opened_witness_member_binding
-assert_axioms OpenedX1Accept
-assert_axioms openedMemberDecode_of_x1Prob
-assert_axioms rotatedFeed
-assert_axioms member_constraint_of_relation_and_batch
-assert_axioms poly_eq_of_agree_on_family
-assert_axioms foldl_range_add_eq_sum
-assert_axioms foldl_range_guardProd_eq_prod
-assert_axioms guardProd_eq_prod_erase
-assert_axioms lagrangePoly
-assert_axioms lagrangePoly_eval_node
-assert_axioms lagrangePoly_eval
-assert_axioms foldl_mul_inv_eq_prod
-assert_axioms multiopenEval_powerForm
-assert_axioms coeffs_zero_of_power_sum_vanishes
-assert_axioms multiopenEval_perSet_zero_of_samples
-assert_axioms lagrangePoly_natDegree_lt
-assert_axioms col_eq_lagrangePoly_of_samples
-assert_axioms col_eval_node_eq_claimed
-assert_axioms Msm.eval_zero
-assert_axioms Msm.eval_scale
-assert_axioms Msm.eval_add
-assert_axioms claimedEval_of_x3Prob
-assert_axioms gateGood_of_xProb
-assert_axioms deployedSetPts
-assert_axioms deployedAllPts
-assert_axioms deployedSetPts_subset
-assert_axioms deployed_query_point_mem
+assert_axioms Zcash.Snark.vandermonde_decode_map
+assert_axioms Zcash.Snark.vandermonde_reconstruct_map
+assert_axioms Zcash.Snark.openedColumnDecode
+assert_axioms Zcash.Snark.openedDecodedCols
+assert_axioms Zcash.Snark.openedDecodedCols_eval_x3
+assert_axioms Zcash.Snark.openedDecodedCols_top_eval_x3
+assert_axioms Zcash.Snark.openedX4Batch_of_witnessFamily
+assert_axioms Zcash.Snark.OpenedX4Accept
+assert_axioms Zcash.Snark.OpenedX3Accept
+assert_axioms Zcash.Snark.OpenedX2Accept
+assert_axioms Zcash.Snark.openedX4Rewind_of_x4Prob
+assert_axioms Zcash.Snark.openedX4Rewind_of_x4Prob_forked
+assert_axioms Zcash.Snark.opened_constraint_of_relation_and_batch
+assert_axioms Zcash.Snark.x1DecodeComp
+assert_axioms Zcash.Snark.opened_witness_member_binding
+assert_axioms Zcash.Snark.OpenedX1Accept
+assert_axioms Zcash.Snark.openedMemberDecode_of_x1Prob
+assert_axioms Zcash.Snark.rotatedFeed
+assert_axioms Zcash.Snark.member_constraint_of_relation_and_batch
+assert_axioms Zcash.Snark.poly_eq_of_agree_on_family
+assert_axioms Zcash.Snark.foldl_range_add_eq_sum
+assert_axioms Zcash.Snark.foldl_range_guardProd_eq_prod
+assert_axioms Zcash.Snark.guardProd_eq_prod_erase
+assert_axioms Zcash.Snark.lagrangePoly
+assert_axioms Zcash.Snark.lagrangePoly_eval_node
+assert_axioms Zcash.Snark.lagrangePoly_eval
+assert_axioms Zcash.Snark.foldl_mul_inv_eq_prod
+assert_axioms Zcash.Snark.multiopenEval_powerForm
+assert_axioms Zcash.Snark.coeffs_zero_of_power_sum_vanishes
+assert_axioms Zcash.Snark.multiopenEval_perSet_zero_of_samples
+assert_axioms Zcash.Snark.lagrangePoly_natDegree_lt
+assert_axioms Zcash.Snark.col_eq_lagrangePoly_of_samples
+assert_axioms Zcash.Snark.col_eval_node_eq_claimed
+assert_axioms Zcash.Snark.Msm.eval_zero
+assert_axioms Zcash.Snark.Msm.eval_scale
+assert_axioms Zcash.Snark.Msm.eval_add
+assert_axioms Zcash.Snark.claimedEval_of_x3Prob
+assert_axioms Zcash.Snark.gateGood_of_xProb
+assert_axioms Zcash.Snark.deployedSetPts
+assert_axioms Zcash.Snark.deployedAllPts
+assert_axioms Zcash.Snark.deployedSetPts_subset
+assert_axioms Zcash.Snark.deployed_query_point_mem
 -- The avoidance-strengthened forking count (`Soundness.Forking.Probability`): the counting lemma
 -- that buys the multiopen grid's interpolation samples off the opened set points, so the value
 -- check takes no sample-avoidance hypothesis.
-assert_axioms exists_injective_accepting_avoiding_of_measure
+assert_axioms Zcash.Snark.exists_injective_accepting_avoiding_of_measure
 -- The good-challenge production (`Soundness.GoodChallenge`): the Schwartz-Zippel exclusion budget
 -- and the pigeonhole that produces an accepting challenge outside the bad set.
-assert_axioms uniformChallenge_szBadSet
-assert_axioms uniformChallenge_szGoodSet
-assert_axioms uniformChallenge_quotient_szBadSet
-assert_axioms uniformChallenge_szBadSet_union
-assert_axioms exists_accepting_good_challenge
-assert_axioms exists_accepting_good_challenge_quotient
+assert_axioms Zcash.Snark.uniformChallenge_szBadSet
+assert_axioms Zcash.Snark.uniformChallenge_szGoodSet
+assert_axioms Zcash.Snark.uniformChallenge_quotient_szBadSet
+assert_axioms Zcash.Snark.uniformChallenge_szBadSet_union
+assert_axioms Zcash.Snark.exists_accepting_good_challenge
+assert_axioms Zcash.Snark.exists_accepting_good_challenge_quotient
 -- The deployed Vesta capstone family: the decoded-column rungs and the terminal, alongside the
 -- derived capstone already pinned below.
-assert_axioms orchard_verifier_vesta_decoded_constraint_of_forked_x4 +native
+assert_axioms Zcash.Snark.orchard_verifier_vesta_decoded_constraint_of_forked_x4 +native
 
 -- Deterministic verifier routing used by the rewind-free deployed constraint decoder.
-assert_axioms vanishing_query_mem_assembleQueries
-assert_axioms assembleQueries_vanishingH_unique
-assert_axioms constructIntermediateSets_unique_comm_routed
-assert_axioms vanishing_slot_routed
-assert_axioms hfold_of_expectedHEval_binding
-assert_axioms hfold_of_vanishing_slot_binding
-assert_axioms deployedAccepts_xn_ne_one
-assert_axioms deployedAccepts_pipeline
-assert_axioms deployed_member_commitment_eq_assembled
-assert_axioms lagrangeBasisPoly_eval
-assert_axioms lagrange_bind_derived
+assert_axioms Zcash.Snark.vanishing_query_mem_assembleQueries
+assert_axioms Zcash.Snark.assembleQueries_vanishingH_unique
+assert_axioms Zcash.Snark.constructIntermediateSets_unique_comm_routed
+assert_axioms Zcash.Snark.vanishing_slot_routed
+assert_axioms Zcash.Snark.hfold_of_expectedHEval_binding
+assert_axioms Zcash.Snark.hfold_of_vanishing_slot_binding
+assert_axioms Zcash.Snark.deployedAccepts_xn_ne_one
+assert_axioms Zcash.Snark.deployedAccepts_pipeline
+assert_axioms Zcash.Snark.deployed_member_commitment_eq_assembled
+assert_axioms Zcash.Snark.lagrangeBasisPoly_eval
+assert_axioms Zcash.Snark.lagrange_bind_derived
 -- The permutation and lookup arguments folded into the constraint model: the verifier's expression
 -- list is the generic builder run on its own claimed evaluations, the same builder over column
 -- polynomials evaluates back onto it, and the fold equation therefore needs no fingerprint premise.
-assert_axioms permutationExpressions_map
-assert_axioms lookupExpressions_map
-assert_axioms subProofConstraints_map
-assert_axioms allConstraints_map
-assert_axioms subProofExpressions_eq
-assert_axioms allExpressions_eq
-assert_axioms eval_constraintPolys
-assert_axioms eval_combineConstraints
-assert_axioms eval_combineConstraints_deployed
-assert_axioms hfold_of_constraint_polys_of_xn_ne_direct
-assert_axioms constraints_supply_of_deployedAlgebraicDecode
+assert_axioms Zcash.Snark.permutationExpressions_map
+assert_axioms Zcash.Snark.lookupExpressions_map
+assert_axioms Zcash.Snark.subProofConstraints_map
+assert_axioms Zcash.Snark.allConstraints_map
+assert_axioms Zcash.Snark.subProofExpressions_eq
+assert_axioms Zcash.Snark.allExpressions_eq
+assert_axioms Zcash.Snark.eval_constraintPolys
+assert_axioms Zcash.Snark.eval_combineConstraints
+assert_axioms Zcash.Snark.eval_combineConstraints_deployed
+assert_axioms Zcash.Snark.hfold_of_constraint_polys_of_xn_ne_direct
+assert_axioms Zcash.Snark.constraints_supply_of_deployedAlgebraicDecode
 -- The permutation and lookup arguments closed from the verifier's own row checks: the combined
 -- check splits into its parts, the running product telescopes across the rows, two challenge root
 -- counts turn the product into a multiset identity, and the existing structural theorems turn that
 -- into the copy constraints and the lookup inclusion.
-assert_axioms constraints_dvd_of_good_y
-assert_axioms telescope_running_product
-assert_axioms grandProduct_eq_or_cell_eq_zero
-assert_axioms multiset_pair_eq_of_prod_eval_eq
-assert_axioms cellPairs_eq_of_running_product
-assert_axioms perm_copy_constraints_of_running_product
-assert_axioms lookup_multisets_of_prod_eval_eq
-assert_axioms lookup_multisets_of_diff_eq_zero
-assert_axioms lookup_subset_of_components
-assert_axioms lookup_subset_of_prod_eval_eq
+assert_axioms Zcash.Snark.constraints_dvd_of_good_y
+assert_axioms Zcash.Snark.telescope_running_product
+assert_axioms Zcash.Snark.grandProduct_eq_or_cell_eq_zero
+assert_axioms Zcash.Snark.multiset_pair_eq_of_prod_eval_eq
+assert_axioms Zcash.Snark.cellPairs_eq_of_running_product
+assert_axioms Zcash.Snark.perm_copy_constraints_of_running_product
+assert_axioms Zcash.Snark.lookup_multisets_of_prod_eval_eq
+assert_axioms Zcash.Snark.lookup_multisets_of_diff_eq_zero
+assert_axioms Zcash.Snark.lookup_subset_of_components
+assert_axioms Zcash.Snark.lookup_subset_of_prod_eval_eq
 -- The deployed row reading: the step rule's folds are running products, the boundary rules pin the
 -- product at the first and last rows, and the cell names separate. These are theorems about
 -- `permChunkExpression` itself, so the chain above starts at the verifier's own constraint list.
-assert_axioms permChunk_left_eq_prod
-assert_axioms permChunk_right_eq_prod
-assert_axioms permChunkExpression_eq
-assert_axioms eval_eq_zero_of_dvd_vanishing
-assert_axioms perm_row_recurrence
-assert_axioms running_product_start
-assert_axioms running_product_end
-assert_axioms name_injective_of_coset
-assert_axioms deployed_perm_copy_constraints
+assert_axioms Zcash.Snark.permChunk_left_eq_prod
+assert_axioms Zcash.Snark.permChunk_right_eq_prod
+assert_axioms Zcash.Snark.permChunkExpression_eq
+assert_axioms Zcash.Snark.eval_eq_zero_of_dvd_vanishing
+assert_axioms Zcash.Snark.perm_row_recurrence
+assert_axioms Zcash.Snark.running_product_start
+assert_axioms Zcash.Snark.running_product_end
+assert_axioms Zcash.Snark.name_injective_of_coset
+assert_axioms Zcash.Snark.deployed_perm_copy_constraints
 -- Locating a single rule inside the verifier's flat constraint list, fixing the permutation sets to
 -- committed running products, and chaining the two: the copy constraints now follow from the
 -- polynomial constraint identity itself, with no hypothesis about the shape of the checks.
-assert_axioms permChunkExpression_mem_permutationExpressions
-assert_axioms start_mem_permutationExpressions
-assert_axioms end_mem_permutationExpressions
-assert_axioms mem_subProofConstraints_of_mem_permutationExpressions
-assert_axioms mem_allConstraints_of_mem_subProofConstraints
-assert_axioms mem_constraintPolys_of_mem_permutationExpressions
-assert_axioms head?_deployedPermSets
-assert_axioms getLast?_deployedPermSets
-assert_axioms deployed_copy_constraints_of_identity
+assert_axioms Zcash.Snark.permChunkExpression_mem_permutationExpressions
+assert_axioms Zcash.Snark.start_mem_permutationExpressions
+assert_axioms Zcash.Snark.end_mem_permutationExpressions
+assert_axioms Zcash.Snark.mem_subProofConstraints_of_mem_permutationExpressions
+assert_axioms Zcash.Snark.mem_allConstraints_of_mem_subProofConstraints
+assert_axioms Zcash.Snark.mem_constraintPolys_of_mem_permutationExpressions
+assert_axioms Zcash.Snark.head?_deployedPermSets
+assert_axioms Zcash.Snark.getLast?_deployedPermSets
+assert_axioms Zcash.Snark.deployed_copy_constraints_of_identity
 -- The same for the lookup argument: its five rules located in the list, read row by row, and
 -- chained to the inclusion.
-assert_axioms lookupExpressions_eq
-assert_axioms mem_subProofConstraints_of_mem_lookupExpressions
-assert_axioms mem_constraintPolys_of_mem_lookupExpressions
-assert_axioms running_product_end_flipped
-assert_axioms lookup_row_recurrence
-assert_axioms lookup_row_zero
-assert_axioms lookup_row_step
-assert_axioms lookup_rules_dvd_of_identity
-assert_axioms deployed_lookup_subset_of_identity
-assert_axioms deployed_lookup_relation_of_identity
+assert_axioms Zcash.Snark.lookupExpressions_eq
+assert_axioms Zcash.Snark.mem_subProofConstraints_of_mem_lookupExpressions
+assert_axioms Zcash.Snark.mem_constraintPolys_of_mem_lookupExpressions
+assert_axioms Zcash.Snark.running_product_end_flipped
+assert_axioms Zcash.Snark.lookup_row_recurrence
+assert_axioms Zcash.Snark.lookup_row_zero
+assert_axioms Zcash.Snark.lookup_row_step
+assert_axioms Zcash.Snark.lookup_rules_dvd_of_identity
+assert_axioms Zcash.Snark.deployed_lookup_subset_of_identity
+assert_axioms Zcash.Snark.deployed_lookup_relation_of_identity
 -- Decompression: the θ-compressed membership becomes membership of whole rows, since the
 -- compression is the fold polynomial of the row's values and a good θ separates distinct tuples.
-assert_axioms foldPoly_sub
-assert_axioms tuple_eq_of_foldPoly_eval_eq
-assert_axioms compress_eval_eq_foldPoly
-assert_axioms deployed_lookup_tuple_of_identity
+assert_axioms Zcash.Snark.foldPoly_sub
+assert_axioms Zcash.Snark.tuple_eq_of_foldPoly_eval_eq
+assert_axioms Zcash.Snark.compress_eval_eq_foldPoly
+assert_axioms Zcash.Snark.deployed_lookup_tuple_of_identity
 -- Every new challenge surface priced the way `hgood` is: a uniform-challenge measure bound per
 -- root-set event — the fold split's `y`, the bridge's `β` and `γ`, the vanishing-factor escapes,
 -- and the decompression's pairwise `θ`. Sequential conditioning across the squeezes is the same
 -- coupling hook `hgood` carries, documented with the `hfold`/`hgood` surfaces.
-assert_axioms uniformChallenge_szBadSet_iUnion_le
-assert_axioms goodY_failure_measure_le
-assert_axioms perm_gamma_failure_measure_le
-assert_axioms perm_beta_failure_measure_le
-assert_axioms escape_measure_le
-assert_axioms theta_failure_measure_le
+assert_axioms Zcash.Snark.uniformChallenge_szBadSet_iUnion_le
+assert_axioms Zcash.Snark.goodY_failure_measure_le
+assert_axioms Zcash.Snark.perm_gamma_failure_measure_le
+assert_axioms Zcash.Snark.perm_beta_failure_measure_le
+assert_axioms Zcash.Snark.escape_measure_le
+assert_axioms Zcash.Snark.theta_failure_measure_le
 -- The last links: the point check lifted to the polynomial identity, the permutation taken to be the
 -- one keygen builds from the circuit's copy constraints, the cells of every chunk covered at once,
 -- and circuit satisfaction defined by the whole constraint list rather than the gates alone.
-assert_axioms constraint_identity_of_hfold
-assert_axioms declared_equalities_of_running_product
-assert_axioms deployed_declared_equalities_of_identity
-assert_axioms prod_map_chunkCellPairs
-assert_axioms perm_copy_constraints_of_chunk_products
-assert_axioms chunkName_injective_of_coset
-assert_axioms deployed_declared_equalities_of_identity_chunks
-assert_axioms circuitSatViaConstraints_of_check
+assert_axioms Zcash.Snark.constraint_identity_of_hfold
+assert_axioms Zcash.Snark.declared_equalities_of_running_product
+assert_axioms Zcash.Snark.deployed_declared_equalities_of_identity
+assert_axioms Zcash.Snark.prod_map_chunkCellPairs
+assert_axioms Zcash.Snark.perm_copy_constraints_of_chunk_products
+assert_axioms Zcash.Snark.chunkName_injective_of_coset
+assert_axioms Zcash.Snark.deployed_declared_equalities_of_identity_chunks
+assert_axioms Zcash.Snark.circuitSatViaConstraints_of_check
 -- Closing the loop: the capstone hands over an opening paired with satisfaction of the whole
 -- constraint list, and the two arguments' relations are read back out of that same predicate.
-assert_axioms snarkRelation_constraints
-assert_axioms declared_equalities_of_circuitSat
-assert_axioms lookup_relation_of_circuitSat
-assert_axioms lookup_tuple_of_circuitSat
+assert_axioms Zcash.Snark.snarkRelation_constraints
+assert_axioms Zcash.Snark.declared_equalities_of_circuitSat
+assert_axioms Zcash.Snark.lookup_relation_of_circuitSat
+assert_axioms Zcash.Snark.lookup_tuple_of_circuitSat
 -- Several permutation chunks, not one: the chaining rule located in the list, read at row zero, and
 -- the chunks flattened into a single running product so the permutation acts on every cell.
-assert_axioms chain_mem_permutationExpressions
-assert_axioms running_product_chain
-assert_axioms deployed_copy_constraints_of_identity_chunks
-assert_axioms hgood_of_good_challenge
+assert_axioms Zcash.Snark.chain_mem_permutationExpressions
+assert_axioms Zcash.Snark.running_product_chain
+assert_axioms Zcash.Snark.deployed_copy_constraints_of_identity_chunks
+assert_axioms Zcash.Snark.hgood_of_good_challenge
 -- The UNCONDITIONAL decomposition: `hExtract` removed, the residual quantified as the
 -- clean-but-not-extracted measure term (bounded by the multiopen budget under the coupling
 -- documented in `Composition.Decomposition`, not assumed here).
-assert_axioms ComputedAlgebraicFSFamily.snarkExtractionFailureEvent_subset_union +native
-assert_axioms snarkExtraction_prob_le_of_generatorRO_textbookDL_decomposed +native
+assert_axioms Zcash.Snark.ComputedAlgebraicFSFamily.snarkExtractionFailureEvent_subset_union +native
+assert_axioms Zcash.Snark.snarkExtraction_prob_le_of_generatorRO_textbookDL_decomposed +native
 -- Product-measure lifting, now used by the direct pinned-root composition.
-assert_axioms independentProductPMF_fiber_bound
+assert_axioms Zcash.Snark.independentProductPMF_fiber_bound
 -- Acceptance through `assemble?`, isolated from the historical completeness ladder.
-assert_axioms fullAlgebraicAcceptDeployed +native
-assert_axioms fullAlgebraicAccept_of_deployed +native
-assert_axioms snarkExtractionFailureEventDeployed +native
-assert_axioms snarkExtractionFailureEventDeployed_subset_union +native
+assert_axioms Zcash.Snark.fullAlgebraicAcceptDeployed +native
+assert_axioms Zcash.Snark.fullAlgebraicAccept_of_deployed +native
+assert_axioms Zcash.Snark.snarkExtractionFailureEventDeployed +native
+assert_axioms Zcash.Snark.snarkExtractionFailureEventDeployed_subset_union +native
 
 -- Rewind-free AGM unbatching and its direct additive root pricing.
-assert_axioms algebraicBatchErrorPolynomial_eval
-assert_axioms algebraicBatchErrorPolynomial_natDegree_le
-assert_axioms algebraicBatch_values_of_errorPolynomial_eq_zero
-assert_axioms algebraicBatch_badSet_measure_le
-assert_axioms deployedX4AlgebraicValues_of_good
-assert_axioms deployedClearedQuotientIdentity_of_good_x3
-assert_axioms deployedAggregateNodeBinding_of_good_x2
-assert_axioms deployedMemberNodeBinding_of_good_x1
-assert_axioms deployedMemberNodeBinding_of_good_challenges
-assert_axioms xEscTable_measure_le
-assert_axioms xEscAtPoint_measure_le
-assert_axioms PinnedRootEvent.landing_measure_le
-assert_axioms PinnedRootFamily.landing_measure_le
-assert_axioms deployedRootBad_measure_le +native
+assert_axioms Zcash.Snark.algebraicBatchErrorPolynomial_eval
+assert_axioms Zcash.Snark.algebraicBatchErrorPolynomial_natDegree_le
+assert_axioms Zcash.Snark.algebraicBatch_values_of_errorPolynomial_eq_zero
+assert_axioms Zcash.Snark.algebraicBatch_badSet_measure_le
+assert_axioms Zcash.Snark.deployedX4AlgebraicValues_of_good
+assert_axioms Zcash.Snark.deployedClearedQuotientIdentity_of_good_x3
+assert_axioms Zcash.Snark.deployedAggregateNodeBinding_of_good_x2
+assert_axioms Zcash.Snark.deployedMemberNodeBinding_of_good_x1
+assert_axioms Zcash.Snark.deployedMemberNodeBinding_of_good_challenges
+assert_axioms Zcash.Snark.xEscTable_measure_le
+assert_axioms Zcash.Snark.xEscAtPoint_measure_le
+assert_axioms Zcash.Snark.PinnedRootEvent.landing_measure_le
+assert_axioms Zcash.Snark.PinnedRootFamily.landing_measure_le
+assert_axioms Zcash.Snark.deployedRootBad_measure_le +native
 -- The shape-only root budget is monotone, so its consensus-maximum specialization bounds every
 -- smaller captured Orchard bundle rather than only the exact endpoint shape.
-assert_axioms algebraicRootBudget_mono
-assert_axioms DeployedRootPrefixDetermined +native
-assert_axioms DeployedRootSqueezeInvariance +native
-assert_axioms deployedRootSqueezeInvariance_of_prefixDetermined +native
-assert_axioms DeployedRootOnlineTrace.toSqueezeInvariance +native
-assert_axioms ComputedDeployedRootFSFamily.pinned +native
-assert_axioms DeployedConstraintXOnlineTrace.toPinning +native
-assert_axioms ComputedDeployedConstraintFSFamily.pinnedX +native
-assert_axioms tableReadingPinnedRootEvent
-assert_axioms tableReadingPinnedRootEvent_landing_measure_le
-assert_axioms deployedRootEventBudget_sum_le
-assert_axioms badX_le_via_squeeze_prefixed +native
+assert_axioms Zcash.Snark.algebraicRootBudget_mono
+assert_axioms Zcash.Snark.DeployedRootPrefixDetermined +native
+assert_axioms Zcash.Snark.DeployedRootSqueezeInvariance +native
+assert_axioms Zcash.Snark.deployedRootSqueezeInvariance_of_prefixDetermined +native
+assert_axioms Zcash.Snark.DeployedRootOnlineTrace.toSqueezeInvariance +native
+assert_axioms Zcash.Snark.ComputedDeployedRootFSFamily.pinned +native
+assert_axioms Zcash.Snark.DeployedConstraintXOnlineTrace.toPinning +native
+assert_axioms Zcash.Snark.ComputedDeployedConstraintFSFamily.pinnedX +native
+assert_axioms Zcash.Snark.tableReadingPinnedRootEvent
+assert_axioms Zcash.Snark.tableReadingPinnedRootEvent_landing_measure_le
+assert_axioms Zcash.Snark.deployedRootEventBudget_sum_le
+assert_axioms Zcash.Snark.badX_le_via_squeeze_prefixed +native
 -- Squeeze-point toolkit: prefix-determinism makes the `x` point stable under self-reprogramming.
 -- This is not the live constraint schedule's chronology discharge: point stability alone does not
 -- prove that the bad set was fixed before `x`.
-assert_axioms hstab_of_xPrefixDetermined +native
+assert_axioms Zcash.Snark.hstab_of_xPrefixDetermined +native
 -- Prefix injectivity at the multiopen squeeze points (`Forking.Adversary.PreIpa`): each point
 -- pins every field absorbed before it — the toolkit for the deployed squeeze-invariance
 -- schedules, which need each root-set datum emitted strictly before its own squeeze.
-assert_axioms preXSqueezePoint_inj
-assert_axioms preX1SqueezePoint_inj
-assert_axioms preX2SqueezePoint_inj
-assert_axioms preX3SqueezePoint_inj
-assert_axioms preX4SqueezePoint_inj
+assert_axioms Zcash.Snark.preXSqueezePoint_inj
+assert_axioms Zcash.Snark.preX1SqueezePoint_inj
+assert_axioms Zcash.Snark.preX2SqueezePoint_inj
+assert_axioms Zcash.Snark.preX3SqueezePoint_inj
+assert_axioms Zcash.Snark.preX4SqueezePoint_inj
 -- The degree walk (`Soundness.DegreeWalk`): every constraint family's polynomial stays under an
 -- explicit cap — gates by `Expr.degreeBound`, permutation chunks by width, lookups by their
 -- compressed expressions — the combined bound the `x`-squeeze schedule's `epsilonX` prices.
-assert_axioms natDegree_combineConstraints_le
+assert_axioms Zcash.Snark.natDegree_combineConstraints_le
 -- The schedule, priced (`Composition.ScheduleBudget`): the committed carriers stay under the
 -- walk's caps, root witnesses at one table share the family's own outcome so the root set
 -- collapses across fork tapes, and the schedule constructor discharges `measure_le` outright.
 -- The captured family carries an explicit fresh-query `OracleComp` trace and derives exact
 -- pinning from its query log. The lower-level direct-pinning constructor remains generic plumbing;
 -- it is not a standalone captured-capstone premise.
-assert_axioms natDegree_committedPreXConstraintDifference_le
-assert_axioms natDegree_deployedConstraintDifferenceOfRoot_le +native
-assert_axioms deployedConstraintDifference_witness_congr +native
-assert_axioms deployedConstraintXBadSet_measure_le +native
-assert_axioms DeployedConstraintXPrefixDetermined +native
-assert_axioms deployedConstraintXPinning_of_prefixDetermined +native
-assert_axioms deployedConstraintXSqueezeSchedule_of_pinned +native
-assert_axioms deployedConstraintXSqueezeSchedule_of_prefixDetermined +native
+assert_axioms Zcash.Snark.natDegree_committedPreXConstraintDifference_le
+assert_axioms Zcash.Snark.natDegree_deployedConstraintDifferenceOfRoot_le +native
+assert_axioms Zcash.Snark.deployedConstraintDifference_witness_congr +native
+assert_axioms Zcash.Snark.deployedConstraintXBadSet_measure_le +native
+assert_axioms Zcash.Snark.DeployedConstraintXPrefixDetermined +native
+assert_axioms Zcash.Snark.deployedConstraintXPinning_of_prefixDetermined +native
+assert_axioms Zcash.Snark.deployedConstraintXSqueezeSchedule_of_pinned +native
+assert_axioms Zcash.Snark.deployedConstraintXSqueezeSchedule_of_prefixDetermined +native
 -- The pinned-root witness family (`AGM.PinnedRootWitness`): the zero data over the degenerate
 -- shape, whose assembled multiopen commitment is the zero point for every basis and record.
-assert_axioms multiopenCommitment_witness_zero +native
-assert_axioms witnessProof +native
-assert_axioms witnessFamily +native
+assert_axioms Zcash.Snark.multiopenCommitment_witness_zero +native
+assert_axioms Zcash.Snark.witnessProof +native
+assert_axioms Zcash.Snark.witnessFamily +native
 -- The actual strict-prefix property is satisfiable: the constant family's root sets are empty
 -- except at `x₃`, whose point set consumes only earlier answers.  It is packaged as an inhabitant
 -- of `ComputedDeployedRootFSFamily`; the weaker invariance theorem is a corollary.
-assert_axioms witnessFamily_reads_update +native
-assert_axioms deployedRootBad_witness +native
-assert_axioms deployedAllPts_x3_blind
-assert_axioms deployedAllPts_congr_preMultiopen
-assert_axioms deployedRootPrefixDetermined_witness +native
-assert_axioms witnessOnlineMemberFamily +native
-assert_axioms witnessDeployedRootFamily +native
-assert_axioms deployedRootSqueezeInvariance_witness +native
+assert_axioms Zcash.Snark.witnessFamily_reads_update +native
+assert_axioms Zcash.Snark.deployedRootBad_witness +native
+assert_axioms Zcash.Snark.deployedAllPts_x3_blind
+assert_axioms Zcash.Snark.deployedAllPts_congr_preMultiopen
+assert_axioms Zcash.Snark.deployedRootPrefixDetermined_witness +native
+assert_axioms Zcash.Snark.witnessOnlineMemberFamily +native
+assert_axioms Zcash.Snark.witnessDeployedRootFamily +native
+assert_axioms Zcash.Snark.deployedRootSqueezeInvariance_witness +native
 -- The satisfiability witness is itself an executable five-query stage, not a classical
 -- enumeration of the finite oracle domain.
-assert_computable witnessOutcome +choice +native
-assert_computable witnessOnlineMemberFamily +choice +native
-assert_computable witnessRootStage +choice +native
-assert_computable witnessRootTrace +choice +native
-assert_computable witnessDeployedRootFamily +choice +native
+assert_computable Zcash.Snark.witnessOutcome +choice +native
+assert_computable Zcash.Snark.witnessOnlineMemberFamily +choice +native
+assert_computable Zcash.Snark.witnessRootStage +choice +native
+assert_computable Zcash.Snark.witnessRootTrace +choice +native
+assert_computable Zcash.Snark.witnessDeployedRootFamily +choice +native
 -- The direct route (`AGM.DirectX4Columns`): the `x₄` columns are read off the online coverage —
 -- a column below the pair count is its set's `x₁` power sum, the last is the prover's `q′` — so
 -- the batch-or-relation decision needs no offline interpolation and no field-capacity premise.
-assert_axioms x4BatchCommitments_eq_memberPowerSum
-assert_axioms aggregate_opens_deployedCommitment +native
-assert_axioms snarkExtractionDeployed_prob_le_via_wrapped_pinned_roots +native
-assert_axioms ComputedDeployedRootFSFamily.deployedRelation_prob_le_of_generatorRO_textbookDL +native
-assert_axioms deployedRootFailure_subset_landing +native
-assert_axioms deployedDecodeFailure_subset_union +native
-assert_axioms deployedNonRelationFailure_prob_le_of_generatorRO +native
-assert_axioms snarkExtractionDeployed_prob_le_via_deployed_roots +native
+assert_axioms Zcash.Snark.x4BatchCommitments_eq_memberPowerSum
+assert_axioms Zcash.Snark.aggregate_opens_deployedCommitment +native
+assert_axioms Zcash.Snark.snarkExtractionDeployed_prob_le_via_wrapped_pinned_roots +native
+assert_axioms Zcash.Snark.ComputedDeployedRootFSFamily.deployedRelation_prob_le_of_generatorRO_textbookDL +native
+assert_axioms Zcash.Snark.deployedRootFailure_subset_landing +native
+assert_axioms Zcash.Snark.deployedDecodeFailure_subset_union +native
+assert_axioms Zcash.Snark.deployedNonRelationFailure_prob_le_of_generatorRO +native
+assert_axioms Zcash.Snark.snarkExtractionDeployed_prob_le_via_deployed_roots +native
 
 -- Online-source constraint composition.  All disagreement branches retain concrete relation
 -- coefficients and are charged through the same single-instance textbook-DLOG finder.
-assert_axioms deployedConstraint_memberPoly_eq_online +native
-assert_axioms deployedOnlineConstraintOutcomeOfDecode +native
-assert_axioms deployedConstraintFailure_subset_union +native
-assert_axioms deployedConstraintRelation_prob_le_of_generatorRO_textbookDL +native
-assert_axioms snarkConstraintsDeployed_prob_le_via_deployed_roots +native
-assert_axioms snarkConstraintsDeployed_prob_le_of_online_outcome +native
-assert_axioms deployedConstraintUpgradeContained_of_root +native
-assert_axioms deployedConstraintOutcomeOfRoot_relation_eq_online +native
-assert_axioms deployedConstraintDecodedOfRoot +native
-assert_axioms deployedConstraintBadX_subset_landing +native
-assert_axioms deployedConstraintBadX_prob_le +native
-assert_axioms snarkConstraintsDeployed_prob_le_of_root_schedule +native
-assert_axioms DeployedConstraintSemanticUpgradeContained +native
-assert_axioms deployedConstraintSemanticFailure_subset_union +native
-assert_axioms snarkConstraintsSemanticDeployed_prob_le_of_root_schedule +native
+assert_axioms Zcash.Snark.deployedConstraint_memberPoly_eq_online +native
+assert_axioms Zcash.Snark.deployedOnlineConstraintOutcomeOfDecode +native
+assert_axioms Zcash.Snark.deployedConstraintFailure_subset_union +native
+assert_axioms Zcash.Snark.deployedConstraintRelation_prob_le_of_generatorRO_textbookDL +native
+assert_axioms Zcash.Snark.snarkConstraintsDeployed_prob_le_via_deployed_roots +native
+assert_axioms Zcash.Snark.snarkConstraintsDeployed_prob_le_of_online_outcome +native
+assert_axioms Zcash.Snark.deployedConstraintUpgradeContained_of_root +native
+assert_axioms Zcash.Snark.deployedConstraintOutcomeOfRoot_relation_eq_online +native
+assert_axioms Zcash.Snark.deployedConstraintDecodedOfRoot +native
+assert_axioms Zcash.Snark.deployedConstraintBadX_subset_landing +native
+assert_axioms Zcash.Snark.deployedConstraintBadX_prob_le +native
+assert_axioms Zcash.Snark.snarkConstraintsDeployed_prob_le_of_root_schedule +native
+assert_axioms Zcash.Snark.DeployedConstraintSemanticUpgradeContained +native
+assert_axioms Zcash.Snark.deployedConstraintSemanticFailure_subset_union +native
+assert_axioms Zcash.Snark.snarkConstraintsSemanticDeployed_prob_le_of_root_schedule +native
 
 /-! ## The Action circuit — the halo2-native soundness trust surface
 


### PR DESCRIPTION
Motivated by finding 2 of [the #99 re-audit](https://github.com/zcash/ironwood/pull/99#issuecomment-5095766985): an unqualified `assert_axioms` entry resolved silently to a generic homonym while the intended deployed theorem was not in scope at all, so the census read as covering the PR's headline result while checking a different theorem.

- The first commit qualifies every `assert_axioms` / `assert_computable` entry (569 across `Zcash/TrustBoundary.lean`, both fixture censuses, and `BridgeTests.lean`) and the eight `#guard_msgs`-pinned `#print axioms` targets, and drops the opens the census files no longer need. The guard pins now record the `native_decide` axioms' full names. An audit of every rewritten entry against its census section found no wrong-cousin resolutions on main — the finding-2 hazard was introduced on #99's branch, not latent here.

- The second commit makes `unc_thirteen_not_isSquare` public: it owns a `native_decide` axiom that appears in downstream axiom footprints, where a private owner can only be written in its mangled form.

- The third commit makes the macros enforce both conventions. `assert_axioms` / `assert_computable` error unless the written name equals the resolved constant's full name (a `_root_.` prefix is accepted), so the silent-capture case becomes a loud error: writing the intended full name of a declaration whose module is not imported is an unknown identifier, not a quiet resolution to a same-named cousin. And `+native` now requires naming the declarations that own the permitted `native_decide` axioms — `+native(D₁, ...)`, fully qualified — since a bare `+native` would accept a native axiom smuggled in by any declaration entering the dependency cone. The annotation is checked exactly: a new native axiom, or a stale entry, fails the build with the list to write. The 204 `+native` entries now each name their native trust surface (for example, `orchardActionCircuit` names its six fixed-base window-table certificates plus CompElliptic's two Pallas curve facts); five entries whose `+native` reached no native axiom at all lose the flag.

In-flight PRs will hit the new checks on rebase for any census entries they add; that is the point. The same change should be mirrored into CompElliptic's copy of `AxiomCheck.lean` (the file header notes the two are kept in sync); that is queued with the native-code split.

Full build green.

🤖 Claude Fable 5
