### PR TITLE
fv: the all-prefixes probabilistic capstones and Orchard bounds

### DIFF
--- a/Zcash/Security/Ledger/Capstone.lean
+++ b/Zcash/Security/Ledger/Capstone.lean
@@ -3,6 +3,9 @@ import Mathlib.Probability.Distributions.Uniform
 import Zcash.Security.Ledger.Balance
 import Zcash.Security.Ledger.SpendAuthority
 
+-- This lint enforces Mathlib's minimal-hypothesis style, from which we deliberately depart.
+set_option linter.unusedSectionVars false
+
 /-!
 # Probabilistic capstones
 
@@ -23,12 +26,18 @@ sample". An existential break predicate would need choice to extract data from; 
 branch of a computed reduction needs none. The composition is pure event algebra — the
 violation event is contained in the union of the arm events, so its probability is at
 most the sum of the per-arm probabilities (`measure_mono` plus `measure_union_le`).
-No independence, no counting. Each arm's probability is then bounded by a named ε
-hypothesis. The key-binding arm's ε is discharged in `KeyBindingArm.lean` against the
-key-binding layer's probability bound (`toInterface_break_measure_le`), for a ledger
-adversary in the oracle model. Connecting that bound to this layer's named-ε slot — an
-oracle machine against a `PMF` over valid annotated ledgers — is still open, as are the
-Merkle and note-commitment arms (against Sinsemilla/DLR hardness).
+No independence, no counting. The all-prefixes variants name each ε on one event
+shared across prefixes, so a bound over `k` prefixes costs no factor of `k`. The
+value-side events are prefix-indexed and the Balance-subset events step-indexed; a
+statement taking an event at a successor prefix — the one step/prefix crossing,
+where non-negativity after the first `i + 1` transactions rests on subset step
+`i` — carries `_succ` in its name, and everything else is same-index. Each arm's
+probability is then bounded by a named ε hypothesis. The key-binding arm's ε is
+discharged in `KeyBindingArm.lean` against the key-binding layer's probability bound
+(`toInterface_break_measure_le`), for a ledger adversary in the oracle model.
+Connecting that bound to this layer's named-ε slot — an oracle machine against a `PMF`
+over valid annotated ledgers — is still open, as are the Merkle and note-commitment
+arms (against Sinsemilla/DLR hardness).
 -/
 
 namespace Zcash.Security.Ledger.Model
@@ -126,9 +135,10 @@ theorem shieldedBalanceCapViolation_subset {VB : Type*}
   · exact absurd (by have := ω.2.transparent_nonneg i; omega) hω
   · exact ⟨b, h⟩
 
