### PR TITLE
fv: deployed capstone discharges

### DIFF
--- a/Zcash/Circuits/Specs/Sinsemilla.lean
+++ b/Zcash/Circuits/Specs/Sinsemilla.lean
@@ -279,6 +279,30 @@ theorem chunksOf_inj {a b n : ℕ} (ha : a < 2 ^ (K * n)) (hb : b < 2 ^ (K * n))
   have hfin := hmod n le_rfl
   rwa [Nat.mod_eq_of_lt ha, Nat.mod_eq_of_lt hb] at hfin
 
+set_option exponentiation.threshold 600 in
+/-- `merkleChunks` is the 52-chunk decomposition of its packed message. -/
+theorem merkleChunks_eq_chunksOf (l lv rv : ℕ) :
+    merkleChunks l lv rv = chunksOf (l + 2 ^ 10 * lv + 2 ^ 265 * rv) 52 := by
+  simp [merkleChunks, chunksOf, bitrange]
+
+set_option exponentiation.threshold 600 in
+/-- The 52-chunk Merkle compression encoding is injective on components within
+their widths. -/
+theorem merkleChunks_inj {l lv rv l' lv' rv' : ℕ}
+    (h1 : l < 2 ^ 10) (h2 : lv < 2 ^ 255) (h3 : rv < 2 ^ 255)
+    (h1' : l' < 2 ^ 10) (h2' : lv' < 2 ^ 255) (h3' : rv' < 2 ^ 255)
+    (h : merkleChunks l lv rv = merkleChunks l' lv' rv') :
+    l = l' ∧ lv = lv' ∧ rv = rv' := by
+  rw [merkleChunks_eq_chunksOf, merkleChunks_eq_chunksOf] at h
+  have hK : (2 : ℕ) ^ (K * 52) = 2 ^ 520 := by norm_num [K]
+  have hbound : ∀ {a b c : ℕ}, a < 2 ^ 10 → b < 2 ^ 255 → c < 2 ^ 255 →
+      a + 2 ^ 10 * b + 2 ^ 265 * c < 2 ^ (K * 52) := by
+    intro a b c ha hb hc
+    rw [hK]
+    omega
+  have hmsg := chunksOf_inj (hbound h1 h2 h3) (hbound h1' h2' h3') h
+  omega
+
 /-- Chunks below position `n` are unaffected by reducing `val` mod `2 ^ (K * n)`. -/
 theorem chunksOf_mod (val n : ℕ) : chunksOf (val % 2 ^ (K * n)) n = chunksOf val n := by
   unfold chunksOf
@@ -464,9 +488,9 @@ def noteCommitChunks (gdX gdY pkdX pkdY v rho psi : ℕ) : List ℕ :=
 theorem noteCommitMessage_inj
     {gdX gdY pkdX pkdY v rho psi gdX' gdY' pkdX' pkdY' v' rho' psi' : ℕ}
     (h1 : gdX < 2 ^ 255) (h2 : gdY < 2) (h3 : pkdX < 2 ^ 255) (h4 : pkdY < 2)
-    (h5 : v < 2 ^ 64) (h6 : rho < 2 ^ 255) (h7 : psi < 2 ^ 255)
+    (h5 : v < 2 ^ 64) (h6 : rho < 2 ^ 255) (_h7 : psi < 2 ^ 255)
     (h1' : gdX' < 2 ^ 255) (h2' : gdY' < 2) (h3' : pkdX' < 2 ^ 255) (h4' : pkdY' < 2)
-    (h5' : v' < 2 ^ 64) (h6' : rho' < 2 ^ 255) (h7' : psi' < 2 ^ 255)
+    (h5' : v' < 2 ^ 64) (h6' : rho' < 2 ^ 255) (_h7' : psi' < 2 ^ 255)
     (h : noteCommitMessage gdX gdY pkdX pkdY v rho psi
         = noteCommitMessage gdX' gdY' pkdX' pkdY' v' rho' psi') :
     gdX = gdX' ∧ gdY = gdY' ∧ pkdX = pkdX' ∧ pkdY = pkdY' ∧ v = v' ∧ rho = rho'

--- a/Zcash/Circuits/Specs/Sinsemilla.lean
+++ b/Zcash/Circuits/Specs/Sinsemilla.lean
@@ -258,6 +258,27 @@ theorem chunksOf_add (val m n : ℕ) :
   congr 2
   ring
 
+/-- `chunksOf` is injective below `2 ^ (K * n)`: the `K`-bit digits determine the value. -/
+theorem chunksOf_inj {a b n : ℕ} (ha : a < 2 ^ (K * n)) (hb : b < 2 ^ (K * n))
+    (h : chunksOf a n = chunksOf b n) : a = b := by
+  have hdig : ∀ i, i < n → bitrange a (K * i) K = bitrange b (K * i) K := by
+    intro i hi
+    have hgd := congrArg (fun l => l.getD i 0) h
+    simpa [chunksOf, List.getD_eq_getElem?_getD, List.getElem?_map, List.getElem?_range, hi]
+      using hgd
+  have hmod : ∀ m, m ≤ n → a % 2 ^ (K * m) = b % 2 ^ (K * m) := by
+    intro m
+    induction m with
+    | zero => simp [Nat.mod_one]
+    | succ i ih =>
+      intro hi
+      have hstep := hdig i (by omega)
+      simp only [bitrange] at hstep
+      rw [show K * (i + 1) = K * i + K from by ring, pow_add, Nat.mod_mul, Nat.mod_mul,
+        ih (by omega), hstep]
+  have hfin := hmod n le_rfl
+  rwa [Nat.mod_eq_of_lt ha, Nat.mod_eq_of_lt hb] at hfin
+
 /-- Chunks below position `n` are unaffected by reducing `val` mod `2 ^ (K * n)`. -/
 theorem chunksOf_mod (val n : ℕ) : chunksOf (val % 2 ^ (K * n)) n = chunksOf val n := by
   unfold chunksOf
@@ -474,6 +495,32 @@ def commitIvkMessage (ak nk : ℕ) : ℕ :=
 /-- The 51 `K`-bit chunks of the `CommitIvk` message (510 bits = 51 chunks). -/
 def commitIvkChunks (ak nk : ℕ) : List ℕ :=
   chunksOf (commitIvkMessage ak nk) 51
+
+/-- The 51-chunk `CommitIvk` message encoding is injective on 255-bit components. -/
+theorem commitIvkChunks_inj {ak nk ak' nk' : ℕ}
+    (ha : ak < 2 ^ 255) (hn : nk < 2 ^ 255) (ha' : ak' < 2 ^ 255) (hn' : nk' < 2 ^ 255)
+    (h : commitIvkChunks ak nk = commitIvkChunks ak' nk') : ak = ak' ∧ nk = nk' := by
+  have hbound : ∀ {x y : ℕ}, x < 2 ^ 255 → y < 2 ^ 255 →
+      commitIvkMessage x y < 2 ^ (K * 51) := by
+    intro x y hx hy
+    unfold commitIvkMessage
+    have hK : (2 : ℕ) ^ (K * 51) = 2 ^ 255 * 2 ^ 255 := by
+      rw [← pow_add]; norm_num [K]
+    calc x + 2 ^ 255 * y < 2 ^ 255 + 2 ^ 255 * y := by omega
+      _ = 2 ^ 255 * (y + 1) := by ring
+      _ ≤ 2 ^ 255 * 2 ^ 255 := Nat.mul_le_mul_left _ hy
+      _ = 2 ^ (K * 51) := hK.symm
+  have hmsg : commitIvkMessage ak nk = commitIvkMessage ak' nk' :=
+    chunksOf_inj (hbound ha hn) (hbound ha' hn') h
+  unfold commitIvkMessage at hmsg
+  have hak : ak = ak' := by
+    have hcong := congrArg (· % 2 ^ 255) hmsg
+    simp only [Nat.add_mul_mod_self_left] at hcong
+    rwa [Nat.mod_eq_of_lt ha, Nat.mod_eq_of_lt ha'] at hcong
+  refine ⟨hak, ?_⟩
+  subst hak
+  have hmul : 2 ^ 255 * nk = 2 ^ 255 * nk' := by omega
+  exact Nat.eq_of_mul_eq_mul_left (Nat.two_pow_pos 255) hmul
 
 /-- The 51 message chunks tile into the 4 Sinsemilla message pieces `a, b, c, d` at their
 `K`-bit boundaries: piece sizes `25, 1, 24, 1` chunks starting at bits `0, 250, 260, 500`. -/

--- a/Zcash/Circuits/Specs/Sinsemilla.lean
+++ b/Zcash/Circuits/Specs/Sinsemilla.lean
@@ -460,6 +460,43 @@ def noteCommitMessage (gdX gdY pkdX pkdY v rho psi : ℕ) : ℕ :=
 def noteCommitChunks (gdX gdY pkdX pkdY v rho psi : ℕ) : List ℕ :=
   chunksOf (noteCommitMessage gdX gdY pkdX pkdY v rho psi) 109
 
+/-- The note-commit message packing is injective on components within their widths. -/
+theorem noteCommitMessage_inj
+    {gdX gdY pkdX pkdY v rho psi gdX' gdY' pkdX' pkdY' v' rho' psi' : ℕ}
+    (h1 : gdX < 2 ^ 255) (h2 : gdY < 2) (h3 : pkdX < 2 ^ 255) (h4 : pkdY < 2)
+    (h5 : v < 2 ^ 64) (h6 : rho < 2 ^ 255) (h7 : psi < 2 ^ 255)
+    (h1' : gdX' < 2 ^ 255) (h2' : gdY' < 2) (h3' : pkdX' < 2 ^ 255) (h4' : pkdY' < 2)
+    (h5' : v' < 2 ^ 64) (h6' : rho' < 2 ^ 255) (h7' : psi' < 2 ^ 255)
+    (h : noteCommitMessage gdX gdY pkdX pkdY v rho psi
+        = noteCommitMessage gdX' gdY' pkdX' pkdY' v' rho' psi') :
+    gdX = gdX' ∧ gdY = gdY' ∧ pkdX = pkdX' ∧ pkdY = pkdY' ∧ v = v' ∧ rho = rho'
+      ∧ psi = psi' := by
+  unfold noteCommitMessage at h
+  omega
+
+/-- The 109-chunk note-commit encoding is injective on components within their widths. -/
+theorem noteCommitChunks_inj
+    {gdX gdY pkdX pkdY v rho psi gdX' gdY' pkdX' pkdY' v' rho' psi' : ℕ}
+    (h1 : gdX < 2 ^ 255) (h2 : gdY < 2) (h3 : pkdX < 2 ^ 255) (h4 : pkdY < 2)
+    (h5 : v < 2 ^ 64) (h6 : rho < 2 ^ 255) (h7 : psi < 2 ^ 255)
+    (h1' : gdX' < 2 ^ 255) (h2' : gdY' < 2) (h3' : pkdX' < 2 ^ 255) (h4' : pkdY' < 2)
+    (h5' : v' < 2 ^ 64) (h6' : rho' < 2 ^ 255) (h7' : psi' < 2 ^ 255)
+    (h : noteCommitChunks gdX gdY pkdX pkdY v rho psi
+        = noteCommitChunks gdX' gdY' pkdX' pkdY' v' rho' psi') :
+    gdX = gdX' ∧ gdY = gdY' ∧ pkdX = pkdX' ∧ pkdY = pkdY' ∧ v = v' ∧ rho = rho'
+      ∧ psi = psi' := by
+  have hK : (2 : ℕ) ^ (K * 109) = 2 ^ 1090 := by norm_num [K]
+  have hbound : ∀ {a b c d e f g : ℕ}, a < 2 ^ 255 → b < 2 → c < 2 ^ 255 → d < 2 →
+      e < 2 ^ 64 → f < 2 ^ 255 → g < 2 ^ 255 →
+      noteCommitMessage a b c d e f g < 2 ^ (K * 109) := by
+    intro a b c d e f g ha hb hc hd he hf hg
+    unfold noteCommitMessage
+    rw [hK]
+    omega
+  have hmsg := chunksOf_inj (hbound h1 h2 h3 h4 h5 h6 h7)
+    (hbound h1' h2' h3' h4' h5' h6' h7') h
+  exact noteCommitMessage_inj h1 h2 h3 h4 h5 h6 h7 h1' h2' h3' h4' h5' h6' h7' hmsg
+
 /-- The 109 message chunks tile into the 8 Sinsemilla message pieces `a..h` at their
 `K`-bit boundaries: piece sizes `25, 1, 25, 6, 1, 25, 25, 1` chunks starting at bits
 `0, 250, 260, 510, 570, 580, 830, 1080`. -/

--- a/Zcash/Common/DiscreteLogRelation.lean
+++ b/Zcash/Common/DiscreteLogRelation.lean
@@ -40,4 +40,61 @@ structure NontrivialRelationOne {n : ℕ} (g : Fin n → G) (U : G) where
   nontrivial : a ≠ 0 ∨ α ≠ 0
   relation : (∑ i, a i • g i) + α • U = 0
 
+/-- The commitment over arbitrary generators `g`: `⟨a, g⟩ = Σᵢ aᵢ • gᵢ`. -/
+def commitGen {n : ℕ} (g : Fin n → G) (a : Fin n → F) : G := ∑ i, a i • g i
+
+/-- Additivity in the witness. -/
+theorem commitGen_add_left {n : ℕ} (g : Fin n → G) (a a' : Fin n → F) :
+    commitGen g (a + a') = commitGen g a + commitGen g a' := by
+  simp only [commitGen, Pi.add_apply, add_smul, Finset.sum_add_distrib]
+
+/-- Homogeneity in the witness. -/
+theorem commitGen_smul_left {n : ℕ} (g : Fin n → G) (c : F) (a : Fin n → F) :
+    commitGen g (c • a) = c • commitGen g a := by
+  simp only [commitGen, Pi.smul_apply, smul_eq_mul, mul_smul, Finset.smul_sum]
+
+/-- Additivity in the generators. -/
+theorem commitGen_add_gen {n : ℕ} (g g' : Fin n → G) (a : Fin n → F) :
+    commitGen (g + g') a = commitGen g a + commitGen g' a := by
+  simp only [commitGen, Pi.add_apply, smul_add, Finset.sum_add_distrib]
+
+/-- Homogeneity in the generators. -/
+theorem commitGen_smul_gen {n : ℕ} (c : F) (g : Fin n → G) (a : Fin n → F) :
+    commitGen (c • g) a = c • commitGen g a := by
+  simp only [commitGen, Pi.smul_apply, Finset.smul_sum]
+  exact Finset.sum_congr rfl fun i _ => smul_comm (a i) c (g i)
+
+/-- Subtractivity in the witness. -/
+theorem commitGen_sub {n : ℕ} (g : Fin n → G) (a a' : Fin n → F) :
+    commitGen g (a - a') = commitGen g a - commitGen g a' := by
+  simp only [commitGen, Pi.sub_apply, sub_smul, Finset.sum_sub_distrib]
+
+/-- Negation in the witness. -/
+theorem commitGen_neg {n : ℕ} (g : Fin n → G) (a : Fin n → F) :
+    commitGen g (-a) = -commitGen g a := by
+  simpa using commitGen_smul_left g (-1) a
+
+/-- **The combination-collision assembler.** Two `(g, U, W)`-combinations equal as group
+elements, with coordinates that do not all agree, compute a nontrivial discrete-log
+relation: the coordinate differences `(a − a', α − α', β − β')`. -/
+def NontrivialRelation.ofCombinationCollision [DecidableEq F] {n : ℕ} {g : Fin n → G} {U W : G}
+    {a a' : Fin n → F} {α α' β β' : F}
+    (e : commitGen g a + α • U + β • W = commitGen g a' + α' • U + β' • W)
+    (hne : ¬(a = a' ∧ α = α' ∧ β = β')) : NontrivialRelation (F := F) g U W where
+  a := a - a'
+  α := α - α'
+  β := β - β'
+  nontrivial := by
+    by_cases ha : a = a'
+    · by_cases hα : α = α'
+      · exact Or.inr (Or.inr (sub_ne_zero.mpr (fun hβ => hne ⟨ha, hα, hβ⟩)))
+      · exact Or.inr (Or.inl (sub_ne_zero.mpr hα))
+    · exact Or.inl (sub_ne_zero.mpr ha)
+  relation := by
+    show commitGen g (a - a') + (α - α') • U + (β - β') • W = 0
+    have hrw : commitGen g (a - a') + (α - α') • U + (β - β') • W
+        = (commitGen g a + α • U + β • W) - (commitGen g a' + α' • U + β' • W) := by
+      rw [commitGen_sub, sub_smul, sub_smul]; abel
+    rw [hrw, e, sub_self]
+
 end Zcash

--- a/Zcash/Common/DiscreteLogRelation.lean
+++ b/Zcash/Common/DiscreteLogRelation.lean
@@ -97,4 +97,18 @@ def NontrivialRelation.ofCombinationCollision [DecidableEq F] {n : ℕ} {g : Fin
       rw [commitGen_sub, sub_smul, sub_smul]; abel
     rw [hrw, e, sub_self]
 
+/-- Over a zero third generator, a relation with a nonzero table-coefficient vector
+or a nonzero distinguished coefficient converts to the one-generator form. The third
+coefficient contributes nothing — it scales the zero point — so it cannot carry the
+nontriviality. -/
+def NontrivialRelation.toOne {n : ℕ} {g : Fin n → G} {U : G}
+    (rel : NontrivialRelation (F := F) g U (0 : G))
+    (h : rel.a ≠ 0 ∨ rel.α ≠ 0) : NontrivialRelationOne (F := F) g U where
+  a := rel.a
+  α := rel.α
+  nontrivial := h
+  relation := by
+    have hr := rel.relation
+    simpa [smul_zero] using hr
+
 end Zcash

--- a/Zcash/Security.lean
+++ b/Zcash/Security.lean
@@ -20,6 +20,10 @@ import Zcash.Security.Ledger.Capstone
 import Zcash.Security.Ledger.Nullifier
 import Zcash.Security.Ledger.Value
 import Zcash.Security.Ledger.KeyBindingArm
+import Zcash.Security.Ledger.KeyBindingDLR
+import Zcash.Security.Ledger.NoteCommitDLR
+import Zcash.Security.Ledger.MerkleDLR
+import Zcash.Security.Ledger.DeployedCapstone
 import Zcash.Security.Common.RandomOracle
 import Zcash.Security.Common.Birthday
 import Zcash.Security.KeyBinding.Basic

--- a/Zcash/Security/Concrete/PallasGroup.lean
+++ b/Zcash/Security/Concrete/PallasGroup.lean
@@ -208,6 +208,40 @@ theorem embedFp_injective : Function.Injective embedFp := by
   apply ZMod.val_injective PALLAS_BASE_CARD
   simpa only [embedFp_val] using congrArg ZMod.val hxy
 
+/-- Equal `x`-coordinate and equal `y`-parity pin the group element. Two elements
+with equal `x`-coordinates are equal up to sign, so their `y`-coordinates agree up
+to negation; the parities of `y` and `-y` differ for `y ≠ 0` in the odd-order base
+field; and `y = 0` occurs only at the identity encoding, which is alone in its
+fibre. -/
+theorem eq_of_toPoint_x_eq_of_y_parity_eq {P Q : PallasGroup}
+    (hx : (toPoint P).x = (toPoint Q).x)
+    (hy : (toPoint P).y.val % 2 = (toPoint Q).y.val % 2) : P = Q := by
+  rcases (toPoint_x_eq_iff P Q).mp hx with h | h
+  · exact h
+  · subst h
+    by_cases hy0 : (toPoint Q).y = 0
+    · have hQ0 : toPoint Q = 0 := by
+        rcases toPoint_valid Q with hoc | hz
+        · exfalso
+          have h3 : (toPoint Q).x ^ 3 = -(5 : Zcash.Circuits.Fp) := by
+            have h := hoc
+            rw [Point.OnCurve, hy0] at h
+            simp only [pallasB] at h
+            linear_combination -h
+          exact CompElliptic.Curves.Pasta.Pallas.neg_five_not_isCube ⟨_, h3⟩
+        · exact hz
+      have hQ : Q = 0 := pmfib_toPoint_injective (hQ0.trans toPoint_zero.symm)
+      rw [hQ, neg_zero]
+    · exfalso
+      haveI : NeZero (toPoint Q).y := ⟨hy0⟩
+      rw [show ((-Q).toPoint.y) = -(Q.toPoint.y) from rfl,
+        ZMod.val_neg_of_ne_zero _] at hy
+      have hlt := ZMod.val_lt (toPoint Q).y
+      have hpos : 0 < (toPoint Q).y.val := ZMod.val_pos.mpr hy0
+      have hodd : CompElliptic.Fields.Pasta.PALLAS_BASE_CARD % 2 = 1 := by
+        norm_num [CompElliptic.Fields.Pasta.PALLAS_BASE_CARD]
+      omega
+
 end PallasGroup
 
 end Zcash.Security.Concrete

--- a/Zcash/Security/Ledger/Balance.lean
+++ b/Zcash/Security/Ledger/Balance.lean
@@ -589,6 +589,85 @@ def balanceValueOrBreak {VB : Type*}
       have hnn := hval.transparent_nonneg i
       omega)
 
+omit [Field F] [AddCommGroup G] [Module F G] in
+/-- A sub-multiset of positioned openings sums to no more value: the opening values are
+non-negative. -/
+theorem sum_val_le_of_le
+    {s t : Multiset (PositionedOpening F G RHO PSI)} (h : s ≤ t) :
+    (s.map fun p => (p.opening.note.v : ℤ)).sum
+      ≤ (t.map fun p => (p.opening.note.v : ℤ)).sum := by
+  obtain ⟨u, rfl⟩ := Multiset.le_iff_exists_add.mp h
+  rw [Multiset.map_add, Multiset.sum_add]
+  have hu : 0 ≤ (u.map fun p => (p.opening.note.v : ℤ)).sum :=
+    Multiset.sum_nonneg fun x hx => by
+      obtain ⟨p, -, rfl⟩ := Multiset.mem_map.mp hx
+      exact Int.natCast_nonneg _
+  linarith
+
+omit [Field F] [AddCommGroup G] [Module F G] in
+/-- The positioned outputs' total value is monotone in the prefix length: outputs only
+accumulate, and their values are non-negative. -/
+theorem positionedOutputs_value_sum_mono
+    (ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG d) {i j : ℕ} (hij : i ≤ j) :
+    ((positionedOutputs ledger i).map fun p => (p.opening.note.v : ℤ)).sum
+      ≤ ((positionedOutputs ledger j).map fun p => (p.opening.note.v : ℤ)).sum := by
+  rw [positionedOutputs_value_sum, positionedOutputs_value_sum]
+  obtain ⟨r, hr⟩ := take_prefix_take (l := ledger) hij
+  rw [← hr, List.map_append, List.sum_append]
+  have : 0 ≤ (r.map fun tx =>
+      (tx.actions.map fun a => (a.w.note_new.v : ℤ)).sum).sum :=
+    List.sum_nonneg fun x hx => by
+      obtain ⟨tx, -, rfl⟩ := List.mem_map.mp hx
+      exact List.sum_nonneg fun y hy => by
+        obtain ⟨a, -, rfl⟩ := List.mem_map.mp hy
+        exact Int.natCast_nonneg _
+  linarith
+
+omit [Field F] [AddCommGroup G] [Module F G] in
+/-- **Balance-value, lower bound.** When the nonzero spends of the first `i + 1`
+transactions are covered by the positioned outputs of the first `i` — the Balance-subset
+conclusion — the shielded pool holds non-negative value: no value is spent that was not
+created. -/
+theorem poolValueBalance_nonneg
+    (ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG d) (i : ℕ)
+    (hsub : nonZeroSpends ledger (i + 1) ≤ (↑(positionedOutputs ledger i) : Multiset _)) :
+    0 ≤ poolValueBalance ledger (i + 1) := by
+  rw [poolValueBalance, sub_nonneg]
+  have h1 : ((nonZeroSpends ledger (i + 1)).map fun p => (p.opening.note.v : ℤ)).sum
+      ≤ ((positionedOutputs ledger i).map fun p => (p.opening.note.v : ℤ)).sum := by
+    refine le_trans (sum_val_le_of_le hsub) ?_
+    rw [Multiset.map_coe, Multiset.sum_coe]
+  exact le_trans h1 (positionedOutputs_value_sum_mono ledger (Nat.le_succ i))
+
+/-- **Balance.** In a valid ledger, either the value after the first `i + 1`
+transactions is accounted for exactly — the shielded and transparent pools are both
+non-negative and sum to the minted issuance — or the ledger's own data computes a break:
+a Balance-subset break (a Merkle, note-commitment, or key-binding break) or the value
+premiss's break. The three facts come from three places. The shielded pool is
+non-negative by spend-integrity (`poolValueBalance_nonneg`, from Balance-subset: no value
+is spent that was not created). The transparent pool is non-negative by validity
+(`transparent_nonneg`). The two pools sum to issuance by per-transaction value
+conservation (`valueConservationOrBreak`, from the binding signature: no value is created
+within a transaction). Together they place each pool in `[0, issuanceTotal]` and compose
+the two arguments into one statement. -/
+def balanceOrBreak [DecidableEq F] [DecidableEq G] [DecidableEq RHO]
+    [DecidableEq PSI] [DecidableEq MHASH] [DecidableEq MENC] [DecidableEq NK]
+    [NoZeroSMulDivisors F G] {VB : Type*}
+    (hval : ValidLedger P kv issuance maxActions ledger)
+    (perTx : (tx : Tx KW F G RHO PSI MHASH MENC MSG SIG P.depth) → tx ∈ ledger →
+      (txNetValue tx = tx.vBalance) ⊕' VB) (i : ℕ) :
+    (0 ≤ poolValueBalance ledger (i + 1)
+        ∧ 0 ≤ transparentPoolBalance issuance ledger (i + 1)
+        ∧ poolValueBalance ledger (i + 1) + transparentPoolBalance issuance ledger (i + 1)
+            = issuanceTotal issuance ledger (i + 1))
+      ⊕' (BalanceBreak P kv ⊕' VB) :=
+  match balanceSubsetOrBreak hval i,
+      valueConservationOrBreak (issuance := issuance) perTx (i + 1) with
+  | .inr b, _ => .inr (.inl b)
+  | _, .inr vb => .inr (.inr vb)
+  | .inl hsub, .inl hcons =>
+      .inl ⟨poolValueBalance_nonneg ledger i hsub, hval.transparent_nonneg (i + 1), hcons⟩
+
 end Conservation
 
 end Zcash.Security.Ledger.Model

--- a/Zcash/Security/Ledger/DeployedCapstone.lean
+++ b/Zcash/Security/Ledger/DeployedCapstone.lean
@@ -1,0 +1,66 @@
+import Mathlib
+import Zcash.Security.Ledger.Capstone
+import Zcash.Security.Ledger.KeyBindingDLR
+import Zcash.Security.Ledger.NoteCommitDLR
+import Zcash.Security.Ledger.MerkleDLR
+
+/-!
+# The deployed instantiation: every Balance-subset arm computes a discrete-log relation
+
+At the deployed Orchard primitives, each of the three Balance-subset break arms reduces
+to a nontrivial discrete-log relation among the fixed Sinsemilla bases. These are the
+event-level reductions that discharge the capstone's three named ε hypotheses at the
+deployed instantiation. Each takes a sample on which the reduction lands in one arm and
+returns the arm's relation, so the arm's probability is the probability that the
+composite produces a relation. Under the pre-quantum hardness of the deployed bases
+(their independence, spec Theorems 5.4.3 and 5.4.4), that probability is the
+discrete-log-relation advantage — the same terminal the Merkle and note-commitment arms
+already share, with no random-oracle model.
+
+Composing these with `balanceSubset_measure_le` replaces the three opaque arm ε's with
+one discrete-log-relation assumption per domain point, and the key-binding arm no longer
+needs the oracle model at the deployed instantiation.
+-/
+
+namespace Zcash.Security.Ledger.Bridge
+
+open Zcash.Circuits
+open Zcash.Security.Concrete
+open Zcash.Security.Ledger.Pool
+open Zcash.Security.Ledger.Model
+
+variable {MSG SIG : Type*}
+  (verify bverify : PallasGroup → MSG → SIG → Prop)
+  (issuance : ℕ → ℕ) (maxActions : ℕ)
+
+/-- The deployed instantiation's sample space. -/
+abbrev DeployedAnnotated :=
+  ValidAnnotated (primitives (MSG := MSG) (SIG := SIG) verify bverify) keyBinding
+    issuance maxActions
+
+/-- The three deployed Balance-subset relation targets: the key-binding and
+note-commitment arms land in two-generator relations at their domain points, the
+Merkle arm in a one-generator relation. -/
+inductive DeployedBalanceRelation where
+  | keyBinding (r : NontrivialRelation (F := Fq) pallasS ivkQpt commitIvkRpt)
+  | noteCommit (r : NontrivialRelation (F := Fq) pallasS noteQpt noteCommitRpt)
+  | merkle (r : NontrivialRelationOne (F := Fq) pallasS merkleQpt)
+
+/-- **The deployed Balance-subset reduction.** In a valid deployed ledger, either the
+nonzero spends of the first `i + 1` transactions are covered by the positioned outputs
+of the first `i`, or the ledger's own data computes a nontrivial discrete-log relation
+among the fixed Sinsemilla bases. Each Balance-subset break arm is routed through its
+deployed reducer, so the three named ε hypotheses collapse to one discrete-log-relation
+assumption per domain point, with no random-oracle model. -/
+def deployedBalanceSubsetOrRelation {ledger : Ledger _ Fq PallasGroup Fp Fp Fp Encoding MSG SIG _}
+    (hval : ValidLedger (primitives (MSG := MSG) (SIG := SIG) verify bverify) keyBinding
+      issuance maxActions ledger) (i : ℕ) :
+    (nonZeroSpends ledger (i + 1) ≤ ↑(positionedOutputs ledger i))
+      ⊕' DeployedBalanceRelation :=
+  match balanceSubsetOrBreak hval i with
+  | .inl hsub => .inl hsub
+  | .inr (.keyBinding _ _ h) => .inr (.keyBinding (relationOfKeyBindingBreak h))
+  | .inr (.noteCommit nb) => .inr (.noteCommit (relationOfNoteCommitBreak verify bverify nb))
+  | .inr (.merkle c) => .inr (.merkle (relationOfMerkleCollision c.2))
+
+end Zcash.Security.Ledger.Bridge

--- a/Zcash/Security/Ledger/KeyBindingDLR.lean
+++ b/Zcash/Security/Ledger/KeyBindingDLR.lean
@@ -1,0 +1,107 @@
+import Mathlib
+import Zcash.Security.Ledger.Pool
+import Zcash.Security.Ledger.SinsemillaDLR
+
+/-!
+# The deployed key-binding break computes a discrete-log relation
+
+The pre-quantum discharge of the key-binding arm's ε: a `KeyBinding.Pool.Break` — two
+valid `Commit^ivk` openings of the same `ivk` disagreeing on their opening projection —
+computes a nontrivial discrete-log relation among the Sinsemilla table generators, the
+`CommitIvk` domain point, and the `CommitIvk` randomness base. This folds ε_kb into the
+same DL terminal as the Merkle and note-commitment arms, with no random-oracle model
+and no probability accounting: the reduction is deterministic.
+
+The shared machinery is `Bridge.relationOfChainPmEq` (`SinsemillaDLR`); this module
+instantiates it at the `CommitIvk` domain point and randomness base, unpacking the
+break's two openings into their defined hash chains and turning the equal-`ivk`
+extraction into the up-to-sign equation via the `Extract_ℙ` ±-fibre property.
+-/
+
+namespace Zcash.Security.Ledger.Bridge
+
+open Zcash.Circuits
+open Zcash.Circuits.Specs (K)
+open Zcash.Circuits.Specs.Sinsemilla
+open Zcash.Security.Concrete
+open Zcash.Security.Ledger.Pool
+
+/-- The `CommitIvk` domain point `Q("z.cash:Orchard-CommitIvk-M")`, as a group element. -/
+def ivkQpt : PallasGroup := PallasGroup.ofPoint ivkQ (Or.inl ivkQ_onCurve)
+
+/-- The `CommitIvk` randomness base, as a group element — the `commitIvkR` argument of
+the deployed `keyBinding` interface. -/
+def commitIvkRpt : PallasGroup :=
+  PallasGroup.ofPoint Ecc.MulFixed.Certs.commitIvkR.point
+    (Or.inl Ecc.MulFixed.Certs.commitIvkR.onCurve)
+
+/-- A defined `commitIvkHash` hit names a defined, valid `hashToPoint` chain. -/
+theorem commitIvkHash_isSome {a n : Fp} {g : PallasGroup}
+    (h : commitIvkHash a n = some g) :
+    (hashToPoint orchardGenerators.S ivkQ (commitIvkChunks a.val n.val)).isSome := by
+  unfold commitIvkHash at h
+  rcases Option.bind_eq_some_iff.mp h with ⟨p, hp, -⟩
+  exact hp ▸ rfl
+
+/-- The chain a defined `commitIvkHash` hit names is valid, and the hit is its image. -/
+theorem commitIvkHash_get_spec {a n : Fp} {g : PallasGroup}
+    (h : commitIvkHash a n = some g) :
+    ∃ hv : ((hashToPoint orchardGenerators.S ivkQ
+        (commitIvkChunks a.val n.val)).get (commitIvkHash_isSome h)).Valid,
+      g = PallasGroup.ofPoint _ hv := by
+  unfold commitIvkHash at h
+  rcases Option.bind_eq_some_iff.mp h with ⟨p, hp, hop⟩
+  have hget : (hashToPoint orchardGenerators.S ivkQ
+      (commitIvkChunks a.val n.val)).get (commitIvkHash_isSome h) = p := by
+    simp [hp]
+  rw [hget]
+  unfold PallasGroup.ofPoint? at hop
+  split at hop
+  · rename_i hv
+    exact ⟨hv, (Option.some_inj.mp hop).symm⟩
+  · exact absurd hop (by simp)
+
+/-- **The deployed key-binding break computes a discrete-log relation.** Two valid
+`Commit^ivk` openings of the same `ivk` disagreeing on their opening projection land in
+the chain-collision reducer at the `CommitIvk` domain point and randomness base.
+`hcoeffs` is the chunk-coefficient injectivity (the binary-expansion core of spec
+Theorem 5.4.3) and `hchunks` the injectivity of the 51-chunk `(ak, nk)` encoding, both
+at the break's own two chunk lists; discharging them from the digit machinery is
+tracked alongside this reduction. -/
+def relationOfKeyBindingBreak
+    {w₁ w₂ : KeyBinding.Pool.Witness Fq PallasGroup Fp}
+    (b : KeyBinding.Pool.Break extract commitIvkHash commitIvkRpt w₁ w₂)
+    (hcoeffs :
+      preCoeffs (commitIvkChunks (extract w₁.akP).val w₁.nk.val)
+          = preCoeffs (commitIvkChunks (extract w₂.akP).val w₂.nk.val) →
+        commitIvkChunks (extract w₁.akP).val w₁.nk.val
+          = commitIvkChunks (extract w₂.akP).val w₂.nk.val)
+    (hchunks :
+      commitIvkChunks (extract w₁.akP).val w₁.nk.val
+          = commitIvkChunks (extract w₂.akP).val w₂.nk.val →
+        extract w₁.akP = extract w₂.akP ∧ w₁.nk = w₂.nk) :
+    NontrivialRelation (F := Fq) pallasS ivkQpt commitIvkRpt :=
+  let hs₁ := commitIvkHash_isSome b.kb₁.hash_eq
+  let hs₂ := commitIvkHash_isSome b.kb₂.hash_eq
+  relationOfChainPmEq (Q := ivkQ) (Or.inl ivkQ_onCurve) (W := commitIvkRpt)
+    (fun _ hm => chunksOf_mem_lt hm) (fun _ hm => chunksOf_mem_lt hm)
+    (by simp)
+    (Option.some_get hs₁).symm (commitIvkHash_get_spec b.kb₁.hash_eq).choose
+    (Option.some_get hs₂).symm (commitIvkHash_get_spec b.kb₂.hash_eq).choose
+    (by
+      have hx : extract (w₁.hashPoint + w₁.rivk • commitIvkRpt)
+          = extract (w₂.hashPoint + w₂.rivk • commitIvkRpt) := by
+        rw [← b.kb₁.ivk_eq, ← b.kb₂.ivk_eq]
+        exact b.ivk_eq
+      have hpm := (PallasGroup.toPoint_x_eq_iff _ _).mp hx
+      rwa [(commitIvkHash_get_spec b.kb₁.hash_eq).choose_spec,
+        (commitIvkHash_get_spec b.kb₂.hash_eq).choose_spec] at hpm)
+    hcoeffs
+    (by
+      rintro ⟨hl, hr⟩
+      obtain ⟨hak, hnk⟩ := hchunks hl
+      refine b.projection_ne ?_
+      unfold KeyBinding.Pool.Witness.breakProjection
+      rw [hak, hnk, hr])
+
+end Zcash.Security.Ledger.Bridge

--- a/Zcash/Security/Ledger/KeyBindingDLR.lean
+++ b/Zcash/Security/Ledger/KeyBindingDLR.lean
@@ -68,17 +68,12 @@ theorem commitIvkHash_get_spec {a n : Fp} {g : PallasGroup}
 /-- **The deployed key-binding break computes a discrete-log relation.** Two valid
 `Commit^ivk` openings of the same `ivk` disagreeing on their opening projection land in
 the chain-collision reducer at the `CommitIvk` domain point and randomness base.
-`hcoeffs` is the chunk-coefficient injectivity at the break's own two chunk lists —
-the binary-expansion core of spec Theorem 5.4.3, and the one named hypothesis left;
-the chunk-encoding injectivity is discharged by `commitIvkChunks_inj`. -/
+The reduction is hypothesis-free: the chunk-coefficient
+injectivity is `preCoeffs_inj` (spec Theorem 5.4.3's binary-expansion core, proven)
+and the chunk-encoding injectivity is `commitIvkChunks_inj`. -/
 def relationOfKeyBindingBreak
     {w₁ w₂ : KeyBinding.Pool.Witness Fq PallasGroup Fp}
     (b : KeyBinding.Pool.Break extract commitIvkHash commitIvkRpt w₁ w₂)
-    (hcoeffs :
-      preCoeffs (commitIvkChunks (extract w₁.akP).val w₁.nk.val)
-          = preCoeffs (commitIvkChunks (extract w₂.akP).val w₂.nk.val) →
-        commitIvkChunks (extract w₁.akP).val w₁.nk.val
-          = commitIvkChunks (extract w₂.akP).val w₂.nk.val)
  :
     NontrivialRelation (F := Fq) pallasS ivkQpt commitIvkRpt :=
   let hs₁ := commitIvkHash_isSome b.kb₁.hash_eq
@@ -96,7 +91,7 @@ def relationOfKeyBindingBreak
       have hpm := (PallasGroup.toPoint_x_eq_iff _ _).mp hx
       rwa [(commitIvkHash_get_spec b.kb₁.hash_eq).choose_spec,
         (commitIvkHash_get_spec b.kb₂.hash_eq).choose_spec] at hpm)
-    hcoeffs
+    (by simp)
     (by
       rintro ⟨hl, hr⟩
       obtain ⟨hak, hnk⟩ := commitIvkChunks_inj

--- a/Zcash/Security/Ledger/KeyBindingDLR.lean
+++ b/Zcash/Security/Ledger/KeyBindingDLR.lean
@@ -35,6 +35,10 @@ def commitIvkRpt : PallasGroup :=
   PallasGroup.ofPoint Ecc.MulFixed.Certs.commitIvkR.point
     (Or.inl Ecc.MulFixed.Certs.commitIvkR.onCurve)
 
+/-- Every `Fp` value is below `2^255`: the Pallas base field's order is. -/
+private theorem fp_val_lt (x : Fp) : x.val < 2 ^ 255 :=
+  lt_trans (ZMod.val_lt x) (by norm_num [CompElliptic.Fields.Pasta.PALLAS_BASE_CARD])
+
 /-- A defined `commitIvkHash` hit names a defined, valid `hashToPoint` chain. -/
 theorem commitIvkHash_isSome {a n : Fp} {g : PallasGroup}
     (h : commitIvkHash a n = some g) :
@@ -64,10 +68,9 @@ theorem commitIvkHash_get_spec {a n : Fp} {g : PallasGroup}
 /-- **The deployed key-binding break computes a discrete-log relation.** Two valid
 `Commit^ivk` openings of the same `ivk` disagreeing on their opening projection land in
 the chain-collision reducer at the `CommitIvk` domain point and randomness base.
-`hcoeffs` is the chunk-coefficient injectivity (the binary-expansion core of spec
-Theorem 5.4.3) and `hchunks` the injectivity of the 51-chunk `(ak, nk)` encoding, both
-at the break's own two chunk lists; discharging them from the digit machinery is
-tracked alongside this reduction. -/
+`hcoeffs` is the chunk-coefficient injectivity at the break's own two chunk lists —
+the binary-expansion core of spec Theorem 5.4.3, and the one named hypothesis left;
+the chunk-encoding injectivity is discharged by `commitIvkChunks_inj`. -/
 def relationOfKeyBindingBreak
     {w₁ w₂ : KeyBinding.Pool.Witness Fq PallasGroup Fp}
     (b : KeyBinding.Pool.Break extract commitIvkHash commitIvkRpt w₁ w₂)
@@ -76,10 +79,7 @@ def relationOfKeyBindingBreak
           = preCoeffs (commitIvkChunks (extract w₂.akP).val w₂.nk.val) →
         commitIvkChunks (extract w₁.akP).val w₁.nk.val
           = commitIvkChunks (extract w₂.akP).val w₂.nk.val)
-    (hchunks :
-      commitIvkChunks (extract w₁.akP).val w₁.nk.val
-          = commitIvkChunks (extract w₂.akP).val w₂.nk.val →
-        extract w₁.akP = extract w₂.akP ∧ w₁.nk = w₂.nk) :
+ :
     NontrivialRelation (F := Fq) pallasS ivkQpt commitIvkRpt :=
   let hs₁ := commitIvkHash_isSome b.kb₁.hash_eq
   let hs₂ := commitIvkHash_isSome b.kb₂.hash_eq
@@ -99,9 +99,10 @@ def relationOfKeyBindingBreak
     hcoeffs
     (by
       rintro ⟨hl, hr⟩
-      obtain ⟨hak, hnk⟩ := hchunks hl
+      obtain ⟨hak, hnk⟩ := commitIvkChunks_inj
+        (fp_val_lt _) (fp_val_lt _) (fp_val_lt _) (fp_val_lt _) hl
       refine b.projection_ne ?_
       unfold KeyBinding.Pool.Witness.breakProjection
-      rw [hak, hnk, hr])
+      rw [ZMod.val_injective _ hak, ZMod.val_injective _ hnk, hr])
 
 end Zcash.Security.Ledger.Bridge

--- a/Zcash/Security/Ledger/KeyBindingDLR.lean
+++ b/Zcash/Security/Ledger/KeyBindingDLR.lean
@@ -14,7 +14,7 @@ and no probability accounting: the reduction is deterministic.
 
 The shared machinery is `Bridge.relationOfChainPmEq` (`SinsemillaDLR`); this module
 instantiates it at the `CommitIvk` domain point and randomness base, unpacking the
-break's two openings into their defined hash chains and turning the equal-`ivk`
+break's two openings into their defined Sinsemilla chains and turning the equal-`ivk`
 extraction into the up-to-sign equation via the `Extract_ℙ` ±-fibre property.
 -/
 
@@ -34,10 +34,6 @@ the deployed `keyBinding` interface. -/
 def commitIvkRpt : PallasGroup :=
   PallasGroup.ofPoint Ecc.MulFixed.Certs.commitIvkR.point
     (Or.inl Ecc.MulFixed.Certs.commitIvkR.onCurve)
-
-/-- Every `Fp` value is below `2^255`: the Pallas base field's order is. -/
-private theorem fp_val_lt (x : Fp) : x.val < 2 ^ 255 :=
-  lt_trans (ZMod.val_lt x) (by norm_num [CompElliptic.Fields.Pasta.PALLAS_BASE_CARD])
 
 /-- A defined `commitIvkHash` hit names a defined, valid `hashToPoint` chain. -/
 theorem commitIvkHash_isSome {a n : Fp} {g : PallasGroup}
@@ -66,7 +62,8 @@ theorem commitIvkHash_get_spec {a n : Fp} {g : PallasGroup}
   · exact absurd hop (by simp)
 
 /-- **The deployed key-binding break computes a discrete-log relation.** Two valid
-`Commit^ivk` openings of the same `ivk` disagreeing on their opening projection land in
+`Commit^ivk` openings of the same `ivk` disagreeing on their opening projection: the
+reduction unpacks them into their defined Sinsemilla chains and blinding scalars and applies
 the chain-collision reducer at the `CommitIvk` domain point and randomness base.
 The reduction is hypothesis-free: the chunk-coefficient
 injectivity is `preCoeffs_inj` (spec Theorem 5.4.3's binary-expansion core, proven)

--- a/Zcash/Security/Ledger/MerkleDLR.lean
+++ b/Zcash/Security/Ledger/MerkleDLR.lean
@@ -1,0 +1,106 @@
+import Mathlib
+import Zcash.Security.Common.RandomOracle
+import Zcash.Security.Ledger.Pool
+import Zcash.Security.Ledger.SinsemillaDLR
+
+/-!
+# A deployed Merkle collision computes a Sinsemilla discrete-log relation
+
+The pre-quantum discharge of the Merkle arm: a defined collision of the layer-`i`
+compression — two distinct child pairs with the same defined output — computes a
+nontrivial relation among the Sinsemilla table and the Merkle domain point. The
+reduction unpacks both children into their defined Sinsemilla chains and applies the
+chain-collision reducer with zero blinding. The resulting relation has no
+randomness-base component, so it converts to the one-generator form.
+
+The reduction is hypothesis-free: the chunk-coefficient injectivity is
+`preCoeffs_inj`, and the 52-chunk compression encoding is injective by
+`merkleChunks_inj`.
+-/
+
+set_option exponentiation.threshold 600
+
+namespace Zcash.Security.Ledger.Bridge
+
+open Zcash.Circuits
+open Zcash.Circuits.Specs (K)
+open Zcash.Circuits.Specs.Sinsemilla
+open Zcash.Security.Concrete
+open Zcash.Security.Ledger.Pool
+
+/-- The Merkle domain point `Q("z.cash:Orchard-MerkleCRH")`, as a group element. -/
+def merkleQpt : PallasGroup := PallasGroup.ofPoint merkleQ (Or.inl merkleQ_onCurve)
+
+/-- The chunk values of a Merkle compression message are table indices. -/
+theorem merkleChunks_mem_lt {l lv rv m : ℕ} (hm : m ∈ merkleChunks l lv rv) :
+    m < 2 ^ K :=
+  chunksOf_mem_lt (merkleChunks_eq_chunksOf l lv rv ▸ hm)
+
+/-- A defined layer compression names a defined Sinsemilla chain. -/
+theorem merkleCompress_isSome {i : Fin 32} {ch : Encoding × Encoding} {out : Fp}
+    (h : merkleCompress i ch = some out) :
+    (hashToPoint orchardGenerators.S merkleQ (merkleChunks i.1 ch.1.1 ch.2.1)).isSome := by
+  unfold merkleCompress at h
+  rcases Option.map_eq_some_iff.mp h with ⟨p, hp, -⟩
+  exact hp ▸ rfl
+
+/-- The defined output is the chain value's `x`-coordinate. -/
+theorem merkleCompress_get_x {i : Fin 32} {ch : Encoding × Encoding} {out : Fp}
+    (h : merkleCompress i ch = some out) :
+    out = ((hashToPoint orchardGenerators.S merkleQ
+      (merkleChunks i.1 ch.1.1 ch.2.1)).get (merkleCompress_isSome h)).x := by
+  unfold merkleCompress at h
+  rcases Option.map_eq_some_iff.mp h with ⟨p, hp, hout⟩
+  have hget : (hashToPoint orchardGenerators.S merkleQ
+      (merkleChunks i.1 ch.1.1 ch.2.1)).get (merkleCompress_isSome h) = p := by
+    simp [hp]
+  rw [hget, hout]
+
+/-- The chain a defined layer compression names is valid. -/
+theorem merkleCompress_get_valid {i : Fin 32} {ch : Encoding × Encoding} {out : Fp}
+    (h : merkleCompress i ch = some out) :
+    ((hashToPoint orchardGenerators.S merkleQ
+      (merkleChunks i.1 ch.1.1 ch.2.1)).get (merkleCompress_isSome h)).Valid :=
+  hashToPoint_valid (Or.inl merkleQ_onCurve) (fun _ hm => merkleChunks_mem_lt hm)
+    (Option.some_get (merkleCompress_isSome h)).symm
+
+/-- **A deployed Merkle collision computes a Sinsemilla discrete-log relation.** The
+collision's two children are unpacked into their defined Sinsemilla chains, and the
+chain-collision reducer is applied with zero blinding at the Merkle domain point.
+The relation then converts to the one-generator form, because its randomness-base
+coefficient is zero. -/
+def relationOfMerkleCollision {i : Fin 32}
+    (c : Zcash.Security.RandomOracle.DefinedCollision (merkleCompress i)) :
+    NontrivialRelationOne (F := Fq) pallasS merkleQpt :=
+  let rel := relationOfChainPmEq (Q := merkleQ) (Or.inl merkleQ_onCurve)
+    (W := (0 : PallasGroup))
+    (fun _ hm => merkleChunks_mem_lt hm) (fun _ hm => merkleChunks_mem_lt hm)
+    (by simp [merkleChunks_eq_chunksOf])
+    (Option.some_get (merkleCompress_isSome c.eval₁)).symm
+    (merkleCompress_get_valid c.eval₁)
+    (Option.some_get (merkleCompress_isSome c.eval₂)).symm
+    (merkleCompress_get_valid c.eval₂)
+    (r₁ := 0) (r₂ := 0)
+    (by
+      have hx : (PallasGroup.toPoint (PallasGroup.ofPoint _
+            (merkleCompress_get_valid c.eval₁))).x
+          = (PallasGroup.toPoint (PallasGroup.ofPoint _
+            (merkleCompress_get_valid c.eval₂))).x := by
+        rw [PallasGroup.toPoint_ofPoint, PallasGroup.toPoint_ofPoint,
+          ← merkleCompress_get_x c.eval₁, ← merkleCompress_get_x c.eval₂]
+      have hpm := (PallasGroup.toPoint_x_eq_iff _ _).mp hx
+      simpa [zero_smul, add_zero] using hpm)
+    (by simp [merkleChunks_eq_chunksOf])
+    (by
+      rintro ⟨hl, -⟩
+      obtain ⟨-, hlv, hrv⟩ := merkleChunks_inj
+        (lt_trans i.2 (by norm_num)) c.q₁.1.2 c.q₁.2.2
+        (lt_trans i.2 (by norm_num)) c.q₂.1.2 c.q₂.2.2 hl
+      exact c.ne (Prod.ext (Subtype.ext hlv) (Subtype.ext hrv)))
+  rel.toOne (by
+    rcases rel.nontrivial with ha | hα | hβ
+    · exact Or.inl ha
+    · exact Or.inr hα
+    · exact absurd (relationOfChainPmEq_zero_beta _ _ _ _ _ _ _ _ _ _ _) hβ)
+
+end Zcash.Security.Ledger.Bridge

--- a/Zcash/Security/Ledger/NoteCommitDLR.lean
+++ b/Zcash/Security/Ledger/NoteCommitDLR.lean
@@ -14,7 +14,7 @@ the two openings into their defined Sinsemilla chains and blinding scalars and a
 chain-collision reducer `relationOfChainPmEq`.
 
 The reduction is hypothesis-free. The chunk-coefficient injectivity is `preCoeffs_inj`
-and the 109-chunk message encoding is injective by `noteCommitChunks_inj`; recovering
+and the 109-chunk message encoding is injective by `noteCommitChunks_inj`. Recovering
 the note from its scalars additionally uses `eq_of_toPoint_x_eq_of_y_parity_eq`,
 because the message carries each point as its `x`-coordinate and `y`-parity bit.
 -/

--- a/Zcash/Security/Ledger/NoteCommitDLR.lean
+++ b/Zcash/Security/Ledger/NoteCommitDLR.lean
@@ -1,0 +1,129 @@
+import Mathlib
+import Zcash.Security.Ledger.Statement
+import Zcash.Security.Ledger.Pool
+import Zcash.Security.Ledger.SinsemillaDLR
+
+/-!
+# The deployed note-commitment break computes a discrete-log relation
+
+The pre-quantum discharge of the note-commitment arm: a `NoteCommitBreak` at the
+deployed primitives — two openings with distinct `(rcm, note)` pairs whose commitments
+share an extracted coordinate — computes a nontrivial relation among the Sinsemilla
+table, the `NoteCommit` domain point, and the randomness base. The reduction unpacks
+the two openings into their defined Sinsemilla chains and blinding scalars and applies the
+chain-collision reducer `relationOfChainPmEq`.
+
+The reduction is hypothesis-free. The chunk-coefficient injectivity is `preCoeffs_inj`
+and the 109-chunk message encoding is injective by `noteCommitChunks_inj`; recovering
+the note from its scalars additionally uses `eq_of_toPoint_x_eq_of_y_parity_eq`,
+because the message carries each point as its `x`-coordinate and `y`-parity bit.
+-/
+
+namespace Zcash.Security.Ledger.Bridge
+
+open Zcash.Circuits
+open Zcash.Circuits.Specs (K)
+open Zcash.Circuits.Specs.Sinsemilla
+open Zcash.Security.Concrete
+open Zcash.Security.Ledger.Pool
+
+/-- The `NoteCommit` domain point `Q("z.cash:Orchard-NoteCommit-M")`, as a group
+element. -/
+def noteQpt : PallasGroup := PallasGroup.ofPoint noteQ (Or.inl noteQ_onCurve)
+
+/-- The `NoteCommit` randomness base, as a group element. -/
+def noteCommitRpt : PallasGroup :=
+  PallasGroup.ofPoint Ecc.MulFixed.Certs.noteCommitR.point
+    (Or.inl Ecc.MulFixed.Certs.noteCommitR.onCurve)
+
+/-- A scalar acts on the group as its canonical natural representative. -/
+theorem smul_eq_val_nsmul (r : Fq) (P : PallasGroup) : r • P = r.val • P := by
+  rw [← Nat.cast_smul_eq_nsmul Fq, ZMod.natCast_zmod_val]
+
+/-- Every note value below the deployed bound is below the base-field order. -/
+theorem valueBound_lt_card {v : ℕ} (hv : v < 2 ^ 64) :
+    v < CompElliptic.Fields.Pasta.PALLAS_BASE_CARD :=
+  lt_trans hv (by norm_num [CompElliptic.Fields.Pasta.PALLAS_BASE_CARD])
+
+/-- A defined `noteCommit` hit names a defined `noteHash` chain. -/
+theorem noteCommit_hash_isSome {rcm : Fq} {n : Note PallasGroup Fp Fp}
+    {cm : PallasGroup} (h : noteCommit rcm n = some cm) : (noteHash n).isSome := by
+  unfold noteCommit at h
+  rcases Option.bind_eq_some_iff.mp h with ⟨bp, hbp, -⟩
+  exact hbp ▸ rfl
+
+/-- The chain a defined `noteCommit` hit names is valid, and the hit decomposes as
+the chain plus the blinding term. -/
+theorem noteCommit_get_spec {rcm : Fq} {n : Note PallasGroup Fp Fp}
+    {cm : PallasGroup} (h : noteCommit rcm n = some cm) :
+    ∃ hv : ((noteHash n).get (noteCommit_hash_isSome h)).Valid,
+      cm = PallasGroup.ofPoint _ hv + rcm • noteCommitRpt := by
+  unfold noteCommit at h
+  rcases Option.bind_eq_some_iff.mp h with ⟨bp, hbp, hop⟩
+  have hget : (noteHash n).get (noteCommit_hash_isSome h) = bp := by simp [hbp]
+  have hbpv : bp.Valid := hashToPoint_valid (Or.inl noteQ_onCurve)
+    (fun m hm => chunksOf_mem_lt hm) hbp
+  rw [hget]
+  refine ⟨hbpv, ?_⟩
+  unfold PallasGroup.ofPoint? at hop
+  split at hop
+  · rw [← Option.some_inj.mp hop]
+    rw [smul_eq_val_nsmul, noteCommitRpt, ← PallasGroup.ofPoint_nsmul,
+      ← PallasGroup.ofPoint_add hbpv
+        (Point.valid_nsmul (Or.inl Ecc.MulFixed.Certs.noteCommitR.onCurve) rcm.val)]
+  · exact absurd hop (by simp)
+
+/-- **The deployed note-commitment break computes a discrete-log relation.** Two
+openings with distinct `(rcm, note)` pairs whose commitments share an extracted
+coordinate: the reduction unpacks them into their defined Sinsemilla chains and blinding
+scalars and applies the chain-collision reducer at the `NoteCommit` domain point and
+randomness base. -/
+def relationOfNoteCommitBreak {MSG SIG : Type*}
+    (verify bverify : PallasGroup → MSG → SIG → Prop)
+    (b : NoteCommitBreak (primitives (MSG := MSG) (SIG := SIG) verify bverify)) :
+    NontrivialRelation (F := Fq) pallasS noteQpt noteCommitRpt :=
+  relationOfChainPmEq (Q := noteQ) (Or.inl noteQ_onCurve) (W := noteCommitRpt)
+    (fun _ hm => chunksOf_mem_lt hm) (fun _ hm => chunksOf_mem_lt hm)
+    (by simp [Pool.noteScalars])
+    (Option.some_get (noteCommit_hash_isSome b.open₁)).symm
+    (noteCommit_get_spec b.open₁).choose
+    (Option.some_get (noteCommit_hash_isSome b.open₂)).symm
+    (noteCommit_get_spec b.open₂).choose
+    (by
+      have hx : extract b.cm₁ = extract b.cm₂ := b.extract_eq
+      rw [(noteCommit_get_spec b.open₁).choose_spec,
+        (noteCommit_get_spec b.open₂).choose_spec] at hx
+      exact (PallasGroup.toPoint_x_eq_iff _ _).mp hx)
+    (by simp [Pool.noteScalars])
+    (by
+      rintro ⟨hl, hr⟩
+      simp only [Pool.noteScalars, NoteCommit.noteScalars] at hl
+      obtain ⟨hgx, hgy, hpx, hpy, hv, hrho, hpsi⟩ := noteCommitChunks_inj
+        (fp_val_lt _) (Nat.mod_lt _ (by norm_num)) (fp_val_lt _)
+        (Nat.mod_lt _ (by norm_num))
+        (by
+          rw [ZMod.val_natCast_of_lt (valueBound_lt_card b.v₁_lt)]
+          exact b.v₁_lt)
+        (fp_val_lt _) (fp_val_lt _)
+        (fp_val_lt _) (Nat.mod_lt _ (by norm_num)) (fp_val_lt _)
+        (Nat.mod_lt _ (by norm_num))
+        (by
+          rw [ZMod.val_natCast_of_lt (valueBound_lt_card b.v₂_lt)]
+          exact b.v₂_lt)
+        (fp_val_lt _) (fp_val_lt _) hl
+      have hgd : b.n₁.gd = b.n₂.gd :=
+        PallasGroup.eq_of_toPoint_x_eq_of_y_parity_eq (ZMod.val_injective _ hgx) hgy
+      have hpkd : b.n₁.pkd = b.n₂.pkd :=
+        PallasGroup.eq_of_toPoint_x_eq_of_y_parity_eq (ZMod.val_injective _ hpx) hpy
+      have hvv : b.n₁.v = b.n₂.v := by
+        rwa [ZMod.val_natCast_of_lt (valueBound_lt_card b.v₁_lt),
+          ZMod.val_natCast_of_lt (valueBound_lt_card b.v₂_lt)] at hv
+      have hrho' : b.n₁.ρ = b.n₂.ρ := ZMod.val_injective _ hrho
+      have hpsi' : b.n₁.ψ = b.n₂.ψ := ZMod.val_injective _ hpsi
+      refine b.ne ?_
+      have hn : b.n₁ = b.n₂ := by
+        rw [show b.n₁ = ⟨b.n₁.gd, b.n₁.pkd, b.n₁.v, b.n₁.ρ, b.n₁.ψ⟩ from rfl,
+          hgd, hpkd, hvv, hrho', hpsi']
+      rw [hn, hr])
+
+end Zcash.Security.Ledger.Bridge

--- a/Zcash/Security/Ledger/SinsemillaDLR.lean
+++ b/Zcash/Security/Ledger/SinsemillaDLR.lean
@@ -611,7 +611,7 @@ point, blinded by `r₁ • W` and `r₂ • W`, whose outputs agree up to sign,
 nontrivial relation among the table, the domain point, and `W` — provided the pair
 `(chunk list, blinding scalar)` differs. The equality case rests on
 `preCoeffs_inj` — chunk lists of length at most 253 are determined by their
-coefficients; every deployed Sinsemilla message is far shorter. The negation case is
+coefficients, and every deployed Sinsemilla message is far shorter. The negation case is
 unconditional: the domain-point coefficients `2^n` and `-2^n` cannot agree because
 `2^(n+1) ≠ 0` in the odd-order scalar field. -/
 def relationOfChainPmEq {Q : Point Fp} (hQ : Q.Valid) {W : PallasGroup}
@@ -655,6 +655,23 @@ def relationOfChainPmEq {Q : Point Fp} (hQ : Q.Valid) {W : PallasGroup}
           rw [pow_succ, mul_two]
           exact add_eq_zero_iff_eq_neg.mpr hα
         exact two_pow_ne_zero _ h0)
+
+
+/-- With zero blinding scalars, the reducer's randomness-base coefficient is zero. -/
+theorem relationOfChainPmEq_zero_beta {Q : Point Fp} (hQ : Q.Valid) {W : PallasGroup}
+    {l₁ l₂ : List ℕ} (hb₁ : ∀ m ∈ l₁, m < 2 ^ K) (hb₂ : ∀ m ∈ l₂, m < 2 ^ K)
+    (hlen : l₁.length = l₂.length)
+    {p₁ p₂ : Point Fp}
+    (h₁ : hashToPoint orchardGenerators.S Q l₁ = some p₁) (hv₁ : p₁.Valid)
+    (h₂ : hashToPoint orchardGenerators.S Q l₂ = some p₂) (hv₂ : p₂.Valid)
+    (heq : PallasGroup.ofPoint p₁ hv₁ + (0 : Fq) • W
+        = PallasGroup.ofPoint p₂ hv₂ + (0 : Fq) • W ∨
+      PallasGroup.ofPoint p₁ hv₁ + (0 : Fq) • W
+        = -(PallasGroup.ofPoint p₂ hv₂ + (0 : Fq) • W))
+    (hn : l₁.length ≤ 253) (hne : ¬(l₁ = l₂ ∧ (0 : Fq) = 0)) :
+    (relationOfChainPmEq hQ hb₁ hb₂ hlen h₁ hv₁ h₂ hv₂ heq hn hne).β = 0 := by
+  unfold relationOfChainPmEq
+  split <;> simp [Zcash.NontrivialRelation.ofCombinationCollision]
 
 
 end Zcash.Security.Ledger.Bridge

--- a/Zcash/Security/Ledger/SinsemillaDLR.lean
+++ b/Zcash/Security/Ledger/SinsemillaDLR.lean
@@ -504,6 +504,10 @@ theorem blinded_chain_eq {Q : Point Fp} (hQ : Q.Valid) (W : PallasGroup)
   rw [sum_preCoeffs_smul hb]
   abel
 
+/-- Every Pallas base-field value is below `2^255`: the field's order is. -/
+theorem fp_val_lt (x : Fp) : x.val < 2 ^ 255 :=
+  lt_trans (ZMod.val_lt x) (by norm_num [CompElliptic.Fields.Pasta.PALLAS_BASE_CARD])
+
 /-- The `ℕ`-level chunk coefficients: generator `t` receives `2^(n−1−j)` for every
 position `j` holding chunk value `t`, summed in `ℕ`. -/
 def natCoeffs (l : List ℕ) (t : ℕ) : ℕ :=

--- a/Zcash/Security/Ledger/SinsemillaDLR.lean
+++ b/Zcash/Security/Ledger/SinsemillaDLR.lean
@@ -504,14 +504,112 @@ theorem blinded_chain_eq {Q : Point Fp} (hQ : Q.Valid) (W : PallasGroup)
   rw [sum_preCoeffs_smul hb]
   abel
 
+/-- The `ℕ`-level chunk coefficients: generator `t` receives `2^(n−1−j)` for every
+position `j` holding chunk value `t`, summed in `ℕ`. -/
+def natCoeffs (l : List ℕ) (t : ℕ) : ℕ :=
+  ∑ j ∈ Finset.range l.length,
+    if l.getD j 0 = t then 2 ^ (l.length - 1 - j) else 0
+
+/-- The scalar-field coefficients are the `ℕ`-level coefficients, cast. -/
+theorem preCoeffs_eq_natCoeffs (l : List ℕ) (t : Fin (2 ^ K)) :
+    preCoeffs l t = ((natCoeffs l t.1 : ℕ) : Fq) := by
+  simp [preCoeffs, natCoeffs, apply_ite (Nat.cast : ℕ → Fq)]
+
+/-- Head decomposition of the `ℕ`-level coefficients. -/
+theorem natCoeffs_cons (c : ℕ) (rest : List ℕ) (t : ℕ) :
+    natCoeffs (c :: rest) t
+      = (if c = t then 2 ^ rest.length else 0) + natCoeffs rest t := by
+  simp only [natCoeffs, List.length_cons, Finset.sum_range_succ', List.getD_cons_succ,
+    List.getD_cons_zero, Nat.add_sub_cancel, Nat.sub_zero]
+  rw [Nat.add_comm]
+  congr 1
+  apply Finset.sum_congr rfl
+  intro j hj
+  have he : rest.length - (j + 1) = rest.length - 1 - j := by omega
+  rw [he]
+
+/-- The `ℕ`-level coefficients stay below `2^n`: the exponents are distinct. -/
+theorem natCoeffs_lt (l : List ℕ) (t : ℕ) : natCoeffs l t < 2 ^ l.length := by
+  induction l with
+  | nil => simp [natCoeffs]
+  | cons c rest ih =>
+    rw [natCoeffs_cons, List.length_cons, pow_succ]
+    split <;> omega
+
+/-- **The `ℕ`-level coefficients determine the list** (same lengths): the head's
+`2^n` term dominates the tail's `≤ 2^n − 1`, forcing head equality, and the tails
+follow by cancellation. -/
+theorem natCoeffs_inj : ∀ {l₁ l₂ : List ℕ}, l₁.length = l₂.length →
+    (∀ t, natCoeffs l₁ t = natCoeffs l₂ t) → l₁ = l₂ := by
+  intro l₁
+  induction l₁ with
+  | nil =>
+    intro l₂ hlen _
+    exact (List.length_eq_zero_iff.mp hlen.symm).symm ▸ rfl
+  | cons c₁ rest₁ ih =>
+    intro l₂ hlen h
+    obtain ⟨c₂, rest₂, rfl⟩ : ∃ c₂ rest₂, l₂ = c₂ :: rest₂ := by
+      cases l₂ with
+      | nil => simp at hlen
+      | cons c₂ rest₂ => exact ⟨c₂, rest₂, rfl⟩
+    have hrl : rest₁.length = rest₂.length := by simpa using hlen
+    have hc : c₂ = c₁ := by
+      by_contra hne
+      have h₁ := h c₁
+      rw [natCoeffs_cons, natCoeffs_cons, if_pos rfl, if_neg hne] at h₁
+      have hb₂ := natCoeffs_lt rest₂ c₁
+      rw [← hrl] at hb₂
+      omega
+    subst hc
+    have htail : ∀ t, natCoeffs rest₁ t = natCoeffs rest₂ t := by
+      intro t
+      have ht := h t
+      rw [natCoeffs_cons, natCoeffs_cons, hrl] at ht
+      exact Nat.add_left_cancel ht
+    rw [ih hrl htail]
+
+/-- **The chunk coefficients determine the list** — the binary-expansion core of spec
+Theorem 5.4.3, over the scalar field: for chunk lists of equal length at most 253, the
+`ℕ`-level coefficient sums stay below the field order, so the cast is faithful and
+`natCoeffs_inj` applies. -/
+theorem preCoeffs_inj {l₁ l₂ : List ℕ}
+    (hb₁ : ∀ m ∈ l₁, m < 2 ^ K) (hb₂ : ∀ m ∈ l₂, m < 2 ^ K)
+    (hlen : l₁.length = l₂.length) (hn : l₁.length ≤ 253)
+    (h : preCoeffs l₁ = preCoeffs l₂) : l₁ = l₂ := by
+  refine natCoeffs_inj hlen fun t => ?_
+  by_cases ht : t < 2 ^ K
+  · have hcast := congrFun h ⟨t, ht⟩
+    rw [preCoeffs_eq_natCoeffs, preCoeffs_eq_natCoeffs] at hcast
+    have hlt : ∀ (l : List ℕ), l.length ≤ 253 →
+        natCoeffs l t < CompElliptic.Fields.Pasta.PALLAS_SCALAR_CARD := by
+      intro l hl
+      calc natCoeffs l t < 2 ^ l.length := natCoeffs_lt l t
+        _ ≤ 2 ^ 253 := Nat.pow_le_pow_right (by norm_num) hl
+        _ < _ := by norm_num [CompElliptic.Fields.Pasta.PALLAS_SCALAR_CARD]
+    have hv := congrArg ZMod.val hcast
+    rwa [ZMod.val_natCast_of_lt (hlt l₁ hn), ZMod.val_natCast_of_lt (hlt l₂ (hlen ▸ hn))]
+      at hv
+  · -- Out-of-table values never occur in bounded lists, so both coefficients vanish.
+    have hz : ∀ (l : List ℕ), (∀ m ∈ l, m < 2 ^ K) → natCoeffs l t = 0 := by
+      intro l hbl
+      refine Finset.sum_eq_zero fun j hj => ?_
+      have hjl : j < l.length := Finset.mem_range.mp hj
+      have hmem : l.getD j 0 ∈ l := by
+        rw [List.getD_eq_getElem _ _ hjl]
+        exact List.getElem_mem _
+      rw [if_neg]
+      intro hEq
+      exact ht (hEq ▸ hbl _ hmem)
+    rw [hz l₁ hb₁, hz l₂ hb₂]
+
 /-- **The chain-collision reducer.** Two defined Sinsemilla chains at the same domain
 point, blinded by `r₁ • W` and `r₂ • W`, whose outputs agree up to sign, compute a
 nontrivial relation among the table, the domain point, and `W` — provided the pair
-`(chunk list, blinding scalar)` differs. `hcoeffs` is the injectivity of the
-chunk-coefficient encoding, the binary-expansion core of spec Theorem 5.4.3; it is
-consumed only in the equality case. The negation case is unconditional: the
-domain-point coefficients `2^n` and `-2^n` cannot agree because `2^(n+1) ≠ 0` in the
-odd-order scalar field. -/
+`(chunk list, blinding scalar)` differs. The equality case rests on
+`preCoeffs_inj` — chunk lists of length at most 253 are determined by their
+coefficients; every deployed Sinsemilla message is far shorter. The negation case is
+unconditional: the domain-point coefficients `2^n` and `-2^n` cannot agree because
+`2^(n+1) ≠ 0` in the odd-order scalar field. -/
 def relationOfChainPmEq {Q : Point Fp} (hQ : Q.Valid) {W : PallasGroup}
     {l₁ l₂ : List ℕ} (hb₁ : ∀ m ∈ l₁, m < 2 ^ K) (hb₂ : ∀ m ∈ l₂, m < 2 ^ K)
     (hlen : l₁.length = l₂.length)
@@ -521,7 +619,7 @@ def relationOfChainPmEq {Q : Point Fp} (hQ : Q.Valid) {W : PallasGroup}
     {r₁ r₂ : Fq}
     (heq : PallasGroup.ofPoint p₁ hv₁ + r₁ • W = PallasGroup.ofPoint p₂ hv₂ + r₂ • W ∨
       PallasGroup.ofPoint p₁ hv₁ + r₁ • W = -(PallasGroup.ofPoint p₂ hv₂ + r₂ • W))
-    (hcoeffs : preCoeffs l₁ = preCoeffs l₂ → l₁ = l₂)
+    (hn : l₁.length ≤ 253)
     (hne : ¬(l₁ = l₂ ∧ r₁ = r₂)) :
     NontrivialRelation (F := Fq) pallasS (PallasGroup.ofPoint Q hQ) W :=
   if hplus : PallasGroup.ofPoint p₁ hv₁ + r₁ • W = PallasGroup.ofPoint p₂ hv₂ + r₂ • W then
@@ -534,7 +632,7 @@ def relationOfChainPmEq {Q : Point Fp} (hQ : Q.Valid) {W : PallasGroup}
         rw [blinded_chain_eq hQ W hb₁ h₁ hv₁ r₁,
           blinded_chain_eq hQ W hb₂ h₂ hv₂ r₂] at h
         exact h)
-      (by rintro ⟨ha, -, hr⟩; exact hne ⟨hcoeffs ha, hr⟩)
+      (by rintro ⟨ha, -, hr⟩; exact hne ⟨preCoeffs_inj hb₁ hb₂ hlen hn ha, hr⟩)
   else
     NontrivialRelation.ofCombinationCollision
       (a := preCoeffs l₁) (a' := -(preCoeffs l₂))

--- a/Zcash/Security/Ledger/SinsemillaDLR.lean
+++ b/Zcash/Security/Ledger/SinsemillaDLR.lean
@@ -482,4 +482,77 @@ theorem classifyRelation_site {wit : ActionData} {dlb : ActionDLBreak}
   · exact absurd h (by simp)
   · next abr heq => exact ⟨abr, heq, by injection h with h'; rw [← h']⟩
 
+/-! ## The chain-collision reducer
+
+Shared by every arm whose break compares two blinded Sinsemilla outputs: the
+key-binding break compares two `Commit^ivk` openings, the note-commitment break two
+note commitments, and a Merkle collision two compressions (with zero blinding). Two
+defined chains at the same domain point whose blinded outputs agree up to sign
+compute a relation among the table, the domain point, and the blinding base. -/
+
+/-- A defined, blinded Sinsemilla chain as the explicit `(table, Q, W)`-combination
+determined by its chunk list. -/
+theorem blinded_chain_eq {Q : Point Fp} (hQ : Q.Valid) (W : PallasGroup)
+    {l : List ℕ} (hb : ∀ m ∈ l, m < 2 ^ K)
+    {p : Point Fp} (h : hashToPoint orchardGenerators.S Q l = some p) (hv : p.Valid)
+    (r : Fq) :
+    PallasGroup.ofPoint p hv + r • W =
+      commitGen pallasS (preCoeffs l)
+        + ((2 : Fq) ^ l.length) • PallasGroup.ofPoint Q hQ + r • W := by
+  rw [ofPoint_hashToPoint hQ hb h hv]
+  simp only [← two_pow_smul_eq_nsmul, commitGen]
+  rw [sum_preCoeffs_smul hb]
+  abel
+
+/-- **The chain-collision reducer.** Two defined Sinsemilla chains at the same domain
+point, blinded by `r₁ • W` and `r₂ • W`, whose outputs agree up to sign, compute a
+nontrivial relation among the table, the domain point, and `W` — provided the pair
+`(chunk list, blinding scalar)` differs. `hcoeffs` is the injectivity of the
+chunk-coefficient encoding, the binary-expansion core of spec Theorem 5.4.3; it is
+consumed only in the equality case. The negation case is unconditional: the
+domain-point coefficients `2^n` and `-2^n` cannot agree because `2^(n+1) ≠ 0` in the
+odd-order scalar field. -/
+def relationOfChainPmEq {Q : Point Fp} (hQ : Q.Valid) {W : PallasGroup}
+    {l₁ l₂ : List ℕ} (hb₁ : ∀ m ∈ l₁, m < 2 ^ K) (hb₂ : ∀ m ∈ l₂, m < 2 ^ K)
+    (hlen : l₁.length = l₂.length)
+    {p₁ p₂ : Point Fp}
+    (h₁ : hashToPoint orchardGenerators.S Q l₁ = some p₁) (hv₁ : p₁.Valid)
+    (h₂ : hashToPoint orchardGenerators.S Q l₂ = some p₂) (hv₂ : p₂.Valid)
+    {r₁ r₂ : Fq}
+    (heq : PallasGroup.ofPoint p₁ hv₁ + r₁ • W = PallasGroup.ofPoint p₂ hv₂ + r₂ • W ∨
+      PallasGroup.ofPoint p₁ hv₁ + r₁ • W = -(PallasGroup.ofPoint p₂ hv₂ + r₂ • W))
+    (hcoeffs : preCoeffs l₁ = preCoeffs l₂ → l₁ = l₂)
+    (hne : ¬(l₁ = l₂ ∧ r₁ = r₂)) :
+    NontrivialRelation (F := Fq) pallasS (PallasGroup.ofPoint Q hQ) W :=
+  if hplus : PallasGroup.ofPoint p₁ hv₁ + r₁ • W = PallasGroup.ofPoint p₂ hv₂ + r₂ • W then
+    NontrivialRelation.ofCombinationCollision
+      (a := preCoeffs l₁) (a' := preCoeffs l₂)
+      (α := (2 : Fq) ^ l₁.length) (α' := (2 : Fq) ^ l₂.length)
+      (β := r₁) (β' := r₂)
+      (by
+        have h := hplus
+        rw [blinded_chain_eq hQ W hb₁ h₁ hv₁ r₁,
+          blinded_chain_eq hQ W hb₂ h₂ hv₂ r₂] at h
+        exact h)
+      (by rintro ⟨ha, -, hr⟩; exact hne ⟨hcoeffs ha, hr⟩)
+  else
+    NontrivialRelation.ofCombinationCollision
+      (a := preCoeffs l₁) (a' := -(preCoeffs l₂))
+      (α := (2 : Fq) ^ l₁.length) (α' := -((2 : Fq) ^ l₂.length))
+      (β := r₁) (β' := -r₂)
+      (by
+        have h := heq.resolve_left hplus
+        rw [blinded_chain_eq hQ W hb₁ h₁ hv₁ r₁,
+          blinded_chain_eq hQ W hb₂ h₂ hv₂ r₂] at h
+        rw [h, commitGen_neg, neg_smul, neg_smul]
+        abel)
+      (by
+        rintro ⟨-, hα, -⟩
+        rw [hlen] at hα
+        have h0 : (2 : Fq) ^ (l₂.length + 1) = 0 := by
+          rw [pow_succ, mul_two]
+          exact add_eq_zero_iff_eq_neg.mpr hα
+        exact two_pow_ne_zero _ h0)
+
+
 end Zcash.Security.Ledger.Bridge

--- a/Zcash/Snark/Soundness/AGM/BindingSignature.lean
+++ b/Zcash/Snark/Soundness/AGM/BindingSignature.lean
@@ -51,7 +51,7 @@ def NontrivialRelation.toAlgebraicRelationWitness (V R : M)
         · exact hβ' hβ
     relation := by
       rw [representationEval_bindingSignatureBasis]
-      simpa [Zcash.Snark.commitGen] using r.relation }
+      simpa [Zcash.commitGen] using r.relation }
 
 /-- Compute the discrete log of `V` base `R` from a two-base relation, assuming `R ≠ 0`. -/
 def NontrivialRelation.toDiscreteLog [DecidableEq F] (V R : M)
@@ -66,7 +66,7 @@ def NontrivialRelation.toDiscreteLog [DecidableEq F] (V R : M)
         · exact False.elim (hα' hα)
         · exact hβ'
     have hβR : r.β • R = 0 := by
-      simpa [Zcash.Snark.commitGen, hα] using r.relation
+      simpa [Zcash.commitGen, hα] using r.relation
     have hR0 : R = 0 := by
       have h := congrArg (fun X : M => r.β⁻¹ • X) hβR
       simpa [smul_smul, inv_mul_cancel₀ hβ] using h

--- a/Zcash/Snark/Soundness/CommitFold.lean
+++ b/Zcash/Snark/Soundness/CommitFold.lean
@@ -1,5 +1,6 @@
 import Mathlib
 import Zcash.Snark.Soundness.InnerProduct
+import Zcash.Common.DiscreteLogRelation
 
 /-!
 # The commitment respects the IPA round fold
@@ -20,34 +21,13 @@ namespace Zcash.Snark
 
 variable {F G : Type*} [Field F] [AddCommGroup G] [Module F G]
 
-/-- The commitment over arbitrary generators `g`: `⟨a, g⟩ = Σᵢ aᵢ • gᵢ`. Specialises to the URS
-commitment: `commit urs = commitGen urs.g`. -/
-def commitGen {n : ℕ} (g : Fin n → G) (a : Fin n → F) : G := ∑ i, a i • g i
-
 /-- The fingerprint/URS commitment is the generator-commitment at the URS generators. -/
 theorem commit_eq_commitGen (urs : URS G) (a : Fin (2 ^ urs.k) → F) :
     commit urs a = commitGen urs.g a := rfl
 
-/-- Additivity in the witness. -/
-theorem commitGen_add_left {n : ℕ} (g : Fin n → G) (a a' : Fin n → F) :
-    commitGen g (a + a') = commitGen g a + commitGen g a' := by
-  simp only [commitGen, Pi.add_apply, add_smul, Finset.sum_add_distrib]
 
-/-- Homogeneity in the witness. -/
-theorem commitGen_smul_left {n : ℕ} (g : Fin n → G) (c : F) (a : Fin n → F) :
-    commitGen g (c • a) = c • commitGen g a := by
-  simp only [commitGen, Pi.smul_apply, smul_eq_mul, mul_smul, Finset.smul_sum]
 
-/-- Additivity in the generators. -/
-theorem commitGen_add_gen {n : ℕ} (g g' : Fin n → G) (a : Fin n → F) :
-    commitGen (g + g') a = commitGen g a + commitGen g' a := by
-  simp only [commitGen, Pi.add_apply, smul_add, Finset.sum_add_distrib]
 
-/-- Homogeneity in the generators. -/
-theorem commitGen_smul_gen {n : ℕ} (c : F) (g : Fin n → G) (a : Fin n → F) :
-    commitGen (c • g) a = c • commitGen g a := by
-  simp only [commitGen, Pi.smul_apply, Finset.smul_sum]
-  exact Finset.sum_congr rfl fun i _ => smul_comm (a i) c (g i)
 
 /-- **One IPA round's commitment fold (completeness).** Folding the witness by `u⁻¹` and the generators
 by `u` sends the parent commitment to the folded commitment plus the two cross terms `⟨aLo, gHi⟩` and
@@ -104,10 +84,6 @@ reduction extends this to the augmented `(g, U, W)` generators
 computational/AGM layer — is outside this
 development. -/
 
-/-- Additivity over subtraction in the witness. -/
-theorem commitGen_sub {n : ℕ} (g : Fin n → G) (a a' : Fin n → F) :
-    commitGen g (a - a') = commitGen g a - commitGen g a' := by
-  simp only [commitGen, Pi.sub_apply, sub_smul, Finset.sum_sub_distrib]
 
 /-- A nontrivial discrete-log relation among the URS generators, as data: a nonzero coefficient
 vector the generators send to `0`. DLR hardness is the assumption that no feasible adversary can

--- a/Zcash/Snark/Soundness/Deployed/Binding.lean
+++ b/Zcash/Snark/Soundness/Deployed/Binding.lean
@@ -24,27 +24,4 @@ namespace Zcash.Snark
 
 variable {F G : Type*} [Field F] [AddCommGroup G] [Module F G]
 
-/-- **The augmented binding reduction, as a computed relation.** Two `(g, U, W)`-combinations
-equal as group elements, with coordinates that do not all agree, compute a nontrivial
-discrete-log relation: the coordinate differences `(a − a', α − α', β − β')`. -/
-def NontrivialRelation.ofCombinationCollision [DecidableEq F] {n : ℕ} {g : Fin n → G} {U W : G}
-    {a a' : Fin n → F} {α α' β β' : F}
-    (e : commitGen g a + α • U + β • W = commitGen g a' + α' • U + β' • W)
-    (hne : ¬(a = a' ∧ α = α' ∧ β = β')) : NontrivialRelation (F := F) g U W where
-  a := a - a'
-  α := α - α'
-  β := β - β'
-  nontrivial := by
-    by_cases ha : a = a'
-    · by_cases hα : α = α'
-      · exact Or.inr (Or.inr (sub_ne_zero.mpr (fun hβ => hne ⟨ha, hα, hβ⟩)))
-      · exact Or.inr (Or.inl (sub_ne_zero.mpr hα))
-    · exact Or.inl (sub_ne_zero.mpr ha)
-  relation := by
-    show commitGen g (a - a') + (α - α') • U + (β - β') • W = 0
-    have hrw : commitGen g (a - a') + (α - α') • U + (β - β') • W
-        = (commitGen g a + α • U + β • W) - (commitGen g a' + α' • U + β' • W) := by
-      rw [commitGen_sub, sub_smul, sub_smul]; abel
-    rw [hrw, e, sub_self]
-
 end Zcash.Snark

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -36,6 +36,10 @@ import Zcash.Snark.Soundness.PermutationRows
 import Zcash.Snark.Soundness.ConstraintRelations
 import Zcash.Snark.Soundness.ChallengePricing
 import Zcash.Snark.Soundness.ActionVesta
+import Zcash.Security.Ledger.KeyBindingDLR
+import Zcash.Security.Ledger.NoteCommitDLR
+import Zcash.Security.Ledger.MerkleDLR
+import Zcash.Security.Ledger.DeployedCapstone
 import Zcash.Snark.Soundness.DegreeWalk
 import Zcash.Snark.Soundness.Composition.ScheduleBudget
 import Zcash.Snark.Soundness.AGM.PinnedRootWitness
@@ -274,6 +278,51 @@ assert_axioms Zcash.Security.Ledger.Model.balanceSubset_measure_le
 assert_axioms Zcash.Security.Ledger.Model.valueConservation_measure_le
 assert_axioms Zcash.Security.Ledger.Model.balanceValue_measure_le
 assert_axioms Zcash.Security.Ledger.Model.spendAuthority_measure_le
+
+/-! ## The deployed discrete-log-relation discharges
+
+Each deployed Balance-subset break arm reduces to a nontrivial discrete-log relation
+among the fixed Sinsemilla bases (`deployedBalanceSubsetOrRelation`), routing the three
+named ε hypotheses to one discrete-log-relation assumption per domain point. The
+reductions are computable, so they get assert_computable. The encoding-injectivity and
+coefficient-injectivity facts they consume are theorems. -/
+
+assert_axioms Zcash.NontrivialRelation.toOne
+assert_axioms Zcash.Circuits.Specs.Sinsemilla.chunksOf_inj
+assert_axioms Zcash.Circuits.Specs.Sinsemilla.commitIvkChunks_inj
+assert_axioms Zcash.Circuits.Specs.Sinsemilla.noteCommitChunks_inj
+assert_axioms Zcash.Circuits.Specs.Sinsemilla.merkleChunks_inj
+assert_axioms Zcash.Security.Ledger.Bridge.preCoeffs_inj
+assert_axioms Zcash.Security.Concrete.PallasGroup.eq_of_toPoint_x_eq_of_y_parity_eq +native(
+  CompElliptic.Curves.Pasta.Pallas.neg_five_not_isCube)
+assert_computable Zcash.Security.Ledger.Bridge.relationOfChainPmEq +choice +native(
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt)
+assert_computable Zcash.Security.Ledger.Bridge.relationOfKeyBindingBreak +choice +native(
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt,
+  Zcash.Circuits.Ecc.MulFixed.Certs.commitIvkRCert_check)
+assert_computable Zcash.Security.Ledger.Bridge.relationOfNoteCommitBreak +choice +native(
+  CompElliptic.Curves.Pasta.Pallas.neg_five_not_isCube,
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt,
+  Zcash.Security.Concrete.PallasGroup.pallas_base_card_lt_scalar_card,
+  Zcash.Security.Ledger.Pool.unc_thirteen_not_isSquare,
+  Zcash.Circuits.Ecc.MulFixed.Certs.noteCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.nullifierKCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.spendAuthGCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitVCert_check)
+assert_computable Zcash.Security.Ledger.Bridge.relationOfMerkleCollision +choice +native(
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt)
+assert_computable Zcash.Security.Ledger.Bridge.deployedBalanceSubsetOrRelation +choice +native(
+  CompElliptic.Curves.Pasta.Pallas.neg_five_not_isCube,
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt,
+  Zcash.Security.Concrete.PallasGroup.pallas_base_card_lt_scalar_card,
+  Zcash.Security.Ledger.Pool.unc_thirteen_not_isSquare,
+  Zcash.Circuits.Ecc.MulFixed.Certs.commitIvkRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.noteCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.nullifierKCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.spendAuthGCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitVCert_check)
 
 /-! ## The key-binding arms' ε, discharged
 

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -347,7 +347,7 @@ The binding reductions return computed data (plain `def`s); the same treatment c
 reductions `ipa_extractV`, `ipaRelation_extract`, `produceDeployed`, `deployed_forking_tree`, and
 `deployed_forking_relation`, each computing its witness from an explicit certificate. -/
 
-assert_computable Zcash.Snark.NontrivialRelation.ofCombinationCollision +choice
+assert_computable Zcash.NontrivialRelation.ofCombinationCollision +choice
 assert_computable Zcash.Snark.NontrivialRelation.ofFoldedGens +choice
 assert_computable Zcash.Snark.NontrivialRelation.ofLeafPeel +choice
 assert_computable Zcash.Snark.NontrivialRelation.ofDeployedTree +choice

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -207,6 +207,10 @@ assert_axioms Zcash.Security.Ledger.Model.poolValueBalance_eq_neg
 assert_computable Zcash.Security.Ledger.Model.allValueOrBreak
 assert_computable Zcash.Security.Ledger.Model.valueConservationOrBreak +choice
 assert_computable Zcash.Security.Ledger.Model.balanceValueOrBreak +choice
+assert_axioms Zcash.Security.Ledger.Model.sum_val_le_of_le
+assert_axioms Zcash.Security.Ledger.Model.positionedOutputs_value_sum_mono
+assert_axioms Zcash.Security.Ledger.Model.poolValueBalance_nonneg
+assert_computable Zcash.Security.Ledger.Model.balanceOrBreak +choice
 
 /-! ## Spendability
 


### PR DESCRIPTION
The deployed instantiation's break-to-relation extraction for the ledger-game capstones. Every Balance-subset break arm now reduces deterministically to a discrete-log relation among the fixed Orchard Sinsemilla bases: a violating valid ledger computes the relation as data. This is a deterministic per-ledger extraction, not yet the probabilistic ε discharge — see the scope note below.

The headline is the key-binding arm. In ZIP 2005 its security rests on a random-oracle collision argument — a birthday bound, with `Commit^ivk` modelled as a random oracle, which is a heuristic rather than a falsifiable assumption. The deployed construction needs none of that: two `Commit^ivk` openings of the same `ivk` exhibit an honest discrete-log relation among the fixed Sinsemilla bases, computed as data, with no oracle, no birthday bound, and no oracle-machine → `PMF` bridge. The reduction is deterministic.

With this, all three Balance-subset arms extract to the same target — a nontrivial relation among the deployed Sinsemilla bases, whose intractability is the discrete-log-relation hardness the SNARK soundness stack and the binding-signature balance argument already reduce to. At the deterministic level this removes the birthday/oracle loss the ZIP 2005 key-binding argument incurs. It does **not** yet collapse the capstone's named ε hypotheses: `balanceSubset_measure_le` still takes separate per-arm ε bounds, and instantiating them under DLR hardness needs the efficient-adversary composition (pushing a `PMF` over valid annotated ledgers through the reducer, a runtime/query bound, and applying hardness). That efficiency bridge — the DLR-side analogue of the Recovery oracle-machine → `PMF` bridge (#107) — is not in this PR; the RedDSA obligations stay honestly named (#22, #121).

The second result is a single two-sided Balance theorem. `balanceOrBreak` states: in a valid ledger, either the value after the first `i + 1` transactions is accounted for exactly — both the shielded and transparent pools non-negative and summing to the minted issuance — or the ledger's own data computes a break. This ties the two Balance arguments into one statement, so a reader no longer assembles them by hand: the upper side is "no value created within a transaction" (the binding signature), the lower side is "no value spent that was not created" (spend-integrity, a new lower bound from Balance-subset). Details in the `Balance.lean` bullet below.

- `commitGen`, its linearity lemmas (plus a new `commitGen_neg`), and `NontrivialRelation.ofCombinationCollision` move to `Zcash/Common/DiscreteLogRelation.lean`: they are generic over any `(F, G)`-module and belong with the relation types they serve — the ledger's Sinsemilla reductions consume them too, and importing the SNARK soundness stack into the ledger modules would tangle the census cones. Call sites resolve outward unchanged.

- The chain-collision reducer (`SinsemillaDLR.lean`): two defined Sinsemilla chains at the same domain point, blinded by `r₁ • W` and `r₂ • W`, whose outputs agree up to sign, compute a nontrivial relation among the table, the domain point, and `W` — the shared core of the key-binding, note-commitment, and Merkle arm discharges. The negation case is unconditional (the domain-point coefficients `2^n` and `−2^n` cannot agree in the odd-order scalar field); the equality case rests on the proven `preCoeffs_inj`.

- **The binary-expansion core of spec Theorem 5.4.3 is proven** (`preCoeffs_inj`): chunk lists of equal length at most 253 are determined by their scalar-field coefficients. The ℕ-level coefficient sums cast faithfully because deployed message lengths keep them below the field order, and they determine the list by cons induction — the head's `2^n` term dominates the tail's `≤ 2^n − 1`, forcing head equality, with the tails following by cancellation; no binary-digit machinery is needed. The chunk-encoding side is `chunksOf_inj` / `commitIvkChunks_inj` (`Circuits/Specs/Sinsemilla.lean`): the `K`-bit digits determine the value by a `Nat.mod_mul` induction, and the 51-chunk `(ak, nk)` message splits by mod and cancellation.

- The deployed key-binding discharge (`KeyBindingDLR.lean`) is **hypothesis-free**: a `KeyBinding.Pool.Break` — two valid `Commit^ivk` openings of the same `ivk` disagreeing on their opening projection — computes the nontrivial relation among the Sinsemilla table, the `CommitIvk` domain point, and the randomness base, with the defined chains recovered computably (`Option.get` on the break's own hash hits). What is complete is the deterministic break-to-relation reduction; wiring it into the capstones' named-ε slot, and the onward relation-to-single-DL step, land with the composition below.

- The note-commitment arm (`NoteCommitDLR.lean`) and the Merkle arm (`MerkleDLR.lean`) instantiate the same reducer, both hypothesis-free. The note arm recovers each compressed point from its `x`-coordinate and `y`-parity bit (`eq_of_toPoint_x_eq_of_y_parity_eq`) and its message by `noteCommitChunks_inj`; the Merkle arm applies the reducer with zero blinding and converts the result to the one-generator form (`NontrivialRelation.toOne`), since a zero randomness-base coefficient carries no nontriviality.

- `DeployedCapstone.lean` composes them. `deployedBalanceSubsetOrRelation` is the deployed Balance-subset reduction: a valid deployed ledger either covers its nonzero spends, or its own data computes one of the three discrete-log relations. At the deterministic level the key-binding arm no longer routes through the random-oracle model: the extraction is ROM-free. Wiring this into the capstone's named-ε slots (instantiating `balanceSubset_measure_le`) is the efficient-adversary composition noted above, and is not done here. The relation-to-single-DL step remains the named pre-quantum hardness (independence of the deployed bases, spec Theorems 5.4.3 and 5.4.4).

The three arm modules and the composition are in the library root and censused, with the native provenance the deployed constants inherit (the Pallas curve-order witness and the fixed-base certificates) recorded per entry.

- `balanceOrBreak` (`Balance.lean`) is the two-sided Balance statement, composing the two arguments into one. In a valid ledger, either the value after the first `i + 1` transactions is accounted for exactly — both pools non-negative and summing to the minted issuance — or the ledger's own data computes a break. The shielded pool is non-negative by spend-integrity (`poolValueBalance_nonneg`, new, from Balance-subset: a sub-multiset of positioned openings sums to no more value); the transparent pool by validity (`transparent_nonneg`); the two sum to issuance by per-transaction conservation (`valueConservationOrBreak`, from the binding signature). The value identity is an equality, not a bound — value is not destroyed in the model. This makes the roles of the two Balance halves explicit rather than leaving a reader to assemble them: the upper side is "no value created within a transaction" (binding signature), the lower side is "no value spent that was not created" (spend-integrity).

Still to land: the probabilistic ε discharge — the efficient-adversary composition that instantiates `balanceSubset_measure_le` from the deterministic reducer under DLR hardness (`PMF` pushforward + runtime/query bound + hardness application; the DLR-side analogue of #107); the deployed instantiation of the full two-sided Balance (routing the value premiss to the binding-signature relation); and the NU6.3 flags in `ActionInstance`.

🤖 Claude Fable 5






