### PR TITLE
Minimize soundness-stack Mathlib imports

### DIFF
--- a/Zcash/Arithmetic/Domain.lean
+++ b/Zcash/Arithmetic/Domain.lean
@@ -1,4 +1,5 @@
 import CompElliptic.Curves.Pasta
+import Mathlib.RingTheory.RootsOfUnity.PrimitiveRoots
 import Zcash.Arithmetic.Field
 
 /-!

--- a/Zcash/Arithmetic/Field.lean
+++ b/Zcash/Arithmetic/Field.lean
@@ -1,4 +1,4 @@
-import Mathlib
+import Mathlib.Logic.Equiv.PartialEquiv
 import CompElliptic.Fields.Pasta
 
 /-!

--- a/Zcash/Arithmetic/Group.lean
+++ b/Zcash/Arithmetic/Group.lean
@@ -1,4 +1,4 @@
-import Mathlib
+import Mathlib.Algebra.Group.Nat.Defs
 
 /-!
 # The verifier group `E_q` and the uniform reference string

--- a/Zcash/Arithmetic/LagrangeBasis.lean
+++ b/Zcash/Arithmetic/LagrangeBasis.lean
@@ -1,3 +1,4 @@
+import Mathlib.Algebra.Field.GeomSum
 import Zcash.Arithmetic.Domain
 
 /-!

--- a/Zcash/Arithmetic/Msm.lean
+++ b/Zcash/Arithmetic/Msm.lean
@@ -1,4 +1,4 @@
-import Mathlib
+import Mathlib.Tactic
 import Zcash.Arithmetic.Group
 
 /-!

--- a/Zcash/Arithmetic/VestaModule.lean
+++ b/Zcash/Arithmetic/VestaModule.lean
@@ -1,4 +1,5 @@
 import CompElliptic.Curves.Pasta.Fast.Projective
+import Mathlib.Algebra.Module.ZMod
 import Zcash.Arithmetic.Field
 import CompElliptic.Curves.PastaOrder
 

--- a/Zcash/Circuits/Integration/ActionPermutationDomainCompute.lean
+++ b/Zcash/Circuits/Integration/ActionPermutationDomainCompute.lean
@@ -1,3 +1,4 @@
+import Mathlib.Util.AssertNoSorry
 import Zcash.Snark.Keygen.Derivation
 import Zcash.Snark.Soundness.Canonical.PermutationInstantiation
 

--- a/Zcash/Common/DiscreteLogRelation.lean
+++ b/Zcash/Common/DiscreteLogRelation.lean
@@ -1,4 +1,9 @@
-import Mathlib
+import Mathlib.Algebra.BigOperators.GroupWithZero.Action
+import Mathlib.Algebra.Field.Defs
+import Mathlib.Algebra.Lie.OfAssociative
+import Mathlib.Algebra.Module.Defs
+import Mathlib.Data.Fintype.Basic
+import Mathlib.Tactic.Abel
 
 /-!
 # Nontrivial linear (discrete-log) relations, as computed data

--- a/Zcash/Common/Expr.lean
+++ b/Zcash/Common/Expr.lean
@@ -1,4 +1,4 @@
-import Mathlib
+import Mathlib.Algebra.Lie.OfAssociative
 
 /-!
 # The verifier's gate-polynomial AST

--- a/Zcash/Common/RelationWitness.lean
+++ b/Zcash/Common/RelationWitness.lean
@@ -1,5 +1,3 @@
-import Mathlib
-
 /-!
 # Sequencing a computed break branch
 
@@ -39,7 +37,7 @@ def bindOrRelationWitness {A : Sort u} {B : Sort v} {R : Sort w}
 
 /-- Traverse a `Fin`-indexed family of computed outcomes left to right: every left-hand value, or
 the first right-hand value as data — no existential search. -/
