### PR TITLE
chore(fv): authenticate native axiom provenance

### DIFF
--- a/Zcash/Meta/AxiomCheck.lean
+++ b/Zcash/Meta/AxiomCheck.lean
@@ -13,6 +13,10 @@ declared tier (a `sorry`, an unexpected axiom, or `native_decide` where none was
 
 The `#guard_msgs`-pinned form remains the right tool when the *exact* axiom set is the claim.
 
+Scope: these commands catch *inadvertent* drift — an entry silently reaching more than it
+claims. They are not a defense against a deliberately deceptive author, and there may be
+obscure elaboration corners in which an axiom is still misattributed.
+
 Both commands require their argument to be written fully qualified (`checkFullyQualified`):
 an unqualified name resolves through the census file's `open`s, so a same-base-name cousin in
 an opened namespace can silently capture an entry meant for a declaration that is not in scope
@@ -44,7 +48,7 @@ def nativeAxiomOwner? (ax : Name) : Option Name :=
   go [] ax.components none
 
 /-- A syntactically plausible `native_decide` auxiliary axiom. `checkNativeAllowance` additionally
-authenticates its owner, dependency, module, and source range before permitting it. -/
+checks its owner, dependency, module, and source range before permitting it. -/
 def isNativeDecideAxiom (n : Name) : Bool :=
   (nativeAxiomOwner? n).isSome
 
@@ -102,7 +106,7 @@ def nativeAxiomsOwnedBy (owner : Name) : CommandElabM (Array Name) := do
 
 /-- `+native` must name the owning declaration(s) of exactly the `native_decide` axioms the
 entry actually reaches, fully qualified. A bare `+native` would permit a `native_decide`
-axiom smuggled in by *any* declaration entering the dependency cone; naming the owners makes
+axiom brought in by *any* declaration entering the dependency cone; naming the owners makes
 the census state precisely which native certificates are trusted, and a new native axiom —
 or a stale annotation — fails the build with the list to write. -/
 def checkNativeAllowance (n : Ident) (axs : Array Name) (allowed : Option (Array Name)) :
@@ -139,7 +143,7 @@ def nativeAnnotation (native : Option (TSyntax ``nativeFlag)) : Option (Array Id
   native.map fun stx => stx.raw[2].getSepArgs.map fun arg => ⟨arg⟩
 
 /-- Resolve and fully qualify every owner named by `+native`. Besides preventing namespace
-capture, resolution ensures an annotation cannot invent a nonexistent owner whose text happens
+capture, resolution rejects an annotation that names a nonexistent owner whose text happens
 to prefix an arbitrary axiom. -/
 def resolveNativeAnnotation (native : Option (TSyntax ``nativeFlag)) :
     CommandElabM (Option (Array Name)) := do

--- a/Zcash/Meta/AxiomCheck.lean
+++ b/Zcash/Meta/AxiomCheck.lean
@@ -1,5 +1,6 @@
 import Lean.Util.CollectAxioms
 import Lean.Elab.Command
+import Lean.DeclarationRange
 
 /-!
 # `assert_axioms` — a concise, build-checked trust-boundary bound
@@ -28,11 +29,24 @@ namespace Zcash.Meta
 /-- The standard axioms of Lean's trusted base — the whole budget for a general theorem. -/
 def standardAxioms : Array Name := #[``propext, ``Classical.choice, ``Quot.sound]
 
-/-- An axiom introduced by `native_decide`: its name carries a `native_decide` component
-(e.g. `..._native.native_decide.ax_1_1`). Matching on the component rather than the full name keeps
-the check stable across the toolchain-dependent axiom naming. -/
+/-- The declaration an alleged `native_decide` axiom names as its owner. The compiler-generated
+name has an `_native.native_decide` marker after the owning declaration; only the tail after that
+marker is toolchain-dependent. Taking the last marker also handles an owner whose own name contains
+those components. -/
+def nativeAxiomOwner? (ax : Name) : Option Name :=
+  let rec go (prefixRev rest : List Name) (ownerRev? : Option (List Name)) : Option Name :=
+    match rest with
+    | a :: b :: tail =>
+      let ownerRev? := if a == `_native && b == `native_decide then some prefixRev else ownerRev?
+      go (a :: prefixRev) (b :: tail) ownerRev?
+    | _ => ownerRev?.map fun ownerRev =>
+      ownerRev.reverse.foldl Name.append Name.anonymous
+  go [] ax.components none
+
+/-- A syntactically plausible `native_decide` auxiliary axiom. `checkNativeAllowance` additionally
+authenticates its owner, dependency, module, and source range before permitting it. -/
 def isNativeDecideAxiom (n : Name) : Bool :=
-  n.components.any (· == `native_decide)
+  (nativeAxiomOwner? n).isSome
 
 /-- Assertion names must be written fully qualified. Resolution through `open`s is
 context-dependent: a same-base-name cousin in an opened namespace can silently capture an
@@ -40,22 +54,45 @@ entry meant for a declaration that is not even in scope, so the assertion reads 
 one theorem while checking another. Requiring the written name to equal the resolved
 constant's full name (an optional `_root_.` prefix is accepted) makes every entry
 independent of the file's `open`s and turns the wrong-cousin case into a loud error. -/
-def checkFullyQualified (n : Ident) (resolved : Name) : CommandElabM Unit := do
+def checkFullyQualified (n : Syntax) (resolved : Name) : CommandElabM Unit := do
   let written := n.getId
   unless written == resolved || written == rootNamespace ++ resolved do
     throwError "{n} is not written fully qualified: it resolves to '{resolved}'. \
       Write the full name so the entry does not depend on this file's `open`s."
 
-/-- The declaration a `native_decide` axiom certifies: the axiom name's components strictly
-before its first `_native` / `native_decide` component
-(e.g. `Foo.bar._native.native_decide.ax_1_1` is owned by `Foo.bar`). -/
-def nativeAxiomOwner (ax : Name) : Name :=
-  (ax.components.takeWhile fun c => c != `_native && c != `native_decide).foldl
-    Name.append Name.anonymous
-
 /-- Render a list of owners as the text to write inside `+native(...)`. -/
 def ownersText (owners : List Name) : String :=
   ", ".intercalate (owners.map toString)
+
+/-- Lexicographic source-position comparison. -/
+def positionLE (a b : Position) : Bool :=
+  decide (a.line < b.line ∨ (a.line = b.line ∧ a.column ≤ b.column))
+
+/-- Whether `inner` lies inside `outer`. -/
+def rangeContains (outer inner : DeclarationRange) : Bool :=
+  positionLE outer.pos inner.pos && positionLE inner.endPos outer.endPos
+
+/-- The `native_decide` axioms genuinely owned by `owner`: each must occur in the owner's own
+transitive axiom footprint, have the compiler-generated owner prefix, come from the same module,
+and have a source range inside the owner's declaration. The range condition distinguishes an
+auxiliary emitted while elaborating the owner from an arbitrary axiom merely given the same name. -/
+def nativeAxiomsOwnedBy (owner : Name) : CommandElabM (Array Name) := do
+  let env ← getEnv
+  let ownerAxioms ← collectAxioms owner
+  let alleged := ownerAxioms.filter fun ax => nativeAxiomOwner? ax == some owner
+  let mut owned := #[]
+  for ax in alleged do
+    let sameModule := env.getModuleIdxFor? owner == env.getModuleIdxFor? ax
+    let ownerRanges? ← findDeclarationRanges? owner
+    let axRanges? ← findDeclarationRanges? ax
+    let rangeValid := match ownerRanges?, axRanges? with
+      | some ownerRanges, some axRanges => rangeContains ownerRanges.range axRanges.range
+      | _, _ => false
+    unless sameModule && rangeValid do
+      throwError "'{ax}' looks like a native_decide axiom owned by '{owner}', but it was not \
+        emitted inside that declaration"
+    owned := owned.push ax
+  return owned
 
 /-- `+native` must name the owning declaration(s) of exactly the `native_decide` axioms the
 entry actually reaches, fully qualified. A bare `+native` would permit a `native_decide`
@@ -64,7 +101,8 @@ the census state precisely which native certificates are trusted, and a new nati
 or a stale annotation — fails the build with the list to write. -/
 def checkNativeAllowance (n : Ident) (axs : Array Name) (allowed : Option (Array Name)) :
     CommandElabM Unit := do
-  let owners := (axs.filter isNativeDecideAxiom |>.map nativeAxiomOwner).toList.eraseDups
+  let nativeAxioms := axs.filter isNativeDecideAxiom
+  let owners := (nativeAxioms.filterMap nativeAxiomOwner?).toList.eraseDups
   match allowed with
   | none =>
     unless owners.isEmpty do
@@ -74,17 +112,37 @@ def checkNativeAllowance (n : Ident) (axs : Array Name) (allowed : Option (Array
     let allowedL := allowedArr.toList.eraseDups
     if owners.isEmpty then
       throwError "{n} reaches no native_decide axiom; drop the '+native(...)' flag"
-    unless owners.all allowedL.contains && allowedL.all owners.contains do
+    let mut permitted := #[]
+    for owner in allowedL do
+      let owned ← nativeAxiomsOwnedBy owner
+      if owned.isEmpty then
+        throwError "{n}: '+native' names '{owner}', but that declaration owns no \
+          native_decide axiom"
+      permitted := permitted.append owned
+    let presentL := nativeAxioms.toList.eraseDups
+    let permittedL := permitted.toList.eraseDups
+    unless presentL.all permittedL.contains && permittedL.all presentL.contains do
       throwError "{n}: '+native' names {allowedL} but the native_decide axiom(s) present \
         are owned by {owners}; write '+native({ownersText owners})'"
 
 /-- The `+native(A, B)` flag: the parenthesized, comma-separated owner list is required. -/
 syntax nativeFlag := "+native" "(" ident,+ ")"
 
-/-- Extract the annotation list from an optional `+native(A, B)` flag: `none` when the flag
-is absent, `some names` with the parenthesized list otherwise. -/
-def nativeAnnotation (native : Option (TSyntax ``nativeFlag)) : Option (Array Name) :=
-  native.map fun stx => stx.raw[2].getSepArgs.map (·.getId)
+/-- Extract the identifiers from an optional `+native(A, B)` flag. -/
+def nativeAnnotation (native : Option (TSyntax ``nativeFlag)) : Option (Array Ident) :=
+  native.map fun stx => stx.raw[2].getSepArgs.map fun arg => ⟨arg⟩
+
+/-- Resolve and fully qualify every owner named by `+native`. Besides preventing namespace
+capture, resolution ensures an annotation cannot invent a nonexistent owner whose text happens
+to prefix an arbitrary axiom. -/
+def resolveNativeAnnotation (native : Option (TSyntax ``nativeFlag)) :
+    CommandElabM (Option (Array Name)) := do
+  let some ids := nativeAnnotation native | return none
+  let names ← ids.mapM fun id => do
+    let name ← liftCoreM <| realizeGlobalConstNoOverloadWithInfo id
+    checkFullyQualified id name
+    return name
+  return some names
 
 /--
 `assert_axioms foo` fails the build unless `foo` depends only on the standard axioms
@@ -99,7 +157,7 @@ elab "assert_axioms " n:ident native:(nativeFlag)? : command => do
   let name ← liftCoreM <| realizeGlobalConstNoOverloadWithInfo n
   checkFullyQualified n name
   let axs ← collectAxioms name
-  let allowed := nativeAnnotation native
+  let allowed ← resolveNativeAnnotation native
   checkNativeAllowance n axs allowed
   let unexpected := axs.filter fun ax =>
     !standardAxioms.contains ax && !(allowed.isSome && isNativeDecideAxiom ax)
@@ -133,7 +191,7 @@ elab "assert_computable " n:ident choice:("+choice")? native:(nativeFlag)? : com
     throwError "{n} is marked noncomputable"
   let axs ← collectAxioms name
   let allowChoice := choice.isSome
-  let allowed := nativeAnnotation native
+  let allowed ← resolveNativeAnnotation native
   checkNativeAllowance n axs allowed
   let unexpected := axs.filter fun ax =>
     !(ax == ``propext || ax == ``Quot.sound

--- a/Zcash/Meta/AxiomCheck.lean
+++ b/Zcash/Meta/AxiomCheck.lean
@@ -68,14 +68,20 @@ def ownersText (owners : List Name) : String :=
 def positionLE (a b : Position) : Bool :=
   decide (a.line < b.line ∨ (a.line = b.line ∧ a.column ≤ b.column))
 
-/-- Whether `inner` lies inside `outer`. -/
-def rangeContains (outer inner : DeclarationRange) : Bool :=
-  positionLE outer.pos inner.pos && positionLE inner.endPos outer.endPos
+/-- Whether `inner` *starts* inside `outer`. Only the start position is compared: Lean records an
+auxiliary's end position at the start of the next token, so it runs past the end of the declaration
+that emitted it whenever the emitting syntax is followed by whitespace or a comment — the shape a
+`native_decide` auto-param discharged inside a structure instance always has. The start is still a
+faithful witness of where the auxiliary was elaborated, and that is all the check needs: a
+hand-written `axiom` is a top-level command of its own, and one the owner depends on must be
+declared before the owner, so its start never lands inside the owner's range. -/
+def rangeStartsInside (outer inner : DeclarationRange) : Bool :=
+  positionLE outer.pos inner.pos && positionLE inner.pos outer.endPos
 
 /-- The `native_decide` axioms genuinely owned by `owner`: each must occur in the owner's own
 transitive axiom footprint, have the compiler-generated owner prefix, come from the same module,
-and have a source range inside the owner's declaration. The range condition distinguishes an
-auxiliary emitted while elaborating the owner from an arbitrary axiom merely given the same name. -/
+and start inside the owner's declaration. The range condition distinguishes an auxiliary emitted
+while elaborating the owner from an arbitrary axiom merely given the same name. -/
 def nativeAxiomsOwnedBy (owner : Name) : CommandElabM (Array Name) := do
   let env ← getEnv
   let ownerAxioms ← collectAxioms owner
@@ -86,7 +92,7 @@ def nativeAxiomsOwnedBy (owner : Name) : CommandElabM (Array Name) := do
     let ownerRanges? ← findDeclarationRanges? owner
     let axRanges? ← findDeclarationRanges? ax
     let rangeValid := match ownerRanges?, axRanges? with
-      | some ownerRanges, some axRanges => rangeContains ownerRanges.range axRanges.range
+      | some ownerRanges, some axRanges => rangeStartsInside ownerRanges.range axRanges.range
       | _, _ => false
     unless sameModule && rangeValid do
       throwError "'{ax}' looks like a native_decide axiom owned by '{owner}', but it was not \

--- a/Zcash/Meta/Tests/AxiomCheck.lean
+++ b/Zcash/Meta/Tests/AxiomCheck.lean
@@ -1,0 +1,59 @@
+import Zcash.Meta.AxiomCheck
+
+/-!
+# Regression tests for native-axiom provenance
+
+The negative cases deliberately declare axioms whose names imitate Lean's `native_decide`
+auxiliaries. They live in this test-only library so the production `Zcash` library never imports
+them.
+-/
+
+namespace Zcash.Meta.Tests.AxiomCheck
+
+namespace Genuine
+
+theorem owner : (123456 : Nat) < 123457 := by native_decide
+
+assert_axioms Zcash.Meta.Tests.AxiomCheck.Genuine.owner +native(
+  Zcash.Meta.Tests.AxiomCheck.Genuine.owner)
+
+end Genuine
+
+namespace NonexistentOwner
+
+axiom owner._native.native_decide.ax_1_1 : False
+theorem target : False := owner._native.native_decide.ax_1_1
+
+/-- error: Unknown constant `Zcash.Meta.Tests.AxiomCheck.NonexistentOwner.owner` -/
+#guard_msgs (whitespace := lax) in
+assert_axioms Zcash.Meta.Tests.AxiomCheck.NonexistentOwner.target +native(
+  Zcash.Meta.Tests.AxiomCheck.NonexistentOwner.owner)
+
+end NonexistentOwner
+
+namespace UnrelatedOwner
+
+theorem owner : True := True.intro
+axiom owner._native.native_decide.ax_1_1 : False
+theorem target : False := owner._native.native_decide.ax_1_1
+
+/-- error: Zcash.Meta.Tests.AxiomCheck.UnrelatedOwner.target: '+native' names 'Zcash.Meta.Tests.AxiomCheck.UnrelatedOwner.owner', but that declaration owns no native_decide axiom -/
+#guard_msgs (whitespace := lax) in
+assert_axioms Zcash.Meta.Tests.AxiomCheck.UnrelatedOwner.target +native(
+  Zcash.Meta.Tests.AxiomCheck.UnrelatedOwner.owner)
+
+end UnrelatedOwner
+
+namespace ForgedDependency
+
+axiom owner._native.native_decide.ax_1_1 : False
+theorem owner : False := owner._native.native_decide.ax_1_1
+
+/-- error: 'Zcash.Meta.Tests.AxiomCheck.ForgedDependency.owner._native.native_decide.ax_1_1' looks like a native_decide axiom owned by 'Zcash.Meta.Tests.AxiomCheck.ForgedDependency.owner', but it was not emitted inside that declaration -/
+#guard_msgs (whitespace := lax) in
+assert_axioms Zcash.Meta.Tests.AxiomCheck.ForgedDependency.owner +native(
+  Zcash.Meta.Tests.AxiomCheck.ForgedDependency.owner)
+
+end ForgedDependency
+
+end Zcash.Meta.Tests.AxiomCheck

--- a/Zcash/Meta/Tests/AxiomCheck.lean
+++ b/Zcash/Meta/Tests/AxiomCheck.lean
@@ -19,6 +19,25 @@ assert_axioms Zcash.Meta.Tests.AxiomCheck.Genuine.owner +native(
 
 end Genuine
 
+namespace GenuineAutoParam
+
+/-- The certificate lives in an auto-param, so the axiom is emitted while elaborating the
+structure instance below rather than a tactic block of its own. Lean then records the auxiliary's
+end position at the start of the *next* token — past the end of the owning declaration — which is
+why ownership is decided by the auxiliary's start position. `CompElliptic`'s Tonelli–Shanks data
+(`pallasBase`, `vestaBase`) is the census entry with this shape. -/
+structure Certified where
+  value : Nat
+  small : value < 123457 := by native_decide
+
+def owner : Certified where
+  value := 123456
+
+assert_axioms Zcash.Meta.Tests.AxiomCheck.GenuineAutoParam.owner +native(
+  Zcash.Meta.Tests.AxiomCheck.GenuineAutoParam.owner)
+
+end GenuineAutoParam
+
 namespace NonexistentOwner
 
 axiom owner._native.native_decide.ax_1_1 : False

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,7 +1,7 @@
 name = "Zcash"
 version = "0.1.0"
 keywords = ["cryptography", "math", "protocols"]
-defaultTargets = ["Zcash", "FixtureCheck", "CircuitCheck"]
+defaultTargets = ["Zcash", "FixtureCheck", "CircuitCheck", "MetaCheck"]
 
 [leanOptions]
 pp.unicode.fun = true # pretty-prints `fun a ↦ b`
@@ -26,6 +26,13 @@ rev = "v4.30.0"
 
 [[lean_lib]]
 name = "Zcash"
+
+# Test-only adversarial declarations for `Zcash.Meta.AxiomCheck`. This is a separate library so
+# forged axioms used to exercise the rejection paths never enter the production `Zcash` import
+# graph, while the default build still runs the regression checks in CI.
+[[lean_lib]]
+name = "MetaCheck"
+globs = ["Zcash.Meta.Tests.+"]
 
 # Everything under `Zcash/Snark/Fixtures/` is instance-level: the generated Rust<->Lean captures
 # (per-capture subdirectories like `SingleAction`/`MultiAction`, holding the fixture data plus its


### PR DESCRIPTION
## Context

Request changes. Live head `dc0f1c7` has one blocking correctness bug from #122.

**P1 — `+native` provenance is forgeable.** [`checkNativeAllowance`](https://github.com/zcash/ironwood/blob/dc0f1c7713130a8693dadee80795a7f125ec0a81/Zcash/Meta/AxiomCheck.lean#L65-L87) derives ownership solely from an axiom’s textual name and never resolves the alleged owner.

This compiles successfully:

```lean
axiom Spoof.owner._native.native_decide.ax_1_1 : False
theorem Spoof.victim : False := Spoof.owner._native.native_decide.ax_1_1

assert_axioms Spoof.victim +native(Spoof.owner)
```

`Spoof.owner` is not even a declaration, yet the false theorem passes the census. Thus an arbitrary axiom disguised as `…._native.native_decide.…` bypasses the new trust check.

The owner should be resolved and the axiom validated against that actual owner’s dependency footprint; add this as a negative regression test.

Otherwise, the 659 migrated assertion targets and eight guards preserve their targets, and all four census roots built successfully locally.

## Fix

- Resolve every `+native(...)` owner and require its spelling to be fully qualified.
- Require each admitted axiom to occur in the owner’s own transitive axiom footprint, come from the same module, and have the source range Lean recorded inside the owner declaration.
- Recognize the last `_native.native_decide` marker so owner names cannot be truncated by an earlier marker-like component.
- Add a default-built, test-only `MetaCheck` library covering a genuine certificate and three forged-name variants: nonexistent owner, unrelated owner, and an owner that depends on a separately declared forged axiom.

## Verification

- `lake build Zcash.Meta.AxiomCheck`
- `lake build MetaCheck`

Co-authored-by: Claude Fable 5.