### PR TITLE
Remove the per-file copyright notices

### DIFF
--- a/Zcash/Arithmetic.lean
+++ b/Zcash/Arithmetic.lean
@@ -1,7 +1,3 @@
-/-
-Copyright (c) 2026 Ironwood Contributors.
-Released under the Apache License, Version 2.0.
--/
 import Zcash.Arithmetic.Field
 import Zcash.Arithmetic.Group
 

--- a/Zcash/Arithmetic/Fft.lean
+++ b/Zcash/Arithmetic/Fft.lean
@@ -1,7 +1,3 @@
-/-
-Copyright (c) 2026 Ironwood Contributors.
-Released under the Apache License, Version 2.0.
--/
 import Zcash.Arithmetic.Domain
 import Zcash.Arithmetic.Group
 

--- a/Zcash/Arithmetic/FftSpec.lean
+++ b/Zcash/Arithmetic/FftSpec.lean
@@ -1,7 +1,3 @@
-/-
-Copyright (c) 2026 Ironwood Contributors.
-Released under the Apache License, Version 2.0.
--/
 import Zcash.Arithmetic.Fft
 
 /-!

--- a/Zcash/Arithmetic/InvDft.lean
+++ b/Zcash/Arithmetic/InvDft.lean
@@ -1,7 +1,3 @@
-/-
-Copyright (c) 2026 Ironwood Contributors.
-Released under the Apache License, Version 2.0.
--/
 import Zcash.Arithmetic.FftSpec
 import CompElliptic.Curves.Pasta.Fast.Msm
 

--- a/Zcash/Arithmetic/NatKernel.lean
+++ b/Zcash/Arithmetic/NatKernel.lean
@@ -1,8 +1,3 @@
-/-
-Copyright (c) 2026 Ironwood Contributors.
-Released under the Apache License, Version 2.0.
--/
-
 /-!
 # The `Nat` kernel for Vesta group arithmetic — the certificate's evaluation lane
 

--- a/Zcash/Arithmetic/NatKernelEquiv.lean
+++ b/Zcash/Arithmetic/NatKernelEquiv.lean
@@ -1,7 +1,3 @@
-/-
-Copyright (c) 2026 Ironwood Contributors.
-Released under the Apache License, Version 2.0.
--/
 import CompElliptic.Curves.Pasta.Fast.Projective
 import CompElliptic.Curves.Pasta.Fast.MsmProj
 import Zcash.Arithmetic.NatKernel

--- a/Zcash/Arithmetic/VestaModule.lean
+++ b/Zcash/Arithmetic/VestaModule.lean
@@ -1,7 +1,3 @@
-/-
-Copyright (c) 2026 Ironwood Contributors.
-Released under the Apache License, Version 2.0.
--/
 import CompElliptic.Curves.Pasta.Fast.Projective
 import Zcash.Arithmetic.Field
 import CompElliptic.Curves.PastaOrder

--- a/Zcash/Common/ParMap.lean
+++ b/Zcash/Common/ParMap.lean
@@ -1,7 +1,3 @@
-/-
-Copyright (c) 2026 Ironwood Contributors.
-Released under the Apache License, Version 2.0.
--/
 import Mathlib.Data.List.Basic
 
 /-!

--- a/Zcash/Snark/Core.lean
+++ b/Zcash/Snark/Core.lean
@@ -1,7 +1,3 @@
-/-
-Copyright (c) 2026 Ironwood Contributors.
-Released under the Apache License, Version 2.0.
--/
 import Zcash.Arithmetic.Msm
 
 /-!


### PR DESCRIPTION
Nine files carried copyright headers reading "Ironwood Contributors" under the Apache License 2.0 alone. This is [wrong in three ways](https://github.com/zcash/ironwood/pull/99#discussion_r3662094041):

* the attribution is "Copyright 2026 Zcash Protocol Developers";
* the licence is dual MIT / Apache 2.0;
* per-file notices are unnecessary in the first place — the README's Contribution section already places contributions under the dual licence with that copyright holder, so the notice belongs there alone.

This removes all nine headers. The only other copyright mentions in the repo are the licence texts themselves, the README's canonical notice, the vendored Mermaid bundled header, and the fonts' OFL — all deliberately untouched.

🤖 Claude Fable 5