-/-- **Balance conservation, probabilistically.** For any adversary, the probability
-that the ledger fails to balance is at most the transaction-balance premiss arm's ε. -/
-theorem balanceConservation_measure_le {VB : Type*}
+/-- **Balance conservation at one prefix.** For any adversary, the probability that
+the ledger fails to balance after the first `i` transactions is at most the
+transaction-balance premiss arm's ε. -/
+theorem balanceConservationPerTx_measure_le {VB : Type*}
     (A : PMF (ValidAnnotated P kv issuance maxActions))
     (perTx : ∀ ω : ValidAnnotated P kv issuance maxActions,
       (tx : Tx KW F G RHO PSI MHASH MENC MSG SIG P.depth) → tx ∈ ω.1 →
@@ -137,10 +147,10 @@ theorem balanceConservation_measure_le {VB : Type*}
     A.toOuterMeasure (balanceConservationViolation i) ≤ ε_conservation :=
   le_trans (MeasureTheory.measure_mono (balanceConservationViolation_subset perTx i)) hvb
 
-/-- **Shielded balance cap, probabilistically.** For any adversary, the probability
-that the shielded pool exceeds the minted issuance is at most the transaction-balance
-premiss arm's ε. -/
-theorem shieldedBalanceCap_measure_le {VB : Type*}
+/-- **Shielded balance cap at one prefix.** For any adversary, the probability that
+the shielded pool exceeds the minted issuance after the first `i` transactions is at
+most the transaction-balance premiss arm's ε. -/
+theorem shieldedBalanceCapPerTx_measure_le {VB : Type*}
     (A : PMF (ValidAnnotated P kv issuance maxActions))
     (perTx : ∀ ω : ValidAnnotated P kv issuance maxActions,
       (tx : Tx KW F G RHO PSI MHASH MENC MSG SIG P.depth) → tx ∈ ω.1 →
@@ -148,6 +158,79 @@ theorem shieldedBalanceCap_measure_le {VB : Type*}
     (hvb : A.toOuterMeasure (txBalanceBreakEvent perTx i) ≤ ε_cap) :
     A.toOuterMeasure (shieldedBalanceCapViolation i) ≤ ε_cap :=
   le_trans (MeasureTheory.measure_mono (shieldedBalanceCapViolation_subset perTx i)) hvb
+
+/-- The all-prefixes transaction-balance break event: there exists `i < k` such that
+after the first `i` transactions, the conservation reduction is handed a break. -/
+def txBalanceBreakEventBefore {VB : Type*}
+    (perTx : ∀ ω : ValidAnnotated P kv issuance maxActions,
+      (tx : Tx KW F G RHO PSI MHASH MENC MSG SIG P.depth) → tx ∈ ω.1 →
+        (txNetValue tx = tx.vBalance) ⊕' VB) (k : ℕ) :
+    Set (ValidAnnotated P kv issuance maxActions) :=
+  {ω | ∃ i, i < k ∧ ω ∈ txBalanceBreakEvent perTx i}
+
+/-- The all-prefixes balance-conservation violation event: there exists `i < k` such
+that after the first `i` transactions, the shielded pool plus the transparent pool
+differs from the minted issuance. -/
+def balanceConservationViolationBefore (k : ℕ) :
+    Set (ValidAnnotated P kv issuance maxActions) :=
+  {ω | ∃ i, i < k ∧ ω ∈ balanceConservationViolation i}
+
+/-- The all-prefixes shielded-balance-cap violation event: there exists `i < k` such
+that after the first `i` transactions, the shielded pool exceeds the minted issuance. -/
+def shieldedBalanceCapViolationBefore (k : ℕ) :
+    Set (ValidAnnotated P kv issuance maxActions) :=
+  {ω | ∃ i, i < k ∧ ω ∈ shieldedBalanceCapViolation i}
+
+/-- A sample violating conservation at some prefix lands in the all-prefixes
+transaction-balance premiss arm, at that same prefix. -/
+theorem balanceConservationViolationBefore_subset {VB : Type*}
+    (perTx : ∀ ω : ValidAnnotated P kv issuance maxActions,
+      (tx : Tx KW F G RHO PSI MHASH MENC MSG SIG P.depth) → tx ∈ ω.1 →
+        (txNetValue tx = tx.vBalance) ⊕' VB) (k : ℕ) :
+    balanceConservationViolationBefore (P := P) (kv := kv) (maxActions := maxActions) k
+      ⊆ txBalanceBreakEventBefore perTx k := by
+  rintro ω ⟨i, hik, hω⟩
+  exact ⟨i, hik, balanceConservationViolation_subset perTx i hω⟩
+
+/-- A sample violating the cap at some prefix lands in the all-prefixes
+transaction-balance premiss arm, at that same prefix. -/
+theorem shieldedBalanceCapViolationBefore_subset {VB : Type*}
+    (perTx : ∀ ω : ValidAnnotated P kv issuance maxActions,
+      (tx : Tx KW F G RHO PSI MHASH MENC MSG SIG P.depth) → tx ∈ ω.1 →
+        (txNetValue tx = tx.vBalance) ⊕' VB) (k : ℕ) :
+    shieldedBalanceCapViolationBefore (P := P) (kv := kv) (maxActions := maxActions) k
+      ⊆ txBalanceBreakEventBefore perTx k := by
+  rintro ω ⟨i, hik, hω⟩
+  exact ⟨i, hik, shieldedBalanceCapViolation_subset perTx i hω⟩
+
+/-- **Balance conservation at every prefix, at no extra cost in `k`.** For any
+adversary, the probability that the pools fail to sum to issuance after one of the
+first `k` transactions is at most a single ε. A naive union bound over the `k`
+prefixes would pay `k · ε`; instead the hypothesis names one ε on the shared
+all-prefixes break event, and every prefix's violation lands there. -/
+theorem balanceConservation_measure_le {VB : Type*}
+    (A : PMF (ValidAnnotated P kv issuance maxActions))
+    (perTx : ∀ ω : ValidAnnotated P kv issuance maxActions,
+      (tx : Tx KW F G RHO PSI MHASH MENC MSG SIG P.depth) → tx ∈ ω.1 →
+        (txNetValue tx = tx.vBalance) ⊕' VB) (k : ℕ) {ε_conservation : ℝ≥0∞}
+    (hvb : A.toOuterMeasure (txBalanceBreakEventBefore perTx k) ≤ ε_conservation) :
+    A.toOuterMeasure (balanceConservationViolationBefore k) ≤ ε_conservation :=
+  le_trans
+    (MeasureTheory.measure_mono (balanceConservationViolationBefore_subset perTx k)) hvb
+
+/-- **Shielded balance cap at every prefix, at no extra cost in `k`.** For any
+adversary, the probability that the shielded pool exceeds the minted issuance after
+one of the first `k` transactions is at most a single ε, by the same event-sharing
+as balance conservation. -/
+theorem shieldedBalanceCap_measure_le {VB : Type*}
+    (A : PMF (ValidAnnotated P kv issuance maxActions))
+    (perTx : ∀ ω : ValidAnnotated P kv issuance maxActions,
+      (tx : Tx KW F G RHO PSI MHASH MENC MSG SIG P.depth) → tx ∈ ω.1 →
+        (txNetValue tx = tx.vBalance) ⊕' VB) (k : ℕ) {ε_cap : ℝ≥0∞}
+    (hvb : A.toOuterMeasure (txBalanceBreakEventBefore perTx k) ≤ ε_cap) :
+    A.toOuterMeasure (shieldedBalanceCapViolationBefore k) ≤ ε_cap :=
+  le_trans
+    (MeasureTheory.measure_mono (shieldedBalanceCapViolationBefore_subset perTx k)) hvb
 
 /-! ## Balance-subset -/
 
@@ -194,11 +277,12 @@ theorem balanceSubsetViolation_subset (i : ℕ) :
     | noteCommit nb => exact Or.inl (Or.inr ⟨_, h, rfl⟩)
     | keyBinding w₁ w₂ hbr => exact Or.inr ⟨_, h, rfl⟩
 
-/-- **Balance-subset, probabilistically.** For any adversary — a distribution over
-valid annotated ledgers — the probability that the nonzero spends of the first `i + 1`
-transactions are not covered by the positioned outputs of the first `i` is at most the
-sum of the three break-arm probabilities, each bounded by its named ε hypothesis. -/
-theorem balanceSubset_measure_le (A : PMF (ValidAnnotated P kv issuance maxActions))
+/-- **Balance-subset at one prefix.** For any adversary — a distribution over valid
+annotated ledgers — the probability that the nonzero spends of the first `i + 1`
+transactions are not covered by the positioned outputs of the first `i` is at most
+the sum of the three break-arm probabilities, each bounded by its named ε
+hypothesis. -/
+theorem balanceSubsetPerTx_measure_le (A : PMF (ValidAnnotated P kv issuance maxActions))
     (i : ℕ) {εm εnc εkb : ℝ≥0∞}
     (hm : A.toOuterMeasure (balanceSubsetBreakEvent i .merkle) ≤ εm)
     (hnc : A.toOuterMeasure (balanceSubsetBreakEvent i .noteCommit) ≤ εnc)
@@ -207,7 +291,196 @@ theorem balanceSubset_measure_le (A : PMF (ValidAnnotated P kv issuance maxActio
   le_trans (toOuterMeasure_le_add₃ A (balanceSubsetViolation_subset i))
     (add_le_add (add_le_add hm hnc) hkb)
 
+/-- The all-prefixes event for one arm: at some step `i < k`, the Balance-subset
+reduction lands in that arm. Step `i` compares the spends of the first `i + 1`
+transactions against the outputs of the first `i`, and so (unlike the conservation
+and cap events) it concerns the state after the first `i + 1` transactions; this
+is natural given the definition of `balanceSubsetBreakEvent`. -/
+def balanceSubsetBreakEventUpTo (k : ℕ) (arm : BalanceArm) :
+    Set (ValidAnnotated P kv issuance maxActions) :=
+  {ω | ∃ i, i < k ∧ ω ∈ balanceSubsetBreakEvent i arm}
+
+/-- The all-prefixes Balance-subset violation event: for some `i < k`, the nonzero
+spends of the first `i + 1` transactions are not covered by the positioned outputs
+of the first `i`. -/
+def balanceSubsetViolationUpTo (k : ℕ) :
+    Set (ValidAnnotated P kv issuance maxActions) :=
+  {ω | ∃ i, i < k ∧ ω ∈ balanceSubsetViolation i}
+
+/-- A sample violating Balance-subset at some prefix lands in one of the three arms,
+at that same prefix. -/
+theorem balanceSubsetViolationUpTo_subset (k : ℕ) :
+    balanceSubsetViolationUpTo (P := P) (kv := kv) (issuance := issuance)
+        (maxActions := maxActions) k
+      ⊆ balanceSubsetBreakEventUpTo k .merkle ∪ balanceSubsetBreakEventUpTo k .noteCommit
+        ∪ balanceSubsetBreakEventUpTo k .keyBinding := by
+  rintro ω ⟨i, hik, hω⟩
+  rcases balanceSubsetViolation_subset i hω with (h | h) | h
+  · exact Or.inl (Or.inl ⟨i, hik, h⟩)
+  · exact Or.inl (Or.inr ⟨i, hik, h⟩)
+  · exact Or.inr ⟨i, hik, h⟩
+
+/-- **Balance-subset at every prefix, at no extra cost in `k`.** For any adversary,
+the probability that the nonzero spends escape the earlier positioned outputs at
+some step `i < k` is at most the sum of three ε's — one per arm, each named on that
+arm's shared all-prefixes event. This is the same bound as for a single step,
+independent of `k`. -/
+theorem balanceSubset_measure_le (A : PMF (ValidAnnotated P kv issuance maxActions))
+    (k : ℕ) {εm εnc εkb : ℝ≥0∞}
+    (hm : A.toOuterMeasure (balanceSubsetBreakEventUpTo k .merkle) ≤ εm)
+    (hnc : A.toOuterMeasure (balanceSubsetBreakEventUpTo k .noteCommit) ≤ εnc)
+    (hkb : A.toOuterMeasure (balanceSubsetBreakEventUpTo k .keyBinding) ≤ εkb) :
+    A.toOuterMeasure (balanceSubsetViolationUpTo k) ≤ εm + εnc + εkb :=
+  le_trans (toOuterMeasure_le_add₃ A (balanceSubsetViolationUpTo_subset k))
+    (add_le_add (add_le_add hm hnc) hkb)
+
 end BalanceSubset
+
+/-! ## Balance integrity -/
+
+section BalanceIntegrity
+
+variable [DecidableEq F] [DecidableEq G] [DecidableEq RHO] [DecidableEq PSI]
+  [DecidableEq MHASH] [DecidableEq MENC] [DecidableEq NK] [NoZeroSMulDivisors F G]
+
+/-- The shielded-balance non-negativity violation event: the shielded pool goes
+negative after the first `i` transactions — value spent that was never created. -/
+def shieldedBalanceNonNegativeViolation (i : ℕ) :
+    Set (ValidAnnotated P kv issuance maxActions) :=
+  {ω | ¬ 0 ≤ shieldedPoolBalance ω.1 i}
+
+/-- The one step/prefix crossing: the pool can only go negative after a transaction,
+so a non-negativity violation at prefix `i + 1` lands in the three Balance-subset
+arms at step `i` — were the spends covered by the earlier outputs, the pool could
+not go negative (`shieldedPoolBalance_nonneg`). -/
+theorem shieldedBalanceNonNegativeViolation_succ_subset (i : ℕ) :
+    shieldedBalanceNonNegativeViolation (P := P) (kv := kv) (issuance := issuance)
+        (maxActions := maxActions) (i + 1)
+      ⊆ balanceSubsetBreakEvent i .merkle ∪ balanceSubsetBreakEvent i .noteCommit
+        ∪ balanceSubsetBreakEvent i .keyBinding := by
+  intro ω hω
+  exact balanceSubsetViolation_subset i
+    (fun hsub => hω (shieldedPoolBalance_nonneg ω.1 i hsub))
+
+/-- **Shielded non-negativity, probabilistically.** The pool can only go negative
+after a transaction: for any adversary, the probability that the shielded pool goes
+negative after the first `i + 1` transactions is at most the three step-`i`
+Balance-subset arm ε's. -/
+theorem shieldedBalanceNonNegative_succ_measure_le
+    (A : PMF (ValidAnnotated P kv issuance maxActions)) (i : ℕ) {εm εnc εkb : ℝ≥0∞}
+    (hm : A.toOuterMeasure (balanceSubsetBreakEvent i .merkle) ≤ εm)
+    (hnc : A.toOuterMeasure (balanceSubsetBreakEvent i .noteCommit) ≤ εnc)
+    (hkb : A.toOuterMeasure (balanceSubsetBreakEvent i .keyBinding) ≤ εkb) :
+    A.toOuterMeasure (shieldedBalanceNonNegativeViolation (i + 1)) ≤ εm + εnc + εkb :=
+  le_trans
+    (toOuterMeasure_le_add₃ A (shieldedBalanceNonNegativeViolation_succ_subset i))
+    (add_le_add (add_le_add hm hnc) hkb)
+
+/-- The per-prefix Balance-integrity violation event: after the first `i`
+transactions, the shielded pool goes negative, the transparent pool goes negative,
+or the pools fail to sum to the minted issuance. The event mirrors
+`balanceIntegrityOrBreak`'s conclusion; on the valid sample space the transparent
+conjunct cannot fail (`ValidLedger.transparent_nonneg`). -/
+def balanceIntegrityPerTxViolation (i : ℕ) :
+    Set (ValidAnnotated P kv issuance maxActions) :=
+  {ω | ¬ (0 ≤ shieldedPoolBalance ω.1 i
+    ∧ 0 ≤ transparentPoolBalance issuance ω.1 i
+    ∧ shieldedPoolBalance ω.1 i + transparentPoolBalance issuance ω.1 i
+        = issuanceTotal issuance ω.1 i)}
+
+/-- A per-prefix integrity violation at prefix `i` is a shielded non-negativity
+violation or a conservation violation, at that same prefix: the transparent
+conjunct cannot fail on the valid sample space. -/
+theorem balanceIntegrityPerTxViolation_subset (i : ℕ) :
+    balanceIntegrityPerTxViolation (P := P) (kv := kv) (issuance := issuance)
+        (maxActions := maxActions) i
+      ⊆ shieldedBalanceNonNegativeViolation i ∪ balanceConservationViolation i := by
+  intro ω hω
+  rcases not_and_or.mp hω with h | h
+  · exact Or.inl h
+  · rcases not_and_or.mp h with h' | h'
+    · exact absurd (ω.2.transparent_nonneg i) h'
+    · exact Or.inr h'
+
+/-- **Balance integrity at one prefix.** For any adversary, the probability that
+balance integrity fails (the shielded pool goes negative or the pools fail to sum
+to the minted issuance) after the first `i` transactions is at most a
+non-negativity ε plus the transaction-balance premiss arm's ε. Discharge
+`ε_nonneg` at successor prefixes with `shieldedBalanceNonNegative_succ_measure_le`;
+the empty prefix cannot go negative. -/
+theorem balanceIntegrityPerTx_measure_le {VB : Type*}
+    (A : PMF (ValidAnnotated P kv issuance maxActions))
+    (perTx : ∀ ω : ValidAnnotated P kv issuance maxActions,
+      (tx : Tx KW F G RHO PSI MHASH MENC MSG SIG P.depth) → tx ∈ ω.1 →
+        (txNetValue tx = tx.vBalance) ⊕' VB) (i : ℕ) {ε_nonneg ε_conservation : ℝ≥0∞}
+    (hnn : A.toOuterMeasure (shieldedBalanceNonNegativeViolation i) ≤ ε_nonneg)
+    (hvb : A.toOuterMeasure (txBalanceBreakEvent perTx i) ≤ ε_conservation) :
+    A.toOuterMeasure (balanceIntegrityPerTxViolation i) ≤ ε_nonneg + ε_conservation :=
+  le_trans
+    (toOuterMeasure_le_add₂ A
+      ((balanceIntegrityPerTxViolation_subset i).trans
+        (Set.union_subset_union subset_rfl
+          (balanceConservationViolation_subset perTx i))))
+    (add_le_add hnn hvb)
+
+/-- The all-prefixes Balance-integrity violation event: there exists `i < k` such
+that balance integrity fails after the first `i` transactions: the shielded pool
+goes negative or the pools fail to sum to the minted issuance. -/
+def balanceIntegrityViolationBefore (k : ℕ) :
+    Set (ValidAnnotated P kv issuance maxActions) :=
+  {ω | ∃ i, i < k ∧ ω ∈ balanceIntegrityPerTxViolation i}
+
+/-- An integrity violation at some prefix lands in one of the three all-prefixes
+arms or the all-prefixes transaction-balance premiss arm: a negative pool at prefix
+`j + 1` lands in an arm at step `j` (the empty prefix cannot go negative), and a
+conservation violation lands in the premiss arm at its own prefix. One bound `k`
+serves the mixed step-indexed (`UpTo`) and prefix-indexed (`Before`) right-hand
+side: the crossing only produces steps `j` with `j + 1 < k`, so `j < k`. -/
+theorem balanceIntegrityViolationBefore_subset {VB : Type*}
+    (perTx : ∀ ω : ValidAnnotated P kv issuance maxActions,
+      (tx : Tx KW F G RHO PSI MHASH MENC MSG SIG P.depth) → tx ∈ ω.1 →
+        (txNetValue tx = tx.vBalance) ⊕' VB) (k : ℕ) :
+    balanceIntegrityViolationBefore (P := P) (kv := kv) (issuance := issuance)
+        (maxActions := maxActions) k
+      ⊆ (balanceSubsetBreakEventUpTo k .merkle
+          ∪ balanceSubsetBreakEventUpTo k .noteCommit
+          ∪ balanceSubsetBreakEventUpTo k .keyBinding)
+        ∪ txBalanceBreakEventBefore perTx k := by
+  rintro ω ⟨i, hik, hω⟩
+  rcases not_and_or.mp hω with h | h
+  · cases i with
+    | zero => exact absurd (shieldedPoolBalance_zero ω.1).symm.le h
+    | succ j =>
+        rcases shieldedBalanceNonNegativeViolation_succ_subset j h with (h' | h') | h'
+        · exact Or.inl (Or.inl (Or.inl ⟨j, Nat.lt_of_succ_lt hik, h'⟩))
+        · exact Or.inl (Or.inl (Or.inr ⟨j, Nat.lt_of_succ_lt hik, h'⟩))
+        · exact Or.inl (Or.inr ⟨j, Nat.lt_of_succ_lt hik, h'⟩)
+  · rcases not_and_or.mp h with h' | h'
+    · exact absurd (ω.2.transparent_nonneg i) h'
+    · exact Or.inr ⟨i, hik, balanceConservationViolation_subset perTx i h'⟩
+
+/-- **Balance integrity at every prefix, at no extra cost in `k`.** For any adversary,
+the probability that balance integrity is violated (the shielded pool goes negative
+or the pools fail to sum to the minted issuance) at some prefix `i < k` is at most
+the three Balance-subset arm ε's plus the transaction-balance premiss arm's ε. This
+is the same bound as for a single prefix, independent of `k`. -/
+theorem balanceIntegrity_measure_le {VB : Type*}
+    (A : PMF (ValidAnnotated P kv issuance maxActions))
+    (perTx : ∀ ω : ValidAnnotated P kv issuance maxActions,
+      (tx : Tx KW F G RHO PSI MHASH MENC MSG SIG P.depth) → tx ∈ ω.1 →
+        (txNetValue tx = tx.vBalance) ⊕' VB) (k : ℕ) {εm εnc εkb ε_conservation : ℝ≥0∞}
+    (hm : A.toOuterMeasure (balanceSubsetBreakEventUpTo k .merkle) ≤ εm)
+    (hnc : A.toOuterMeasure (balanceSubsetBreakEventUpTo k .noteCommit) ≤ εnc)
+    (hkb : A.toOuterMeasure (balanceSubsetBreakEventUpTo k .keyBinding) ≤ εkb)
+    (hvb : A.toOuterMeasure (txBalanceBreakEventBefore perTx k) ≤ ε_conservation) :
+    A.toOuterMeasure (balanceIntegrityViolationBefore k) ≤ εm + εnc + εkb + ε_conservation :=
+  le_trans (toOuterMeasure_le_add₂ A (balanceIntegrityViolationBefore_subset perTx k))
+    (add_le_add
+      (le_trans (toOuterMeasure_le_add₃ A subset_rfl)
+        (add_le_add (add_le_add hm hnc) hkb))
+      hvb)
+
+end BalanceIntegrity
 
 /-! ## Spend Authority -/
 

--- a/Zcash/Security/Ledger/Capstone.lean
+++ b/Zcash/Security/Ledger/Capstone.lean
@@ -36,8 +36,8 @@ probability is then bounded by a named ε hypothesis. The key-binding arm's ε i
 discharged in `KeyBindingArm.lean` against the key-binding layer's probability bound
 (`toInterface_break_measure_le`), for a ledger adversary in the oracle model.
 Connecting that bound to this layer's named-ε slot — an oracle machine against a `PMF`
-over valid annotated ledgers — is still open, as are the Merkle and note-commitment
-arms (against Sinsemilla/DLR hardness).
+over valid annotated ledgers — is still open (#155), as are the Merkle and
+note-commitment arms (against Sinsemilla/DLR hardness).
 -/
 
 namespace Zcash.Security.Ledger.Model

--- a/Zcash/Security/Ledger/Effects.lean
+++ b/Zcash/Security/Ledger/Effects.lean
@@ -91,4 +91,11 @@ def shieldedPoolBalance (ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG d) (i
   (((positionedOutputs ledger i).map fun p => (p.opening.note.v : ℤ)).sum : ℤ)
     - ((nonZeroSpends ledger i).map fun p => (p.opening.note.v : ℤ)).sum
 
+/-- The empty prefix holds an empty shielded pool. -/
+@[simp] theorem shieldedPoolBalance_zero
+    (ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG d) :
+    shieldedPoolBalance ledger 0 = 0 := by
+  simp [shieldedPoolBalance, positionedOutputs, nonZeroSpends, spendActions,
+    outputOpenings, outputActions]
+
 end Zcash.Security.Ledger.Model

--- a/Zcash/Security/Ledger/OrchardCapstone.lean
+++ b/Zcash/Security/Ledger/OrchardCapstone.lean
@@ -292,7 +292,10 @@ def orchardSpendAuthorityOrRelation
 /-- The Orchard Spend Authority relation event, for a victim key witness `wV` with
 signing history `Signed`: the samples on which the reduction, run on an Action
 spending a note addressed to `wV` over an unsigned sighash, computes a nontrivial
-discrete-log relation at the `CommitIvk` bases. -/
+discrete-log relation at the `CommitIvk` bases. The firing Action is selected
+existentially; #155 tracks the oracle-machine layer that connects the ε named on
+this event to an adversary experiment and recovers the Action from the adversary's
+announced indices. -/
 def orchardSpendAuthorityRelationEvent (wV : KeyBinding.Pool.Witness Fq PallasGroup Fp)
     (hKB : keyBinding.KB wV) (Signed : MSG → Prop) :
     Set (OrchardAnnotated verify bverify issuance maxActions) :=

--- a/Zcash/Security/Ledger/OrchardCapstone.lean
+++ b/Zcash/Security/Ledger/OrchardCapstone.lean
@@ -270,4 +270,74 @@ def relationOfSpendAuthorityKBBreak (b : KeyBindingBreakData keyBinding) :
     NontrivialRelation (F := Fq) pallasS ivkQpt commitIvkRpt :=
   relationOfKeyBindingBreak b.h
 
+/-- The Orchard Spend Authority reduction with its key-binding arm routed to the
+discrete-log terminal: as `spendAuthorityOrBreak`, with a key-binding break converted
+to its nontrivial relation at the `CommitIvk` bases by
+`relationOfSpendAuthorityKBBreak`. -/
+def orchardSpendAuthorityOrRelation
+    {ledger : Ledger _ Fq PallasGroup Fp Fp Fp Encoding MSG SIG _}
+    (hval : ValidLedger (primitives (MSG := MSG) (SIG := SIG) verify bverify) keyBinding
+      issuance maxActions ledger)
+    {tx} (htx : tx ∈ ledger) {a} (ha : a ∈ tx.actions)
+    {wV : KeyBinding.Pool.Witness Fq PallasGroup Fp} (hKB : keyBinding.KB wV)
+    (hrecv : a.w.note_old.pkd
+      = (primitives verify bverify).emb (keyBinding.ivk wV) • a.w.note_old.gd)
+    {Signed : MSG → Prop} (hfresh : ¬ Signed tx.sighash) :
+    SpendAuthForgery (primitives verify bverify) (keyBinding.akP wV) Signed
+      ⊕' NontrivialRelation (F := Fq) pallasS ivkQpt commitIvkRpt :=
+  match spendAuthorityOrBreak hval htx ha hKB hrecv hfresh with
+  | .inl f => .inl f
+  | .inr b => .inr (relationOfSpendAuthorityKBBreak b)
+
+/-- The Orchard Spend Authority relation event, for a victim key witness `wV` with
+signing history `Signed`: the samples on which the reduction, run on an Action
+spending a note addressed to `wV` over an unsigned sighash, computes a nontrivial
+discrete-log relation at the `CommitIvk` bases. -/
+def orchardSpendAuthorityRelationEvent (wV : KeyBinding.Pool.Witness Fq PallasGroup Fp)
+    (hKB : keyBinding.KB wV) (Signed : MSG → Prop) :
+    Set (OrchardAnnotated verify bverify issuance maxActions) :=
+  {ω | ∃ tx, ∃ htx : tx ∈ ω.1, ∃ a, ∃ ha : a ∈ tx.actions,
+    ∃ hrecv : a.w.note_old.pkd
+      = (primitives verify bverify).emb (keyBinding.ivk wV) • a.w.note_old.gd,
+    ∃ hfresh : ¬ Signed tx.sighash, ∃ r,
+    orchardSpendAuthorityOrRelation verify bverify issuance maxActions ω.2 htx ha hKB
+      hrecv hfresh = .inr r}
+
+/-- A break-arm sample lands in the relation event: on it, the reduction's key-binding
+break converts to a relation, so the composed reduction returns one. -/
+theorem spendAuthorityBreakEvent_subset_relation
+    (wV : KeyBinding.Pool.Witness Fq PallasGroup Fp) (hKB : keyBinding.KB wV)
+    (Signed : MSG → Prop) :
+    spendAuthorityBreakEvent (P := primitives verify bverify) wV hKB Signed
+      ⊆ orchardSpendAuthorityRelationEvent verify bverify issuance maxActions wV hKB
+          Signed := by
+  rintro ω ⟨tx, htx, a, ha, hrecv, hfresh, b, hb⟩
+  refine ⟨tx, htx, a, ha, hrecv, hfresh, relationOfSpendAuthorityKBBreak b, ?_⟩
+  unfold orchardSpendAuthorityOrRelation
+  rw [hb]
+
+/-- **The Orchard Spend Authority probability bound.** For any adversary over valid
+Orchard ledgers, the probability that some Action spends a note addressed to `wV` over
+a sighash the holder of `wV` never signed is at most the forgery arm's ε plus the
+discrete-log-relation advantage at the `CommitIvk` bases: the key-binding arm's
+hypothesis is named on the relation event — every break-arm sample computes a relation
+(`spendAuthorityBreakEvent_subset_relation`) — with no oracle model. The forgery arm's
+ε is RedDSA ±-randomized unforgeability, a named hypothesis. -/
+theorem orchardSpendAuthority_measure_le
+    (A : PMF (OrchardAnnotated verify bverify issuance maxActions))
+    (wV : KeyBinding.Pool.Witness Fq PallasGroup Fp) (hKB : keyBinding.KB wV)
+    (Signed : MSG → Prop) {εf ε_sinsemilladlr : ℝ≥0∞}
+    (hf : A.toOuterMeasure
+      (spendAuthorityForgeryEvent (P := primitives verify bverify) wV hKB Signed) ≤ εf)
+    (hsin : A.toOuterMeasure
+      (orchardSpendAuthorityRelationEvent verify bverify issuance maxActions wV hKB
+        Signed) ≤ ε_sinsemilladlr) :
+    A.toOuterMeasure
+      (spendAuthorityViolation (P := primitives verify bverify) wV Signed)
+      ≤ εf + ε_sinsemilladlr :=
+  spendAuthority_measure_le A wV hKB Signed hf
+    (le_trans (MeasureTheory.measure_mono
+      (spendAuthorityBreakEvent_subset_relation verify bverify issuance maxActions wV
+        hKB Signed)) hsin)
+
 end Zcash.Security.Ledger.Bridge

--- a/Zcash/Security/Ledger/OrchardCapstone.lean
+++ b/Zcash/Security/Ledger/OrchardCapstone.lean
@@ -256,4 +256,18 @@ theorem orchardBalanceIntegrity_measure_le
       (balanceIntegrityViolationBefore_subset_relation verify bverify issuance maxActions k))
     (add_le_add hsin hbind)
 
+/-! ## The Orchard Spend Authority key-binding arm -/
+
+/-- **The Orchard-protocol Spend Authority key-binding break computes a discrete-log
+relation.** The Spend Authority reduction's key-binding break is two valid `Commit^ivk`
+openings of the same `ivk` that differ in the extracted `ak` coordinate, `nk`, or
+`rivk` (`Witness.breakProjection`). At the Orchard `keyBinding` interface that break is
+the `CommitIvkCollision` that `relationOfKeyBindingBreak` consumes, so the Spend
+Authority key-binding arm reaches the same discrete-log terminal as the Balance
+key-binding arm. The break is computed from the exhibited witness pair, and the
+reduction needs no oracle model. -/
+def relationOfSpendAuthorityKBBreak (b : KeyBindingBreakData keyBinding) :
+    NontrivialRelation (F := Fq) pallasS ivkQpt commitIvkRpt :=
+  relationOfKeyBindingBreak b.h
+
 end Zcash.Security.Ledger.Bridge

--- a/Zcash/Security/Ledger/OrchardCapstone.lean
+++ b/Zcash/Security/Ledger/OrchardCapstone.lean
@@ -15,13 +15,23 @@ function from the arm's break to its relation, so it needs no random-oracle mode
 computes either the Balance-subset containment or a nontrivial relation among the
 fixed bases.
 
-This is the deterministic core of the Orchard ε discharge. The probability that a
-sampled ledger produces a relation is the discrete-log-relation advantage for the
-fixed bases, under their pre-quantum hardness (their independence, spec Theorems 5.4.3
-and 5.4.4). That is the same terminal as the Merkle and note-commitment arms, and the
-key-binding arm reaches it here without the oracle model. Turning this deterministic
-reduction into a bound on the capstone's named ε — composing it with
-`balanceSubset_measure_le` over a `PMF` of Orchard ledgers — is not yet formalized.
+The probability layer names the relation event — the samples on which the reduction
+computes a relation — and bounds every capstone violation by it. One ε suffices where
+the abstract capstones name one per arm, and one ε suffices for every prefix of a
+`k`-transaction ledger where a naive union bound would pay `k · ε`: the arms and the
+prefixes all land in the same event, a nontrivial discrete-log relation among the same
+fixed bases.
+
+That probability, `ε_sinsemilladlr`, is the advantage in finding a nontrivial
+discrete-log relation among the Sinsemilla bases (spec Theorems 5.4.3 and 5.4.4,
+re-proved as `preCoeffs_inj` and `relationOfChainPmEq`). It reduces tightly to
+discrete-log hardness of the fixed bases (Jaeger–Tessaro, eprint 2020/1213 Lemma 3,
+re-proved as `relation_prob_le_of_textbookDL`). The witness-level model quantifies
+over valid annotated ledgers, so it abstracts away Halo 2 knowledge soundness — a
+separate, lossy reduction on the different Halo 2 bases; that is where the end-to-end
+reduction loss lives. `ε_bindsig`, the binding-signature advantage, bounds the value
+side — value conservation rests on the binding signature — and is not yet reduced to
+its own terminal.
 -/
 
 namespace Zcash.Security.Ledger.Bridge
@@ -30,6 +40,7 @@ open Zcash.Circuits
 open Zcash.Security.Concrete
 open Zcash.Security.Ledger.Pool
 open Zcash.Security.Ledger.Model
+open scoped ENNReal
 
 variable {MSG SIG : Type*}
   (verify bverify : PallasGroup → MSG → SIG → Prop)
@@ -64,5 +75,185 @@ def orchardBalanceSubsetOrRelation {ledger : Ledger _ Fq PallasGroup Fp Fp Fp En
   | .inr (.keyBinding _ _ h) => .inr (.keyBinding (relationOfKeyBindingBreak h))
   | .inr (.noteCommit nb) => .inr (.noteCommit (relationOfNoteCommitBreak verify bverify nb))
   | .inr (.merkle c) => .inr (.merkle (relationOfMerkleCollision c.2))
+
+/-! ## The Orchard Balance-subset probability bound -/
+
+/-- The Orchard relation event: the samples on which the Orchard reduction computes a
+nontrivial discrete-log relation among the fixed Sinsemilla bases. -/
+def orchardRelationEvent (i : ℕ) :
+    Set (OrchardAnnotated verify bverify issuance maxActions) :=
+  {ω | ∃ r : OrchardBalanceRelation,
+    orchardBalanceSubsetOrRelation verify bverify issuance maxActions ω.2 i = .inr r}
+
+/-- A Balance-subset-violating Orchard ledger lands in the relation event: the total
+reduction cannot return the containment on such a sample, so it returns a relation. -/
+theorem balanceSubsetViolation_subset_relation (i : ℕ) :
+    balanceSubsetViolation (P := primitives verify bverify) (kv := keyBinding)
+        (issuance := issuance) (maxActions := maxActions) i
+      ⊆ orchardRelationEvent verify bverify issuance maxActions i := by
+  intro ω hω
+  rcases h : orchardBalanceSubsetOrRelation verify bverify issuance maxActions ω.2 i
+    with hle | r
+  · exact absurd hle hω
+  · exact ⟨r, h⟩
+
+/-- **The Orchard Balance-subset probability bound.** For any adversary — a
+distribution over valid Orchard ledgers — the probability that the nonzero spends of
+the first `i + 1` transactions escape the positioned outputs of the first `i` is at
+most the probability that the ledger computes a nontrivial discrete-log relation among
+the fixed Sinsemilla bases. That single discrete-log-relation advantage
+`ε_sinsemilladlr` bounds the whole event, in place of the three named per-arm ε's of
+`balanceSubsetPerTx_measure_le`, with no random-oracle model. -/
+theorem orchardBalanceSubsetPerTx_measure_le
+    (A : PMF (OrchardAnnotated verify bverify issuance maxActions)) (i : ℕ)
+    {ε_sinsemilladlr : ℝ≥0∞}
+    (hsin : A.toOuterMeasure
+      (orchardRelationEvent verify bverify issuance maxActions i) ≤ ε_sinsemilladlr) :
+    A.toOuterMeasure (balanceSubsetViolation (P := primitives verify bverify)
+        (kv := keyBinding) (issuance := issuance) (maxActions := maxActions) i)
+      ≤ ε_sinsemilladlr :=
+  le_trans (MeasureTheory.measure_mono
+    (balanceSubsetViolation_subset_relation verify bverify issuance maxActions i)) hsin
+
+/-- The all-prefixes Orchard relation event: at some step `i < k`, the reduction
+computes a nontrivial discrete-log relation. -/
+def orchardRelationEventUpTo (k : ℕ) :
+    Set (OrchardAnnotated verify bverify issuance maxActions) :=
+  {ω | ∃ i, i < k ∧ ω ∈ orchardRelationEvent verify bverify issuance maxActions i}
+
+/-- A sample violating Balance-subset at some step lands in the all-prefixes relation
+event, at that same step. -/
+theorem balanceSubsetViolationUpTo_subset_relation (k : ℕ) :
+    balanceSubsetViolationUpTo (P := primitives verify bverify) (kv := keyBinding)
+        (issuance := issuance) (maxActions := maxActions) k
+      ⊆ orchardRelationEventUpTo verify bverify issuance maxActions k := by
+  rintro ω ⟨i, hik, hω⟩
+  exact ⟨i, hik,
+    balanceSubsetViolation_subset_relation verify bverify issuance maxActions i hω⟩
+
+/-- **The Orchard Balance-subset bound at every prefix, at no extra cost in `k`.** One
+`ε_sinsemilladlr` bounds the Balance-subset violation at every step `i < k`, where the
+abstract bound names three ε's per arm family: every step's break lands in the one
+relation event, a nontrivial relation among the same fixed bases. -/
+theorem orchardBalanceSubset_measure_le
+    (A : PMF (OrchardAnnotated verify bverify issuance maxActions)) (k : ℕ)
+    {ε_sinsemilladlr : ℝ≥0∞}
+    (hsin : A.toOuterMeasure
+      (orchardRelationEventUpTo verify bverify issuance maxActions k) ≤ ε_sinsemilladlr) :
+    A.toOuterMeasure (balanceSubsetViolationUpTo (P := primitives verify bverify)
+        (kv := keyBinding) (issuance := issuance) (maxActions := maxActions) k)
+      ≤ ε_sinsemilladlr :=
+  le_trans (MeasureTheory.measure_mono
+    (balanceSubsetViolationUpTo_subset_relation verify bverify issuance maxActions k)) hsin
+
+/-! ## The Orchard shielded pool is non-negative -/
+
+/-- A negative shielded pool lands in the relation event: by spend integrity
+(`shieldedPoolBalance_nonneg`) the Balance-subset containment forces a non-negative
+pool, so a negative pool refutes the containment and the reduction returns a
+relation. The one step/prefix crossing at the Orchard instantiation. -/
+theorem shieldedBalanceNonNegativeViolation_succ_subset_relation (i : ℕ) :
+    shieldedBalanceNonNegativeViolation (P := primitives verify bverify)
+        (kv := keyBinding) (issuance := issuance) (maxActions := maxActions) (i + 1)
+      ⊆ orchardRelationEvent verify bverify issuance maxActions i := by
+  intro ω hω
+  exact balanceSubsetViolation_subset_relation verify bverify issuance maxActions i
+    (fun hsub => hω (shieldedPoolBalance_nonneg ω.1 i hsub))
+
+/-- **The Orchard shielded pool is non-negative, probabilistically.** For any
+adversary over valid Orchard ledgers, the probability that the shielded pool goes
+negative after the first `i + 1` transactions is at most the single
+discrete-log-relation advantage `ε_sinsemilladlr`: no value is spent that was never
+created. -/
+theorem orchardShieldedBalanceNonNegative_succ_measure_le
+    (A : PMF (OrchardAnnotated verify bverify issuance maxActions)) (i : ℕ)
+    {ε_sinsemilladlr : ℝ≥0∞}
+    (hsin : A.toOuterMeasure
+      (orchardRelationEvent verify bverify issuance maxActions i) ≤ ε_sinsemilladlr) :
+    A.toOuterMeasure (shieldedBalanceNonNegativeViolation
+        (P := primitives verify bverify) (kv := keyBinding) (issuance := issuance)
+        (maxActions := maxActions) (i + 1))
+      ≤ ε_sinsemilladlr :=
+  le_trans (MeasureTheory.measure_mono
+    (shieldedBalanceNonNegativeViolation_succ_subset_relation verify bverify issuance
+      maxActions i)) hsin
+
+/-! ## Full Orchard Balance integrity -/
+
+/-- **Full Orchard Balance, probabilistically.** Balance integrity holds after the
+first `i` transactions — the shielded pool is non-negative and the pools sum to the
+minted issuance — except with probability at most `ε_nonneg + ε_bindsig`. Discharge
+`ε_nonneg` at successor prefixes with
+`orchardShieldedBalanceNonNegative_succ_measure_le`, giving `ε_sinsemilladlr`: no
+value is spent that was never created, except with the discrete-log-relation
+advantage. `ε_bindsig` bounds the conservation side: value conservation rests on the
+binding signature, and is not yet reduced to its own terminal. -/
+theorem orchardBalanceIntegrityPerTx_measure_le
+    (A : PMF (OrchardAnnotated verify bverify issuance maxActions)) (i : ℕ)
+    {ε_nonneg ε_bindsig : ℝ≥0∞}
+    (hnn : A.toOuterMeasure (shieldedBalanceNonNegativeViolation
+        (P := primitives verify bverify) (kv := keyBinding) (issuance := issuance)
+        (maxActions := maxActions) i) ≤ ε_nonneg)
+    (hbind : A.toOuterMeasure (balanceConservationViolation
+        (P := primitives verify bverify) (kv := keyBinding) (issuance := issuance)
+        (maxActions := maxActions) i) ≤ ε_bindsig) :
+    A.toOuterMeasure (balanceIntegrityPerTxViolation (P := primitives verify bverify)
+        (kv := keyBinding) (issuance := issuance) (maxActions := maxActions) i)
+      ≤ ε_nonneg + ε_bindsig :=
+  le_trans
+    (toOuterMeasure_le_add₂ A
+      (balanceIntegrityPerTxViolation_subset (P := primitives verify bverify)
+        (kv := keyBinding) (issuance := issuance) (maxActions := maxActions) i))
+    (add_le_add hnn hbind)
+
+/-- An integrity violation at some prefix lands in the all-prefixes relation event
+or the all-prefixes conservation violation: a negative pool at prefix `j + 1` lands
+in the relation event at step `j` (the empty prefix cannot go negative), and a
+conservation violation lands at its own prefix. One bound `k` serves the mixed
+step-indexed (`UpTo`) and prefix-indexed (`Before`) right-hand side: the crossing
+only produces steps `j` with `j + 1 < k`, so `j < k`. -/
+theorem balanceIntegrityViolationBefore_subset_relation (k : ℕ) :
+    balanceIntegrityViolationBefore (P := primitives verify bverify) (kv := keyBinding)
+        (issuance := issuance) (maxActions := maxActions) k
+      ⊆ orchardRelationEventUpTo verify bverify issuance maxActions k
+        ∪ balanceConservationViolationBefore (P := primitives verify bverify)
+          (kv := keyBinding) (issuance := issuance) (maxActions := maxActions) k := by
+  rintro ω ⟨i, hik, hω⟩
+  rcases not_and_or.mp hω with h | h
+  · cases i with
+    | zero => exact absurd (shieldedPoolBalance_zero ω.1).symm.le h
+    | succ j =>
+        exact Or.inl ⟨j, Nat.lt_of_succ_lt hik,
+          shieldedBalanceNonNegativeViolation_succ_subset_relation verify bverify
+            issuance maxActions j h⟩
+  · rcases not_and_or.mp h with h' | h'
+    · exact absurd (ω.2.transparent_nonneg i) h'
+    · exact Or.inr ⟨i, hik, h'⟩
+
+/-- **Orchard Balance integrity at every prefix, at no extra cost in `k`.** Balance
+integrity (the shielded pool is non-negative and the pools sum to the minted
+issuance) holds at every prefix `i < k`, except with probability at most
+`ε_sinsemilladlr + ε_bindsig` — the same bound as for a single prefix, with no
+factor of `k`. A naive union bound over the prefixes would pay `k · ε`, but the
+prefix violations are not independent: the reduction sends every step's break to a
+relation among the same fixed Sinsemilla bases, so a break at any step lands in the
+one event `orchardRelationEventUpTo`, a single discrete-log-relation advantage
+independent of `k`. The conservation side collapses the same way onto the binding
+signature. -/
+theorem orchardBalanceIntegrity_measure_le
+    (A : PMF (OrchardAnnotated verify bverify issuance maxActions)) (k : ℕ)
+    {ε_sinsemilladlr ε_bindsig : ℝ≥0∞}
+    (hsin : A.toOuterMeasure
+      (orchardRelationEventUpTo verify bverify issuance maxActions k) ≤ ε_sinsemilladlr)
+    (hbind : A.toOuterMeasure (balanceConservationViolationBefore
+        (P := primitives verify bverify) (kv := keyBinding) (issuance := issuance)
+        (maxActions := maxActions) k) ≤ ε_bindsig) :
+    A.toOuterMeasure (balanceIntegrityViolationBefore (P := primitives verify bverify)
+        (kv := keyBinding) (issuance := issuance) (maxActions := maxActions) k)
+      ≤ ε_sinsemilladlr + ε_bindsig :=
+  le_trans
+    (toOuterMeasure_le_add₂ A
+      (balanceIntegrityViolationBefore_subset_relation verify bverify issuance maxActions k))
+    (add_le_add hsin hbind)
 
 end Zcash.Security.Ledger.Bridge

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -401,6 +401,17 @@ assert_axioms Zcash.Security.Ledger.Bridge.orchardBalanceIntegrity_measure_le +n
   Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitRCert_check,
   Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitVCert_check)
 
+/-! ## The Orchard Spend Authority key-binding arm
+
+The Spend Authority key-binding break is the same Orchard-protocol `CommitIvkCollision`
+as the Balance key-binding arm. `relationOfSpendAuthorityKBBreak` sends it to a
+nontrivial discrete-log relation at the `CommitIvk` domain point and randomness base —
+the same terminal as the Balance key-binding arm, with no oracle model. -/
+
+assert_computable Zcash.Security.Ledger.Bridge.relationOfSpendAuthorityKBBreak +choice +native(
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt,
+  Zcash.Circuits.Ecc.MulFixed.Certs.commitIvkRCert_check)
+
 /-! ## The key-binding arms' ε, discharged
 
 The Balance-subset and Spend Authority key-binding arms' probability in the

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -181,6 +181,7 @@ assert_computable Zcash.Security.Ledger.Model.outputOpenings
 assert_computable Zcash.Security.Ledger.Model.positionedOutputs
 assert_computable Zcash.Security.Ledger.Model.nonZeroSpends
 assert_computable Zcash.Security.Ledger.Model.shieldedPoolBalance
+assert_axioms Zcash.Security.Ledger.Model.shieldedPoolBalance_zero
 assert_axioms Zcash.Security.Ledger.Model.posVal_lt
 assert_axioms Zcash.Security.Ledger.Model.rootAfter_prefix
 assert_axioms Zcash.Security.Ledger.Model.output_rho_eq_nullifiers
@@ -297,11 +298,19 @@ assert_computable Zcash.Security.Ledger.Model.spendabilityOrBreak +choice
 /-! ## Probabilistic capstones
 
 The game-level probability statements: pure event algebra over an adversary
-distribution of valid annotated ledgers, with a named ε hypothesis per break arm. -/
+distribution of valid annotated ledgers, with a named ε hypothesis per break arm.
+The all-prefixes bounds name their ε's on events shared across prefixes, so they
+cost no factor of `k` over the single-prefix bounds. -/
 
+assert_axioms Zcash.Security.Ledger.Model.balanceSubsetPerTx_measure_le
 assert_axioms Zcash.Security.Ledger.Model.balanceSubset_measure_le
+assert_axioms Zcash.Security.Ledger.Model.balanceConservationPerTx_measure_le
 assert_axioms Zcash.Security.Ledger.Model.balanceConservation_measure_le
+assert_axioms Zcash.Security.Ledger.Model.shieldedBalanceCapPerTx_measure_le
 assert_axioms Zcash.Security.Ledger.Model.shieldedBalanceCap_measure_le
+assert_axioms Zcash.Security.Ledger.Model.shieldedBalanceNonNegative_succ_measure_le
+assert_axioms Zcash.Security.Ledger.Model.balanceIntegrityPerTx_measure_le
+assert_axioms Zcash.Security.Ledger.Model.balanceIntegrity_measure_le
 assert_axioms Zcash.Security.Ledger.Model.spendAuthority_measure_le
 
 /-! ## The Orchard-protocol discrete-log-relation discharges

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -406,11 +406,34 @@ assert_axioms Zcash.Security.Ledger.Bridge.orchardBalanceIntegrity_measure_le +n
 The Spend Authority key-binding break is the same Orchard-protocol `CommitIvkCollision`
 as the Balance key-binding arm. `relationOfSpendAuthorityKBBreak` sends it to a
 nontrivial discrete-log relation at the `CommitIvk` domain point and randomness base —
-the same terminal as the Balance key-binding arm, with no oracle model. -/
+the same terminal as the Balance key-binding arm, with no oracle model.
+`orchardSpendAuthorityOrRelation` composes it into the Spend Authority reduction, and
+`orchardSpendAuthority_measure_le` names the key-binding arm's hypothesis on that
+composed reduction's relation event, so the bound is the forgery arm's ε plus a
+discrete-log-relation advantage; the forgery arm's ε is RedDSA ±-randomized
+unforgeability. -/
 
 assert_computable Zcash.Security.Ledger.Bridge.relationOfSpendAuthorityKBBreak +choice +native(
   CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt,
   Zcash.Circuits.Ecc.MulFixed.Certs.commitIvkRCert_check)
+assert_computable Zcash.Security.Ledger.Bridge.orchardSpendAuthorityOrRelation +choice +native(
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt,
+  Zcash.Security.Ledger.Pool.unc_thirteen_not_isSquare,
+  Zcash.Circuits.Ecc.MulFixed.Certs.commitIvkRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.noteCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.nullifierKCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.spendAuthGCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitVCert_check)
+assert_axioms Zcash.Security.Ledger.Bridge.orchardSpendAuthority_measure_le +native(
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt,
+  Zcash.Security.Ledger.Pool.unc_thirteen_not_isSquare,
+  Zcash.Circuits.Ecc.MulFixed.Certs.commitIvkRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.noteCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.nullifierKCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.spendAuthGCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitVCert_check)
 
 /-! ## The key-binding arms' ε, discharged
 

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -317,9 +317,12 @@ assert_axioms Zcash.Security.Ledger.Model.spendAuthority_measure_le
 
 Each Orchard-protocol Balance-subset break arm reduces to a nontrivial discrete-log
 relation among the fixed Sinsemilla bases, and `orchardBalanceSubsetOrRelation` routes
-all three from a valid Orchard ledger. The reductions are computable, so they get
-assert_computable. The encoding-injectivity and coefficient-injectivity facts they
-consume are theorems. -/
+all three from a valid Orchard ledger. The probability layer bounds each capstone
+violation by the relation event — the branch preimage of that reduction — so a single
+`ε_sinsemilladlr` replaces the abstract capstones' per-arm ε's, and the all-prefixes
+bounds cost no factor of `k`. The reductions are computable, so they get
+assert_computable. The probability bounds and the encoding-injectivity and
+coefficient-injectivity facts they consume are theorems, so they get assert_axioms. -/
 
 assert_axioms Zcash.NontrivialRelation.toOne
 assert_axioms Zcash.Circuits.Specs.Sinsemilla.chunksOf_inj
@@ -344,6 +347,51 @@ assert_computable Zcash.Security.Ledger.Bridge.relationOfNoteCommitBreak +choice
 assert_computable Zcash.Security.Ledger.Bridge.relationOfMerkleCollision +choice +native(
   CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt)
 assert_computable Zcash.Security.Ledger.Bridge.orchardBalanceSubsetOrRelation +choice +native(
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt,
+  Zcash.Security.Ledger.Pool.unc_thirteen_not_isSquare,
+  Zcash.Circuits.Ecc.MulFixed.Certs.commitIvkRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.noteCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.nullifierKCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.spendAuthGCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitVCert_check)
+assert_axioms Zcash.Security.Ledger.Bridge.orchardBalanceSubsetPerTx_measure_le +native(
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt,
+  Zcash.Security.Ledger.Pool.unc_thirteen_not_isSquare,
+  Zcash.Circuits.Ecc.MulFixed.Certs.commitIvkRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.noteCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.nullifierKCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.spendAuthGCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitVCert_check)
+assert_axioms Zcash.Security.Ledger.Bridge.orchardBalanceSubset_measure_le +native(
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt,
+  Zcash.Security.Ledger.Pool.unc_thirteen_not_isSquare,
+  Zcash.Circuits.Ecc.MulFixed.Certs.commitIvkRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.noteCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.nullifierKCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.spendAuthGCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitVCert_check)
+assert_axioms Zcash.Security.Ledger.Bridge.orchardShieldedBalanceNonNegative_succ_measure_le +native(
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt,
+  Zcash.Security.Ledger.Pool.unc_thirteen_not_isSquare,
+  Zcash.Circuits.Ecc.MulFixed.Certs.commitIvkRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.noteCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.nullifierKCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.spendAuthGCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitVCert_check)
+assert_axioms Zcash.Security.Ledger.Bridge.orchardBalanceIntegrityPerTx_measure_le +native(
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt,
+  Zcash.Security.Ledger.Pool.unc_thirteen_not_isSquare,
+  Zcash.Circuits.Ecc.MulFixed.Certs.commitIvkRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.noteCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.nullifierKCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.spendAuthGCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitVCert_check)
+assert_axioms Zcash.Security.Ledger.Bridge.orchardBalanceIntegrity_measure_le +native(
   CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt,
   Zcash.Security.Ledger.Pool.unc_thirteen_not_isSquare,
   Zcash.Circuits.Ecc.MulFixed.Certs.commitIvkRCert_check,

--- a/book/src/formal-verification/security-definitions.md
+++ b/book/src/formal-verification/security-definitions.md
@@ -39,7 +39,7 @@ flowchart TD
   BAL --> BS["Binding-signature<br/>balance"]
   BAL --> NCB["Note-commitment<br/>binding"]
   BAL --> MERK["Merkle-path<br/>binding"]
-  BAL --> KB["Key binding<br/>ZIP 2005 (ROM)"]
+  BAL --> KB["Key binding<br/>ZIP 2005"]
   SPEND --> NCB
   SPEND --> MERK
   SPEND --> KB

--- a/book/src/formal-verification/security-definitions.md
+++ b/book/src/formal-verification/security-definitions.md
@@ -31,9 +31,9 @@ So each definition sits on a three-layer stack:
 %%{init: {"flowchart": {"nodeSpacing": 20, "rankSpacing": 50, "padding": 6, "diagramPadding": 4, "subGraphTitleMargin": {"top": 4, "bottom": 18}}, "themeCSS": ".cluster-label { font-weight: 700; font-size: 1.1em; font-family: raleway, sans-serif; }"}}%%
 flowchart TD
   subgraph GAMES["Ledger security games — the capstones"]
-    BAL["Balance<br/>balanceSubsetOrBreak<br/>balanceValueOrBreak"]
+    BAL["Balance integrity<br/>orchardBalanceIntegrity_measure_le"]
     SPEND["Spendability<br/>faerieGoldCore<br/>validLedger_append"]
-    SPENDAUTH["Spend authority<br/>spendAuthorityOrBreak"]
+    SPENDAUTH["Spend authority<br/>spendAuthority_measure_le"]
   end
 
   BAL --> BS["Binding-signature<br/>balance"]
@@ -62,6 +62,7 @@ flowchart TD
   MERK --->|"<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Security/Ledger/Merkle.lean'>wrong Merkle<br/>path computes</a>"| MC["DefinedCollision<br/>(one height, encoding<br/>domain, success-only)"]
   KB --> STMT
   KB --->|"<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Security/KeyBinding/Basic.lean'>conflicting ivk<br/>witnesses compute</a>"| CUS["CollisionUpToSign<br/>shifted oracle,<br/>distinct queries"]
+  KB --->|"<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Security/Ledger/KeyBindingDLR.lean'>Orchard-protocol<br/>CommitIvkCollision<br/>computes</a>"| SDLR
   NFB --> STMT
   NFB --->|"<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Security/Ledger/Spendability.lean'>distinct derive-inputs +<br/>equal nullifier<br/>computes</a>"| NFC["NullifierCollision"]
   SPENDAUTH --->|"<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Security/Ledger/SpendAuthority.lean'>verified signature over<br/>unsigned sighash computes</a>"| SAF["SpendAuthForgery<br/>(randomization<br/>of ±ak)"]
@@ -107,15 +108,15 @@ flowchart TD
   classDef hyp fill:#cf222e,stroke:#a40e26,color:#ffffff
   classDef assumed fill:#57606a,stroke:#424a53,color:#ffffff
   class BAL,SPEND,SPENDAUTH,KS partial
-  class NCB,BS,KB,MERK,NFB,STMT,NDLR,CUS,NCBK,MC,NFC,SAF checked
-  class SDLR,RDSA hyp
+  class NCB,BS,KB,MERK,NFB,STMT,NDLR,CUS,NCBK,MC,NFC,SAF,SDLR checked
+  class RDSA hyp
   class DL,ROM assumed
 ```
 
 <p>
 <span style="color:#1a7f37">■</span> fully proven — nothing here yet<br/>
 <span style="color:#0969da">■</span> stated and machine-checked in Lean, over abstract primitives<br/>
-<span style="color:#9a6700">■</span> partly machine-checked; remainder tracked (the games' probabilistic capstones; knowledge soundness's <code>hencodes</code> bridge)<br/>
+<span style="color:#9a6700">■</span> partly machine-checked; remainder tracked (discharging the capstones' named ε's end to end: the key-binding oracle connection, the binding-signature extractability, RedDSA; knowledge soundness's <code>hencodes</code> bridge)<br/>
 <span style="color:#cf222e">■</span> named hypothesis; formalization deferred<br/>
 <span style="color:#57606a">■</span> assumption or heuristic model; terminal by design
 </p>
@@ -202,6 +203,14 @@ circuit soundness proof.
 <div class="g"><div class="g-head"><span class="term">pinning lemmas</span><span class="anchor">ivk_pinned · nk_eq_or_break · nf_old_eq_or_break</span></div><div class="def">The deterministic steps of the Balance argument: an address <code>(g_d, pk_d)</code> determines <code>ivk</code> (needs only <code>g_d ≠ 0</code> and torsion-freeness), hence <code>nk</code> is determined up to an exhibited key-binding break, and spends of the same note tuple reveal the same nullifier up to a break.</div></div>
 <div class="g"><div class="g-head"><span class="term">NoteCommitBreak</span><span class="anchor">Ledger.NoteCommitBreak · noteCommitBreakOfNe</span></div><div class="def">A note-commitment opening collision, as data. <code>noteCommitBreakOfNe</code> computes one when an <code>extract</code>-equal commitment fails to pin the note tuple <code>(rcm, note)</code>. Prequantumly, note-commitment binding reduces to a Sinsemilla / discrete-log-relation break.</div></div>
 <div class="g"><div class="g-head"><span class="term">Merkle position binding</span><span class="anchor">Ledger.Merkle.collisionOfWrongLeaf</span></div><div class="def">Fixed-depth Merkle trees are position-binding up to a hash collision: a validating authentication path for a leaf that is <em>not</em> the committed one, against a defined tree, computes a <code>DefinedCollision</code> of one height’s compression — escaped (⊥) evaluations never count as collisions. The vector-commitment property the Balance and Spendability arguments require of the note-commitment tree. Prequantumly, the Sinsemilla compression’s collision resistance reduces to a discrete-log-relation break (SDLR) — the same terminal as note-commitment binding — so BLAKE2b collision resistance does not enter the pre-quantum Balance argument.</div></div>
+</section>
+
+<section>
+<div class="grp">Probabilistic capstones · Ledger/Capstone + Ledger/OrchardCapstone</div>
+<div class="g"><div class="g-head"><span class="term">Balance integrity</span><span class="anchor">Model.balanceIntegrityOrBreak · balanceIntegrityPerTxViolation</span></div><div class="def">The shielded pool is non-negative and the pools sum to the minted issuance. The deterministic <code>balanceIntegrityOrBreak</code> proves it up to a computed break; the probabilistic violation events mirror its conclusion (the transparent conjunct cannot fail on the valid sample space). The interval consequence <code>pool ∈ [0, issuanceTotal]</code> is weaker, and survives as the separate shielded-balance-cap capstones.</div></div>
+<div class="g"><div class="g-head"><span class="term">events as branch preimages</span><span class="anchor">Model.balanceSubsetBreakEvent · txBalanceBreakEvent</span></div><div class="def">An adversary is a <code>PMF</code> over valid annotated ledgers; each event is "the computed reduction lands in this branch on this sample", so no choice is needed to extract break data. Violation events are contained in unions of break events, and each break event's probability is a named ε hypothesis.</div></div>
+<div class="g"><div class="g-head"><span class="term">all-prefixes bounds, no factor of k</span><span class="anchor">Model.balanceIntegrity_measure_le · *Before / *UpTo</span></div><div class="def">One ε per shared break event bounds the violation at <em>every</em> prefix below a bound, where a naive union bound would pay <code>k · ε</code>. Prefix-indexed value events are named <code>*Before</code> and step-indexed Balance-subset events <code>*UpTo</code> (EWD 831 half-open ranges, exclusive bound as the parameter); the one step/prefix crossing is confined to <code>_succ</code>-marked lemmas.</div></div>
+<div class="g"><div class="g-head"><span class="term">the Orchard single-ε collapse</span><span class="anchor">Bridge.orchardRelationEvent · orchardBalanceIntegrity_measure_le</span></div><div class="def">At the Orchard-protocol bases, every Balance-subset arm's break computes a nontrivial discrete-log relation among the fixed Sinsemilla bases, so one <code>ε_sinsemilladlr</code> replaces the three per-arm ε's — and every prefix lands in the same relation event, so the all-prefixes bounds cost no factor of <code>k</code>. <code>ε_sinsemilladlr</code> reduces tightly to discrete-log hardness (Jaeger–Tessaro, <a href="https://eprint.iacr.org/2020/1213">2020/1213</a> Lemma 3, re-proved as <code>relation_prob_le_of_textbookDL</code>); the witness-level model abstracts away Halo 2 knowledge soundness, a separate, lossy reduction on the different Halo 2 bases. <code>ε_bindsig</code> bounds the conservation side (RedDSA discharge: <a href="https://github.com/zcash/ironwood/issues/22">#22</a>).</div></div>
 </section>
 
 <section>

--- a/book/src/formal-verification/security-definitions.md
+++ b/book/src/formal-verification/security-definitions.md
@@ -33,7 +33,7 @@ flowchart TD
   subgraph GAMES["Ledger security games — the capstones"]
     BAL["Balance integrity<br/>orchardBalanceIntegrity_measure_le"]
     SPEND["Spendability<br/>faerieGoldCore<br/>validLedger_append"]
-    SPENDAUTH["Spend authority<br/>spendAuthority_measure_le"]
+    SPENDAUTH["Spend authority<br/>orchardSpendAuthority_measure_le"]
   end
 
   BAL --> BS["Binding-signature<br/>balance"]

--- a/book/src/formal-verification/source-map.md
+++ b/book/src/formal-verification/source-map.md
@@ -352,7 +352,7 @@ computed data.
   and `SpendAuthority` (an unsigned spend yields a signature forgery or a key-binding break), with
   `Merkle` proving fixed-depth Merkle trees position-binding up to an exhibited tree-hash collision
   and `Nullifier` reducing a nullifier collision to a discrete-log relation. `Pool` instantiates
-  the abstract primitives at the deployed pool, `Value` discharges the balance-value premiss
+  the abstract primitives at the deployed pool, `Value` discharges the transaction-balance premiss
   against the binding-signature layer, `KeyBindingArm` discharges the key-binding ε in the oracle
   model, `Capstone` lifts the deterministic layer to a distribution over valid annotated ledgers,
   and `Completeness` checks the other direction — that an honest wallet's spend actually verifies.


### PR DESCRIPTION
On top of the merged docs-and-naming PR: the generic all-prefixes probabilistic capstones, their instantiation at the Orchard-protocol bases and parameters, the Orchard Spend Authority probability bound, and the book's security-definitions page brought up to date.

## The all-prefixes probabilistic capstones

Balance-subset, Balance-conservation, the shielded-balance cap, and Balance integrity over every prefix below a bound, at no extra cost in the bound: each ε hypothesis is named on one break event shared across prefixes — every prefix's violation lands in it — rather than summed per prefix. A naive union bound would pay `k · ε`.

The all-prefixes events follow EWD 831: half-open ranges `i < k` over unshifted families, with the exclusive bound as the parameter. The value-side events are prefix-indexed and named `*Before`; the Balance-subset events are step-indexed and keep `*UpTo`. The one step/prefix crossing — non-negativity after the first `i + 1` transactions rests on subset step `i` — is confined to lemmas carrying `_succ` in their names; every other statement is same-index, and the empty prefix cannot violate anything.

Balance integrity is the intended property, mirroring `balanceIntegrityOrBreak`'s conclusion: the shielded pool is non-negative and the pools sum to the minted issuance (the transparent conjunct cannot fail on the valid sample space). Its bound composes a non-negativity ε with the transaction-balance premiss arm's `ε_conservation`; the earlier interval form `pool ∈ [0, issuanceTotal]` is the weaker consequence and survives only as the separate shielded-balance-cap capstones.

## The Orchard probability bounds

The relation event is the branch preimage of `orchardBalanceSubsetOrRelation`, and every Balance capstone violation is bounded by it: one `ε_sinsemilladlr` replaces the abstract capstones' three per-arm ε's, and the all-prefixes bounds cost no factor of `k`, because the arms and the prefixes all land in the same event — a nontrivial discrete-log relation among the same fixed Sinsemilla bases. `ε_sinsemilladlr` reduces tightly to discrete-log hardness of those bases (Jaeger–Tessaro, eprint 2020/1213 Lemma 3, re-proved as `relation_prob_le_of_textbookDL`). The witness-level model abstracts away Halo 2 knowledge soundness, a separate, lossy reduction on the different Halo 2 bases; that is where the end-to-end reduction loss lives. `ε_bindsig`, the binding-signature advantage, bounds the conservation side (its RedDSA discharge is #22). The census pins the new bounds with the reduction's native provenance.

## The Orchard Spend Authority bound

At the Orchard `keyBinding` interface, the Spend Authority reduction's key-binding break is the same `CommitIvkCollision` that the Balance key-binding arm reduces. `relationOfSpendAuthorityKBBreak` sends it to the same discrete-log terminal at the `CommitIvk` bases, `orchardSpendAuthorityOrRelation` composes that conversion into the Spend Authority reduction, and `orchardSpendAuthority_measure_le` names the key-binding arm's hypothesis on the composed reduction's relation event — so the Spend Authority violation (some Action spends a note addressed to the victim key over a sighash its holder never signed) is bounded by the forgery arm's ε plus a discrete-log-relation advantage, with no oracle model. The forgery arm's ε is RedDSA ±-randomized unforgeability, a named hypothesis (#22). Connecting the named ε's to adversary experiments — the oracle-machine layer, including recovering the firing Action from the adversary's announced indices — is tracked in #155.

## The book

The connected picture's top-level nodes carry the probabilistic capstones where they exist, the Orchard-protocol key-binding arm gains its edge to the Sinsemilla discrete-log-relation terminal, and that terminal moves from named-hypothesis to machine-checked (its inbound reductions and the tight onward reduction to discrete log are all proven; RedDSA stays a named hypothesis). A new glossary section covers Balance integrity's definition, events as branch preimages, the all-prefixes no-factor-of-`k` bounds, and the Orchard single-ε collapse. The Key binding node also drops its blanket ROM tag: the model split is visible on its outgoing edges — the ZIP 2005 route through the shifted-oracle collision, and the oracle-free Orchard-protocol `CommitIvkCollision` route.

Full build green at every commit.

🤖 Claude Fable 5


