### PR TITLE
Replace CF with flatten VerifierIpa and centralized expression

### DIFF
--- a/Zcash/Snark.lean
+++ b/Zcash/Snark.lean
@@ -62,6 +62,7 @@ import Zcash.Snark.Soundness.Canonical.InstanceCommitment
 -- Deployed halo2-verifier soundness path: peel the deployed IPA (U/W/S apparatus) onto the clean
 -- `ipa_soundV`, with commitment binding expressed as a discrete-log-relation reduction.
 import Zcash.Snark.Soundness.Deployed.Binding
+import Zcash.Snark.Soundness.Deployed.Flat
 import Zcash.Snark.Soundness.Deployed.Fold
 import Zcash.Snark.Soundness.Deployed.Ipa
 import Zcash.Snark.Soundness.Deployed.IpaPeel

--- a/Zcash/Snark/Soundness/AGM/PinnedRootWitness.lean
+++ b/Zcash/Snark/Soundness/AGM/PinnedRootWitness.lean
@@ -57,7 +57,7 @@ theorem multiopenCommitment_witness_zero
       witnessVk witnessIc witnessPs (chRecord ν (fun _ => 0)) = 0 := by
   simp [multiopenCommitment, assembleQueries, witnessVk, witnessPs, witnessShape, witnessIc,
     vanishingQueries, columnQueries, permutationCommonQueries, vanishingHCommitment,
-    constructIntermediateSets, assembleOpening, compressSet, Msm.eval, Msm.zero,
+    constructIntermediateSets, openedPair, assembleOpening, compressSet, Msm.eval, Msm.zero,
     accumulateCommitment, List.ofFn_zero, multiopenCombine, Msm.appendTerm, Msm.scale,
     Msm.add, expectedHEval, allExpressions, subProofExpressions, List.findIdx]
 
@@ -560,7 +560,7 @@ theorem multiopenValue_witness_zero (ch : Challenges witnessShape.k Fp) :
     multiopenValue witnessVk witnessIc witnessPs ch = 0 := by
   simp [multiopenValue, assembleQueries, witnessVk, witnessPs, witnessShape, witnessIc,
     vanishingQueries, columnQueries, permutationCommonQueries, vanishingHCommitment,
-    constructIntermediateSets, assembleOpening, compressSet, Msm.zero,
+    constructIntermediateSets, openedPair, assembleOpening, compressSet, Msm.zero,
     accumulateCommitment, List.ofFn_zero, multiopenCombine, Msm.appendTerm, Msm.scale,
     Msm.add, expectedHEval, allExpressions, subProofExpressions, List.findIdx,
     multiopenEval]

--- a/Zcash/Snark/Soundness/Deployed/Flat.lean
+++ b/Zcash/Snark/Soundness/Deployed/Flat.lean
@@ -1,0 +1,75 @@
+import Zcash.Snark.Soundness.Deployed.Fold
+
+/-!
+# The closed form of the deployed IPA verifier equation
+
+halo2's IPA verifier checks one group identity, the *closed form*:
+
+`P' + Σⱼ([uⱼ⁻¹]Lⱼ + [uⱼ]Rⱼ) + [-c·b·z]U + [-f]W + [-c]G'₀ = 0`
+
+`Lⱼ`/`Rⱼ` are the round points and `uⱼ` the round challenges; `c` and `f` are the prover's final
+scalar and blinding; `b` is the folded eval vector; `G'₀` is the fully folded generator; `U` and `W`
+are the inner-product and blinding generators.
+
+## What this module names
+
+* `adjustedCommitment` — the *adjusted commitment* `P' = P − [v]g₀ + [ξ]S`: the commitment being
+  opened, with the claimed value `v` folded into the first generator and the opening's synthetic
+  blinding `[ξ]S` added.
+* `roundSum` — the round total `Σⱼ([uⱼ⁻¹]Lⱼ + [uⱼ]Rⱼ)`.
+* `CF` — the identity's whole left side, with *abstract* `U` and `W` coefficients. Keeping them
+  abstract is what lets the forking proof feed `CF` round points represented over `(g, U, W)`;
+  `CF_cons` folds one such round into the commitment and those two coefficients exactly as the
+  recursive verifier folds it.
+
+Nothing here mentions the halo2 assembly: `Deployed.Verification` instantiates `CF` at it, and
+`Forking.Assembly` runs the fold. Challenge vectors are lists, mirroring halo2's list-shaped code.
+-/
+
+namespace Zcash.Snark
+
+variable {F G : Type*} [Field F] [AddCommGroup G] [Module F G]
+
+/-- The *adjusted commitment* the IPA verifier opens: `P' = P − [v]g₀ + [ξ]S`, for a commitment `P`
+claimed to open to `v`, blinded by `[ξ]S` (halo2 `poly/commitment/verifier.rs`). The value term is
+spelled as the singleton-list sum `Msm.eval` produces — `[-v]` read at index `0` and zero elsewhere
+— so the deployed assembly's evaluation matches it term for term. -/
+def adjustedCommitment {n : ℕ} (g : Fin n → G) (P : G) (v ξ : F) (S : G) : G :=
+  P + (∑ i, ([-v].getD i.val 0) • g i) + ξ • S
+
+/-- The sum `Σⱼ ([uⱼ⁻¹]Lⱼ + [uⱼ]Rⱼ)` contributed by the IPA rounds. -/
+def roundSum (rounds : List (G × G)) (u : List F) : G :=
+  ((rounds.zip u).map (fun p => p.2⁻¹ • p.1.1 + p.2 • p.1.2)).sum
+
+@[simp] theorem roundSum_nil_rounds (u : List F) : roundSum ([] : List (G × G)) u = 0 := by
+  simp [roundSum]
+
+@[simp] theorem roundSum_nil_challenges (rounds : List (G × G)) : roundSum rounds ([] : List F) = 0 := by
+  simp [roundSum, List.zip_nil_right]
+
+/-- Split the first round's contribution from `roundSum`. -/
+theorem roundSum_cons (L R : G) (rounds : List (G × G)) (u₀ : F) (u : List F) :
+    roundSum ((L, R) :: rounds) (u₀ :: u) = (u₀⁻¹ • L + u₀ • R) + roundSum rounds u := by
+  simp [roundSum]
+
+/-- The closed-form verifier equation's left side, with abstract coefficients for `U` and `W`:
+`P + Σⱼ([uⱼ⁻¹]Lⱼ + [uⱼ]Rⱼ) + [Uc]U + [Wc]W + [-c]G'₀`, where `P` is the adjusted commitment and the
+folded generator is `G'₀ = foldAll u g 0`. -/
+def CF (rounds : List (G × G)) (u : List F) (g : Fin (2 ^ u.length) → G) (P : G) (c : F)
+    (Uc : F) (U : G) (Wc : F) (W : G) : G :=
+  P + roundSum rounds u + Uc • U + Wc • W + (-c) • foldAll u g 0
+
+/-- Fold one represented round point through the closed form. With `Lⱼ` and `Rⱼ` given as
+`Lg + [Lv]U + [Lw]W` and `Rg + [Rv]U + [Rw]W`, the round's `g`-parts move into the commitment
+(`P + [u₀⁻¹]Lg + [u₀]Rg`) and its `U`- and `W`-parts into those coefficients, while one challenge
+leaves both the round sum and the generator fold. This is the same commitment, value, and blinding
+recursion `DeployedIpaAcceptV` runs. -/
+theorem CF_cons (Lg Rg U W : G) (Lv Lw Rv Rw : F) (rounds : List (G × G)) (u₀ : F) (u : List F)
+    (g : Fin (2 ^ (u₀ :: u).length) → G) (P : G) (c Uc Wc : F) :
+    CF ((Lg + Lv • U + Lw • W, Rg + Rv • U + Rw • W) :: rounds) (u₀ :: u) g P c Uc U Wc W
+      = CF rounds u (foldGens g u₀⁻¹) (P + u₀⁻¹ • Lg + u₀ • Rg) c
+          (Uc + u₀⁻¹ * Lv + u₀ * Rv) U (Wc + u₀⁻¹ * Lw + u₀ * Rw) W := by
+  simp only [CF, roundSum_cons, foldAll]
+  module
+
+end Zcash.Snark

--- a/Zcash/Snark/Soundness/Deployed/Flat.lean
+++ b/Zcash/Snark/Soundness/Deployed/Flat.lean
@@ -16,11 +16,13 @@ are the inner-product and blinding generators.
 * `adjustedCommitment` — the *adjusted commitment* `P' = P − [v]g₀ + [ξ]S`: the commitment being
   opened, with the claimed value `v` folded into the first generator and the opening's synthetic
   blinding `[ξ]S` added.
+* `valueScalar` — the value `-c·b·z` the inner-product generator's coefficient carries when the
+  equation comes from a transcript.
 * `VerifierIpa` — the identity's whole left side as a structure with named fields, read against the
   generators by `VerifierIpa.eval`. Its `U` and `W` coefficients are *abstract*, which is what lets
   the forking proof feed it round points represented over `(g, U, W)`. `eval_peel` folds one round
-  into the commitment exactly as the recursive verifier does, and `leaf` is the depth-zero shape the
-  fork tree checks.
+  into the commitment exactly as the recursive verifier does; `leaf`/`eval_leaf` are the depth-zero
+  shape the fork tree checks.
 
 The structure indexes its rounds and challenges by `Fin d`, while halo2's code — and so `foldAll`,
 `computeB`, and the multiopen assembly — is list-shaped. `roundSum`/`roundSumFin_eq` and
@@ -41,6 +43,16 @@ spelled as the singleton-list sum `Msm.eval` produces — `[-v]` read at index `
 — so the deployed assembly's evaluation matches it term for term. -/
 def adjustedCommitment {n : ℕ} (g : Fin n → G) (P : G) (v ξ : F) (S : G) : G :=
   P + (∑ i, ([-v].getD i.val 0) • g i) + ξ • S
+
+/-- The value `VerifierIpa.uScalar` carries when the equation comes from a transcript: `-c·b·z`, the
+coefficient halo2 adds to the inner-product generator's scalar (`add_to_u_scalar`). It binds the
+claimed value through the folded eval vector `b` and the challenge `z`.
+
+Not the same thing as the `uScalar` field, which stays an arbitrary coefficient — the fork tree's
+leaves set it to `-z·c·b₀` written another way. One name here keeps the deployed side (`b` is
+`computeB`) and the fold side (`b` is `foldAllFin`) in a single spelling, so they differ only in
+`b` and `foldAllFin_evalVector` reconciles them. -/
+def valueScalar (c b z : F) : F := -c * b * z
 
 /-- The sum `Σⱼ ([uⱼ⁻¹]Lⱼ + [uⱼ]Rⱼ)` contributed by the IPA rounds, over lists — the shape the
 multiopen assembly produces. `roundSumFin_eq` reads it as the depth-indexed `roundSumFin`. -/
@@ -154,8 +166,8 @@ theorem eval_peel {d : ℕ} (e : VerifierIpa (d + 1) F G) (g : Fin (2 ^ (d + 1))
   simp only [eval, peel, roundSumFin, foldAllFin]
   abel
 
-/-- The depth-zero equation: no rounds and no challenges, so `eval` reduces to
-`P + [Uc]U + [Wc]W + [-c]g₀`. This is the shape the fork tree's leaves check. -/
+/-- The depth-zero equation: no rounds and no challenges left, only the commitment, the two
+coefficients, and the final scalar. This is the shape the fork tree's leaves check. -/
 def leaf (P : G) (c Uc Wc : F) : VerifierIpa 0 F G where
   commitment := P
   rounds := Fin.elim0
@@ -163,6 +175,12 @@ def leaf (P : G) (c Uc Wc : F) : VerifierIpa 0 F G where
   final := c
   uScalar := Uc
   wScalar := Wc
+
+/-- The depth-zero equation reads `P + [Uc]U + [Wc]W + [-c]g₀`: the round sum is empty and the
+generator fold is the single remaining generator. -/
+theorem eval_leaf (P : G) (c Uc Wc : F) (g : Fin (2 ^ 0) → G) (U W : G) :
+    (leaf P c Uc Wc).eval g U W = P + Uc • U + Wc • W + (-c) • g 0 := by
+  simp only [eval, leaf, roundSumFin, foldAllFin, add_zero]
 
 end VerifierIpa
 

--- a/Zcash/Snark/Soundness/Deployed/Flat.lean
+++ b/Zcash/Snark/Soundness/Deployed/Flat.lean
@@ -16,18 +16,19 @@ are the inner-product and blinding generators.
 * `adjustedCommitment` — the *adjusted commitment* `P' = P − [v]g₀ + [ξ]S`: the commitment being
   opened, with the claimed value `v` folded into the first generator and the opening's synthetic
   blinding `[ξ]S` added.
-* `roundSum` — the round total `Σⱼ([uⱼ⁻¹]Lⱼ + [uⱼ]Rⱼ)`.
-* `CF` — the identity's whole left side, with *abstract* `U` and `W` coefficients. Keeping them
-  abstract is what lets the forking proof feed `CF` round points represented over `(g, U, W)`;
-  `CF_cons` folds one such round into the commitment and those two coefficients exactly as the
-  recursive verifier folds it.
-* `VerifierIpa` — the same left side as a structure with named fields, evaluated by
-  `VerifierIpa.eval`. `eval_eq_CF` connects the two.
+* `VerifierIpa` — the identity's whole left side as a structure with named fields, read against the
+  generators by `VerifierIpa.eval`. Its `U` and `W` coefficients are *abstract*, which is what lets
+  the forking proof feed it round points represented over `(g, U, W)`. `eval_peel` folds one round
+  into the commitment exactly as the recursive verifier does, and `leaf` is the depth-zero shape the
+  fork tree checks.
+
+The structure indexes its rounds and challenges by `Fin d`, while halo2's code — and so `foldAll`,
+`computeB`, and the multiopen assembly — is list-shaped. `roundSum`/`roundSumFin_eq` and
+`foldAllFin`/`foldAllFin_eq` are the two crossings, and `Deployed.Verification` pays them once when
+it reads the assembly's output as a `VerifierIpa`.
 
 Nothing here mentions the halo2 assembly: `Deployed.Verification` instantiates the equation at it,
-and `Forking.Assembly` runs the fold. `CF`'s challenge vectors are lists, mirroring halo2's
-list-shaped code; `foldAllFin` and `foldAllFin_eq` are where the `Fin d`-indexed tree side crosses
-over.
+and `Forking.Assembly` runs the fold.
 -/
 
 namespace Zcash.Snark
