### PR TITLE
fv: suppress the library-suggestions indexer's heartbeat panic

### DIFF
--- a/Zcash/Meta/LibrarySuggestionsDeny.lean
+++ b/Zcash/Meta/LibrarySuggestionsDeny.lean
@@ -1,0 +1,26 @@
+import Lean
+
+/-!
+# Suppress the library-suggestions symbol-frequency indexer
+
+On toolchains before v4.31.0, the `symbolFrequency` environment extension's export
+function runs `whnf` over every local theorem signature with the default heartbeat
+limit, and panics on a timeout (leanprover/lean4#12989, fixed upstream by
+leanprover/lean4#13202). The limit cannot be raised from outside. Some deployed AGM
+modules in this repository have signatures large enough to exceed it, so their builds
+print panics and the Lean InfoView becomes unusable.
+
+Adding `Zcash` to the library-suggestions name deny list makes the indexer skip every
+declaration with a `Zcash` name component before reading its signature; the export
+fold only visits the current module's declarations, so the entry affects only this
+repository's theorems. The cost is that they are excluded from library-suggestions
+ranking and candidate pools, which are used only by opt-in suggestion-driven tactics —
+nothing in this repository enables one, and the in-tree `grind` calls run on explicit
+lemma lists and `@[grind]` annotations. `exact?`, `apply?`, and `aesop?` use separate
+machinery (`librarySearch` and Aesop rule sets) and are unaffected. Import this module
+from any module whose export hits the panic; the entry also propagates to that
+module's importers. The suppression is only needed on toolchains before v4.31.0.
+-/
+
+open Lean LibrarySuggestions in
+run_cmd modifyEnv fun env => nameDenyListExt.addEntry env "Zcash"

--- a/Zcash/Snark/Soundness/AGM/OnlineMembers.lean
+++ b/Zcash/Snark/Soundness/AGM/OnlineMembers.lean
@@ -1,3 +1,4 @@
+import Zcash.Meta.LibrarySuggestionsDeny
 import Zcash.Snark.Soundness.AGM.DeployedCoordinateDecode
 import Zcash.Snark.Soundness.AGM.DeployedX1
 


### PR DESCRIPTION
On toolchains before v4.31.0, the `symbolFrequency` environment extension's export function runs `whnf` over every local theorem signature with the default heartbeat limit and panics on a timeout (leanprover/lean4#12989, fixed upstream by leanprover/lean4#13202); the limit cannot be raised from outside. The deployed AGM modules' signatures exceed it, so builds print panics and the Lean InfoView becomes unusable.

This adds a `Zcash` entry to the library-suggestions name deny list in a new module that the offending modules import, so the indexer skips their declarations before reading the signatures. Only opt-in suggestion-driven tactics consult the deny list — nothing in the repository enables a suggestion selector — and `exact?`, `apply?`, and `aesop?` use separate machinery and are unaffected. The export fold only visits the current module's declarations, so the entry cannot affect anything outside this repository.

Full build green with zero panics (previously two per build). The suppression is only needed before v4.31.0 and can be removed when the toolchain moves (Clean is expected to port to v4.31.0).

🤖 Claude Fable 5