-def finForallOrRelationWitness {n : ℕ} {A : Fin n → Sort v} {R : Sort w}
+def finForallOrRelationWitness {n : Nat} {A : Fin n → Sort v} {R : Sort w}
     (outcome : ∀ i, A i ⊕' R) : (∀ i, A i) ⊕' R := by
   induction n with
   | zero => exact PSum.inl fun i => Fin.elim0 i
@@ -54,7 +52,7 @@ def finForallOrRelationWitness {n : ℕ} {A : Fin n → Sort v} {R : Sort w}
 /-- The bounded-`ℕ` analogue of `finForallOrRelationWitness`. Column and row families in the
 compiled constraint system are indexed by a natural number under a bound rather than by `Fin n`,
 so this is the shape their folds actually have. -/
-def boundedForallOrRelationWitness {n : ℕ} {A : ℕ → Sort v} {R : Sort w}
+def boundedForallOrRelationWitness {n : Nat} {A : Nat → Sort v} {R : Sort w}
     (outcome : ∀ i, i < n → A i ⊕' R) : (∀ i, i < n → A i) ⊕' R :=
   bindOrRelationWitness
     (finForallOrRelationWitness (A := fun i : Fin n => A i.val)

--- a/Zcash/Snark/Core/Challenges.lean
+++ b/Zcash/Snark/Core/Challenges.lean
@@ -1,4 +1,4 @@
-import Mathlib
+import Mathlib.Tactic
 
 /-!
 # The verifier's challenges

--- a/Zcash/Snark/Core/ProofString.lean
+++ b/Zcash/Snark/Core/ProofString.lean
@@ -1,4 +1,4 @@
-import Mathlib
+import Mathlib.Tactic
 
 /-!
 # The proof string as opaque field and group elements

--- a/Zcash/Snark/Soundness/Canonical/ConstraintSatisfaction.lean
+++ b/Zcash/Snark/Soundness/Canonical/ConstraintSatisfaction.lean
@@ -1,4 +1,4 @@
-import Mathlib
+import Mathlib.Tactic
 import Zcash.Snark.Soundness.Constraints
 import Zcash.Snark.Soundness.FoldSplit
 import Zcash.Snark.Soundness.KnowledgeSoundness

--- a/Zcash/Snark/Soundness/Canonical/LookupInstantiation.lean
+++ b/Zcash/Snark/Soundness/Canonical/LookupInstantiation.lean
@@ -1,4 +1,4 @@
-import Mathlib
+import Mathlib.Tactic
 import Zcash.Snark.Soundness.Canonical.LookupRows
 import Zcash.Snark.Verifier.Parametric
 

--- a/Zcash/Snark/Soundness/Canonical/LookupRows.lean
+++ b/Zcash/Snark/Soundness/Canonical/LookupRows.lean
@@ -1,4 +1,4 @@
-import Mathlib
+import Mathlib.Tactic
 import Zcash.Snark.Soundness.Canonical.ConstraintSatisfaction
 import Zcash.Snark.Soundness.LookupAssembly
 import Zcash.Snark.Soundness.PermutationRows

--- a/Zcash/Snark/Soundness/Canonical/PermutationInstantiation.lean
+++ b/Zcash/Snark/Soundness/Canonical/PermutationInstantiation.lean
@@ -1,5 +1,4 @@
 import Zcash.Common.RelationWitness
-import Mathlib
 import Zcash.Snark.Soundness.Multiopen.ConstraintResolver
 import Zcash.Snark.Soundness.PermutationRows
 

--- a/Zcash/Snark/Soundness/Canonical/PolynomialEnvironment.lean
+++ b/Zcash/Snark/Soundness/Canonical/PolynomialEnvironment.lean
@@ -1,3 +1,4 @@
+import Mathlib.LinearAlgebra.Lagrange
 import Zcash.Snark.Soundness.Constraints
 
 /-!

--- a/Zcash/Snark/Soundness/CommitFold.lean
+++ b/Zcash/Snark/Soundness/CommitFold.lean
@@ -1,4 +1,4 @@
-import Mathlib
+import Mathlib.Tactic
 import Zcash.Snark.Soundness.InnerProduct
 import Zcash.Common.DiscreteLogRelation
 

--- a/Zcash/Snark/Soundness/Constraints.lean
+++ b/Zcash/Snark/Soundness/Constraints.lean
@@ -1,4 +1,4 @@
-import Mathlib
+import Mathlib.Tactic
 import Zcash.Arithmetic
 import Zcash.Snark.Verifier.Expressions
 import Zcash.Snark.Verifier.Assemble

--- a/Zcash/Snark/Soundness/Deployed/Fold.lean
+++ b/Zcash/Snark/Soundness/Deployed/Fold.lean
@@ -1,3 +1,4 @@
+import Mathlib.Data.List.GetD
 import Zcash.Snark.Soundness.IpaSoundness
 import Zcash.Snark.Verifier.Ipa
 

--- a/Zcash/Snark/Soundness/Extraction.lean
+++ b/Zcash/Snark/Soundness/Extraction.lean
@@ -1,4 +1,4 @@
-import Mathlib
+import Mathlib.Tactic
 import Zcash.Snark.Soundness.InnerProduct
 
 /-!

--- a/Zcash/Snark/Soundness/FoldSplit.lean
+++ b/Zcash/Snark/Soundness/FoldSplit.lean
@@ -1,4 +1,4 @@
-import Mathlib
+import Mathlib.Tactic
 import Zcash.Snark.Soundness.Constraints
 
 /-!

--- a/Zcash/Snark/Soundness/Forking/Probability.lean
+++ b/Zcash/Snark/Soundness/Forking/Probability.lean
@@ -1,4 +1,5 @@
-import Mathlib
+import Mathlib.Tactic
+import Mathlib.Algebra.Order.Chebyshev
 import Zcash.Snark.Soundness.Forking.Oracle
 import Zcash.Snark.Soundness.Forking.Tree
 

--- a/Zcash/Snark/Soundness/Forking/Tree.lean
+++ b/Zcash/Snark/Soundness/Forking/Tree.lean
@@ -1,4 +1,4 @@
-import Mathlib
+import Mathlib.Tactic
 
 /-!
 # Multi-round fork-tree extraction

--- a/Zcash/Snark/Soundness/GoodChallenge.lean
+++ b/Zcash/Snark/Soundness/GoodChallenge.lean
@@ -1,4 +1,4 @@
-import Mathlib
+import Mathlib.Tactic
 import Zcash.Snark.Soundness.Constraints
 import Zcash.Snark.Soundness.Forking.Oracle
 

--- a/Zcash/Snark/Soundness/GrandProduct.lean
+++ b/Zcash/Snark/Soundness/GrandProduct.lean
@@ -1,4 +1,4 @@
-import Mathlib
+import Mathlib.Tactic
 
 /-!
 # The grand-product-to-multiset kernel (permutation & lookup soundness)

--- a/Zcash/Snark/Soundness/GrandProductBridge.lean
+++ b/Zcash/Snark/Soundness/GrandProductBridge.lean
@@ -1,4 +1,4 @@
-import Mathlib
+import Mathlib.Tactic
 import Zcash.Snark.Soundness.GrandProduct
 import Zcash.Snark.Soundness.RunningProduct
 import Zcash.Snark.Soundness.Permutation

--- a/Zcash/Snark/Soundness/InnerProduct.lean
+++ b/Zcash/Snark/Soundness/InnerProduct.lean
@@ -1,4 +1,4 @@
-import Mathlib
+import Mathlib.Tactic
 import Zcash.Arithmetic
 
 /-!

--- a/Zcash/Snark/Soundness/IpaSoundness.lean
+++ b/Zcash/Snark/Soundness/IpaSoundness.lean
@@ -1,4 +1,4 @@
-import Mathlib
+import Mathlib.Tactic
 import Zcash.Snark.Soundness.CommitFold
 import Zcash.Snark.Soundness.Consistency
 

--- a/Zcash/Snark/Soundness/KnowledgeSoundness.lean
+++ b/Zcash/Snark/Soundness/KnowledgeSoundness.lean
@@ -1,4 +1,4 @@
-import Mathlib
+import Mathlib.Tactic
 import Zcash.Snark.Soundness.InnerProduct
 import Zcash.Snark.Soundness.Extraction
 import Zcash.Snark.Soundness.Constraints

--- a/Zcash/Snark/Soundness/Lookup.lean
+++ b/Zcash/Snark/Soundness/Lookup.lean
@@ -1,4 +1,4 @@
-import Mathlib
+import Mathlib.Tactic
 import Zcash.Snark.Soundness.GrandProduct
 
 /-!

--- a/Zcash/Snark/Soundness/LookupAssembly.lean
+++ b/Zcash/Snark/Soundness/LookupAssembly.lean
@@ -1,4 +1,4 @@
-import Mathlib
+import Mathlib.Tactic
 import Zcash.Snark.Soundness.Lookup
 import Zcash.Snark.Soundness.GrandProductBridge
 import Zcash.Snark.Soundness.PermutationRows

--- a/Zcash/Snark/Soundness/Main.lean
+++ b/Zcash/Snark/Soundness/Main.lean
@@ -1,4 +1,4 @@
-import Mathlib
+import Mathlib.Tactic
 import Zcash.Snark.Soundness.KnowledgeSoundness
 import Zcash.Snark.Verifier.Assemble
 import Zcash.Snark.Soundness.Consistency

--- a/Zcash/Snark/Soundness/Multiopen/CanonicalSelection.lean
+++ b/Zcash/Snark/Soundness/Multiopen/CanonicalSelection.lean
@@ -1,3 +1,4 @@
+import Mathlib.Util.AssertNoSorry
 import Zcash.Snark.Soundness.Multiopen.CanonicalRelation
 
 /-!

--- a/Zcash/Snark/Soundness/Multiopen/Claimed.lean
+++ b/Zcash/Snark/Soundness/Multiopen/Claimed.lean
@@ -1,4 +1,4 @@
-import Mathlib
+import Mathlib.Tactic
 import Zcash.Snark.Soundness.Multiopen.RPoly
 import Zcash.Snark.Soundness.Multiopen.ValueCheck
 import Zcash.Snark.Soundness.GoodChallenge

--- a/Zcash/Snark/Soundness/Multiopen/Compat.lean
+++ b/Zcash/Snark/Soundness/Multiopen/Compat.lean
@@ -1,4 +1,4 @@
-import Mathlib
+import Mathlib.Tactic
 import Zcash.Snark.Soundness.Main
 import Zcash.Snark.Soundness.Forking.Probability
 import Zcash.Snark.Soundness.Multiopen.Decode

--- a/Zcash/Snark/Soundness/Multiopen/ConstraintResolver.lean
+++ b/Zcash/Snark/Soundness/Multiopen/ConstraintResolver.lean
@@ -1,4 +1,3 @@
-import Mathlib
 import Zcash.Common.RelationWitness
 import Zcash.Snark.Soundness.Canonical.LookupInstantiation
 import Zcash.Snark.Soundness.Multiopen.NodeBinding

--- a/Zcash/Snark/Soundness/Multiopen/Decode.lean
+++ b/Zcash/Snark/Soundness/Multiopen/Decode.lean
@@ -1,4 +1,4 @@
-import Mathlib
+import Mathlib.Tactic
 import Zcash.Snark.Soundness.IpaSoundness
 import Zcash.Snark.Soundness.KnowledgeSoundness
 import Zcash.Snark.Verifier.Assemble

--- a/Zcash/Snark/Soundness/Multiopen/Deployed.lean
+++ b/Zcash/Snark/Soundness/Multiopen/Deployed.lean
@@ -1,4 +1,4 @@
-import Mathlib
+import Mathlib.Tactic
 import Zcash.Snark.Soundness.Main
 import Zcash.Snark.Soundness.Forking.Probability
 import Zcash.Snark.Soundness.Multiopen.Decode

--- a/Zcash/Snark/Soundness/Multiopen/Opened.lean
+++ b/Zcash/Snark/Soundness/Multiopen/Opened.lean
@@ -1,4 +1,4 @@
-import Mathlib
+import Mathlib.Tactic
 import Zcash.Snark.Soundness.Main
 import Zcash.Snark.Soundness.Multiopen.Decode
 import Zcash.Snark.Soundness.Multiopen.Deployed

--- a/Zcash/Snark/Soundness/Multiopen/RPoly.lean
+++ b/Zcash/Snark/Soundness/Multiopen/RPoly.lean
@@ -1,4 +1,5 @@
-import Mathlib
+import Mathlib.Tactic
+import Mathlib.LinearAlgebra.Lagrange
 import Zcash.Snark.Soundness.Main
 import Zcash.Snark.Soundness.Multiopen.Deployed
 

--- a/Zcash/Snark/Soundness/Multiopen/ValueCheck.lean
+++ b/Zcash/Snark/Soundness/Multiopen/ValueCheck.lean
@@ -1,4 +1,4 @@
-import Mathlib
+import Mathlib.Tactic
 import Zcash.Snark.Soundness.Multiopen.RPoly
 
 /-!

--- a/Zcash/Snark/Soundness/Multiopen/ValueCheckDeployed.lean
+++ b/Zcash/Snark/Soundness/Multiopen/ValueCheckDeployed.lean
@@ -1,4 +1,4 @@
-import Mathlib
+import Mathlib.Tactic
 import Zcash.Snark.Soundness.Multiopen.ValueCheck
 import Zcash.Snark.Soundness.Multiopen.Deployed
 import Zcash.Snark.Soundness.Multiopen.Opened

--- a/Zcash/Snark/Soundness/Permutation.lean
+++ b/Zcash/Snark/Soundness/Permutation.lean
@@ -1,4 +1,4 @@
-import Mathlib
+import Mathlib.Tactic
 import Zcash.Snark.Soundness.GrandProduct
 
 /-!

--- a/Zcash/Snark/Soundness/PermutationConstruction.lean
+++ b/Zcash/Snark/Soundness/PermutationConstruction.lean
@@ -1,4 +1,4 @@
-import Mathlib
+import Mathlib.Tactic
 import Zcash.Snark.Soundness.Permutation
 
 /-!

--- a/Zcash/Snark/Soundness/PermutationRows.lean
+++ b/Zcash/Snark/Soundness/PermutationRows.lean
@@ -1,4 +1,3 @@
-import Mathlib
 import Zcash.Snark.Soundness.FoldSplit
 import Zcash.Snark.Soundness.GrandProductBridge
 

--- a/Zcash/Snark/Soundness/RunningProduct.lean
+++ b/Zcash/Snark/Soundness/RunningProduct.lean
@@ -1,4 +1,4 @@
-import Mathlib
+import Mathlib.Tactic
 import Zcash.Snark.Soundness.GrandProduct
 
 /-!

--- a/Zcash/Snark/Verifier/Assemble.lean
+++ b/Zcash/Snark/Verifier/Assemble.lean
@@ -1,4 +1,5 @@
-import Mathlib
+import Mathlib.Tactic
+import Mathlib.Data.List.GetD
 import Zcash.Snark.Core.ProofString
 import Zcash.Snark.Core.Challenges
 import Zcash.Snark.Verifier.Checks

--- a/Zcash/Snark/Verifier/Checks.lean
+++ b/Zcash/Snark/Verifier/Checks.lean
@@ -1,4 +1,4 @@
-import Mathlib
+import Mathlib.Tactic
 import Zcash.Arithmetic
 import Zcash.Arithmetic.Msm
 

--- a/Zcash/Snark/Verifier/Expressions.lean
+++ b/Zcash/Snark/Verifier/Expressions.lean
@@ -1,4 +1,4 @@
-import Mathlib
+import Mathlib.Tactic
 import Zcash.Common.Expr
 import Zcash.Snark.Core.ProofString
 

--- a/Zcash/Snark/Verifier/FiatShamir.lean
+++ b/Zcash/Snark/Verifier/FiatShamir.lean
@@ -1,4 +1,4 @@
-import Mathlib
+import Mathlib.Tactic
 import Zcash.Snark.Core.ProofString
 import Zcash.Snark.Core.Challenges
 import Zcash.Snark.Verifier.Assemble

--- a/Zcash/Snark/Verifier/Ipa.lean
+++ b/Zcash/Snark/Verifier/Ipa.lean
@@ -1,4 +1,4 @@
-import Mathlib
+import Mathlib.Tactic
 import Zcash.Arithmetic
 import Zcash.Arithmetic.Msm
 

--- a/Zcash/Snark/Verifier/Queries.lean
+++ b/Zcash/Snark/Verifier/Queries.lean
@@ -1,4 +1,4 @@
-import Mathlib
+import Mathlib.Tactic
 import Zcash.Snark.Verifier.Checks
 import Zcash.Snark.Core.ProofString
 


### PR DESCRIPTION
## What changed

- replace umbrella `import Mathlib` statements throughout the soundness-stack dependency closure with `Mathlib.Tactic` or narrower imports
- add precise imports for downstream consumers that had relied on those transitive umbrella imports
- make `Zcash.Common.RelationWitness` use core `Nat`, eliminating its Mathlib dependency entirely

## Why

Importing the Mathlib umbrella made each affected Lean process peak around 6.5 GB RSS. During a parallel Lake build, several such processes could create severe memory and GC pressure; one observed `PermutationInstantiation` build took 648 seconds despite compiling in about five seconds in isolation.

For `PermutationInstantiation`, isolated peak RSS dropped from 6.57 GB to 3.77 GB and wall time dropped from 5.42 seconds to 4.00 seconds.

## Validation

- `lake build` on a fresh branch based on `origin/main`
- all 8,961 jobs completed successfully