@@ -41,40 +42,15 @@ spelled as the singleton-list sum `Msm.eval` produces — `[-v]` read at index `
 def adjustedCommitment {n : ℕ} (g : Fin n → G) (P : G) (v ξ : F) (S : G) : G :=
   P + (∑ i, ([-v].getD i.val 0) • g i) + ξ • S
 
-/-- The sum `Σⱼ ([uⱼ⁻¹]Lⱼ + [uⱼ]Rⱼ)` contributed by the IPA rounds. -/
+/-- The sum `Σⱼ ([uⱼ⁻¹]Lⱼ + [uⱼ]Rⱼ)` contributed by the IPA rounds, over lists — the shape the
+multiopen assembly produces. `roundSumFin_eq` reads it as the depth-indexed `roundSumFin`. -/
 def roundSum (rounds : List (G × G)) (u : List F) : G :=
   ((rounds.zip u).map (fun p => p.2⁻¹ • p.1.1 + p.2 • p.1.2)).sum
-
-@[simp] theorem roundSum_nil_rounds (u : List F) : roundSum ([] : List (G × G)) u = 0 := by
-  simp [roundSum]
-
-@[simp] theorem roundSum_nil_challenges (rounds : List (G × G)) : roundSum rounds ([] : List F) = 0 := by
-  simp [roundSum, List.zip_nil_right]
 
 /-- Split the first round's contribution from `roundSum`. -/
 theorem roundSum_cons (L R : G) (rounds : List (G × G)) (u₀ : F) (u : List F) :
     roundSum ((L, R) :: rounds) (u₀ :: u) = (u₀⁻¹ • L + u₀ • R) + roundSum rounds u := by
   simp [roundSum]
-
-/-- The closed-form verifier equation's left side, with abstract coefficients for `U` and `W`:
-`P + Σⱼ([uⱼ⁻¹]Lⱼ + [uⱼ]Rⱼ) + [Uc]U + [Wc]W + [-c]G'₀`, where `P` is the adjusted commitment and the
-folded generator is `G'₀ = foldAll u g 0`. -/
-def CF (rounds : List (G × G)) (u : List F) (g : Fin (2 ^ u.length) → G) (P : G) (c : F)
-    (Uc : F) (U : G) (Wc : F) (W : G) : G :=
-  P + roundSum rounds u + Uc • U + Wc • W + (-c) • foldAll u g 0
-
-/-- Fold one represented round point through the closed form. With `Lⱼ` and `Rⱼ` given as
-`Lg + [Lv]U + [Lw]W` and `Rg + [Rv]U + [Rw]W`, the round's `g`-parts move into the commitment
-(`P + [u₀⁻¹]Lg + [u₀]Rg`) and its `U`- and `W`-parts into those coefficients, while one challenge
-leaves both the round sum and the generator fold. This is the same commitment, value, and blinding
-recursion `DeployedIpaAcceptV` runs. -/
-theorem CF_cons (Lg Rg U W : G) (Lv Lw Rv Rw : F) (rounds : List (G × G)) (u₀ : F) (u : List F)
-    (g : Fin (2 ^ (u₀ :: u).length) → G) (P : G) (c Uc Wc : F) :
-    CF ((Lg + Lv • U + Lw • W, Rg + Rv • U + Rw • W) :: rounds) (u₀ :: u) g P c Uc U Wc W
-      = CF rounds u (foldGens g u₀⁻¹) (P + u₀⁻¹ • Lg + u₀ • Rg) c
-          (Uc + u₀⁻¹ * Lv + u₀ * Rv) U (Wc + u₀⁻¹ * Lw + u₀ * Rw) W := by
-  simp only [CF, roundSum_cons, foldAll]
-  module
 
 /-! ## The generator fold over a `Fin`-indexed challenge vector
 
@@ -114,10 +90,9 @@ theorem foldAllFin_eq : {d : ℕ} → (χ : Fin d → F) → (g : Fin (2 ^ d) �
 
 /-! ## The equation as a syntax object
 
-`CF` takes its nine pieces positionally, so a call site says nothing about which argument is the
-commitment and which is a coefficient. `VerifierIpa` collects them into named fields and `eval`
-reads them against generators — the same split `Msm` (`Core.Msm`) gives the fingerprint MSM: the
-scalars live in the object, the URS data arrives at the interpretation.
+The equation's six pieces live in named fields, and `eval` reads them against generators — the same
+split `Msm` (`Core.Msm`) gives the fingerprint MSM: the scalars live in the object, the URS data
+arrives at the interpretation.
 -/
 
 /-- The IPA verifier equation at depth `d` as a syntax object: `commitment` is the adjusted
@@ -145,7 +120,7 @@ def roundSumFin : {d : ℕ} → (Fin d → G × G) → (Fin d → F) → G
 /-- `roundSumFin` is `roundSum` on the corresponding lists. -/
 theorem roundSumFin_eq : {d : ℕ} → (R : Fin d → G × G) → (χ : Fin d → F) →
     roundSumFin R χ = roundSum (List.ofFn R) (List.ofFn χ)
-  | 0, _, _ => by simp [roundSumFin]
+  | 0, _, _ => by simp [roundSumFin, roundSum]
   | d + 1, R, χ => by
       have hR : List.ofFn R = ((R 0).1, (R 0).2) :: List.ofFn (Fin.tail R) := by
         rw [List.ofFn_succ]; rfl
@@ -171,22 +146,23 @@ def peel {d : ℕ} (e : VerifierIpa (d + 1) F G) : VerifierIpa d F G where
   uScalar := e.uScalar
   wScalar := e.wScalar
 
-/-- Peeling a round changes nothing, once the generators are folded by that round's challenge. The
-`Fin d` counterpart of `CF_cons` at a round point with no `U`/`W` part — and unlike `CF_cons` it
-carries no reindexing, since the generator type mentions only the depth. -/
+/-- Peeling a round changes nothing, once the generators are folded by that round's challenge. This
+is the same commitment recursion `DeployedIpaAcceptV` runs, and it carries no reindexing because the
+generator type mentions only the depth. -/
 theorem eval_peel {d : ℕ} (e : VerifierIpa (d + 1) F G) (g : Fin (2 ^ (d + 1)) → G) (U W : G) :
     e.eval g U W = e.peel.eval (foldGens g (e.challenges 0)⁻¹) U W := by
   simp only [eval, peel, roundSumFin, foldAllFin]
   abel
 
-/-- `eval` is the list-shaped closed form `CF`. This is the one place the `List.ofFn` transport
-between the depth-indexed and list-shaped sides is paid. -/
-theorem eval_eq_CF {d : ℕ} (e : VerifierIpa d F G) (g : Fin (2 ^ d) → G) (U W : G) :
-    e.eval g U W
-      = CF (List.ofFn e.rounds) (List.ofFn e.challenges)
-          (fun j => g (Fin.cast (congrArg (2 ^ ·) List.length_ofFn) j))
-          e.commitment e.final e.uScalar U e.wScalar W := by
-  rw [eval, CF, roundSumFin_eq, foldAllFin_eq]
+/-- The depth-zero equation: no rounds and no challenges, so `eval` reduces to
+`P + [Uc]U + [Wc]W + [-c]g₀`. This is the shape the fork tree's leaves check. -/
+def leaf (P : G) (c Uc Wc : F) : VerifierIpa 0 F G where
+  commitment := P
+  rounds := Fin.elim0
+  challenges := Fin.elim0
+  final := c
+  uScalar := Uc
+  wScalar := Wc
 
 end VerifierIpa
 

--- a/Zcash/Snark/Soundness/Deployed/Flat.lean
+++ b/Zcash/Snark/Soundness/Deployed/Flat.lean
@@ -21,10 +21,13 @@ are the inner-product and blinding generators.
   abstract is what lets the forking proof feed `CF` round points represented over `(g, U, W)`;
   `CF_cons` folds one such round into the commitment and those two coefficients exactly as the
   recursive verifier folds it.
+* `VerifierIpa` — the same left side as a structure with named fields, evaluated by
+  `VerifierIpa.eval`. `eval_eq_CF` connects the two.
 
-Nothing here mentions the halo2 assembly: `Deployed.Verification` instantiates `CF` at it, and
-`Forking.Assembly` runs the fold. Challenge vectors are lists, mirroring halo2's list-shaped code;
-`foldAllFin` and `foldAllFin_eq` are where the `Fin d`-indexed tree side crosses over.
+Nothing here mentions the halo2 assembly: `Deployed.Verification` instantiates the equation at it,
+and `Forking.Assembly` runs the fold. `CF`'s challenge vectors are lists, mirroring halo2's
+list-shaped code; `foldAllFin` and `foldAllFin_eq` are where the `Fin d`-indexed tree side crosses
+over.
 -/
 
 namespace Zcash.Snark
@@ -108,5 +111,83 @@ theorem foldAllFin_eq : {d : ℕ} → (χ : Fin d → F) → (g : Fin (2 ^ d) �
       simp only [Fin.cast_cast]
       exact congrArg (fun gen => foldAll (List.ofFn (Fin.tail χ)) gen 0)
         (foldGens_comp_cast (List.length_ofFn (f := Fin.tail χ)) g (χ 0)⁻¹).symm
+
+/-! ## The equation as a syntax object
+
+`CF` takes its nine pieces positionally, so a call site says nothing about which argument is the
+commitment and which is a coefficient. `VerifierIpa` collects them into named fields and `eval`
+reads them against generators — the same split `Msm` (`Core.Msm`) gives the fingerprint MSM: the
+scalars live in the object, the URS data arrives at the interpretation.
+-/
+
+/-- The IPA verifier equation at depth `d` as a syntax object: `commitment` is the adjusted
+commitment `P'`, `rounds` the round points `(Lⱼ, Rⱼ)` and `challenges` the round challenges `uⱼ`,
+`final` the prover's final scalar `c`, and `uScalar`/`wScalar` the coefficients of the inner-product
+and blinding generators. The generators themselves are supplied to `eval`.
+
+Rounds and challenges are indexed by `Fin d` rather than carried as lists, so `eval`'s generator
+argument has type `Fin (2 ^ d) → G` — mentioning only the depth, never a projection of the object.
+That is what lets `eval_peel` fold a round with no reindexing. -/
+structure VerifierIpa (d : ℕ) (F G : Type*) where
+  commitment : G
+  rounds : Fin d → G × G
+  challenges : Fin d → F
+  final : F
+  uScalar : F
+  wScalar : F
+
+/-- The round total `Σⱼ ([uⱼ⁻¹]Lⱼ + [uⱼ]Rⱼ)` over a `Fin`-indexed round family — `roundSum` with the
+rounds and challenges indexed rather than zipped. -/
+def roundSumFin : {d : ℕ} → (Fin d → G × G) → (Fin d → F) → G
+  | 0, _, _ => 0
+  | _ + 1, R, χ => ((χ 0)⁻¹ • (R 0).1 + χ 0 • (R 0).2) + roundSumFin (Fin.tail R) (Fin.tail χ)
+
+/-- `roundSumFin` is `roundSum` on the corresponding lists. -/
+theorem roundSumFin_eq : {d : ℕ} → (R : Fin d → G × G) → (χ : Fin d → F) →
+    roundSumFin R χ = roundSum (List.ofFn R) (List.ofFn χ)
+  | 0, _, _ => by simp [roundSumFin]
+  | d + 1, R, χ => by
+      have hR : List.ofFn R = ((R 0).1, (R 0).2) :: List.ofFn (Fin.tail R) := by
+        rw [List.ofFn_succ]; rfl
+      have hχ : List.ofFn χ = χ 0 :: List.ofFn (Fin.tail χ) := by rw [List.ofFn_succ]; rfl
+      rw [roundSumFin, roundSumFin_eq (Fin.tail R) (Fin.tail χ), hR, hχ, roundSum_cons]
+
+namespace VerifierIpa
+
+/-- Read the equation's left side against the generators: `P' + Σⱼ([uⱼ⁻¹]Lⱼ + [uⱼ]Rⱼ) + [Uc]U +
+[Wc]W + [-c]G'₀`, where `U` is the inner-product generator, `W` the blinding generator, and
+`G'₀ = foldAllFin`. The verifier accepts iff this is `0`. -/
+def eval {d : ℕ} (e : VerifierIpa d F G) (g : Fin (2 ^ d) → G) (U W : G) : G :=
+  e.commitment + roundSumFin e.rounds e.challenges + e.uScalar • U + e.wScalar • W
+    + (-e.final) • foldAllFin e.challenges g
+
+/-- Absorb the first round into the commitment: `P' ↦ P' + [u₀⁻¹]L₀ + [u₀]R₀`, dropping that round
+and challenge. This is the recursive verifier's commitment update. -/
+def peel {d : ℕ} (e : VerifierIpa (d + 1) F G) : VerifierIpa d F G where
+  commitment := e.commitment + (e.challenges 0)⁻¹ • (e.rounds 0).1 + e.challenges 0 • (e.rounds 0).2
+  rounds := Fin.tail e.rounds
+  challenges := Fin.tail e.challenges
+  final := e.final
+  uScalar := e.uScalar
+  wScalar := e.wScalar
+
+/-- Peeling a round changes nothing, once the generators are folded by that round's challenge. The
+`Fin d` counterpart of `CF_cons` at a round point with no `U`/`W` part — and unlike `CF_cons` it
+carries no reindexing, since the generator type mentions only the depth. -/
+theorem eval_peel {d : ℕ} (e : VerifierIpa (d + 1) F G) (g : Fin (2 ^ (d + 1)) → G) (U W : G) :
+    e.eval g U W = e.peel.eval (foldGens g (e.challenges 0)⁻¹) U W := by
+  simp only [eval, peel, roundSumFin, foldAllFin]
+  abel
+
+/-- `eval` is the list-shaped closed form `CF`. This is the one place the `List.ofFn` transport
+between the depth-indexed and list-shaped sides is paid. -/
+theorem eval_eq_CF {d : ℕ} (e : VerifierIpa d F G) (g : Fin (2 ^ d) → G) (U W : G) :
+    e.eval g U W
+      = CF (List.ofFn e.rounds) (List.ofFn e.challenges)
+          (fun j => g (Fin.cast (congrArg (2 ^ ·) List.length_ofFn) j))
+          e.commitment e.final e.uScalar U e.wScalar W := by
+  rw [eval, CF, roundSumFin_eq, foldAllFin_eq]
+
+end VerifierIpa
 
 end Zcash.Snark

--- a/Zcash/Snark/Soundness/Deployed/Flat.lean
+++ b/Zcash/Snark/Soundness/Deployed/Flat.lean
@@ -23,7 +23,8 @@ are the inner-product and blinding generators.
   recursive verifier folds it.
 
 Nothing here mentions the halo2 assembly: `Deployed.Verification` instantiates `CF` at it, and
-`Forking.Assembly` runs the fold. Challenge vectors are lists, mirroring halo2's list-shaped code.
+`Forking.Assembly` runs the fold. Challenge vectors are lists, mirroring halo2's list-shaped code;
+`foldAllFin` and `foldAllFin_eq` are where the `Fin d`-indexed tree side crosses over.
 -/
 
 namespace Zcash.Snark
@@ -71,5 +72,41 @@ theorem CF_cons (Lg Rg U W : G) (Lv Lw Rv Rw : F) (rounds : List (G × G)) (u₀
           (Uc + u₀⁻¹ * Lv + u₀ * Rv) U (Wc + u₀⁻¹ * Lw + u₀ * Rw) W := by
   simp only [CF, roundSum_cons, foldAll]
   module
+
+/-! ## The generator fold over a `Fin`-indexed challenge vector
+
+`foldAll` takes its challenges as a list, so its generator argument has type
+`Fin (2 ^ u.length) → G` — a type that mentions a *projection* of the challenges. Every crossing
+from the `Fin d`-indexed tree side therefore has to transport along `List.length_ofFn`.
+`foldAllFin` runs the same fold on a `Fin d → F` challenge vector, where the generator type
+`Fin (2 ^ d) → G` mentions only `d`, and `foldAllFin_eq` pays the transport once.
+-/
+
+/-- `foldGens` commutes with reindexing by `Fin.cast`. -/
+theorem foldGens_comp_cast {m n : ℕ} (h : n = m) (g : Fin (2 ^ (m + 1)) → G) (u : F) :
+    foldGens (fun j : Fin (2 ^ (n + 1)) => g (Fin.cast (by rw [h]) j)) u
+      = fun i : Fin (2 ^ n) => foldGens g u (Fin.cast (by rw [h]) i) := by
+  subst h; rfl
+
+/-- Fold `g` through a `Fin`-indexed challenge vector without dependent casts. -/
+def foldAllFin : {d : ℕ} → (Fin d → F) → (Fin (2 ^ d) → G) → G
+  | 0, _, g => g 0
+  | _ + 1, χ, g => foldAllFin (Fin.tail χ) (foldGens g (χ 0)⁻¹)
+
+/-- Reindex `foldAll` along an equality of challenge lists. -/
+theorem foldAll_congr_cast {u u' : List F} (h : u = u') (g : Fin (2 ^ u.length) → G) :
+    foldAll u g = foldAll u' (fun j => g (Fin.cast (by rw [h]) j)) := by
+  subst h; rfl
+
+/-- `foldAllFin` equals the deployed list-based `foldAll`. -/
+theorem foldAllFin_eq : {d : ℕ} → (χ : Fin d → F) → (g : Fin (2 ^ d) → G) →
+    foldAllFin χ g = foldAll (List.ofFn χ) (fun j => g (Fin.cast (congrArg (2 ^ ·) List.length_ofFn) j)) 0
+  | 0, _, g => by simp only [foldAllFin]; rfl
+  | d + 1, χ, g => by
+      have hchal : List.ofFn χ = χ 0 :: List.ofFn (Fin.tail χ) := by rw [List.ofFn_succ]; rfl
+      rw [foldAllFin, foldAllFin_eq (Fin.tail χ) (foldGens g (χ 0)⁻¹), foldAll_congr_cast hchal, foldAll]
+      simp only [Fin.cast_cast]
+      exact congrArg (fun gen => foldAll (List.ofFn (Fin.tail χ)) gen 0)
+        (foldGens_comp_cast (List.length_ofFn (f := Fin.tail χ)) g (χ 0)⁻¹).symm
 
 end Zcash.Snark

--- a/Zcash/Snark/Soundness/Deployed/Verification.lean
+++ b/Zcash/Snark/Soundness/Deployed/Verification.lean
@@ -1,17 +1,19 @@
 import Zcash.Snark.Verifier.Assemble
-import Zcash.Snark.Soundness.Deployed.Fold
+import Zcash.Snark.Soundness.Deployed.Flat
 
 /-!
 # Deployed acceptance implies the explicit IPA verifier equation
 
-This module combines `eval_assembleFinalMsm` and `deployed_gterm_foldAll` into halo2's IPA equation
-and ties that equation to the deployed accept condition:
+This module instantiates the closed form `CF` (`Deployed.Flat`) at halo2's multiopen assembly and
+ties the resulting equation to the deployed accept condition:
 
 * `multiopenCommitment` / `multiopenValue` — the `P` and `v` halo2's IPA verifier opens, read off the
   multiopen assembly on `(vk, ps, ch)`.
-* `deployed_verification_eq` — `(assembleFinalMsm …).eval` is the explicit equation
-  `P + [-v]g₀ + [ξ]S + Σ(rounds) + [-c·b·z]U + [-f]W + [-c]G'₀`.
-* `DeployedIpaVerifierEq` — that equation set to the identity.
+* `deployedIpaCommitment` — the adjusted commitment `P' = P − [v]g₀ + [ξ]S` at that `P` and `v`.
+* `deployed_verification_eq` — `(assembleFinalMsm …).eval` *is* the closed form, for any multiopen
+  grouping.
+* `DeployedIpaVerifierEq` — the closed form at the grouping the deployed verifier derives, set to
+  the identity.
 * the `…?_eq_some` lemmas — deployed acceptance uses the rejecting `assemble?`; when it
   returns `some m`, `m` is the non-rejecting `assembleFinalMsm`, so the equation transfers.
 
@@ -106,43 +108,44 @@ def multiopenValue {shape : Shape} [DecidableEq F] [DecidableEq G] [Inhabited G]
   (assembleOpening ch.x1 ch.x2 ch.x3 ch.x4 ps.multiopenQPrime (List.ofFn ps.multiopenU)
     (constructIntermediateSets (assembleQueries vk instanceCommitment ps ch)) (Msm.zero shape.k F G)).2
 
-/-- The *adjusted commitment* the deployed IPA verifier actually opens: `P' = P − [v]g₀ + [ξ]S`,
-where `P` is the multiopen commitment, `v` the value it opens to, and `[ξ]S` the synthetic blinding
-of the opening (halo2 `poly/commitment/verifier.rs`). -/
+/-- The adjusted commitment the deployed IPA verifier actually opens: `adjustedCommitment` at the
+multiopen commitment `P` and value `v` derived from `(vk, ps, ch)`, blinded by the proof's `ipaS` at
+`ch.xi`. -/
 abbrev deployedIpaCommitment {shape : Shape} [DecidableEq F] [DecidableEq G] [Inhabited G]
     (g : Fin (2 ^ shape.k) → G) (w u : G)
     (vk : VerifyingKey shape F G) (instanceCommitment : Fin shape.numProofs → ℕ → G)
     (ps : ProofString shape F G) (ch : Challenges shape.k F) : G :=
-  multiopenCommitment g w u vk instanceCommitment ps ch
-    + (∑ i, ([-(multiopenValue vk instanceCommitment ps ch)].getD i.val 0) • g i)
-    + ch.xi • ps.ipaS
+  adjustedCommitment g (multiopenCommitment g w u vk instanceCommitment ps ch)
+    (multiopenValue vk instanceCommitment ps ch) ch.xi ps.ipaS
 
-/-- The deployed fingerprint MSM evaluates to halo2's explicit IPA verifier equation: the
-multiopen commitment, the `[-v]g₀` value term, the `[ξ]S` blinding poly, the round total
-`Σ([uⱼ⁻¹]Lⱼ+[uⱼ]Rⱼ)`, the value-binding `[-c·b·z]U`, the blinding `[-f]W`, and the folded
-generator `[-c]G'₀` (`G'₀ = foldAll`). `eval_assembleFinalMsm` plus `deployed_gterm_foldAll`
-(the `g`-term is `[-c]·G'₀`). -/
+/-- The deployed fingerprint MSM evaluates to the closed form `CF` (`Deployed.Flat`): the adjusted
+commitment `P − [v]g₀ + [ξ]S`, the round total `Σ([uⱼ⁻¹]Lⱼ+[uⱼ]Rⱼ)`, the value-binding `[-c·b·z]U`,
+the blinding `[-f]W`, and the folded generator `[-c]G'₀`. `eval_assembleFinalMsm` plus
+`deployed_gterm_foldAll` (the `g`-term is `[-c]·G'₀`).
+
+The grouping is a parameter, so the adjusted commitment reads `assembleOpening` on that grouping
+directly. At the grouping the deployed verifier derives it is `deployedIpaCommitment`, which is
+where `DeployedIpaVerifierEq` picks it up. -/
 theorem deployed_verification_eq {shape : Shape} (g : Fin (2 ^ shape.k) → G) (w u : G)
     (ps : ProofString shape F G) (ch : Challenges shape.k F)
     (grouped : MultiopenGrouped shape.k F G) :
     (assembleFinalMsm ps ch grouped).eval ⟨shape.k, g, w, u⟩
-      = (assembleOpening ch.x1 ch.x2 ch.x3 ch.x4 ps.multiopenQPrime (List.ofFn ps.multiopenU) grouped
-            (Msm.zero shape.k F G)).1.eval ⟨shape.k, g, w, u⟩
-        + (∑ i, ([-(assembleOpening ch.x1 ch.x2 ch.x3 ch.x4 ps.multiopenQPrime (List.ofFn ps.multiopenU)
-            grouped (Msm.zero shape.k F G)).2].getD i.val 0) • g i)
-        + ch.xi • ps.ipaS
-        + (((List.ofFn ps.ipaRounds).zip (List.ofFn ch.ipaRound)).map
-            (fun p => p.2⁻¹ • p.1.1 + p.2 • p.1.2)).sum
-        + (-ps.ipaC * computeB ch.x3 (List.ofFn ch.ipaRound) * ch.z) • u
-        + (-ps.ipaF) • w
-        + (-ps.ipaC) • foldAll (List.ofFn ch.ipaRound)
-            (fun j => g (Fin.cast (congrArg (2 ^ ·) List.length_ofFn) j)) 0 := by
+      = CF (List.ofFn ps.ipaRounds) (List.ofFn ch.ipaRound)
+          (fun j => g (Fin.cast (congrArg (2 ^ ·) List.length_ofFn) j))
+          (adjustedCommitment g
+            ((assembleOpening ch.x1 ch.x2 ch.x3 ch.x4 ps.multiopenQPrime (List.ofFn ps.multiopenU)
+                grouped (Msm.zero shape.k F G)).1.eval ⟨shape.k, g, w, u⟩)
+            (assembleOpening ch.x1 ch.x2 ch.x3 ch.x4 ps.multiopenQPrime (List.ofFn ps.multiopenU)
+                grouped (Msm.zero shape.k F G)).2
+            ch.xi ps.ipaS)
+          ps.ipaC (-ps.ipaC * computeB ch.x3 (List.ofFn ch.ipaRound) * ch.z) u (-ps.ipaF) w := by
   rw [eval_assembleFinalMsm, deployed_gterm_foldAll]
+  rfl
 
-/-- halo2's explicit IPA verifier equation for the deployed proof, set to the group identity. By
-`deployed_verification_eq` this is exactly `(assembleFinalMsm …).eval = 0`. Stating it explicitly
-lets the forking bridge act on halo2's actual IPA equation, opening the pinned
-`deployedIpaCommitment`.
+/-- halo2's explicit IPA verifier equation for the deployed proof, set to the group identity: the
+closed form `CF` at the derived grouping, opening the pinned `deployedIpaCommitment`. By
+`deployed_verification_eq` this is exactly `(assembleFinalMsm …).eval = 0`. Stating it as its own
+definition lets the forking bridge act on halo2's actual IPA equation.
 
 Totality note: the closed form uses Lean's total inverse (`0⁻¹ = 0`), and the deployed code
 computes the same thing — halo2 batch-inverts the round challenges with ff's `batch_invert`,
@@ -157,12 +160,9 @@ def DeployedIpaVerifierEq {shape : Shape} [DecidableEq F] [DecidableEq G] [Inhab
     (g : Fin (2 ^ shape.k) → G) (w u : G)
     (vk : VerifyingKey shape F G) (instanceCommitment : Fin shape.numProofs → ℕ → G)
     (ps : ProofString shape F G) (ch : Challenges shape.k F) : Prop :=
-  deployedIpaCommitment g w u vk instanceCommitment ps ch
-      + (((List.ofFn ps.ipaRounds).zip (List.ofFn ch.ipaRound)).map
-          (fun p => p.2⁻¹ • p.1.1 + p.2 • p.1.2)).sum
-      + (-ps.ipaC * computeB ch.x3 (List.ofFn ch.ipaRound) * ch.z) • u
-      + (-ps.ipaF) • w
-      + (-ps.ipaC) • foldAll (List.ofFn ch.ipaRound)
-          (fun j => g (Fin.cast (congrArg (2 ^ ·) List.length_ofFn) j)) 0 = 0
+  CF (List.ofFn ps.ipaRounds) (List.ofFn ch.ipaRound)
+      (fun j => g (Fin.cast (congrArg (2 ^ ·) List.length_ofFn) j))
+      (deployedIpaCommitment g w u vk instanceCommitment ps ch)
+      ps.ipaC (-ps.ipaC * computeB ch.x3 (List.ofFn ch.ipaRound) * ch.z) u (-ps.ipaF) w = 0
 
 end Zcash.Snark

--- a/Zcash/Snark/Soundness/Deployed/Verification.lean
+++ b/Zcash/Snark/Soundness/Deployed/Verification.lean
@@ -148,17 +148,18 @@ abbrev deployedIpa {shape : Shape} [DecidableEq F] [DecidableEq G] [Inhabited G]
 /-- The deployed fingerprint MSM evaluates to `assembledIpa`: the adjusted commitment
 `P − [v]g₀ + [ξ]S`, the round total `Σ([uⱼ⁻¹]Lⱼ+[uⱼ]Rⱼ)`, the value-binding `[-c·b·z]U`, the
 blinding `[-f]W`, and the folded generator `[-c]G'₀`. `eval_assembleFinalMsm` plus
-`deployed_gterm_foldAll` (the `g`-term is `[-c]·G'₀`), then `eval_eq_CF` to fold the assembly's
-list-shaped round sum and generator fold into their depth-indexed counterparts.
+`deployed_gterm_foldAll` (the `g`-term is `[-c]·G'₀`), then `roundSumFin_eq` and `foldAllFin_eq` to
+read the assembly's list-shaped round sum and generator fold as their depth-indexed counterparts.
 
-That last step is where the `List.ofFn` transport between the two shapes is paid, once: every
+Those last two steps are where the `List.ofFn` transport between the two shapes is paid, once: every
 statement downstream of here is in `VerifierIpa.eval` terms and carries no cast. -/
 theorem deployed_verification_eq {shape : Shape} (g : Fin (2 ^ shape.k) → G) (w u : G)
     (ps : ProofString shape F G) (ch : Challenges shape.k F)
     (grouped : MultiopenGrouped shape.k F G) :
     (assembleFinalMsm ps ch grouped).eval ⟨shape.k, g, w, u⟩
       = (assembledIpa g w u ps ch grouped).eval g u w := by
-  rw [eval_assembleFinalMsm, deployed_gterm_foldAll, VerifierIpa.eval_eq_CF]
+  rw [eval_assembleFinalMsm, deployed_gterm_foldAll, VerifierIpa.eval, roundSumFin_eq,
+    foldAllFin_eq]
   rfl
 
 /-- halo2's explicit IPA verifier equation for the deployed proof, set to the group identity:

--- a/Zcash/Snark/Soundness/Deployed/Verification.lean
+++ b/Zcash/Snark/Soundness/Deployed/Verification.lean
@@ -4,16 +4,16 @@ import Zcash.Snark.Soundness.Deployed.Flat
 /-!
 # Deployed acceptance implies the explicit IPA verifier equation
 
-This module instantiates the closed form `CF` (`Deployed.Flat`) at halo2's multiopen assembly and
-ties the resulting equation to the deployed accept condition:
+This module builds the `VerifierIpa` equation (`Deployed.Flat`) out of halo2's multiopen assembly and
+ties it to the deployed accept condition:
 
 * `multiopenCommitment` / `multiopenValue` — the `P` and `v` halo2's IPA verifier opens, read off the
   multiopen assembly on `(vk, ps, ch)`.
 * `deployedIpaCommitment` — the adjusted commitment `P' = P − [v]g₀ + [ξ]S` at that `P` and `v`.
-* `deployed_verification_eq` — `(assembleFinalMsm …).eval` *is* the closed form, for any multiopen
-  grouping.
-* `DeployedIpaVerifierEq` — the closed form at the grouping the deployed verifier derives, set to
-  the identity.
+* `assembledIpa` / `deployedIpa` — the equation over an arbitrary multiopen grouping, and over the
+  grouping the deployed verifier derives.
+* `deployed_verification_eq` — `(assembleFinalMsm …).eval` *is* `assembledIpa` read against the URS.
+* `DeployedIpaVerifierEq` — `deployedIpa` set to the identity.
 * the `…?_eq_some` lemmas — deployed acceptance uses the rejecting `assemble?`; when it
   returns `some m`, `m` is the non-rejecting `assembleFinalMsm`, so the equation transfers.
 
@@ -118,34 +118,53 @@ abbrev deployedIpaCommitment {shape : Shape} [DecidableEq F] [DecidableEq G] [In
   adjustedCommitment g (multiopenCommitment g w u vk instanceCommitment ps ch)
     (multiopenValue vk instanceCommitment ps ch) ch.xi ps.ipaS
 
-/-- The deployed fingerprint MSM evaluates to the closed form `CF` (`Deployed.Flat`): the adjusted
-commitment `P − [v]g₀ + [ξ]S`, the round total `Σ([uⱼ⁻¹]Lⱼ+[uⱼ]Rⱼ)`, the value-binding `[-c·b·z]U`,
-the blinding `[-f]W`, and the folded generator `[-c]G'₀`. `eval_assembleFinalMsm` plus
-`deployed_gterm_foldAll` (the `g`-term is `[-c]·G'₀`).
+/-- The IPA verifier equation the deployed assembly produces over a multiopen grouping: the adjusted
+commitment from that grouping's own opening, the proof's IPA rounds `(Lⱼ, Rⱼ)` and the transcript's
+round challenges `uⱼ`, the prover's final scalar `c`, and halo2's coefficients `[-c·b·z]` and `[-f]`
+for the inner-product and blinding generators. -/
+def assembledIpa {shape : Shape} (g : Fin (2 ^ shape.k) → G) (w u : G)
+    (ps : ProofString shape F G) (ch : Challenges shape.k F)
+    (grouped : MultiopenGrouped shape.k F G) : VerifierIpa shape.k F G where
+  commitment := adjustedCommitment g
+    ((assembleOpening ch.x1 ch.x2 ch.x3 ch.x4 ps.multiopenQPrime (List.ofFn ps.multiopenU) grouped
+        (Msm.zero shape.k F G)).1.eval ⟨shape.k, g, w, u⟩)
+    (assembleOpening ch.x1 ch.x2 ch.x3 ch.x4 ps.multiopenQPrime (List.ofFn ps.multiopenU) grouped
+        (Msm.zero shape.k F G)).2
+    ch.xi ps.ipaS
+  rounds := ps.ipaRounds
+  challenges := ch.ipaRound
+  final := ps.ipaC
+  uScalar := -ps.ipaC * computeB ch.x3 (List.ofFn ch.ipaRound) * ch.z
+  wScalar := -ps.ipaF
 
-The grouping is a parameter, so the adjusted commitment reads `assembleOpening` on that grouping
-directly. At the grouping the deployed verifier derives it is `deployedIpaCommitment`, which is
-where `DeployedIpaVerifierEq` picks it up. -/
+/-- The deployed IPA verifier equation for the grouping the deployed verifier derives from
+`(vk, ps, ch)`, so its adjusted commitment is `deployedIpaCommitment`. -/
+abbrev deployedIpa {shape : Shape} [DecidableEq F] [DecidableEq G] [Inhabited G]
+    (g : Fin (2 ^ shape.k) → G) (w u : G)
+    (vk : VerifyingKey shape F G) (instanceCommitment : Fin shape.numProofs → ℕ → G)
+    (ps : ProofString shape F G) (ch : Challenges shape.k F) : VerifierIpa shape.k F G :=
+  assembledIpa g w u ps ch (constructIntermediateSets (assembleQueries vk instanceCommitment ps ch))
+
+/-- The deployed fingerprint MSM evaluates to `assembledIpa`: the adjusted commitment
+`P − [v]g₀ + [ξ]S`, the round total `Σ([uⱼ⁻¹]Lⱼ+[uⱼ]Rⱼ)`, the value-binding `[-c·b·z]U`, the
+blinding `[-f]W`, and the folded generator `[-c]G'₀`. `eval_assembleFinalMsm` plus
+`deployed_gterm_foldAll` (the `g`-term is `[-c]·G'₀`), then `eval_eq_CF` to fold the assembly's
+list-shaped round sum and generator fold into their depth-indexed counterparts.
+
+That last step is where the `List.ofFn` transport between the two shapes is paid, once: every
+statement downstream of here is in `VerifierIpa.eval` terms and carries no cast. -/
 theorem deployed_verification_eq {shape : Shape} (g : Fin (2 ^ shape.k) → G) (w u : G)
     (ps : ProofString shape F G) (ch : Challenges shape.k F)
     (grouped : MultiopenGrouped shape.k F G) :
     (assembleFinalMsm ps ch grouped).eval ⟨shape.k, g, w, u⟩
-      = CF (List.ofFn ps.ipaRounds) (List.ofFn ch.ipaRound)
-          (fun j => g (Fin.cast (congrArg (2 ^ ·) List.length_ofFn) j))
-          (adjustedCommitment g
-            ((assembleOpening ch.x1 ch.x2 ch.x3 ch.x4 ps.multiopenQPrime (List.ofFn ps.multiopenU)
-                grouped (Msm.zero shape.k F G)).1.eval ⟨shape.k, g, w, u⟩)
-            (assembleOpening ch.x1 ch.x2 ch.x3 ch.x4 ps.multiopenQPrime (List.ofFn ps.multiopenU)
-                grouped (Msm.zero shape.k F G)).2
-            ch.xi ps.ipaS)
-          ps.ipaC (-ps.ipaC * computeB ch.x3 (List.ofFn ch.ipaRound) * ch.z) u (-ps.ipaF) w := by
-  rw [eval_assembleFinalMsm, deployed_gterm_foldAll]
+      = (assembledIpa g w u ps ch grouped).eval g u w := by
+  rw [eval_assembleFinalMsm, deployed_gterm_foldAll, VerifierIpa.eval_eq_CF]
   rfl
 
-/-- halo2's explicit IPA verifier equation for the deployed proof, set to the group identity: the
-closed form `CF` at the derived grouping, opening the pinned `deployedIpaCommitment`. By
-`deployed_verification_eq` this is exactly `(assembleFinalMsm …).eval = 0`. Stating it as its own
-definition lets the forking bridge act on halo2's actual IPA equation.
+/-- halo2's explicit IPA verifier equation for the deployed proof, set to the group identity:
+`deployedIpa` read against the URS generators. By `deployed_verification_eq` this is exactly
+`(assembleFinalMsm …).eval = 0`. Stating it as its own definition lets the forking bridge act on
+halo2's actual IPA equation.
 
 Totality note: the closed form uses Lean's total inverse (`0⁻¹ = 0`), and the deployed code
 computes the same thing — halo2 batch-inverts the round challenges with ff's `batch_invert`,
@@ -160,9 +179,6 @@ def DeployedIpaVerifierEq {shape : Shape} [DecidableEq F] [DecidableEq G] [Inhab
     (g : Fin (2 ^ shape.k) → G) (w u : G)
     (vk : VerifyingKey shape F G) (instanceCommitment : Fin shape.numProofs → ℕ → G)
     (ps : ProofString shape F G) (ch : Challenges shape.k F) : Prop :=
-  CF (List.ofFn ps.ipaRounds) (List.ofFn ch.ipaRound)
-      (fun j => g (Fin.cast (congrArg (2 ^ ·) List.length_ofFn) j))
-      (deployedIpaCommitment g w u vk instanceCommitment ps ch)
-      ps.ipaC (-ps.ipaC * computeB ch.x3 (List.ofFn ch.ipaRound) * ch.z) u (-ps.ipaF) w = 0
+  (deployedIpa g w u vk instanceCommitment ps ch).eval g u w = 0
 
 end Zcash.Snark

--- a/Zcash/Snark/Soundness/Deployed/Verification.lean
+++ b/Zcash/Snark/Soundness/Deployed/Verification.lean
@@ -7,8 +7,9 @@ import Zcash.Snark.Soundness.Deployed.Flat
 This module builds the `VerifierIpa` equation (`Deployed.Flat`) out of halo2's multiopen assembly and
 ties it to the deployed accept condition:
 
-* `multiopenCommitment` / `multiopenValue` — the `P` and `v` halo2's IPA verifier opens, read off the
-  multiopen assembly on `(vk, ps, ch)`.
+* `openedPair` — the commitment/value pair the multiopen assembly opens over a grouping.
+* `multiopenCommitment` / `multiopenValue` — that pair's two halves at the grouping the deployed
+  verifier derives from `(vk, ps, ch)`: the `P` and `v` halo2's IPA verifier opens.
 * `deployedIpaCommitment` — the adjusted commitment `P' = P − [v]g₀ + [ξ]S` at that `P` and `v`.
 * `assembledIpa` / `deployedIpa` — the equation over an arbitrary multiopen grouping, and over the
   grouping the deployed verifier derives.
@@ -91,22 +92,28 @@ theorem assemble?_eq_some {shape : Shape} [DecidableEq F] [DecidableEq G] [Inhab
           · rw [if_neg hpts] at h; exact absurd h (by simp)
   · rw [if_neg hwf] at h; exact absurd h (by simp)
 
-/-- The deployed multiopen commitment `P` the IPA verifier opens: the `x₁`-compressed, `x₄`-collapsed
-multiopen assembly on `(vk, ps, ch)`, evaluated against the URS. -/
+/-- The commitment/value pair the multiopen assembly opens over `grouped`: halo2's `x₁`-compressed,
+`x₄`-collapsed batch opening, accumulated from the zero MSM (halo2 `multiopen/verifier.rs`). -/
+def openedPair {shape : Shape} (ps : ProofString shape F G) (ch : Challenges shape.k F)
+    (grouped : MultiopenGrouped shape.k F G) : Msm shape.k F G × F :=
+  assembleOpening ch.x1 ch.x2 ch.x3 ch.x4 ps.multiopenQPrime (List.ofFn ps.multiopenU) grouped
+    (Msm.zero shape.k F G)
+
+/-- The deployed multiopen commitment `P` the IPA verifier opens: `openedPair` at the grouping the
+deployed verifier derives from `(vk, ps, ch)`, evaluated against the URS. -/
 def multiopenCommitment {shape : Shape} [DecidableEq F] [DecidableEq G] [Inhabited G]
     (g : Fin (2 ^ shape.k) → G) (w u : G)
     (vk : VerifyingKey shape F G) (instanceCommitment : Fin shape.numProofs → ℕ → G)
     (ps : ProofString shape F G) (ch : Challenges shape.k F) : G :=
-  (assembleOpening ch.x1 ch.x2 ch.x3 ch.x4 ps.multiopenQPrime (List.ofFn ps.multiopenU)
-    (constructIntermediateSets (assembleQueries vk instanceCommitment ps ch)) (Msm.zero shape.k F G)).1.eval ⟨shape.k, g, w, u⟩
+  (openedPair ps ch (constructIntermediateSets (assembleQueries vk instanceCommitment ps ch))).1.eval
+    ⟨shape.k, g, w, u⟩
 
-/-- The deployed multiopen value `v` the IPA verifier opens `P` to (halo2 `multiopen/verifier.rs`). -/
+/-- The deployed multiopen value `v` the IPA verifier opens `P` to. -/
 def multiopenValue {shape : Shape} [DecidableEq F] [DecidableEq G] [Inhabited G]
     (vk : VerifyingKey shape F G) (instanceCommitment : Fin shape.numProofs → ℕ → G)
     (ps : ProofString shape F G)
     (ch : Challenges shape.k F) : F :=
-  (assembleOpening ch.x1 ch.x2 ch.x3 ch.x4 ps.multiopenQPrime (List.ofFn ps.multiopenU)
-    (constructIntermediateSets (assembleQueries vk instanceCommitment ps ch)) (Msm.zero shape.k F G)).2
+  (openedPair ps ch (constructIntermediateSets (assembleQueries vk instanceCommitment ps ch))).2
 
 /-- The adjusted commitment the deployed IPA verifier actually opens: `adjustedCommitment` at the
 multiopen commitment `P` and value `v` derived from `(vk, ps, ch)`, blinded by the proof's `ipaS` at
@@ -125,16 +132,12 @@ for the inner-product and blinding generators. -/
 def assembledIpa {shape : Shape} (g : Fin (2 ^ shape.k) → G) (w u : G)
     (ps : ProofString shape F G) (ch : Challenges shape.k F)
     (grouped : MultiopenGrouped shape.k F G) : VerifierIpa shape.k F G where
-  commitment := adjustedCommitment g
-    ((assembleOpening ch.x1 ch.x2 ch.x3 ch.x4 ps.multiopenQPrime (List.ofFn ps.multiopenU) grouped
-        (Msm.zero shape.k F G)).1.eval ⟨shape.k, g, w, u⟩)
-    (assembleOpening ch.x1 ch.x2 ch.x3 ch.x4 ps.multiopenQPrime (List.ofFn ps.multiopenU) grouped
-        (Msm.zero shape.k F G)).2
-    ch.xi ps.ipaS
+  commitment := adjustedCommitment g ((openedPair ps ch grouped).1.eval ⟨shape.k, g, w, u⟩)
+    (openedPair ps ch grouped).2 ch.xi ps.ipaS
   rounds := ps.ipaRounds
   challenges := ch.ipaRound
   final := ps.ipaC
-  uScalar := -ps.ipaC * computeB ch.x3 (List.ofFn ch.ipaRound) * ch.z
+  uScalar := valueScalar ps.ipaC (computeB ch.x3 (List.ofFn ch.ipaRound)) ch.z
   wScalar := -ps.ipaF
 
 /-- The deployed IPA verifier equation for the grouping the deployed verifier derives from

--- a/Zcash/Snark/Soundness/Deployed/Verification.lean
+++ b/Zcash/Snark/Soundness/Deployed/Verification.lean
@@ -106,6 +106,17 @@ def multiopenValue {shape : Shape} [DecidableEq F] [DecidableEq G] [Inhabited G]
   (assembleOpening ch.x1 ch.x2 ch.x3 ch.x4 ps.multiopenQPrime (List.ofFn ps.multiopenU)
     (constructIntermediateSets (assembleQueries vk instanceCommitment ps ch)) (Msm.zero shape.k F G)).2
 
+/-- The *adjusted commitment* the deployed IPA verifier actually opens: `P' = P − [v]g₀ + [ξ]S`,
+where `P` is the multiopen commitment, `v` the value it opens to, and `[ξ]S` the synthetic blinding
+of the opening (halo2 `poly/commitment/verifier.rs`). -/
+abbrev deployedIpaCommitment {shape : Shape} [DecidableEq F] [DecidableEq G] [Inhabited G]
+    (g : Fin (2 ^ shape.k) → G) (w u : G)
+    (vk : VerifyingKey shape F G) (instanceCommitment : Fin shape.numProofs → ℕ → G)
+    (ps : ProofString shape F G) (ch : Challenges shape.k F) : G :=
+  multiopenCommitment g w u vk instanceCommitment ps ch
+    + (∑ i, ([-(multiopenValue vk instanceCommitment ps ch)].getD i.val 0) • g i)
+    + ch.xi • ps.ipaS
+
 /-- The deployed fingerprint MSM evaluates to halo2's explicit IPA verifier equation: the
 multiopen commitment, the `[-v]g₀` value term, the `[ξ]S` blinding poly, the round total
 `Σ([uⱼ⁻¹]Lⱼ+[uⱼ]Rⱼ)`, the value-binding `[-c·b·z]U`, the blinding `[-f]W`, and the folded

--- a/Zcash/Snark/Soundness/Deployed/Verification.lean
+++ b/Zcash/Snark/Soundness/Deployed/Verification.lean
@@ -141,8 +141,8 @@ theorem deployed_verification_eq {shape : Shape} (g : Fin (2 ^ shape.k) → G) (
 
 /-- halo2's explicit IPA verifier equation for the deployed proof, set to the group identity. By
 `deployed_verification_eq` this is exactly `(assembleFinalMsm …).eval = 0`. Stating it explicitly
-lets the forking bridge act on halo2's actual IPA equation, with `P`/`v` the pinned
-`multiopenCommitment`/`multiopenValue`.
+lets the forking bridge act on halo2's actual IPA equation, opening the pinned
+`deployedIpaCommitment`.
 
 Totality note: the closed form uses Lean's total inverse (`0⁻¹ = 0`), and the deployed code
 computes the same thing — halo2 batch-inverts the round challenges with ff's `batch_invert`,
@@ -157,11 +157,7 @@ def DeployedIpaVerifierEq {shape : Shape} [DecidableEq F] [DecidableEq G] [Inhab
     (g : Fin (2 ^ shape.k) → G) (w u : G)
     (vk : VerifyingKey shape F G) (instanceCommitment : Fin shape.numProofs → ℕ → G)
     (ps : ProofString shape F G) (ch : Challenges shape.k F) : Prop :=
-  (assembleOpening ch.x1 ch.x2 ch.x3 ch.x4 ps.multiopenQPrime (List.ofFn ps.multiopenU)
-        (constructIntermediateSets (assembleQueries vk instanceCommitment ps ch)) (Msm.zero shape.k F G)).1.eval ⟨shape.k, g, w, u⟩
-      + (∑ i, ([-(assembleOpening ch.x1 ch.x2 ch.x3 ch.x4 ps.multiopenQPrime (List.ofFn ps.multiopenU)
-          (constructIntermediateSets (assembleQueries vk instanceCommitment ps ch)) (Msm.zero shape.k F G)).2].getD i.val 0) • g i)
-      + ch.xi • ps.ipaS
+  deployedIpaCommitment g w u vk instanceCommitment ps ch
       + (((List.ofFn ps.ipaRounds).zip (List.ofFn ch.ipaRound)).map
           (fun p => p.2⁻¹ • p.1.1 + p.2 • p.1.2)).sum
       + (-ps.ipaC * computeB ch.x3 (List.ofFn ch.ipaRound) * ch.z) • u

--- a/Zcash/Snark/Soundness/Forking/Adversary/Algebraic.lean
+++ b/Zcash/Snark/Soundness/Forking/Adversary/Algebraic.lean
@@ -99,6 +99,15 @@ theorem multiopenCommitment_spliceIpa [DecidableEq VestaG]
     multiopenCommitment g w u vk instanceCommitment (spliceIpa ps R cc ff) c
       = multiopenCommitment g w u vk instanceCommitment ps c := rfl
 
+/-- Replacing the IPA proof suffix does not change the adjusted commitment: the splice rewrites only
+`ipaRounds`/`ipaC`/`ipaF`, while `P' = P − [v]g₀ + [ξ]S` reads the multiopen fields and `ipaS`. -/
+theorem deployedIpaCommitment_spliceIpa [DecidableEq VestaG]
+    [Inhabited VestaG] {shape : Shape} (g : Fin (2 ^ shape.k) → VestaG)
+    (w u : VestaG) (vk : VerifyingKey shape Fp VestaG) (instanceCommitment : Fin shape.numProofs → ℕ → VestaG) (ps : ProofString shape Fp VestaG)
+    (R : Fin shape.k → VestaG × VestaG) (cc ff : Fp) (c : Challenges shape.k Fp) :
+    deployedIpaCommitment g w u vk instanceCommitment (spliceIpa ps R cc ff) c
+      = deployedIpaCommitment g w u vk instanceCommitment ps c := rfl
+
 /-- Every pre-IPA squeeze position is no later than the final one. -/
 private theorem preIpaLen_le_last (shape : Shape) (n₀ : ℕ) (i : Fin 11) :
     preIpaLen shape n₀ i ≤ preIpaLen shape n₀ 10 := by
@@ -504,6 +513,9 @@ theorem algebraicForkCertAttempt_valid {shape : Shape}
     · intro i
       exact Fin.elim0 i
     · simpa only [algebraicForkCertAttempt, recursiveAlgebraicFork] using hout
+  -- Stated in the adjusted commitment's components, not through `deployedIpaCommitment`: the
+  -- rewrites below act on those components, and the abbrev is reducible, so `exact hacc` still
+  -- bridges the two forms at the use site.
   have hPwhole : ∀ (chi : Fin shape.k → Fp),
       (multiopenCommitment urs.g urs.w urs.u vk instanceCommitment p₀.proof.1 (chRecord ν₀ chi)
         + (∑ i, ([-(multiopenValue vk instanceCommitment p₀.proof.1 (chRecord ν₀ chi))].getD i.val 0) • urs.g i)
@@ -547,7 +559,7 @@ theorem algebraicForkCertAttempt_valid {shape : Shape}
   rw [algebraicTableAcceptZ, hnu, hchi] at hwin
   have hacc := hwin.1
   rw [deployedVerifierEq_iff_flatAccept] at hacc
-  rw [hsplice, multiopenValue_spliceIpa, multiopenCommitment_spliceIpa] at hacc
+  rw [hsplice, deployedIpaCommitment_spliceIpa] at hacc
   have hrounds : (fun j => grindDecode (ts j)) = p'.proof.1.ipaRounds := by
     funext j
     calc
@@ -557,8 +569,6 @@ theorem algebraicForkCertAttempt_valid {shape : Shape}
   have hc : p'.proof.1.ipaC = c := congrArg Prod.fst hfinal
   have hf : p'.proof.1.ipaF = f := congrArg Prod.snd hfinal
   rw [hrounds, ← hc, ← hf, ← hPwhole cs]
-  rw [show (spliceIpa p₀.proof.1 p'.proof.1.ipaRounds p'.proof.1.ipaC
-    p'.proof.1.ipaF).ipaS = p₀.proof.1.ipaS from rfl] at hacc
   exact hacc
 
 /-- Rewrite a certificate onto the canonical augmented basis of the deployed AGM instance. -/

--- a/Zcash/Snark/Soundness/Forking/Adversary/Algebraic.lean
+++ b/Zcash/Snark/Soundness/Forking/Adversary/Algebraic.lean
@@ -2359,7 +2359,7 @@ theorem multiopenCommitment_eq_eval
     (ch : Challenges shape.k Fp) :
     multiopenCommitment g' w' u' vk instanceCommitment ps ch
       = (multiopenMsm vk instanceCommitment ps ch).eval ⟨shape.k, g', w', u'⟩ := by
-  unfold multiopenCommitment multiopenMsm
+  unfold multiopenCommitment openedPair multiopenMsm
   rfl
 
 attribute [local irreducible] multiopenMsm

--- a/Zcash/Snark/Soundness/Forking/Adversary/Algebraic.lean
+++ b/Zcash/Snark/Soundness/Forking/Adversary/Algebraic.lean
@@ -513,9 +513,6 @@ theorem algebraicForkCertAttempt_valid {shape : Shape}
     · intro i
       exact Fin.elim0 i
     · simpa only [algebraicForkCertAttempt, recursiveAlgebraicFork] using hout
-  -- Stated in the adjusted commitment's components, not through `deployedIpaCommitment`: the
-  -- rewrites below act on those components, and the abbrev is reducible, so `exact hacc` still
-  -- bridges the two forms at the use site.
   have hPwhole : ∀ (chi : Fin shape.k → Fp),
       (multiopenCommitment urs.g urs.w urs.u vk instanceCommitment p₀.proof.1 (chRecord ν₀ chi)
         + (∑ i, ([-(multiopenValue vk instanceCommitment p₀.proof.1 (chRecord ν₀ chi))].getD i.val 0) • urs.g i)

--- a/Zcash/Snark/Soundness/Forking/Assembly.lean
+++ b/Zcash/Snark/Soundness/Forking/Assembly.lean
@@ -202,10 +202,10 @@ theorem deployedVerifierEq_cf {shape : Shape} [DecidableEq F] [DecidableEq G] [I
     DeployedIpaVerifierEq g w u vk instanceCommitment ps ch ↔
       CF (List.ofFn ps.ipaRounds) (List.ofFn ch.ipaRound)
           (fun j => g (Fin.cast (congrArg (2 ^ ·) List.length_ofFn) j))
-          (multiopenCommitment g w u vk instanceCommitment ps ch
-            + (∑ i, ([-(multiopenValue vk instanceCommitment ps ch)].getD i.val 0) • g i) + ch.xi • ps.ipaS)
+          (deployedIpaCommitment g w u vk instanceCommitment ps ch)
           ps.ipaC (-ps.ipaC * computeB ch.x3 (List.ofFn ch.ipaRound) * ch.z) u (-ps.ipaF) w = 0 := by
-  unfold DeployedIpaVerifierEq CF gPart roundSum multiopenCommitment multiopenValue
+  unfold DeployedIpaVerifierEq CF gPart roundSum deployedIpaCommitment multiopenCommitment
+    multiopenValue
   constructor <;> intro h <;> linear_combination (norm := abel) h
 
 end Zcash.Snark

--- a/Zcash/Snark/Soundness/Forking/Assembly.lean
+++ b/Zcash/Snark/Soundness/Forking/Assembly.lean
@@ -9,8 +9,8 @@ rewinding, and converting those transcripts into `DeployedIpaAcceptV`. This modu
 job.
 
 The verifier equation folds one IPA round at a time (`VerifierIpa.eval_peel`, `Deployed.Flat`), and
-`computeB_cons` matches that fold's `b`-value update. `CF_leaf_to_acceptV` identifies the depth-zero
-closed form with the deployed leaf check, and `forkAccept_to_acceptV` assembles the full tree.
+`computeB_cons` matches that fold's `b`-value update. `evalLeaf_to_acceptV` identifies the
+depth-zero equation with the deployed leaf check, and `forkAccept_to_acceptV` assembles the tree.
 
 `Soundness.Forking.Extractor` recovers the parent data, while the algebraic prover supplies AGM
 coefficients. Rewinding and query loss remain outside this structural step.
@@ -77,36 +77,37 @@ theorem foldAll_evalVector {F : Type*} [Field F] (x : F) (u : List F) :
     rw [foldGens_evalVector, inv_inv, foldAll_smul, Pi.smul_apply, ih, smul_eq_mul, computeB_cons]
     ring
 
-/-! ## Leaf reconciliation: the depth-0 closed form is the deployed tree's leaf check
+/-! ## Leaf reconciliation: the depth-0 equation is the deployed tree's leaf check
 
 At depth zero, the flat equation rearranges to the deployed IPA leaf check. This step is pure group
 algebra; the later peel uses `z ≠ 0`.
 -/
 
-/-- Convert the depth-zero flat equation to the deployed IPA leaf check. -/
-theorem CF_leaf_to_acceptV (g : Fin (2 ^ 0) → G) (b : Fin (2 ^ 0) → F) (U W : G) (z : F)
+/-- Convert the depth-zero equation to the deployed IPA leaf check. -/
+theorem evalLeaf_to_acceptV (g : Fin (2 ^ 0) → G) (b : Fin (2 ^ 0) → F) (U W : G) (z : F)
     (aP : Fin (2 ^ 0) → F) (v blind c f : F)
-    (hCF : CF [] [] g (commitGen g aP + (z * v) • U + blind • W) c
-              (-(z * commitGen b (fun _ => c))) U (-f) W = 0) :
+    (hEq : (VerifierIpa.leaf (commitGen g aP + (z * v) • U + blind • W) c
+              (-(z * commitGen b (fun _ => c))) (-f)).eval g U W = 0) :
     DeployedIpaAcceptV g b U W z (commitGen g aP) v blind (.leaf c f aP) := by
   refine ⟨rfl, ?_⟩
   have hg : commitGen g (fun _ => c) = c • g 0 := by simp [commitGen]
-  rw [hg, ← sub_eq_zero, ← hCF]
-  simp only [CF, roundSum, foldAll, List.zip_nil_left, List.map_nil, List.sum_nil, add_zero]
+  rw [hg, ← sub_eq_zero, ← hEq]
+  simp only [VerifierIpa.eval, VerifierIpa.leaf, roundSumFin, foldAllFin, add_zero]
   module
 
 /-! ## The tree assembly: the forking output yields `DeployedIpaAcceptV`
 
-`ForkAccept` records three accepting continuations at each round and a flat verifier equation at each
+`ForkAccept` records three accepting continuations at each round and a verifier equation at each
 leaf. `forkAccept_to_acceptV` converts those leaves and assembles `DeployedIpaAcceptV`.
 -/
 
-/-- A ternary fork tree with the flat verifier equation at each leaf. -/
+/-- A ternary fork tree with the verifier equation at each leaf. -/
 def ForkAccept : {d : ℕ} → (Fin (2 ^ d) → G) → (Fin (2 ^ d) → F) → G → G → F → G → F → F →
     DeployedIpaTreeV F G d → Prop
   | 0, g, b, U, W, z, P, v, blind, .leaf c f aP =>
       P = commitGen g aP ∧
-        CF [] [] g (P + (z * v) • U + blind • W) c (-(z * commitGen b (fun _ => c))) U (-f) W = 0
+        (VerifierIpa.leaf (P + (z * v) • U + blind • W) c
+          (-(z * commitGen b (fun _ => c))) (-f)).eval g U W = 0
   | _ + 1, g, b, U, W, z, P, v, blind, .node L R Lv Rv Lw Rw u₁ u₂ u₃ t₁ t₂ t₃ =>
       u₁ ≠ u₂ ∧ u₁ ≠ u₃ ∧ u₂ ≠ u₃ ∧ u₁ ≠ 0 ∧ u₂ ≠ 0 ∧ u₃ ≠ 0 ∧
         ForkAccept (foldGens g u₁) (foldGens b u₁) U W z
@@ -122,33 +123,14 @@ theorem forkAccept_to_acceptV {U W : G} {z : F} :
       (t : DeployedIpaTreeV F G d) → ForkAccept g b U W z P v blind t →
       DeployedIpaAcceptV g b U W z P v blind t
   | 0, g, b, P, v, blind, .leaf c f aP, h => by
-      obtain ⟨hP, hCF⟩ := h
-      rw [hP] at hCF ⊢
-      exact CF_leaf_to_acceptV g b U W z aP v blind c f hCF
+      obtain ⟨hP, hEq⟩ := h
+      rw [hP] at hEq ⊢
+      exact evalLeaf_to_acceptV g b U W z aP v blind c f hEq
   | _ + 1, g, b, P, v, blind, .node L R Lv Rv Lw Rw u₁ u₂ u₃ t₁ t₂ t₃, h => by
       obtain ⟨h12, h13, h23, hu₁, hu₂, hu₃, ha₁, ha₂, ha₃⟩ := h
       exact ⟨h12, h13, h23, hu₁, hu₂, hu₃,
         forkAccept_to_acceptV _ _ _ _ _ t₁ ha₁,
         forkAccept_to_acceptV _ _ _ _ _ t₂ ha₂,
         forkAccept_to_acceptV _ _ _ _ _ t₃ ha₃⟩
-
-/-! ## The adjusted-commitment connection: halo2's verifier equation is the closed form -/
-
-/-- Halo2's deployed IPA verifier equation is the closed form `CF = 0`. `DeployedIpaVerifierEq` is
-defined as the depth-indexed `VerifierIpa.eval` form (`Deployed.Verification`); this is its
-list-shaped reading, by `eval_eq_CF`. The fork side reaches `CF` at depth zero
-(`CF_leaf_to_acceptV`, `ForkAccept`) through the peel, so this is the escape hatch for anything
-that wants the whole equation in list form. -/
-theorem deployedVerifierEq_cf {shape : Shape} [DecidableEq F] [DecidableEq G] [Inhabited G]
-    (g : Fin (2 ^ shape.k) → G) (w u : G)
-    (vk : VerifyingKey shape F G) (instanceCommitment : Fin shape.numProofs → ℕ → G)
-    (ps : ProofString shape F G) (ch : Challenges shape.k F) :
-    DeployedIpaVerifierEq g w u vk instanceCommitment ps ch ↔
-      CF (List.ofFn ps.ipaRounds) (List.ofFn ch.ipaRound)
-          (fun j => g (Fin.cast (congrArg (2 ^ ·) List.length_ofFn) j))
-          (deployedIpaCommitment g w u vk instanceCommitment ps ch)
-          ps.ipaC (-ps.ipaC * computeB ch.x3 (List.ofFn ch.ipaRound) * ch.z) u (-ps.ipaF) w = 0 := by
-  rw [DeployedIpaVerifierEq, VerifierIpa.eval_eq_CF]
-  exact Iff.rfl
 
 end Zcash.Snark

--- a/Zcash/Snark/Soundness/Forking/Assembly.lean
+++ b/Zcash/Snark/Soundness/Forking/Assembly.lean
@@ -8,7 +8,7 @@ The old `FiatShamirTree` assumption combined two jobs: producing forked transcri
 rewinding, and converting those transcripts into `DeployedIpaAcceptV`. This module proves the second
 job.
 
-The flat verifier equation folds one IPA round at a time. `roundSum_cons`, `computeB_cons`, and
+The closed form `CF` (`Deployed.Flat`) folds one IPA round at a time. `computeB_cons` and
 `CF_cons` match that fold to the recursive commitment, generator, value, and blinding updates.
 `CF_leaf_to_acceptV` identifies the final closed-form equation with the deployed leaf check, and
 `forkAccept_to_acceptV` assembles the full tree.
@@ -20,21 +20,6 @@ coefficients. Rewinding and query loss remain outside this structural step.
 namespace Zcash.Snark
 
 variable {F G : Type*} [Field F] [AddCommGroup G] [Module F G]
-
-/-- The sum `Σⱼ ([uⱼ⁻¹]Lⱼ + [uⱼ]Rⱼ)` contributed by the IPA rounds. -/
-def roundSum (rounds : List (G × G)) (u : List F) : G :=
-  ((rounds.zip u).map (fun p => p.2⁻¹ • p.1.1 + p.2 • p.1.2)).sum
-
-@[simp] theorem roundSum_nil_rounds (u : List F) : roundSum ([] : List (G × G)) u = 0 := by
-  simp [roundSum]
-
-@[simp] theorem roundSum_nil_challenges (rounds : List (G × G)) : roundSum rounds ([] : List F) = 0 := by
-  simp [roundSum, List.zip_nil_right]
-
-/-- Split the first round's contribution from `roundSum`. -/
-theorem roundSum_cons (L R : G) (rounds : List (G × G)) (u₀ : F) (u : List F) :
-    roundSum ((L, R) :: rounds) (u₀ :: u) = (u₀⁻¹ • L + u₀ • R) + roundSum rounds u := by
-  simp [roundSum]
 
 /-! ## The `computeB` round recursion (the `b`-value fold) -/
 
@@ -53,23 +38,6 @@ theorem computeB_cons {F : Type*} [CommRing F] (x u₀ : F) (tail : List F) :
     computeB x (u₀ :: tail) = computeB x tail * (1 + u₀ * x ^ (2 ^ tail.length)) := by
   rw [computeB, computeB, List.reverse_cons, List.foldl_append, List.foldl_cons, List.foldl_nil,
     ← computeB_pt x tail]
-
-/-! ## The commitment/generator side of the closed-form equation folds per round
-
-`gPart` contains the adjusted commitment, round sum, and folded generator. It follows the same
-per-round commitment and generator recursion as `DeployedIpaAcceptV`. -/
-
-/-- The adjusted commitment, IPA round sum, and final folded-generator term. -/
-def gPart (rounds : List (G × G)) (u : List F) (g : Fin (2 ^ u.length) → G) (P' : G) (c : F) : G :=
-  P' + roundSum rounds u + (-c) • foldAll u g 0
-
-/-- Fold the first round point into the commitment and generators. -/
-theorem gPart_cons (L R : G) (rounds : List (G × G)) (u₀ : F) (u : List F)
-    (g : Fin (2 ^ (u₀ :: u).length) → G) (P' : G) (c : F) :
-    gPart ((L, R) :: rounds) (u₀ :: u) g P' c
-      = gPart rounds u (foldGens g u₀⁻¹) (P' + u₀⁻¹ • L + u₀ • R) c := by
-  simp only [gPart, roundSum_cons, foldAll]
-  abel
 
 /-! ## The eval-vector fold telescopes to `computeB`
 
@@ -110,29 +78,6 @@ theorem foldAll_evalVector {F : Type*} [Field F] (x : F) (u : List F) :
     rw [foldGens_evalVector, inv_inv, foldAll_smul, Pi.smul_apply, ih, smul_eq_mul, computeB_cons]
     ring
 
-/-! ## The closed-form verifier equation folds one round (the keystone)
-
-`CF` is the flat verifier equation with abstract `U` and `W` coefficients. `CF_cons` shows that a
-round point represented over `(g, U, W)` folds the commitment, value, and blinding exactly as the
-deployed tree does.
--/
-
-/-- The flat verifier equation with abstract coefficients for `U` and `W`. -/
-def CF (rounds : List (G × G)) (u : List F) (g : Fin (2 ^ u.length) → G) (P : G) (c : F)
-    (Uc : F) (U : G) (Wc : F) (W : G) : G :=
-  gPart rounds u g P c + Uc • U + Wc • W
-
-/-- Fold one represented round point through the flat verifier equation. -/
-theorem CF_cons (Lg Rg U W : G) (Lv Lw Rv Rw : F) (rounds : List (G × G)) (u₀ : F) (u : List F)
-    (g : Fin (2 ^ (u₀ :: u).length) → G) (P : G) (c Uc Wc : F) :
-    CF ((Lg + Lv • U + Lw • W, Rg + Rv • U + Rw • W) :: rounds) (u₀ :: u) g P c Uc U Wc W
-      = CF rounds u (foldGens g u₀⁻¹) (P + u₀⁻¹ • Lg + u₀ • Rg) c
-          (Uc + u₀⁻¹ * Lv + u₀ * Rv) U (Wc + u₀⁻¹ * Lw + u₀ * Rw) W := by
-  simp only [CF]
-  rw [gPart_cons]
-  simp only [gPart]
-  module
-
 /-! ## Leaf reconciliation: the depth-0 closed form is the deployed tree's leaf check
 
 At depth zero, the flat equation rearranges to the deployed IPA leaf check. This step is pure group
@@ -148,7 +93,7 @@ theorem CF_leaf_to_acceptV (g : Fin (2 ^ 0) → G) (b : Fin (2 ^ 0) → F) (U W 
   refine ⟨rfl, ?_⟩
   have hg : commitGen g (fun _ => c) = c • g 0 := by simp [commitGen]
   rw [hg, ← sub_eq_zero, ← hCF]
-  simp only [CF, gPart, roundSum, foldAll, List.zip_nil_left, List.map_nil, List.sum_nil, add_zero]
+  simp only [CF, roundSum, foldAll, List.zip_nil_left, List.map_nil, List.sum_nil, add_zero]
   module
 
 /-! ## The tree assembly: the forking output yields `DeployedIpaAcceptV`
@@ -188,13 +133,11 @@ theorem forkAccept_to_acceptV {U W : G} {z : F} :
         forkAccept_to_acceptV _ _ _ _ _ t₂ ha₂,
         forkAccept_to_acceptV _ _ _ _ _ t₃ ha₃⟩
 
-/-! ## The adjusted-commitment connection: halo2's verifier equation is the closed form
+/-! ## The adjusted-commitment connection: halo2's verifier equation is the closed form -/
 
-The forking proof uses `CF`. The theorem below shows that halo2's deployed verifier equation is the
-same expression with its adjusted commitment and concrete coefficients.
--/
-
-/-- Halo2's deployed IPA verifier equation is the closed form `CF = 0`. -/
+/-- Halo2's deployed IPA verifier equation is the closed form `CF = 0` — definitionally, since
+`DeployedIpaVerifierEq` is *defined* as that equation (`Deployed.Verification`). Named so the forking
+side enters the closed form by rewriting rather than by unfolding. -/
 theorem deployedVerifierEq_cf {shape : Shape} [DecidableEq F] [DecidableEq G] [Inhabited G]
     (g : Fin (2 ^ shape.k) → G) (w u : G)
     (vk : VerifyingKey shape F G) (instanceCommitment : Fin shape.numProofs → ℕ → G)
@@ -203,9 +146,7 @@ theorem deployedVerifierEq_cf {shape : Shape} [DecidableEq F] [DecidableEq G] [I
       CF (List.ofFn ps.ipaRounds) (List.ofFn ch.ipaRound)
           (fun j => g (Fin.cast (congrArg (2 ^ ·) List.length_ofFn) j))
           (deployedIpaCommitment g w u vk instanceCommitment ps ch)
-          ps.ipaC (-ps.ipaC * computeB ch.x3 (List.ofFn ch.ipaRound) * ch.z) u (-ps.ipaF) w = 0 := by
-  unfold DeployedIpaVerifierEq CF gPart roundSum deployedIpaCommitment multiopenCommitment
-    multiopenValue
-  constructor <;> intro h <;> linear_combination (norm := abel) h
+          ps.ipaC (-ps.ipaC * computeB ch.x3 (List.ofFn ch.ipaRound) * ch.z) u (-ps.ipaF) w = 0 :=
+  Iff.rfl
 
 end Zcash.Snark

--- a/Zcash/Snark/Soundness/Forking/Assembly.lean
+++ b/Zcash/Snark/Soundness/Forking/Assembly.lean
@@ -91,8 +91,7 @@ theorem evalLeaf_to_acceptV (g : Fin (2 ^ 0) → G) (b : Fin (2 ^ 0) → F) (U W
     DeployedIpaAcceptV g b U W z (commitGen g aP) v blind (.leaf c f aP) := by
   refine ⟨rfl, ?_⟩
   have hg : commitGen g (fun _ => c) = c • g 0 := by simp [commitGen]
-  rw [hg, ← sub_eq_zero, ← hEq]
-  simp only [VerifierIpa.eval, VerifierIpa.leaf, roundSumFin, foldAllFin, add_zero]
+  rw [hg, ← sub_eq_zero, ← hEq, VerifierIpa.eval_leaf]
   module
 
 /-! ## The tree assembly: the forking output yields `DeployedIpaAcceptV`

--- a/Zcash/Snark/Soundness/Forking/Assembly.lean
+++ b/Zcash/Snark/Soundness/Forking/Assembly.lean
@@ -8,10 +8,9 @@ The old `FiatShamirTree` assumption combined two jobs: producing forked transcri
 rewinding, and converting those transcripts into `DeployedIpaAcceptV`. This module proves the second
 job.
 
-The closed form `CF` (`Deployed.Flat`) folds one IPA round at a time. `computeB_cons` and
-`CF_cons` match that fold to the recursive commitment, generator, value, and blinding updates.
-`CF_leaf_to_acceptV` identifies the final closed-form equation with the deployed leaf check, and
-`forkAccept_to_acceptV` assembles the full tree.
+The verifier equation folds one IPA round at a time (`VerifierIpa.eval_peel`, `Deployed.Flat`), and
+`computeB_cons` matches that fold's `b`-value update. `CF_leaf_to_acceptV` identifies the depth-zero
+closed form with the deployed leaf check, and `forkAccept_to_acceptV` assembles the full tree.
 
 `Soundness.Forking.Extractor` recovers the parent data, while the algebraic prover supplies AGM
 coefficients. Rewinding and query loss remain outside this structural step.
@@ -135,9 +134,11 @@ theorem forkAccept_to_acceptV {U W : G} {z : F} :
 
 /-! ## The adjusted-commitment connection: halo2's verifier equation is the closed form -/
 
-/-- Halo2's deployed IPA verifier equation is the closed form `CF = 0` — definitionally, since
-`DeployedIpaVerifierEq` is *defined* as that equation (`Deployed.Verification`). Named so the forking
-side enters the closed form by rewriting rather than by unfolding. -/
+/-- Halo2's deployed IPA verifier equation is the closed form `CF = 0`. `DeployedIpaVerifierEq` is
+defined as the depth-indexed `VerifierIpa.eval` form (`Deployed.Verification`); this is its
+list-shaped reading, by `eval_eq_CF`. The fork side reaches `CF` at depth zero
+(`CF_leaf_to_acceptV`, `ForkAccept`) through the peel, so this is the escape hatch for anything
+that wants the whole equation in list form. -/
 theorem deployedVerifierEq_cf {shape : Shape} [DecidableEq F] [DecidableEq G] [Inhabited G]
     (g : Fin (2 ^ shape.k) → G) (w u : G)
     (vk : VerifyingKey shape F G) (instanceCommitment : Fin shape.numProofs → ℕ → G)
@@ -146,7 +147,8 @@ theorem deployedVerifierEq_cf {shape : Shape} [DecidableEq F] [DecidableEq G] [I
       CF (List.ofFn ps.ipaRounds) (List.ofFn ch.ipaRound)
           (fun j => g (Fin.cast (congrArg (2 ^ ·) List.length_ofFn) j))
           (deployedIpaCommitment g w u vk instanceCommitment ps ch)
-          ps.ipaC (-ps.ipaC * computeB ch.x3 (List.ofFn ch.ipaRound) * ch.z) u (-ps.ipaF) w = 0 :=
-  Iff.rfl
+          ps.ipaC (-ps.ipaC * computeB ch.x3 (List.ofFn ch.ipaRound) * ch.z) u (-ps.ipaF) w = 0 := by
+  rw [DeployedIpaVerifierEq, VerifierIpa.eval_eq_CF]
+  exact Iff.rfl
 
 end Zcash.Snark

--- a/Zcash/Snark/Soundness/Forking/Rewind.lean
+++ b/Zcash/Snark/Soundness/Forking/Rewind.lean
@@ -762,8 +762,7 @@ theorem deployedVerifierEq_iff_flatAccept {shape : Shape} [DecidableEq Fp] [Deci
     (ch : Challenges shape.k Fp) :
     DeployedIpaVerifierEq g w u vk instanceCommitment ps ch ↔
       flatAccept (proverOfRounds ps.ipaRounds ps.ipaC ps.ipaF) g (evalVector shape.k ch.x3) u w ch.z
-        (multiopenCommitment g w u vk instanceCommitment ps ch
-          + (∑ i, ([-(multiopenValue vk instanceCommitment ps ch)].getD i.val 0) • g i) + ch.xi • ps.ipaS)
+        (deployedIpaCommitment g w u vk instanceCommitment ps ch)
         ch.ipaRound := by
   rw [deployedVerifierEq_cf, flatAccept_proverOfRounds, foldAllFin_evalVector,
     show (-ps.ipaC * computeB ch.x3 (List.ofFn ch.ipaRound) * ch.z)
@@ -817,19 +816,17 @@ theorem deployedVerifierEq_iff_flatAccept_adaptive {shape : Shape} [DecidableEq 
     DeployedIpaVerifierEq g w u vk instanceCommitment
         (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2) {ch with ipaRound := χ} ↔
       flatAccept P g (evalVector shape.k ch.x3) u w ch.z
-        (multiopenCommitment g w u vk instanceCommitment ps ch
-          + (∑ i, ([-(multiopenValue vk instanceCommitment ps ch)].getD i.val 0) • g i) + ch.xi • ps.ipaS) χ := by
+        (deployedIpaCommitment g w u vk instanceCommitment ps ch) χ := by
   rw [deployedVerifierEq_iff_flatAccept]
-  have e1 : multiopenValue vk instanceCommitment
+  -- Splicing touches only `ipaRounds`/`ipaC`/`ipaF` and the challenge update only `ipaRound`, so
+  -- every field the adjusted commitment reads is untouched and the two sides are definitionally
+  -- equal.
+  have e : deployedIpaCommitment g w u vk instanceCommitment
       (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2) {ch with ipaRound := χ}
-      = multiopenValue vk instanceCommitment ps ch := rfl
-  have e2 : multiopenCommitment g w u vk instanceCommitment
-      (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2) {ch with ipaRound := χ}
-      = multiopenCommitment g w u vk instanceCommitment ps ch := rfl
-  rw [e1, e2]
+      = deployedIpaCommitment g w u vk instanceCommitment ps ch := rfl
+  rw [e]
   exact (flatAccept_pathData P g (evalVector shape.k ch.x3)
-    (multiopenCommitment g w u vk instanceCommitment ps ch
-      + (∑ i, ([-(multiopenValue vk instanceCommitment ps ch)].getD i.val 0) • g i) + ch.xi • ps.ipaS) χ).symm
+    (deployedIpaCommitment g w u vk instanceCommitment ps ch) χ).symm
 
 /-! ## Prover-to-verifier bridge
 

--- a/Zcash/Snark/Soundness/Forking/Rewind.lean
+++ b/Zcash/Snark/Soundness/Forking/Rewind.lean
@@ -677,33 +677,6 @@ theorem proverRoundPoint_proverOfRounds : {d : ℕ} → (R : Fin d → G × G) �
       rw [proverRoundPoint_proverOfRounds (Fin.tail R) c f (Fin.tail χ) j (Nat.lt_of_succ_lt_succ hj)]
       rfl
 
-/-- `foldGens` commutes with reindexing by `Fin.cast`. -/
-theorem foldGens_comp_cast {m n : ℕ} (h : n = m) (g : Fin (2 ^ (m + 1)) → G) (u : Fp) :
-    foldGens (fun j : Fin (2 ^ (n + 1)) => g (Fin.cast (by rw [h]) j)) u
-      = fun i : Fin (2 ^ n) => foldGens g u (Fin.cast (by rw [h]) i) := by
-  subst h; rfl
-
-/-- Fold `g` through a `Fin`-indexed challenge vector without dependent casts. -/
-def foldAllFin : {d : ℕ} → (Fin d → Fp) → (Fin (2 ^ d) → G) → G
-  | 0, _, g => g 0
-  | _ + 1, χ, g => foldAllFin (Fin.tail χ) (foldGens g (χ 0)⁻¹)
-
-/-- Reindex `foldAll` along an equality of challenge lists. -/
-theorem foldAll_congr_cast {u u' : List Fp} (h : u = u') (g : Fin (2 ^ u.length) → G) :
-    foldAll u g = foldAll u' (fun j => g (Fin.cast (by rw [h]) j)) := by
-  subst h; rfl
-
-/-- `foldAllFin` equals the deployed list-based `foldAll`. -/
-theorem foldAllFin_eq : {d : ℕ} → (χ : Fin d → Fp) → (g : Fin (2 ^ d) → G) →
-    foldAllFin χ g = foldAll (List.ofFn χ) (fun j => g (Fin.cast (congrArg (2 ^ ·) List.length_ofFn) j)) 0
-  | 0, _, g => by simp only [foldAllFin]; rfl
-  | d + 1, χ, g => by
-      have hchal : List.ofFn χ = χ 0 :: List.ofFn (Fin.tail χ) := by rw [List.ofFn_succ]; rfl
-      rw [foldAllFin, foldAllFin_eq (Fin.tail χ) (foldGens g (χ 0)⁻¹), foldAll_congr_cast hchal, foldAll]
-      simp only [Fin.cast_cast]
-      exact congrArg (fun gen => foldAll (List.ofFn (Fin.tail χ)) gen 0)
-        (foldGens_comp_cast (List.length_ofFn (f := Fin.tail χ)) g (χ 0)⁻¹).symm
-
 /-- Reindex `CF` along an equality of challenge lists. -/
 theorem CF_congr_chal {u u' : List Fp} (h : u = u') (rounds : List (G × G))
     (g : Fin (2 ^ u.length) → G) (P : G) (c Uc Wc : Fp) (U W : G) :

--- a/Zcash/Snark/Soundness/Forking/Rewind.lean
+++ b/Zcash/Snark/Soundness/Forking/Rewind.lean
@@ -721,7 +721,7 @@ theorem flatAccept_proverOfRounds :
           (-(z * c * foldAllFin χ b)) U (-f) W = 0)
   | 0, R, c, f, g, b, U, W, z, P, χ => by
       rw [proverOfRounds, flatAccept]
-      simp only [CF, gPart]
+      simp only [CF]
       rw [← foldAllFin_eq]
       have hg : commitGen g (fun _ : Fin (2 ^ 0) => c) = c • g 0 := by simp [commitGen]
       have hb : commitGen b (fun _ : Fin (2 ^ 0) => c) = c * b 0 := by simp [commitGen]
@@ -818,9 +818,7 @@ theorem deployedVerifierEq_iff_flatAccept_adaptive {shape : Shape} [DecidableEq 
       flatAccept P g (evalVector shape.k ch.x3) u w ch.z
         (deployedIpaCommitment g w u vk instanceCommitment ps ch) χ := by
   rw [deployedVerifierEq_iff_flatAccept]
-  -- Splicing touches only `ipaRounds`/`ipaC`/`ipaF` and the challenge update only `ipaRound`, so
-  -- every field the adjusted commitment reads is untouched and the two sides are definitionally
-  -- equal.
+  -- Neither the splice nor the challenge update touches a field the adjusted commitment reads.
   have e : deployedIpaCommitment g w u vk instanceCommitment
       (spliceIpa ps (pathData P χ).1 (pathData P χ).2.1 (pathData P χ).2.2) {ch with ipaRound := χ}
       = deployedIpaCommitment g w u vk instanceCommitment ps ch := rfl

--- a/Zcash/Snark/Soundness/Forking/Rewind.lean
+++ b/Zcash/Snark/Soundness/Forking/Rewind.lean
@@ -686,12 +686,12 @@ theorem flatAccept_proverOfRounds :
     (flatAccept (proverOfRounds R c f) g b U W z P χ ↔
       VerifierIpa.eval
         { commitment := P, rounds := R, challenges := χ, final := c,
-          uScalar := -(z * c * foldAllFin χ b), wScalar := -f } g U W = 0)
+          uScalar := valueScalar c (foldAllFin χ b) z, wScalar := -f } g U W = 0)
   | 0, R, c, f, g, b, U, W, z, P, χ => by
       rw [proverOfRounds, flatAccept]
       have hg : commitGen g (fun _ : Fin (2 ^ 0) => c) = c • g 0 := by simp [commitGen]
       have hb : commitGen b (fun _ : Fin (2 ^ 0) => c) = c * b 0 := by simp [commitGen]
-      simp only [VerifierIpa.eval, roundSumFin, foldAllFin, add_zero, hg, hb]
+      simp only [VerifierIpa.eval, roundSumFin, foldAllFin, valueScalar, add_zero, hg, hb]
       constructor
       · intro h; rw [h]; module
       · intro h; linear_combination (norm := module) h
@@ -720,9 +720,7 @@ theorem deployedVerifierEq_iff_flatAccept {shape : Shape} [DecidableEq Fp] [Deci
       flatAccept (proverOfRounds ps.ipaRounds ps.ipaC ps.ipaF) g (evalVector shape.k ch.x3) u w ch.z
         (deployedIpaCommitment g w u vk instanceCommitment ps ch)
         ch.ipaRound := by
-  rw [flatAccept_proverOfRounds, foldAllFin_evalVector,
-    show -(ch.z * ps.ipaC * computeB ch.x3 (List.ofFn ch.ipaRound))
-      = -ps.ipaC * computeB ch.x3 (List.ofFn ch.ipaRound) * ch.z from by ring]
+  rw [flatAccept_proverOfRounds, foldAllFin_evalVector]
   exact Iff.rfl
 
 /-! ## The staged (round-adaptive) adversary: `hbridge` discharged beyond the constant strategy

--- a/Zcash/Snark/Soundness/Forking/Rewind.lean
+++ b/Zcash/Snark/Soundness/Forking/Rewind.lean
@@ -677,47 +677,30 @@ theorem proverRoundPoint_proverOfRounds : {d : ℕ} → (R : Fin d → G × G) �
       rw [proverRoundPoint_proverOfRounds (Fin.tail R) c f (Fin.tail χ) j (Nat.lt_of_succ_lt_succ hj)]
       rfl
 
-/-- Reindex `CF` along an equality of challenge lists. -/
-theorem CF_congr_chal {u u' : List Fp} (h : u = u') (rounds : List (G × G))
-    (g : Fin (2 ^ u.length) → G) (P : G) (c Uc Wc : Fp) (U W : G) :
-    CF rounds u g P c Uc U Wc W
-      = CF rounds u' (fun j => g (Fin.cast (by rw [h]) j)) P c Uc U Wc W := by
-  subst h; rfl
-
-/-- For a fixed proof tree, `flatAccept` is exactly the closed-form verifier equation `CF = 0`. -/
+/-- For a fixed proof tree, `flatAccept` is exactly the verifier equation `VerifierIpa.eval = 0`,
+at the commitment `P`, the tree's rounds and final scalars, and the value coefficient
+`[-z·c·b₀]` the eval vector folds to. Each round of the induction is one `eval_peel`. -/
 theorem flatAccept_proverOfRounds :
     {d : ℕ} → (R : Fin d → G × G) → (c f : Fp) → (g : Fin (2 ^ d) → G) → (b : Fin (2 ^ d) → Fp) →
     (U W : G) → (z : Fp) → (P : G) → (χ : Fin d → Fp) →
     (flatAccept (proverOfRounds R c f) g b U W z P χ ↔
-      CF (List.ofFn R) (List.ofFn χ)
-          (fun j => g (Fin.cast (congrArg (2 ^ ·) List.length_ofFn) j)) P c
-          (-(z * c * foldAllFin χ b)) U (-f) W = 0)
+      VerifierIpa.eval
+        { commitment := P, rounds := R, challenges := χ, final := c,
+          uScalar := -(z * c * foldAllFin χ b), wScalar := -f } g U W = 0)
   | 0, R, c, f, g, b, U, W, z, P, χ => by
       rw [proverOfRounds, flatAccept]
-      simp only [CF]
-      rw [← foldAllFin_eq]
       have hg : commitGen g (fun _ : Fin (2 ^ 0) => c) = c • g 0 := by simp [commitGen]
       have hb : commitGen b (fun _ : Fin (2 ^ 0) => c) = c * b 0 := by simp [commitGen]
-      simp only [roundSum, List.ofFn_zero, List.zip_nil_right, List.map_nil, List.sum_nil, add_zero,
-        foldAllFin, hg, hb]
+      simp only [VerifierIpa.eval, roundSumFin, foldAllFin, add_zero, hg, hb]
       constructor
       · intro h; rw [h]; module
       · intro h; linear_combination (norm := module) h
   | d + 1, R, c, f, g, b, U, W, z, P, χ => by
-      have hchal : List.ofFn χ = χ 0 :: List.ofFn (Fin.tail χ) := by rw [List.ofFn_succ]; rfl
-      have hround : List.ofFn R = ((R 0).1, (R 0).2) :: List.ofFn (Fin.tail R) := by
-        rw [List.ofFn_succ]; rfl
       rw [proverOfRounds, flatAccept,
           flatAccept_proverOfRounds (Fin.tail R) c f (foldGens g (χ 0)⁻¹) (foldGens b (χ 0)⁻¹) U W z
-            (P + (χ 0)⁻¹ • (R 0).1 + (χ 0) • (R 0).2) (Fin.tail χ)]
-      rw [hround, CF_congr_chal hchal]
-      rw [show (((R 0).1, (R 0).2) : G × G)
-            = ((R 0).1 + (0 : Fp) • U + (0 : Fp) • W, (R 0).2 + (0 : Fp) • U + (0 : Fp) • W) by simp]
-      rw [CF_cons]
-      simp only [mul_zero, add_zero, Fin.cast_cast]
-      refine iff_of_eq (congrArg (· = (0 : G)) ?_)
-      congr 1
-      exact (foldGens_comp_cast (List.length_ofFn (f := Fin.tail χ)) g (χ 0)⁻¹).symm
+            (P + (χ 0)⁻¹ • (R 0).1 + (χ 0) • (R 0).2) (Fin.tail χ),
+          VerifierIpa.eval_peel]
+      exact Iff.rfl
 
 /-- Folding a `Fin`-indexed eval vector gives the flat verifier's `computeB`. -/
 theorem foldAllFin_evalVector {d : ℕ} (χ : Fin d → Fp) (x : Fp) :
@@ -737,9 +720,10 @@ theorem deployedVerifierEq_iff_flatAccept {shape : Shape} [DecidableEq Fp] [Deci
       flatAccept (proverOfRounds ps.ipaRounds ps.ipaC ps.ipaF) g (evalVector shape.k ch.x3) u w ch.z
         (deployedIpaCommitment g w u vk instanceCommitment ps ch)
         ch.ipaRound := by
-  rw [deployedVerifierEq_cf, flatAccept_proverOfRounds, foldAllFin_evalVector,
-    show (-ps.ipaC * computeB ch.x3 (List.ofFn ch.ipaRound) * ch.z)
-      = -(ch.z * ps.ipaC * computeB ch.x3 (List.ofFn ch.ipaRound)) from by ring]
+  rw [flatAccept_proverOfRounds, foldAllFin_evalVector,
+    show -(ch.z * ps.ipaC * computeB ch.x3 (List.ofFn ch.ipaRound))
+      = -ps.ipaC * computeB ch.x3 (List.ofFn ch.ipaRound) * ch.z from by ring]
+  exact Iff.rfl
 
 /-! ## The staged (round-adaptive) adversary: `hbridge` discharged beyond the constant strategy
 

--- a/Zcash/Snark/Soundness/Main.lean
+++ b/Zcash/Snark/Soundness/Main.lean
@@ -77,7 +77,9 @@ theorem deployedAccepts_verifierEq [DecidableEq G] [Inhabited G] {shape : Shape}
       simp only [] at h
       rw [eval_cast hk m] at h
       have hmeq := assemble?_eq_some vk instanceCommitment ps ch hm
-      unfold DeployedIpaVerifierEq
+      -- `deployed_verification_eq` is generic in the grouping, so its statement is in raw
+      -- `assembleOpening` terms; expand the adjusted commitment to meet it.
+      unfold DeployedIpaVerifierEq deployedIpaCommitment multiopenCommitment multiopenValue
       rw [← deployed_verification_eq (hk ▸ urs.g) urs.w urs.u ps ch
             (constructIntermediateSets (assembleQueries vk instanceCommitment ps ch)), ← hmeq]
       exact h

--- a/Zcash/Snark/Soundness/Main.lean
+++ b/Zcash/Snark/Soundness/Main.lean
@@ -76,12 +76,7 @@ theorem deployedAccepts_verifierEq [DecidableEq G] [Inhabited G] {shape : Shape}
       rw [hm] at h
       simp only [] at h
       rw [eval_cast hk m] at h
-      have hmeq := assemble?_eq_some vk instanceCommitment ps ch hm
-      -- `deployed_verification_eq` is generic in the grouping, so its statement is in raw
-      -- `assembleOpening` terms; expand the adjusted commitment to meet it.
-      unfold DeployedIpaVerifierEq deployedIpaCommitment multiopenCommitment multiopenValue
-      rw [← deployed_verification_eq (hk ▸ urs.g) urs.w urs.u ps ch
-            (constructIntermediateSets (assembleQueries vk instanceCommitment ps ch)), ← hmeq]
+      rw [assemble?_eq_some vk instanceCommitment ps ch hm, deployed_verification_eq] at h
       exact h
 
 /-! ## `IpaRelation` is derived from the transcript tree, not assumed


### PR DESCRIPTION
Human summary: 

As I read the logic related to IPA relation extraction from the deployed proofs. I saw lots of repetition and expanded expression of the IPA for the verifier. Ideally, I'd like to bundle that into a single `structure VerifierIpa` that you can `.eval()` and whose constructor simply takes necessary inputs, so that call sites don't have to repeat the elaborated expression. 

exhibit A:
https://github.com/zcash/ironwood/blob/26dd6a43d066212b79e6c44275ca86cfe2cea0e1/Zcash/Snark/Soundness/Deployed/Verification.lean#L149-L159

and 

https://github.com/zcash/ironwood/blob/26dd6a43d066212b79e6c44275ca86cfe2cea0e1/Zcash/Snark/Soundness/Deployed/Verification.lean#L118-L128 

So I instruct Claude to **centralize the expression under a uniform `VerifierIpa` struct**. 
In the process, realized that we can collapse the closed-form `CF` completely now. So removed that as well.

This PR is **purely readability and cosmetic**. No soundness or security affected, also no extra axiom introduced. 

---

AI summary: 

# Give the deployed IPA verifier equation a structure

## The problem

`DeployedIpaVerifierEq` restated the eight-line right-hand side of `deployed_verification_eq`
verbatim, and neither used the `multiopenCommitment`/`multiopenValue` definitions sitting twenty
lines above them. Around those two, the same subexpressions were written out by hand over and over:

| repeated subexpression | occurrences on `main` |
| --- | --- |
| `ch.xi • ps.ipaS` (the opening's synthetic blinding) | 8 |
| the `[-v]g₀` singleton-list sum | 9 |
| the inlined round-sum `zip`/`map`/`sum` body | 6 |
| the `assembleOpening ch.x1 ch.x2 ch.x3 ch.x4 …` opening pair | 11 |

Nothing was unsound and nothing could drift silently — the duplication was build-checked, since
`deployedAccepts_verifierEq` closed by `rw [← deployed_verification_eq …]`, which only fires if the
two spellings are syntactically identical. The cost was readability and maintenance: the equation
existed twice, its pieces had no names, and `CF` — the structured form living over in
`Forking/Assembly.lean` — took nine positional arguments, four of them inline expressions, with
nothing at a call site to say which was the commitment and which a coefficient.

## What this does

Gives the equation the same syntax-object/interpretation split `Core/Msm.lean` already gives the
fingerprint MSM. New module `Deployed/Flat.lean` owns the shape of halo2's IPA identity

```
P' + Σⱼ([uⱼ⁻¹]Lⱼ + [uⱼ]Rⱼ) + [-c·b·z]U + [-f]W + [-c]G'₀ = 0
```

independently of the multiopen assembly:

```lean
structure VerifierIpa (d : ℕ) (F G : Type*) where
  commitment : G          -- the adjusted P'
  rounds     : Fin d → G × G
  challenges : Fin d → F
  final      : F          -- c
  uScalar    : F
  wScalar    : F
```

with `eval g U W` reading it against generators, `peel`/`eval_peel` folding one round, and
`leaf`/`eval_leaf` for the depth-zero shape the fork tree checks. Generators stay outside the
structure and arrive at `eval`, mirroring `Msm`: scalars in the object, URS data at the
interpretation. Alongside it, the pieces get names — `adjustedCommitment g P v ξ S` for
`P' = P − [v]g₀ + [ξ]S`, `valueScalar c b z` for `-c·b·z`, and `openedPair` for the multiopen
commitment/value pair.

`DeployedIpaVerifierEq` becomes one line:

```lean
def DeployedIpaVerifierEq … : Prop :=
  (deployedIpa g w u vk instanceCommitment ps ch).eval g u w = 0
```

and `deployed_verification_eq` is `(assembleFinalMsm …).eval ⟨shape.k, g, w, u⟩ = (assembledIpa g w u
ps ch grouped).eval g u w`. `assembledIpa` is grouping-generic and `deployedIpa` is it at the
grouping the deployed verifier derives, so the two statements now share one skeleton and meet
definitionally — `deployedAccepts_verifierEq` rewrites its hypothesis forward and closes by `exact`
instead of unfolding four definitions to make the spellings line up.

### Depth-indexing, and why

Rounds and challenges are indexed by `Fin d` rather than carried as lists. That is the load-bearing
choice: `eval`'s generator argument is then `Fin (2 ^ d) → G`, mentioning only the depth and never a
projection of the object, so `eval_peel` folds a round with no reindexing. On `main` the same step
needed `CF_cons` wrapped in `CF_congr_chal` and a `foldGens_comp_cast` fixup, because `CF`'s
generator type was `Fin (2 ^ u.length) → G` — a type mentioning a projection of its own challenge
list. `CF_congr_chal` is deleted and `flatAccept_proverOfRounds`'s inductive step is now one
`eval_peel` plus `Iff.rfl`.

`foldAll` and `computeB` keep their list shape deliberately: they mirror halo2's list-shaped code and
that transcription faithfulness is the point. The two crossings that remain, `roundSumFin_eq` and
`foldAllFin_eq`, are both paid inside `deployed_verification_eq` — at the one boundary where the
list-shaped assembly becomes the depth-indexed equation — so no statement downstream of it carries a
cast.

`CF` is gone entirely. It ended up as a second representation of the same equation joined to
`VerifierIpa` by a bridge lemma, which is the duplication this change set out to remove, one layer
up. `CF`, `CF_cons`, `eval_eq_CF` and `deployedVerifierEq_cf` are deleted; `roundSum` stays, now
named for what it is — the list-shaped round sum the assembly actually produces.

## Effect

Measured on the eight touched files with all comments and docstrings stripped, so the numbers are
proof terms rather than prose:

| | `main` | this branch |
| --- | --- | --- |
| code-only lines | 4043 | **4039** |
| `Fin.cast (congrArg (2 ^ ·) List.length_ofFn)` occurrences, tree-wide | 8 | **4** |
| declarations | 269 | 278 |

The declaration count rises by 9: fifteen genuinely new (the structure, its five API members, and the
named subexpressions) against six deleted (`CF`, `CF_cons`, `CF_congr_chal`, `gPart`, `gPart_cons`,
`deployedVerifierEq_cf`). The additions are names; the deletions are duplication.

The repeated subexpressions from the table above collapse to one home each: the blinding term from 8
sites to 1, the `[-v]g₀` sum from 9 to 4, the round-sum body from 6 to 4, the opening pair from 11 to
9 (the survivors are in `Verifier/Assemble.lean` and the algebraic adversary, outside this change).

Not claimed: this does not remove the `List`/`Fin` friction at the flat/tree boundary. It halves the
generator casts and confines the survivors to the two crossing lemmas and `Deployed/Fold.lean`.
Driving them to zero would mean depth-indexing `foldAll` and `computeB`, trading away the halo2
transcription faithfulness — deliberately not done.

## Review notes

Eight commits, each building on its own, in two groups. Commits 1–3 are pure dedup and naming and
stand alone: they are the drift fix and survive a revert of everything after. Commits 4–8 add the
structure, route the deployed and forking paths through it, then delete `CF` once nothing needs it.

1. `fv: name the adjusted IPA commitment`
2. `fv: state the deployed IPA equation through the adjusted commitment`
3. `fv: define the deployed IPA equation as the closed form CF`
4. `fv: generalize the Fin-indexed generator fold`
5. `fv: the deployed IPA verifier equation as a structure`
6. `fv: route the deployed and forking paths through VerifierIpa`
7. `fv: collapse CF into VerifierIpa`
8. `fv: centralize the equation's remaining expansions`

No downstream theorem's *meaning* changes; `deployedVerifierEq_iff_flatAccept`,
`forkAccept_to_acceptV` and the Vesta endpoints prove the same facts. `CF_leaf_to_acceptV` is renamed
`evalLeaf_to_acceptV`, since it no longer mentions `CF`.

The change is entirely definitional and algebraic, so no declaration's axiom footprint should move —
`Zcash/TrustBoundary.lean`'s build-checked `assert_axioms` census is the regression test for that, and
it passes unchanged.