### PR TITLE
fv: ledger docs and naming clarifications

### DIFF
--- a/Zcash/Security.lean
+++ b/Zcash/Security.lean
@@ -23,7 +23,7 @@ import Zcash.Security.Ledger.KeyBindingArm
 import Zcash.Security.Ledger.KeyBindingDLR
 import Zcash.Security.Ledger.NoteCommitDLR
 import Zcash.Security.Ledger.MerkleDLR
-import Zcash.Security.Ledger.DeployedCapstone
+import Zcash.Security.Ledger.OrchardCapstone
 import Zcash.Security.Common.RandomOracle
 import Zcash.Security.Common.Birthday
 import Zcash.Security.KeyBinding.Basic

--- a/Zcash/Security/KeyBinding/Basic.lean
+++ b/Zcash/Security/KeyBinding/Basic.lean
@@ -21,7 +21,8 @@ The route, each step proven here:
    (consumed by the Balance and Spend Authorization arguments).
 
 The probabilistic side — producing the computed collision is hard — is the birthday bound
-`ε_kb ≤ q(q-1)/r` (`Birthday.lean`), ZIP 2005's `ε_kb` as sharpened in zcash/zips#1338.
+`ε_kb ≤ q(q-1)/|RIVK|` (`Birthday.lean`, with `|RIVK| = r_ℙ` at the intended Pallas
+instantiation), ZIP 2005's `ε_kb` as sharpened in zcash/zips#1338.
 nf-pinning, which the Spendability argument consumes, is the games'
 `nfOldEqOrBreak` (`Security/Ledger/Statement.lean`).
 
@@ -594,7 +595,8 @@ combined final oracle at *distinct* queries: the two witnesses' final queries wh
 (the residual case, `residual_of_finalQuery_eq`) the two `rivk_ext`-derivation queries when they
 coincide. What the birthday bound then adds is that inhabiting this event is hard: `hfn` is
 non-querying, so a fixed shift cannot be steered to manufacture collisions, and ±-colliding the
-shifted oracle at distinct queries has probability at most `q(q-1)/r` (`Birthday.lean`). -/
+shifted oracle at distinct queries has probability at most `q(q-1)/|RIVK|`
+(`Birthday.lean`). -/
 def _root_.Zcash.Security.RandomOracle.CollisionUpToSign.ofBreak
     [DecidableEq AK] [DecidableEq NK] [DecidableEq QK] [DecidableEq SK]
     (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK) (Ggen : G) (hS : S ≠ 0)

--- a/Zcash/Security/KeyBinding/Pool.lean
+++ b/Zcash/Security/KeyBinding/Pool.lean
@@ -53,9 +53,9 @@ structure KB
   ivk_ne : w.ivk ≠ 0
 
 /-- Two valid openings of the same `ivk` which disagree on an opening
-projection.  A later cryptographic layer may reduce this event to the
+projection. A later cryptographic layer may reduce this event to the
 appropriate Sinsemilla/DLR relation. -/
-structure Break
+structure CommitIvkCollision
     (extract : G → B) (hash : B → B → Option G) (commitIvkR : G)
     (w₁ w₂ : Witness F G B) : Prop where
   kb₁ : KB extract hash commitIvkR w₁
@@ -76,7 +76,7 @@ def toInterface
   nk := Witness.nk
   akP := Witness.akP
   KB := KB extract hash commitIvkR
-  Break := Break extract hash commitIvkR
+  Break := CommitIvkCollision extract hash commitIvkR
   break_of_nk_ne {w₁ w₂} h₁ h₂ hivk hnk := by
     refine ⟨h₁, h₂, hivk, fun heq => hnk ?_⟩
     exact congrArg BreakProjection.nk heq

--- a/Zcash/Security/KeyBinding/Probability.lean
+++ b/Zcash/Security/KeyBinding/Probability.lean
@@ -10,7 +10,9 @@ The deterministic key-binding layer ends at a computed event: `CollisionUpToSign
 any key-binding `Break` into a ±-collision of the shifted combined final oracle at two distinct
 queries, and `collision_mem_shifted_pm` places its output pair in the set `Birthday.lean` counts.
 This module adds the probabilistic model that turns those counting facts into a probability
-bound.
+bound. The bound's denominator is the cardinality of the abstract randomness type `RIVK`.
+Nothing here pins `|RIVK|`: at the intended Pallas instantiation `RIVK` is the scalar field,
+so `|RIVK| = r_ℙ`, and an undersized instantiation would make the bounds vacuous.
 
 The model samples the combined final `rivk`-derivation oracle `H^*` as one uniform table
 `O : FinalQuery AK NK RIVK QK SK → RIVK`. A uniform table is the same as independent uniform outputs at
@@ -33,8 +35,9 @@ Results (static model — the query set is fixed before the table is sampled):
 * `finset_shifted_collision_measure_le` — union bound over the `C(q,2)` unordered pairs of a
   query set of size at most `q`: probability at most `q·(q−1)/|F|`.
 * `break_measure_le` — the key-binding capstone: an adversary whose witnesses' derivation
-  queries land in the static set produces a `Break` with probability at most `q·(q−1)/|RIVK|`
-  (ZIP 2005's `ε_kb` as sharpened in zcash/zips#1338; `|RIVK| = r`).
+  queries land in the static set produces a `Break` with probability at most `q·(q−1)/|RIVK|`.
+  This is ZIP 2005's `ε_kb` as sharpened in zcash/zips#1338. At the intended instantiation,
+  `|RIVK|` is the Pallas group order `r_ℙ`.
 
 Results (adaptive — a bounded-query machine choosing queries after seeing earlier answers, as
 an `OracleComp` from the Fiat–Shamir layer):
@@ -589,7 +592,8 @@ theorem ofBreak_queries {Extract : Extractor G IVK AK} {S : G} {hfn : AK → NK 
 table. An adversary —here, any pair of witness choices depending on the whole table— whose
 witnesses' derivation queries lie in a set `Qs` of at most `q` queries *fixed in advance*,
 produces a key-binding `Break` with probability at most `q·(q−1)/|RIVK|`. This is ZIP 2005's
-`ε_kb` as sharpened in zcash/zips#1338, at `|RIVK| = r`. -/
+`ε_kb` as sharpened in zcash/zips#1338. At the intended instantiation, `|RIVK|` is the
+Pallas group order `r_ℙ`. -/
 theorem break_measure_le (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK)
     (Ggen : G) (hS : S ≠ 0)
     (Hask : SK → ASK) (Hnk : SK → NK)
@@ -629,8 +633,9 @@ def derivQueries (Extract : Extractor G IVK AK)
 
 /-- **Adaptive key-binding bound (ZIP 2005 accounting).** An `n`-query machine that queries its
 output witnesses' derivation inputs produces a key-binding `Break` with probability at most
-`n·(n−1)/|RIVK|` — ZIP 2005's `ε_kb` (as sharpened in zcash/zips#1338) at `|RIVK| = r`, with
-the adversary's queries chosen adaptively. -/
+`n·(n−1)/|RIVK|`, with the adversary's queries chosen adaptively. This is ZIP 2005's
+`ε_kb` as sharpened in zcash/zips#1338. At the intended instantiation, `|RIVK|` is the
+Pallas group order `r_ℙ`. -/
 theorem break_measure_le_adaptive (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK)
     (Ggen : G) (hS : S ≠ 0)
     (Hask : SK → ASK) (Hnk : SK → NK)

--- a/Zcash/Security/Ledger/Balance.lean
+++ b/Zcash/Security/Ledger/Balance.lean
@@ -6,11 +6,11 @@ import Zcash.Security.Ledger.Effects
 
 The first Balance theorem, as a computed reduction. For a valid ledger, the nonzero
 spends of the first `i + 1` transactions form a sub-multiset of the positioned outputs
-of the first `i` — outputs of *strictly earlier* transactions, since an anchor
-references the tree at a transaction boundary, so a spend can never match an output of
-its own transaction. Each spend is the opening of the output that created its
-commitment, at that output's leaf position, and no positioned opening is spent twice —
-or the ledger's own data computes a `BalanceBreak`:
+of the first `i` — outputs of *strictly earlier* transactions (since an anchor
+references the tree at a transaction boundary, a spend can never match an output of
+its own transaction). Each spend is the opening of the output that created its
+commitment, at that output's leaf position, and no positioned opening is spent twice;
+otherwise the ledger's own data computes a `BalanceBreak`:
 
 * a Merkle `Collision` — one height's compression collided, with both evaluations
   successful — when a spend's authentication path validates a leaf that is not the
@@ -20,15 +20,19 @@ or the ledger's own data computes a `BalanceBreak`:
 * a key-binding break, when two spends of one note tuple would otherwise have to reveal
   the same nullifier twice.
 
-The shape of the argument (design doc, "The theorems"): the anchor pins each spend's
-path to a prefix tree; position binding pins the leaf; `uncommitted_ne` rules out the
-padding; and the opening comparison pins the output or computes the note-commitment
-break. Duplicate spends of one positioned opening are found by `findPair`. Its result
-is certified as a two-element *sublist*, which carries "two distinct occurrences" with
-no index arithmetic, so `nfOldEqOrBreak` and nullifier uniqueness finish.
+The shape of the argument (design doc, "The theorems"):
 
-Everything is a plain computable `def` per breaks-as-computed-data; the anchor index and
-the duplicate pair are found by decidable search, so no data is conjured from the
+* the anchor pins each spend's path to a prefix tree;
+* position binding pins the leaf;
+* `uncommitted_ne` rules out the note commitment tree padding; and
+* the opening comparison pins the output or computes the note-commitment break.
+
+Duplicate spends of one positioned opening are found by `findPair`. Its result is
+certified as a two-element *sublist*, which carries "two distinct occurrences" with
+no index arithmetic.
+
+Everything is a plain computable `def` per breaks-as-computed-data; the anchor index
+and the duplicate pair are found by decidable search, so no data is conjured from the
 validity hypothesis's existentials.
 -/
 
@@ -212,8 +216,8 @@ theorem anchor_of_spendMem
   exact ⟨j, lt_of_le_of_lt hjk hki, hrt⟩
 
 /-- **Per-spend pinning.** A nonzero spend of a valid ledger is the positioned opening
-of the output that created its commitment — or the ledger data computes a break. The
-anchor prefix is recovered by decidable search (`Nat.find`), so the branches stay
+of the output that created its commitment — or the ledger data computes a `BalanceBreak`.
+The anchor prefix is recovered by decidable search (`Nat.find`), so the branches stay
 computable. -/
 def spendPinnedOrBreak [DecidableEq F] [DecidableEq G] [DecidableEq RHO]
     [DecidableEq PSI] [DecidableEq MHASH] [DecidableEq MENC]
@@ -288,9 +292,9 @@ of the first `i + 1` transactions are a sub-multiset of the positioned outputs o
 first `i` — or the ledger data computes a `BalanceBreak`. The one-transaction lag is the
 strictly-earlier constraint: an anchor references a transaction boundary, so a spend
 never matches an output of its own transaction. Duplicate spends are located by
-`findPair`; sharing a positioned opening
-forces sharing a revealed nullifier (`nfOldEqOrBreak`), which nullifier uniqueness
-forbids, so the surviving branch is a key-binding break. -/
+`findPair`; sharing a positioned opening forces sharing a revealed nullifier
+(`nfOldEqOrBreak`), which nullifier uniqueness forbids, so the surviving branch is a
+key-binding break. -/
 def balanceSubsetOrBreak [DecidableEq F] [DecidableEq G] [DecidableEq RHO]
     [DecidableEq PSI] [DecidableEq MHASH] [DecidableEq MENC] [DecidableEq NK]
     [NoZeroSMulDivisors F G]
@@ -646,17 +650,25 @@ theorem shieldedPoolBalance_nonneg
     rw [Multiset.map_coe, Multiset.sum_coe]
   exact le_trans h1 (positionedOutputs_value_sum_mono ledger (Nat.le_succ i))
 
-/-- **Balance integrity.** In a valid ledger, either the value after the first `i + 1`
-transactions is accounted for exactly — the shielded and transparent pools are both
-non-negative and sum to the minted issuance — or the ledger's own data computes a break:
-a Balance-subset break (a Merkle, note-commitment, or key-binding break) or the
-transaction-balance premiss's break. The three facts come from three places. The
-shielded pool is non-negative by spend-integrity (`shieldedPoolBalance_nonneg`, from
-Balance-subset: no value is spent that was not created). The transparent pool is
-non-negative by validity (`transparent_nonneg`). The two pools sum to issuance by
-balance conservation (`balanceConservationOrBreak`, from the binding signature: no
-value is created within a transaction). Together they place each pool in
-`[0, issuanceTotal]` and compose the two arguments into one statement. -/
+/-- **Balance integrity.** In a valid ledger, either the value after the first
+`i + 1` transactions is accounted for exactly —the shielded and transparent pools
+are both non-negative and sum to the minted issuance— or the ledger's own data
+computes a break: a Balance-subset break (a Merkle, note-commitment, or key-binding
+break) or the transaction-balance premiss's break.
+
+In the absence of a break, this matches (modulo the simplification of only one
+shielded pool made in the modelling) the rules in ZIP 209. More specifically
+it ensures that those rules only reinforce properties that are in any case
+cryptographically guaranteed. That is, there will be no "turnstile violation".
+
+Facts from three places come together to ensure balance integrity:
+
+* The shielded pool is non-negative by `shieldedPoolBalance_nonneg`, from
+  Balance-subset: no value is spent that was not created.
+* The transparent pool is non-negative by validity (`transparent_nonneg`).
+* The two pools sum to issuance by balance conservation
+  (`balanceConservationOrBreak`, from the binding signature: value balances within
+  a transaction). -/
 def balanceIntegrityOrBreak [DecidableEq F] [DecidableEq G] [DecidableEq RHO]
     [DecidableEq PSI] [DecidableEq MHASH] [DecidableEq MENC] [DecidableEq NK]
     [NoZeroSMulDivisors F G] {VB : Type*}

--- a/Zcash/Security/Ledger/Balance.lean
+++ b/Zcash/Security/Ledger/Balance.lean
@@ -407,21 +407,23 @@ theorem balanceSubsetOrBreak_kbPair [DecidableEq F] [DecidableEq G] [DecidableEq
 
 end Validity
 
-/-! ## Balance-value, in conservation form
+/-! ## Balance conservation
 
-The value ledger balances: what the shielded pool holds plus what the transparent pool
-holds is exactly what issuance has minted — up to a per-transaction value premiss. The
-premiss says each transaction's witnessed net value matches its declared `vBalance`, or
-a value break of the caller's type is exhibited. The intended deployed discharge is the
-binding-signature machinery (`NontrivialRelation.ofBundleIntImbalance` with the
-statement's value ranges and the action-count bound), with a nontrivial discrete-log
-relation as the break. That glue *is* formalized — `ValueShape.premissOrBreak` in
-`Value.lean`, against `ValidLedger.binding_verified` — but only relative to the named
-`extractBsk`/`hextract` extractability hypothesis, which is a placeholder rather than a
-theorem: as a total hypothesis it is classically satisfiable, and carries computational
-force only for an efficient `extractBsk` (see `Value.lean`'s module doc). Balance is then
-the corollary: given the transparent
-pool never goes negative (`ValidLedger.transparent_nonneg`), the shielded pool holds at
+The ledger balances: what the shielded pool holds plus what the transparent pool
+holds is exactly what issuance has minted —up to a transaction-balance premiss— and
+both pool balances are non-negative. The premiss says each transaction's witnessed
+net value matches its declared `vBalance`, or a balance break of the caller's type
+is exhibited. The intended deployed discharge is the binding-signature machinery
+(`NontrivialRelation.ofBundleIntImbalance` with the statement's value ranges and the
+action-count bound), with a nontrivial discrete-log relation as the break. That glue
+is formalized —`ValueShape.premissOrBreak` in `Value.lean`, against
+`ValidLedger.binding_verified`— but only relative to the named `extractBsk`/`hextract`
+extractability hypothesis. That hypothesis is a placeholder rather than a theorem: as
+a total hypothesis it is classically satisfiable, and it carries computational force
+only for an efficient `extractBsk` (see `Value.lean`'s module doc).
+
+Modulo that hypothesis, and given the transparent pool balance never goes negative
+(`ValidLedger.transparent_nonneg`), a corollary is that the shielded pool holds at
 most what was minted. -/
 
 /-- A transaction's net value, read off its witnesses: spent minus created, over all
@@ -523,10 +525,10 @@ theorem nonZeroSpends_value_sum
   exact congrArg List.sum (List.map_congr_left fun tx _ => hfil tx.actions)
 
 /-- The shielded pool balance is the negated sum of the transactions' net values. -/
-theorem poolValueBalance_eq_neg
+theorem shieldedPoolBalance_eq_neg
     (ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG d) (i : ℕ) :
-    poolValueBalance ledger i = -((ledger.take i).map txNetValue).sum := by
-  rw [poolValueBalance, positionedOutputs_value_sum, nonZeroSpends_value_sum]
+    shieldedPoolBalance ledger i = -((ledger.take i).map txNetValue).sum := by
+  rw [shieldedPoolBalance, positionedOutputs_value_sum, nonZeroSpends_value_sum]
   rw [show ((ledger.take i).map txNetValue).sum
       = ((ledger.take i).map fun tx =>
             (tx.actions.map fun a => (a.w.note_old.v : ℤ)).sum).sum
@@ -545,8 +547,8 @@ variable {kv : KeyBindingInterface KW G IVK NK}
 variable {ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG P.depth}
 variable {issuance : ℕ → ℕ} {maxActions : ℕ}
 
-/-- Run the per-transaction value premiss over a list, stopping at the first break. -/
-def allValueOrBreak {VB : Type*}
+/-- Run the transaction-balance premiss over a list, stopping at the first break. -/
+def allConservedOrBreak {VB : Type*}
     (perTx : (tx : Tx KW F G RHO PSI MHASH MENC MSG SIG P.depth) → tx ∈ ledger →
       (txNetValue tx = tx.vBalance) ⊕' VB) :
     (L : List (Tx KW F G RHO PSI MHASH MENC MSG SIG P.depth)) → (∀ tx ∈ L, tx ∈ ledger) →
@@ -556,38 +558,39 @@ def allValueOrBreak {VB : Type*}
     match perTx tx (hL tx (by simp)) with
     | .inr b => .inr b
     | .inl heq =>
-      match allValueOrBreak perTx t (fun x hx => hL x (by simp [hx])) with
+      match allConservedOrBreak perTx t (fun x hx => hL x (by simp [hx])) with
       | .inr b => .inr b
       | .inl hall => .inl (by
           intro x hx
           rcases List.mem_cons.mp hx with rfl | hx'
           exacts [heq, hall x hx'])
 
-/-- **Value conservation.** Up to the value premiss's break, the shielded pool plus the
-transparent pool is exactly the minted issuance. -/
-def valueConservationOrBreak {VB : Type*}
+/-- **Balance conservation.** Up to the transaction-balance premiss's break, the
+shielded pool plus the transparent pool is exactly the minted issuance. -/
+def balanceConservationOrBreak {VB : Type*}
     (perTx : (tx : Tx KW F G RHO PSI MHASH MENC MSG SIG P.depth) → tx ∈ ledger →
       (txNetValue tx = tx.vBalance) ⊕' VB) (i : ℕ) :
-    (poolValueBalance ledger i + transparentPoolBalance issuance ledger i
+    (shieldedPoolBalance ledger i + transparentPoolBalance issuance ledger i
         = issuanceTotal issuance ledger i) ⊕' VB :=
-  match allValueOrBreak perTx (ledger.take i)
+  match allConservedOrBreak perTx (ledger.take i)
       (fun _ h => (List.take_sublist i ledger).subset h) with
   | .inr b => .inr b
   | .inl hall => .inl (by
       have hsum : ((ledger.take i).map txNetValue).sum
           = ((ledger.take i).map fun tx => tx.vBalance).sum :=
         congrArg List.sum (List.map_congr_left fun tx htx => hall tx htx)
-      rw [poolValueBalance_eq_neg, transparentPoolBalance_eq, hsum]
+      rw [shieldedPoolBalance_eq_neg, transparentPoolBalance_eq, hsum]
       ring)
 
-/-- **Balance-value.** Given the transparent pool never goes negative, the shielded pool
-holds at most what issuance has minted — up to the value premiss's break. -/
-def balanceValueOrBreak {VB : Type*}
+/-- **Shielded balance cap.** Given that the transparent pool never goes negative,
+the shielded pool holds at most what issuance has minted — up to the transaction-balance
+premiss's break. -/
+def shieldedBalanceCapOrBreak {VB : Type*}
     (hval : ValidLedger P kv issuance maxActions ledger)
     (perTx : (tx : Tx KW F G RHO PSI MHASH MENC MSG SIG P.depth) → tx ∈ ledger →
       (txNetValue tx = tx.vBalance) ⊕' VB) (i : ℕ) :
-    (poolValueBalance ledger i ≤ issuanceTotal issuance ledger i) ⊕' VB :=
-  match valueConservationOrBreak (issuance := issuance) perTx i with
+    (shieldedPoolBalance ledger i ≤ issuanceTotal issuance ledger i) ⊕' VB :=
+  match balanceConservationOrBreak (issuance := issuance) perTx i with
   | .inr b => .inr b
   | .inl h => .inl (by
       have hnn := hval.transparent_nonneg i
@@ -628,49 +631,49 @@ theorem positionedOutputs_value_sum_mono
   linarith
 
 omit [Field F] [AddCommGroup G] [Module F G] in
-/-- **Balance-value, lower bound.** When the nonzero spends of the first `i + 1`
+/-- **Shielded pool balance lower bound.** When the nonzero spends of the first `i + 1`
 transactions are covered by the positioned outputs of the first `i` — the Balance-subset
 conclusion — the shielded pool holds non-negative value: no value is spent that was not
 created. -/
-theorem poolValueBalance_nonneg
+theorem shieldedPoolBalance_nonneg
     (ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG d) (i : ℕ)
     (hsub : nonZeroSpends ledger (i + 1) ≤ (↑(positionedOutputs ledger i) : Multiset _)) :
-    0 ≤ poolValueBalance ledger (i + 1) := by
-  rw [poolValueBalance, sub_nonneg]
+    0 ≤ shieldedPoolBalance ledger (i + 1) := by
+  rw [shieldedPoolBalance, sub_nonneg]
   have h1 : ((nonZeroSpends ledger (i + 1)).map fun p => (p.opening.note.v : ℤ)).sum
       ≤ ((positionedOutputs ledger i).map fun p => (p.opening.note.v : ℤ)).sum := by
     refine le_trans (sum_val_le_of_le hsub) ?_
     rw [Multiset.map_coe, Multiset.sum_coe]
   exact le_trans h1 (positionedOutputs_value_sum_mono ledger (Nat.le_succ i))
 
-/-- **Balance.** In a valid ledger, either the value after the first `i + 1`
+/-- **Balance integrity.** In a valid ledger, either the value after the first `i + 1`
 transactions is accounted for exactly — the shielded and transparent pools are both
 non-negative and sum to the minted issuance — or the ledger's own data computes a break:
-a Balance-subset break (a Merkle, note-commitment, or key-binding break) or the value
-premiss's break. The three facts come from three places. The shielded pool is
-non-negative by spend-integrity (`poolValueBalance_nonneg`, from Balance-subset: no value
-is spent that was not created). The transparent pool is non-negative by validity
-(`transparent_nonneg`). The two pools sum to issuance by per-transaction value
-conservation (`valueConservationOrBreak`, from the binding signature: no value is created
-within a transaction). Together they place each pool in `[0, issuanceTotal]` and compose
-the two arguments into one statement. -/
-def balanceOrBreak [DecidableEq F] [DecidableEq G] [DecidableEq RHO]
+a Balance-subset break (a Merkle, note-commitment, or key-binding break) or the
+transaction-balance premiss's break. The three facts come from three places. The
+shielded pool is non-negative by spend-integrity (`shieldedPoolBalance_nonneg`, from
+Balance-subset: no value is spent that was not created). The transparent pool is
+non-negative by validity (`transparent_nonneg`). The two pools sum to issuance by
+balance conservation (`balanceConservationOrBreak`, from the binding signature: no
+value is created within a transaction). Together they place each pool in
+`[0, issuanceTotal]` and compose the two arguments into one statement. -/
+def balanceIntegrityOrBreak [DecidableEq F] [DecidableEq G] [DecidableEq RHO]
     [DecidableEq PSI] [DecidableEq MHASH] [DecidableEq MENC] [DecidableEq NK]
     [NoZeroSMulDivisors F G] {VB : Type*}
     (hval : ValidLedger P kv issuance maxActions ledger)
     (perTx : (tx : Tx KW F G RHO PSI MHASH MENC MSG SIG P.depth) → tx ∈ ledger →
       (txNetValue tx = tx.vBalance) ⊕' VB) (i : ℕ) :
-    (0 ≤ poolValueBalance ledger (i + 1)
+    (0 ≤ shieldedPoolBalance ledger (i + 1)
         ∧ 0 ≤ transparentPoolBalance issuance ledger (i + 1)
-        ∧ poolValueBalance ledger (i + 1) + transparentPoolBalance issuance ledger (i + 1)
+        ∧ shieldedPoolBalance ledger (i + 1) + transparentPoolBalance issuance ledger (i + 1)
             = issuanceTotal issuance ledger (i + 1))
       ⊕' (BalanceBreak P kv ⊕' VB) :=
   match balanceSubsetOrBreak hval i,
-      valueConservationOrBreak (issuance := issuance) perTx (i + 1) with
+      balanceConservationOrBreak (issuance := issuance) perTx (i + 1) with
   | .inr b, _ => .inr (.inl b)
   | _, .inr vb => .inr (.inr vb)
   | .inl hsub, .inl hcons =>
-      .inl ⟨poolValueBalance_nonneg ledger i hsub, hval.transparent_nonneg (i + 1), hcons⟩
+      .inl ⟨shieldedPoolBalance_nonneg ledger i hsub, hval.transparent_nonneg (i + 1), hcons⟩
 
 end Conservation
 

--- a/Zcash/Security/Ledger/Capstone.lean
+++ b/Zcash/Security/Ledger/Capstone.lean
@@ -73,77 +73,80 @@ abbrev ValidAnnotated :=
   {ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG P.depth //
     ValidLedger P kv issuance maxActions ledger}
 
-/-! ## Balance-value -/
+/-! ## Balance conservation and shielded balance cap -/
 
-/-- The value-premiss arm event: the samples on which the per-transaction value
-premiss hands the conservation reduction a break of the abstract type `VB`. -/
-def valueBreakEvent {VB : Type*}
+/-- The transaction-balance premiss violation event: the samples on which the
+transaction-balance premiss hands the conservation reduction a break of the abstract
+type `VB`. -/
+def txBalanceBreakEvent {VB : Type*}
     (perTx : ∀ ω : ValidAnnotated P kv issuance maxActions,
       (tx : Tx KW F G RHO PSI MHASH MENC MSG SIG P.depth) → tx ∈ ω.1 →
         (txNetValue tx = tx.vBalance) ⊕' VB) (i : ℕ) :
     Set (ValidAnnotated P kv issuance maxActions) :=
-  {ω | ∃ b : VB, valueConservationOrBreak (issuance := issuance) (perTx ω) i = .inr b}
+  {ω | ∃ b : VB, balanceConservationOrBreak (issuance := issuance) (perTx ω) i = .inr b}
 
-/-- The value-conservation violation event: the shielded pool plus the transparent
+/-- The balance-conservation violation event: the shielded pool plus the transparent
 pool differs from the minted issuance after the first `i` transactions. -/
-def valueConservationViolation (i : ℕ) :
+def balanceConservationViolation (i : ℕ) :
     Set (ValidAnnotated P kv issuance maxActions) :=
-  {ω | poolValueBalance ω.1 i + transparentPoolBalance issuance ω.1 i
+  {ω | shieldedPoolBalance ω.1 i + transparentPoolBalance issuance ω.1 i
     ≠ issuanceTotal issuance ω.1 i}
 
-/-- The Balance-value violation event: the shielded pool exceeds the minted issuance
-after the first `i` transactions. -/
-def balanceValueViolation (i : ℕ) :
+/-- The shielded-balance-cap violation event: the shielded pool exceeds the minted
+issuance after the first `i` transactions. -/
+def shieldedBalanceCapViolation (i : ℕ) :
     Set (ValidAnnotated P kv issuance maxActions) :=
-  {ω | ¬ poolValueBalance ω.1 i ≤ issuanceTotal issuance ω.1 i}
+  {ω | ¬ shieldedPoolBalance ω.1 i ≤ issuanceTotal issuance ω.1 i}
 
-/-- A conservation-violating sample lands in the value-premiss arm: on it, the
-conservation reduction cannot return the equation. -/
-theorem valueConservationViolation_subset {VB : Type*}
+/-- A conservation-violating sample lands in the transaction-balance premiss arm: on
+it, the conservation reduction cannot return the equation. -/
+theorem balanceConservationViolation_subset {VB : Type*}
     (perTx : ∀ ω : ValidAnnotated P kv issuance maxActions,
       (tx : Tx KW F G RHO PSI MHASH MENC MSG SIG P.depth) → tx ∈ ω.1 →
         (txNetValue tx = tx.vBalance) ⊕' VB) (i : ℕ) :
-    valueConservationViolation (P := P) (kv := kv) (maxActions := maxActions) i
-      ⊆ valueBreakEvent perTx i := by
+    balanceConservationViolation (P := P) (kv := kv) (maxActions := maxActions) i
+      ⊆ txBalanceBreakEvent perTx i := by
   intro ω hω
-  rcases h : valueConservationOrBreak (issuance := issuance) (perTx ω) i with heq | b
+  rcases h : balanceConservationOrBreak (issuance := issuance) (perTx ω) i with heq | b
   · exact absurd heq hω
   · exact ⟨b, h⟩
 
-/-- A balance-violating sample lands in the value-premiss arm too: if the reduction
-returned the conservation equation, transparent nonnegativity would force the bound. -/
-theorem balanceValueViolation_subset {VB : Type*}
+/-- A cap-violating sample lands in the transaction-balance premiss arm too: if the
+reduction returned the conservation equation, transparent nonnegativity would force the
+bound. -/
+theorem shieldedBalanceCapViolation_subset {VB : Type*}
     (perTx : ∀ ω : ValidAnnotated P kv issuance maxActions,
       (tx : Tx KW F G RHO PSI MHASH MENC MSG SIG P.depth) → tx ∈ ω.1 →
         (txNetValue tx = tx.vBalance) ⊕' VB) (i : ℕ) :
-    balanceValueViolation (P := P) (kv := kv) (maxActions := maxActions) i
-      ⊆ valueBreakEvent perTx i := by
+    shieldedBalanceCapViolation (P := P) (kv := kv) (maxActions := maxActions) i
+      ⊆ txBalanceBreakEvent perTx i := by
   intro ω hω
-  rcases h : valueConservationOrBreak (issuance := issuance) (perTx ω) i with heq | b
+  rcases h : balanceConservationOrBreak (issuance := issuance) (perTx ω) i with heq | b
   · exact absurd (by have := ω.2.transparent_nonneg i; omega) hω
   · exact ⟨b, h⟩
 
-/-- **Value conservation, probabilistically.** For any adversary, the probability that
-the value ledger fails to balance is at most the value-premiss arm's ε. -/
-theorem valueConservation_measure_le {VB : Type*}
+/-- **Balance conservation, probabilistically.** For any adversary, the probability
+that the ledger fails to balance is at most the transaction-balance premiss arm's ε. -/
+theorem balanceConservation_measure_le {VB : Type*}
     (A : PMF (ValidAnnotated P kv issuance maxActions))
     (perTx : ∀ ω : ValidAnnotated P kv issuance maxActions,
       (tx : Tx KW F G RHO PSI MHASH MENC MSG SIG P.depth) → tx ∈ ω.1 →
-        (txNetValue tx = tx.vBalance) ⊕' VB) (i : ℕ) {εvb : ℝ≥0∞}
-    (hvb : A.toOuterMeasure (valueBreakEvent perTx i) ≤ εvb) :
-    A.toOuterMeasure (valueConservationViolation i) ≤ εvb :=
-  le_trans (MeasureTheory.measure_mono (valueConservationViolation_subset perTx i)) hvb
+        (txNetValue tx = tx.vBalance) ⊕' VB) (i : ℕ) {ε_conservation : ℝ≥0∞}
+    (hvb : A.toOuterMeasure (txBalanceBreakEvent perTx i) ≤ ε_conservation) :
+    A.toOuterMeasure (balanceConservationViolation i) ≤ ε_conservation :=
+  le_trans (MeasureTheory.measure_mono (balanceConservationViolation_subset perTx i)) hvb
 
-/-- **Balance-value, probabilistically.** For any adversary, the probability that the
-shielded pool exceeds the minted issuance is at most the value-premiss arm's ε. -/
-theorem balanceValue_measure_le {VB : Type*}
+/-- **Shielded balance cap, probabilistically.** For any adversary, the probability
+that the shielded pool exceeds the minted issuance is at most the transaction-balance
+premiss arm's ε. -/
+theorem shieldedBalanceCap_measure_le {VB : Type*}
     (A : PMF (ValidAnnotated P kv issuance maxActions))
     (perTx : ∀ ω : ValidAnnotated P kv issuance maxActions,
       (tx : Tx KW F G RHO PSI MHASH MENC MSG SIG P.depth) → tx ∈ ω.1 →
-        (txNetValue tx = tx.vBalance) ⊕' VB) (i : ℕ) {εvb : ℝ≥0∞}
-    (hvb : A.toOuterMeasure (valueBreakEvent perTx i) ≤ εvb) :
-    A.toOuterMeasure (balanceValueViolation i) ≤ εvb :=
-  le_trans (MeasureTheory.measure_mono (balanceValueViolation_subset perTx i)) hvb
+        (txNetValue tx = tx.vBalance) ⊕' VB) (i : ℕ) {ε_cap : ℝ≥0∞}
+    (hvb : A.toOuterMeasure (txBalanceBreakEvent perTx i) ≤ ε_cap) :
+    A.toOuterMeasure (shieldedBalanceCapViolation i) ≤ ε_cap :=
+  le_trans (MeasureTheory.measure_mono (shieldedBalanceCapViolation_subset perTx i)) hvb
 
 /-! ## Balance-subset -/
 

--- a/Zcash/Security/Ledger/Completeness.lean
+++ b/Zcash/Security/Ledger/Completeness.lean
@@ -22,7 +22,7 @@ The Merkle side rests on `Merkle.path_of_root`: the honest authentication data
 exists because the referenced tree is defined (`root_defined`). Inclusion is only
 required of nonzero-valued spends, so zero-valued dummy spends — whose path data is
 arbitrary — are covered; `HonestAction.withDummySpend` constructs one. The honest
-transaction declares its true net value, so the Balance game's per-transaction value
+transaction declares its true net value, so the Balance game's transaction-balance
 premiss holds for it (`txNetValue_honestTx`).
 
 The Actions of one honest transaction may reference different anchors, matching the
@@ -255,7 +255,7 @@ def honestTx (spends : List (HonestAction P kv ledger × SIG)) (sighash : MSG)
   bindingSig := bindingSig
 
 /-- The honest transaction declares its true net value, so the Balance game's
-per-transaction value premiss holds for it. -/
+transaction-balance premiss holds for it. -/
 theorem txNetValue_honestTx (spends : List (HonestAction P kv ledger × SIG))
     (sighash : MSG) (bindingSig : SIG) :
     txNetValue (honestTx spends sighash bindingSig) = (honestTx spends sighash bindingSig).vBalance := by

--- a/Zcash/Security/Ledger/DeployedCapstone.lean
+++ b/Zcash/Security/Ledger/DeployedCapstone.lean
@@ -8,18 +8,19 @@ import Zcash.Security.Ledger.MerkleDLR
 # The deployed instantiation: every Balance-subset arm computes a discrete-log relation
 
 At the deployed Orchard primitives, each of the three Balance-subset break arms reduces
-to a nontrivial discrete-log relation among the fixed Sinsemilla bases. These are the
-event-level reductions that discharge the capstone's three named ε hypotheses at the
-deployed instantiation. Each takes a sample on which the reduction lands in one arm and
-returns the arm's relation, so the arm's probability is the probability that the
-composite produces a relation. Under the pre-quantum hardness of the deployed bases
-(their independence, spec Theorems 5.4.3 and 5.4.4), that probability is the
-discrete-log-relation advantage — the same terminal the Merkle and note-commitment arms
-already share, with no random-oracle model.
+to a nontrivial discrete-log relation among the fixed Sinsemilla bases. Each reducer is a
+total, hypothesis-free function from the arm's break to its relation, so it needs no
+random-oracle model. `deployedBalanceSubsetOrRelation` runs all three: from a valid
+deployed ledger it computes either the Balance-subset containment or a nontrivial relation
+among the fixed bases.
 
-Composing these with `balanceSubset_measure_le` replaces the three opaque arm ε's with
-one discrete-log-relation assumption per domain point, and the key-binding arm no longer
-needs the oracle model at the deployed instantiation.
+This is the deterministic core of the deployed ε discharge. The probability that a sampled
+ledger produces a relation is the discrete-log-relation advantage for the fixed bases,
+under their pre-quantum hardness (their independence, spec Theorems 5.4.3 and 5.4.4). That
+is the same terminal as the Merkle and note-commitment arms, and the key-binding arm
+reaches it here without the oracle model. Turning this deterministic reduction into a bound
+on the capstone's named ε — composing it with `balanceSubset_measure_le` over a `PMF` of
+deployed ledgers — is not yet formalized.
 -/
 
 namespace Zcash.Security.Ledger.Bridge
@@ -50,8 +51,8 @@ inductive DeployedBalanceRelation where
 nonzero spends of the first `i + 1` transactions are covered by the positioned outputs
 of the first `i`, or the ledger's own data computes a nontrivial discrete-log relation
 among the fixed Sinsemilla bases. Each Balance-subset break arm is routed through its
-deployed reducer, so the three named ε hypotheses collapse to one discrete-log-relation
-assumption per domain point, with no random-oracle model. -/
+deployed reducer, so a break in any arm becomes a nontrivial relation among the fixed
+bases, with no random-oracle model. -/
 def deployedBalanceSubsetOrRelation {ledger : Ledger _ Fq PallasGroup Fp Fp Fp Encoding MSG SIG _}
     (hval : ValidLedger (primitives (MSG := MSG) (SIG := SIG) verify bverify) keyBinding
       issuance maxActions ledger) (i : ℕ) :

--- a/Zcash/Security/Ledger/Effects.lean
+++ b/Zcash/Security/Ledger/Effects.lean
@@ -87,7 +87,7 @@ def nonZeroSpends (ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG d) (i : ℕ
 
 /-- The shielded pool balance after the first `i` transactions: output value total minus
 nonzero-spend value total, both read off the witnesses. -/
-def poolValueBalance (ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG d) (i : ℕ) : ℤ :=
+def shieldedPoolBalance (ledger : Ledger KW F G RHO PSI MHASH MENC MSG SIG d) (i : ℕ) : ℤ :=
   (((positionedOutputs ledger i).map fun p => (p.opening.note.v : ℤ)).sum : ℤ)
     - ((nonZeroSpends ledger i).map fun p => (p.opening.note.v : ℤ)).sum
 

--- a/Zcash/Security/Ledger/KeyBindingDLR.lean
+++ b/Zcash/Security/Ledger/KeyBindingDLR.lean
@@ -3,7 +3,7 @@ import Zcash.Security.Ledger.Pool
 import Zcash.Security.Ledger.SinsemillaDLR
 
 /-!
-# The deployed key-binding break computes a discrete-log relation
+# The Orchard-protocol key-binding break computes a discrete-log relation
 
 The pre-quantum discharge of the key-binding arm's ε: a
 `KeyBinding.Pool.CommitIvkCollision` — two valid `Commit^ivk` openings of the same `ivk`
@@ -31,7 +31,7 @@ open Zcash.Security.Ledger.Pool
 def ivkQpt : PallasGroup := PallasGroup.ofPoint ivkQ (Or.inl ivkQ_onCurve)
 
 /-- The `CommitIvk` randomness base, as a group element — the `commitIvkR` argument of
-the deployed `keyBinding` interface. -/
+the Orchard-protocol `keyBinding` interface. -/
 def commitIvkRpt : PallasGroup :=
   PallasGroup.ofPoint Ecc.MulFixed.Certs.commitIvkR.point
     (Or.inl Ecc.MulFixed.Certs.commitIvkR.onCurve)
@@ -62,13 +62,13 @@ theorem commitIvkHash_get_spec {a n : Fp} {g : PallasGroup}
     exact ⟨hv, (Option.some_inj.mp hop).symm⟩
   · exact absurd hop (by simp)
 
-/-- **The deployed key-binding break computes a discrete-log relation.** Two valid
-`Commit^ivk` openings of the same `ivk` disagreeing on their opening projection: the
-reduction unpacks them into their defined Sinsemilla chains and blinding scalars and applies
-the chain-collision reducer at the `CommitIvk` domain point and randomness base.
-The reduction is hypothesis-free: the chunk-coefficient
-injectivity is `preCoeffs_inj` (spec Theorem 5.4.3's binary-expansion core, proven)
-and the chunk-encoding injectivity is `commitIvkChunks_inj`. -/
+/-- **The Orchard-protocol key-binding break computes a discrete-log relation.** Two
+valid `Commit^ivk` openings of the same `ivk` disagreeing on their opening projection:
+the reduction unpacks them into their defined Sinsemilla chains and blinding scalars
+and applies the chain-collision reducer at the `CommitIvk` domain point and randomness
+base. The reduction is hypothesis-free: the chunk-coefficient injectivity is
+`preCoeffs_inj` (spec Theorem 5.4.3's binary-expansion core, proven) and the
+chunk-encoding injectivity is `commitIvkChunks_inj`. -/
 def relationOfKeyBindingBreak
     {w₁ w₂ : KeyBinding.Pool.Witness Fq PallasGroup Fp}
     (b : KeyBinding.Pool.CommitIvkCollision extract commitIvkHash commitIvkRpt w₁ w₂)

--- a/Zcash/Security/Ledger/KeyBindingDLR.lean
+++ b/Zcash/Security/Ledger/KeyBindingDLR.lean
@@ -5,12 +5,13 @@ import Zcash.Security.Ledger.SinsemillaDLR
 /-!
 # The deployed key-binding break computes a discrete-log relation
 
-The pre-quantum discharge of the key-binding arm's ε: a `KeyBinding.Pool.Break` — two
-valid `Commit^ivk` openings of the same `ivk` disagreeing on their opening projection —
-computes a nontrivial discrete-log relation among the Sinsemilla table generators, the
-`CommitIvk` domain point, and the `CommitIvk` randomness base. This folds ε_kb into the
-same DL terminal as the Merkle and note-commitment arms, with no random-oracle model
-and no probability accounting: the reduction is deterministic.
+The pre-quantum discharge of the key-binding arm's ε: a
+`KeyBinding.Pool.CommitIvkCollision` — two valid `Commit^ivk` openings of the same `ivk`
+disagreeing on their opening projection — computes a nontrivial discrete-log relation
+among the Sinsemilla table generators, the `CommitIvk` domain point, and the `CommitIvk`
+randomness base. This folds ε_kb into the same DL terminal as the Merkle and
+note-commitment arms, with no random-oracle model and no probability accounting: the
+reduction is deterministic.
 
 The shared machinery is `Bridge.relationOfChainPmEq` (`SinsemillaDLR`); this module
 instantiates it at the `CommitIvk` domain point and randomness base, unpacking the
@@ -70,7 +71,7 @@ injectivity is `preCoeffs_inj` (spec Theorem 5.4.3's binary-expansion core, prov
 and the chunk-encoding injectivity is `commitIvkChunks_inj`. -/
 def relationOfKeyBindingBreak
     {w₁ w₂ : KeyBinding.Pool.Witness Fq PallasGroup Fp}
-    (b : KeyBinding.Pool.Break extract commitIvkHash commitIvkRpt w₁ w₂)
+    (b : KeyBinding.Pool.CommitIvkCollision extract commitIvkHash commitIvkRpt w₁ w₂)
  :
     NontrivialRelation (F := Fq) pallasS ivkQpt commitIvkRpt :=
   let hs₁ := commitIvkHash_isSome b.kb₁.hash_eq

--- a/Zcash/Security/Ledger/MerkleDLR.lean
+++ b/Zcash/Security/Ledger/MerkleDLR.lean
@@ -4,7 +4,7 @@ import Zcash.Security.Ledger.Pool
 import Zcash.Security.Ledger.SinsemillaDLR
 
 /-!
-# A deployed Merkle collision computes a Sinsemilla discrete-log relation
+# An Orchard-protocol Merkle collision computes a Sinsemilla discrete-log relation
 
 The pre-quantum discharge of the Merkle arm: a defined collision of the layer-`i`
 compression — two distinct child pairs with the same defined output — computes a
@@ -64,9 +64,10 @@ theorem merkleCompress_get_valid {i : Fin 32} {ch : Encoding × Encoding} {out :
   hashToPoint_valid (Or.inl merkleQ_onCurve) (fun _ hm => merkleChunks_mem_lt hm)
     (Option.some_get (merkleCompress_isSome h)).symm
 
-/-- **A deployed Merkle collision computes a Sinsemilla discrete-log relation.** The
-collision's two children are unpacked into their defined Sinsemilla chains, and the
-chain-collision reducer is applied with zero blinding at the Merkle domain point.
+/-- **An Orchard-protocol Merkle collision computes a Sinsemilla discrete-log
+relation.** The collision's two children are unpacked into their defined Sinsemilla
+chains, and the chain-collision reducer is applied with zero blinding at the Merkle
+domain point.
 The relation then converts to the one-generator form, because its randomness-base
 coefficient is zero. -/
 def relationOfMerkleCollision {i : Fin 32}

--- a/Zcash/Security/Ledger/NoteCommitDLR.lean
+++ b/Zcash/Security/Ledger/NoteCommitDLR.lean
@@ -4,14 +4,14 @@ import Zcash.Security.Ledger.Pool
 import Zcash.Security.Ledger.SinsemillaDLR
 
 /-!
-# The deployed note-commitment break computes a discrete-log relation
+# The Orchard-protocol note-commitment break computes a discrete-log relation
 
 The pre-quantum discharge of the note-commitment arm: a `NoteCommitBreak` at the
-deployed primitives — two openings with distinct `(rcm, note)` pairs whose commitments
-share an extracted coordinate — computes a nontrivial relation among the Sinsemilla
-table, the `NoteCommit` domain point, and the randomness base. The reduction unpacks
-the two openings into their defined Sinsemilla chains and blinding scalars and applies the
-chain-collision reducer `relationOfChainPmEq`.
+Orchard-protocol primitives — two openings with distinct `(rcm, note)` pairs whose
+commitments share an extracted coordinate — computes a nontrivial relation among the
+Sinsemilla table, the `NoteCommit` domain point, and the randomness base. The
+reduction unpacks the two openings into their defined Sinsemilla chains and blinding
+scalars and applies the chain-collision reducer `relationOfChainPmEq`.
 
 The reduction is hypothesis-free. The chunk-coefficient injectivity is `preCoeffs_inj`
 and the 109-chunk message encoding is injective by `noteCommitChunks_inj`. Recovering
@@ -40,7 +40,7 @@ def noteCommitRpt : PallasGroup :=
 theorem smul_eq_val_nsmul (r : Fq) (P : PallasGroup) : r • P = r.val • P := by
   rw [← Nat.cast_smul_eq_nsmul Fq, ZMod.natCast_zmod_val]
 
-/-- Every note value below the deployed bound is below the base-field order. -/
+/-- Every note value below the Orchard-protocol bound is below the base-field order. -/
 theorem valueBound_lt_card {v : ℕ} (hv : v < 2 ^ 64) :
     v < CompElliptic.Fields.Pasta.PALLAS_BASE_CARD :=
   lt_trans hv (by norm_num [CompElliptic.Fields.Pasta.PALLAS_BASE_CARD])
@@ -73,7 +73,7 @@ theorem noteCommit_get_spec {rcm : Fq} {n : Note PallasGroup Fp Fp}
         (Point.valid_nsmul (Or.inl Ecc.MulFixed.Certs.noteCommitR.onCurve) rcm.val)]
   · exact absurd hop (by simp)
 
-/-- **The deployed note-commitment break computes a discrete-log relation.** Two
+/-- **The Orchard-protocol note-commitment break computes a discrete-log relation.** Two
 openings with distinct `(rcm, note)` pairs whose commitments share an extracted
 coordinate: the reduction unpacks them into their defined Sinsemilla chains and blinding
 scalars and applies the chain-collision reducer at the `NoteCommit` domain point and

--- a/Zcash/Security/Ledger/OrchardCapstone.lean
+++ b/Zcash/Security/Ledger/OrchardCapstone.lean
@@ -5,22 +5,23 @@ import Zcash.Security.Ledger.NoteCommitDLR
 import Zcash.Security.Ledger.MerkleDLR
 
 /-!
-# The deployed instantiation: every Balance-subset arm computes a discrete-log relation
+# The Orchard instantiation: every Balance-subset arm computes a discrete-log relation
 
-At the deployed Orchard primitives, each of the three Balance-subset break arms reduces
-to a nontrivial discrete-log relation among the fixed Sinsemilla bases. Each reducer is a
-total, hypothesis-free function from the arm's break to its relation, so it needs no
-random-oracle model. `deployedBalanceSubsetOrRelation` runs all three: from a valid
-deployed ledger it computes either the Balance-subset containment or a nontrivial relation
-among the fixed bases.
+These are the instantiations that use the Orchard-protocol bases and parameters. At
+them, each of the three Balance-subset break arms reduces to a nontrivial discrete-log
+relation among the fixed Sinsemilla bases. Each reducer is a total, hypothesis-free
+function from the arm's break to its relation, so it needs no random-oracle model.
+`orchardBalanceSubsetOrRelation` runs all three: from a valid Orchard ledger it
+computes either the Balance-subset containment or a nontrivial relation among the
+fixed bases.
 
-This is the deterministic core of the deployed ε discharge. The probability that a sampled
-ledger produces a relation is the discrete-log-relation advantage for the fixed bases,
-under their pre-quantum hardness (their independence, spec Theorems 5.4.3 and 5.4.4). That
-is the same terminal as the Merkle and note-commitment arms, and the key-binding arm
-reaches it here without the oracle model. Turning this deterministic reduction into a bound
-on the capstone's named ε — composing it with `balanceSubset_measure_le` over a `PMF` of
-deployed ledgers — is not yet formalized.
+This is the deterministic core of the Orchard ε discharge. The probability that a
+sampled ledger produces a relation is the discrete-log-relation advantage for the
+fixed bases, under their pre-quantum hardness (their independence, spec Theorems 5.4.3
+and 5.4.4). That is the same terminal as the Merkle and note-commitment arms, and the
+key-binding arm reaches it here without the oracle model. Turning this deterministic
+reduction into a bound on the capstone's named ε — composing it with
+`balanceSubset_measure_le` over a `PMF` of Orchard ledgers — is not yet formalized.
 -/
 
 namespace Zcash.Security.Ledger.Bridge
@@ -34,30 +35,30 @@ variable {MSG SIG : Type*}
   (verify bverify : PallasGroup → MSG → SIG → Prop)
   (issuance : ℕ → ℕ) (maxActions : ℕ)
 
-/-- The deployed instantiation's sample space. -/
-abbrev DeployedAnnotated :=
+/-- The Orchard instantiation's sample space. -/
+abbrev OrchardAnnotated :=
   ValidAnnotated (primitives (MSG := MSG) (SIG := SIG) verify bverify) keyBinding
     issuance maxActions
 
-/-- The three deployed Balance-subset relation targets: the key-binding and
+/-- The three Orchard Balance-subset relation targets: the key-binding and
 note-commitment arms land in two-generator relations at their domain points, the
 Merkle arm in a one-generator relation. -/
-inductive DeployedBalanceRelation where
+inductive OrchardBalanceRelation where
   | keyBinding (r : NontrivialRelation (F := Fq) pallasS ivkQpt commitIvkRpt)
   | noteCommit (r : NontrivialRelation (F := Fq) pallasS noteQpt noteCommitRpt)
   | merkle (r : NontrivialRelationOne (F := Fq) pallasS merkleQpt)
 
-/-- **The deployed Balance-subset reduction.** In a valid deployed ledger, either the
+/-- **The Orchard Balance-subset reduction.** In a valid Orchard ledger, either the
 nonzero spends of the first `i + 1` transactions are covered by the positioned outputs
 of the first `i`, or the ledger's own data computes a nontrivial discrete-log relation
 among the fixed Sinsemilla bases. Each Balance-subset break arm is routed through its
-deployed reducer, so a break in any arm becomes a nontrivial relation among the fixed
+Orchard reducer, so a break in any arm becomes a nontrivial relation among the fixed
 bases, with no random-oracle model. -/
-def deployedBalanceSubsetOrRelation {ledger : Ledger _ Fq PallasGroup Fp Fp Fp Encoding MSG SIG _}
+def orchardBalanceSubsetOrRelation {ledger : Ledger _ Fq PallasGroup Fp Fp Fp Encoding MSG SIG _}
     (hval : ValidLedger (primitives (MSG := MSG) (SIG := SIG) verify bverify) keyBinding
       issuance maxActions ledger) (i : ℕ) :
     (nonZeroSpends ledger (i + 1) ≤ ↑(positionedOutputs ledger i))
-      ⊕' DeployedBalanceRelation :=
+      ⊕' OrchardBalanceRelation :=
   match balanceSubsetOrBreak hval i with
   | .inl hsub => .inl hsub
   | .inr (.keyBinding _ _ h) => .inr (.keyBinding (relationOfKeyBindingBreak h))

--- a/Zcash/Security/Ledger/SinsemillaDLR.lean
+++ b/Zcash/Security/Ledger/SinsemillaDLR.lean
@@ -7,8 +7,8 @@ import Zcash.Common.DiscreteLogRelation
 The onward reduction step for the classified Action escapes: a plain `def`
 converting an `ActionBreakData` — the site and escape datum computed by
 `classifyAction` — into a `NontrivialRelationOne`, the games-facing
-discrete-log-relation break among the deployed Sinsemilla generator table and the
-escaped site's domain point.  This is protocol-spec Theorem 5.4.4 made
+discrete-log-relation break among the Orchard-protocol Sinsemilla generator table and
+the escaped site's domain point.  This is protocol-spec Theorem 5.4.4 made
 computational end to end: the coefficients of the relation are read off the break
 datum's consumed prefix (`breakCoeffs`), and its `Prop` fields are discharged from
 `ValidBreak` alone.
@@ -36,9 +36,9 @@ open Zcash.Security.Concrete
 
 /-! ## The lifted generator table -/
 
-/-- The deployed Sinsemilla generator table, lifted into the Pallas group.  Total on
-`ℕ` for convenient use under chunk lists; off-table indices (never produced by a
-`K`-bit chunk) map to the identity. -/
+/-- The Orchard-protocol Sinsemilla generator table, lifted into the Pallas group.
+Total on `ℕ` for convenient use under chunk lists; off-table indices (never produced
+by a `K`-bit chunk) map to the identity. -/
 def pallasSAt (m : ℕ) : PallasGroup :=
   if h : m < 2 ^ K then
     PallasGroup.ofPoint (orchardGenerators.S m) (orchardGenerators.valid h)
@@ -454,8 +454,8 @@ def relationOfBreakData (wit : ActionData) (abr : ActionBreakData)
     (break_bounds h).1 (break_bounds h).2
 
 /-- A classified Action escape reduced onward: the site together with a nontrivial
-discrete-log relation among the deployed generator table and that site's domain
-point. -/
+discrete-log relation among the Orchard-protocol generator table and that site's
+domain point. -/
 structure ActionDLBreak where
   site : BreakSite
   rel : NontrivialRelationOne (F := Fq) pallasS (sitePoint site)
@@ -611,9 +611,9 @@ point, blinded by `r₁ • W` and `r₂ • W`, whose outputs agree up to sign,
 nontrivial relation among the table, the domain point, and `W` — provided the pair
 `(chunk list, blinding scalar)` differs. The equality case rests on
 `preCoeffs_inj` — chunk lists of length at most 253 are determined by their
-coefficients, and every deployed Sinsemilla message is far shorter. The negation case is
-unconditional: the domain-point coefficients `2^n` and `-2^n` cannot agree because
-`2^(n+1) ≠ 0` in the odd-order scalar field. -/
+coefficients, and every Orchard-protocol Sinsemilla message is far shorter. The
+negation case is unconditional: the domain-point coefficients `2^n` and `-2^n` cannot
+agree because `2^(n+1) ≠ 0` in the odd-order scalar field. -/
 def relationOfChainPmEq {Q : Point Fp} (hQ : Q.Valid) {W : PallasGroup}
     {l₁ l₂ : List ℕ} (hb₁ : ∀ m ∈ l₁, m < 2 ^ K) (hb₂ : ∀ m ∈ l₂, m < 2 ^ K)
     (hlen : l₁.length = l₂.length)

--- a/Zcash/Security/Ledger/Value.lean
+++ b/Zcash/Security/Ledger/Value.lean
@@ -6,10 +6,10 @@ import Zcash.Security.BindingSignature.Balance
 set_option linter.unusedSectionVars false
 
 /-!
-# The value-premiss discharge at the Pedersen shape
+# The transaction-balance premiss discharge at the Pedersen shape
 
-Balance-value's per-transaction premiss — the witnessed net value matches the declared
-`vBalance`, or a break of the abstract type `VB` is exhibited — is discharged here
+The transaction-balance premiss —the witnessed net value matches the declared
+`vBalance`, or a break of the abstract type `VB` is exhibited— is discharged here
 against the binding-signature layer, with `VB` concretely the nontrivial `(V, R)`
 discrete-log relation.
 
@@ -37,10 +37,10 @@ efficient against a binding-signature forger, delivering the relation only with 
 extractor's success probability. Proving it by forking is #22's scope (#107/#67 track the
 restructuring into the knowledge-error form).
 
-`ValueShape.balanceOrBreak` and `ValueShape.conservationOrBreak` compose
-the premiss into the Balance-value capstones: the shielded pool exceeding the minted
-issuance (or the value ledger failing to balance) computes a nontrivial `(V, R)`
-relation.
+`ValueShape.conservationOrBreak` and `ValueShape.capOrBreak` compose the premiss into
+the balance-conservation and shielded-balance-cap capstones: the ledger failing to
+balance (or the shielded pool exceeding the minted issuance) computes a nontrivial
+`(V, R)` relation.
 -/
 
 namespace Zcash.Security.Ledger.Model
@@ -121,14 +121,14 @@ theorem txNetValue_natAbs_le
             simp only [List.length_cons]
             ring
 
-/-- **The value-premiss discharge.** Decide the per-transaction net-value equation;
-on failure, compute the nontrivial `(V, R)` relation from the witnessed bundle. The
-no-overflow bound is discharged from the statement's value ranges and validity's
-action-count and `vBalance` range rules; the extraction input applies the named
-RedDSA-extractability form (`extractBsk`/`hextract`) to validity's binding-signature
-conjunct. `hextract` is a placeholder, not a theorem: as a total hypothesis it is
-classically satisfiable, computational only relative to an efficient `extractBsk` (see
-the module doc). -/
+/-- **The transaction-balance premiss discharge.** Decide the per-transaction
+net-value equation; on failure, compute the nontrivial `(V, R)` relation from the
+witnessed bundle. The no-overflow bound is discharged from the statement's value
+ranges and validity's action-count and `vBalance` range rules; the extraction input
+applies the named RedDSA-extractability form (`extractBsk`/`hextract`) to validity's
+binding-signature conjunct. `hextract` is a placeholder, not a theorem: as a total
+hypothesis it is classically satisfiable, computational only relative to an efficient
+`extractBsk` (see the module doc). -/
 def ValueShape.premissOrBreak {issuance : ℕ → ℕ} {maxActions : ℕ}
     {ledger : Ledger KW (ZMod r) G RHO PSI MHASH MENC MSG SIG P.depth}
     (S : ValueShape P)
@@ -161,7 +161,7 @@ def ValueShape.premissOrBreak {issuance : ℕ → ℕ} {maxActions : ℕ}
       ((bvk_eq S (hval.satisfied tx htx)).symm.trans
         (hextract _ _ _ (hval.binding_verified tx htx))))
 
-/-- **Value conservation at the Pedersen shape.** The value ledger failing to balance
+/-- **Balance conservation at the Pedersen shape.** The ledger failing to balance
 computes a nontrivial `(V, R)` relation. -/
 def ValueShape.conservationOrBreak {issuance : ℕ → ℕ} {maxActions : ℕ}
     {ledger : Ledger KW (ZMod r) G RHO PSI MHASH MENC MSG SIG P.depth}
@@ -171,15 +171,15 @@ def ValueShape.conservationOrBreak {issuance : ℕ → ℕ} {maxActions : ℕ}
     (extractBsk : G → MSG → SIG → ZMod r)
     (hextract : ∀ bvk msg sig, P.bindingVerify bvk msg sig
       → bvk = extractBsk bvk msg sig • S.R) (i : ℕ) :
-    (poolValueBalance ledger i + transparentPoolBalance issuance ledger i
+    (shieldedPoolBalance ledger i + transparentPoolBalance issuance ledger i
         = issuanceTotal issuance ledger i)
       ⊕' BindingSignature.NontrivialRelation (F := ZMod r) S.V S.R :=
-  valueConservationOrBreak (S.premissOrBreak hval hr extractBsk hextract) i
+  balanceConservationOrBreak (S.premissOrBreak hval hr extractBsk hextract) i
 
-/-- **Balance-value at the Pedersen shape.** The shielded pool exceeding the minted
-issuance computes a nontrivial `(V, R)` relation — the Balance-value chain composed,
-with the abstract `VB` instantiated at the shape level. -/
-def ValueShape.balanceOrBreak {issuance : ℕ → ℕ} {maxActions : ℕ}
+/-- **Shielded balance cap at the Pedersen shape.** The shielded pool exceeding the
+minted issuance computes a nontrivial `(V, R)` relation — the conservation-and-cap
+chain composed, with the abstract `VB` instantiated at the shape level. -/
+def ValueShape.capOrBreak {issuance : ℕ → ℕ} {maxActions : ℕ}
     {ledger : Ledger KW (ZMod r) G RHO PSI MHASH MENC MSG SIG P.depth}
     (S : ValueShape P)
     (hval : ValidLedger P kv issuance maxActions ledger)
@@ -187,8 +187,8 @@ def ValueShape.balanceOrBreak {issuance : ℕ → ℕ} {maxActions : ℕ}
     (extractBsk : G → MSG → SIG → ZMod r)
     (hextract : ∀ bvk msg sig, P.bindingVerify bvk msg sig
       → bvk = extractBsk bvk msg sig • S.R) (i : ℕ) :
-    (poolValueBalance ledger i ≤ issuanceTotal issuance ledger i)
+    (shieldedPoolBalance ledger i ≤ issuanceTotal issuance ledger i)
       ⊕' BindingSignature.NontrivialRelation (F := ZMod r) S.V S.R :=
-  balanceValueOrBreak hval (S.premissOrBreak hval hr extractBsk hextract) i
+  shieldedBalanceCapOrBreak hval (S.premissOrBreak hval hr extractBsk hextract) i
 
 end Zcash.Security.Ledger.Model

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -37,7 +37,7 @@ import Zcash.Snark.Soundness.ActionVesta
 import Zcash.Security.Ledger.KeyBindingDLR
 import Zcash.Security.Ledger.NoteCommitDLR
 import Zcash.Security.Ledger.MerkleDLR
-import Zcash.Security.Ledger.DeployedCapstone
+import Zcash.Security.Ledger.OrchardCapstone
 import Zcash.Snark.Soundness.DegreeWalk
 import Zcash.Snark.Soundness.Composition.ScheduleBudget
 import Zcash.Snark.Soundness.AGM.PinnedRootWitness
@@ -304,11 +304,11 @@ assert_axioms Zcash.Security.Ledger.Model.balanceConservation_measure_le
 assert_axioms Zcash.Security.Ledger.Model.shieldedBalanceCap_measure_le
 assert_axioms Zcash.Security.Ledger.Model.spendAuthority_measure_le
 
-/-! ## The deployed discrete-log-relation discharges
+/-! ## The Orchard-protocol discrete-log-relation discharges
 
-Each deployed Balance-subset break arm reduces to a nontrivial discrete-log relation
-among the fixed Sinsemilla bases, and `deployedBalanceSubsetOrRelation` routes all three
-from a valid deployed ledger. The reductions are computable, so they get
+Each Orchard-protocol Balance-subset break arm reduces to a nontrivial discrete-log
+relation among the fixed Sinsemilla bases, and `orchardBalanceSubsetOrRelation` routes
+all three from a valid Orchard ledger. The reductions are computable, so they get
 assert_computable. The encoding-injectivity and coefficient-injectivity facts they
 consume are theorems. -/
 
@@ -334,7 +334,7 @@ assert_computable Zcash.Security.Ledger.Bridge.relationOfNoteCommitBreak +choice
   Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitVCert_check)
 assert_computable Zcash.Security.Ledger.Bridge.relationOfMerkleCollision +choice +native(
   CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt)
-assert_computable Zcash.Security.Ledger.Bridge.deployedBalanceSubsetOrRelation +choice +native(
+assert_computable Zcash.Security.Ledger.Bridge.orchardBalanceSubsetOrRelation +choice +native(
   CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt,
   Zcash.Security.Ledger.Pool.unc_thirteen_not_isSquare,
   Zcash.Circuits.Ecc.MulFixed.Certs.commitIvkRCert_check,

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -307,10 +307,10 @@ assert_axioms Zcash.Security.Ledger.Model.spendAuthority_measure_le
 /-! ## The deployed discrete-log-relation discharges
 
 Each deployed Balance-subset break arm reduces to a nontrivial discrete-log relation
-among the fixed Sinsemilla bases (`deployedBalanceSubsetOrRelation`), routing the three
-named ε hypotheses to one discrete-log-relation assumption per domain point. The
-reductions are computable, so they get assert_computable. The encoding-injectivity and
-coefficient-injectivity facts they consume are theorems. -/
+among the fixed Sinsemilla bases, and `deployedBalanceSubsetOrRelation` routes all three
+from a valid deployed ledger. The reductions are computable, so they get
+assert_computable. The encoding-injectivity and coefficient-injectivity facts they
+consume are theorems. -/
 
 assert_axioms Zcash.NontrivialRelation.toOne
 assert_axioms Zcash.Circuits.Specs.Sinsemilla.chunksOf_inj

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -180,7 +180,7 @@ assert_computable Zcash.Security.Ledger.Model.outputActions
 assert_computable Zcash.Security.Ledger.Model.outputOpenings
 assert_computable Zcash.Security.Ledger.Model.positionedOutputs
 assert_computable Zcash.Security.Ledger.Model.nonZeroSpends
-assert_computable Zcash.Security.Ledger.Model.poolValueBalance
+assert_computable Zcash.Security.Ledger.Model.shieldedPoolBalance
 assert_axioms Zcash.Security.Ledger.Model.posVal_lt
 assert_axioms Zcash.Security.Ledger.Model.rootAfter_prefix
 assert_axioms Zcash.Security.Ledger.Model.output_rho_eq_nullifiers
@@ -214,9 +214,9 @@ assert_computable Zcash.Security.Ledger.Model.spendPinnedOrBreak +choice
 assert_computable Zcash.Security.Ledger.Model.allPinnedOrBreak +choice
 assert_computable Zcash.Security.Ledger.Model.balanceSubsetOrBreak +choice
 
-/-! ## Balance-value (conservation form)
+/-! ## Balance integrity
 
-`+choice` on the two endpoints is again the erased-positions tier: choice arrives with
+`+choice` on the three endpoints is again the erased-positions tier: choice arrives with
 the `ring`/`omega` proof terms in their `Prop` fields, never the data path. -/
 
 assert_computable Zcash.Security.Ledger.Model.txNetValue
@@ -224,14 +224,14 @@ assert_computable Zcash.Security.Ledger.Model.issuanceTotal
 assert_axioms Zcash.Security.Ledger.Model.transparentPoolBalance_eq
 assert_axioms Zcash.Security.Ledger.Model.positionedOutputs_value_sum
 assert_axioms Zcash.Security.Ledger.Model.nonZeroSpends_value_sum
-assert_axioms Zcash.Security.Ledger.Model.poolValueBalance_eq_neg
-assert_computable Zcash.Security.Ledger.Model.allValueOrBreak
-assert_computable Zcash.Security.Ledger.Model.valueConservationOrBreak +choice
-assert_computable Zcash.Security.Ledger.Model.balanceValueOrBreak +choice
+assert_axioms Zcash.Security.Ledger.Model.shieldedPoolBalance_eq_neg
+assert_computable Zcash.Security.Ledger.Model.allConservedOrBreak
+assert_computable Zcash.Security.Ledger.Model.balanceConservationOrBreak +choice
+assert_computable Zcash.Security.Ledger.Model.shieldedBalanceCapOrBreak +choice
 assert_axioms Zcash.Security.Ledger.Model.sum_val_le_of_le
 assert_axioms Zcash.Security.Ledger.Model.positionedOutputs_value_sum_mono
-assert_axioms Zcash.Security.Ledger.Model.poolValueBalance_nonneg
-assert_computable Zcash.Security.Ledger.Model.balanceOrBreak +choice
+assert_axioms Zcash.Security.Ledger.Model.shieldedPoolBalance_nonneg
+assert_computable Zcash.Security.Ledger.Model.balanceIntegrityOrBreak +choice
 
 /-! ## Spendability
 
@@ -254,9 +254,9 @@ argument's terminal. `+choice` is the erased-positions tier: choice arrives with
 
 assert_computable Zcash.Security.Ledger.Model.NontrivialRelation.ofNullifierCollision +choice
 
-/-! ## The value-premiss discharge
+/-! ## The transaction-balance premiss discharge
 
-Computed reductions at the Pedersen value-commitment shape: the Balance-value
+Computed reductions at the Pedersen value-commitment shape: the transaction-balance
 premiss lands in the binding-signature layer's nontrivial `(V, R)` relation via
 `ofBundleIntImbalance`, with the no-overflow bound discharged from the statement's
 value ranges, validity's action-count and `vBalance` range rules, and the named
@@ -265,7 +265,7 @@ erased-positions tier. -/
 
 assert_computable Zcash.Security.Ledger.Model.ValueShape.premissOrBreak +choice
 assert_computable Zcash.Security.Ledger.Model.ValueShape.conservationOrBreak +choice
-assert_computable Zcash.Security.Ledger.Model.ValueShape.balanceOrBreak +choice
+assert_computable Zcash.Security.Ledger.Model.ValueShape.capOrBreak +choice
 
 /-! ## Spend Authority
 
@@ -300,8 +300,8 @@ The game-level probability statements: pure event algebra over an adversary
 distribution of valid annotated ledgers, with a named ε hypothesis per break arm. -/
 
 assert_axioms Zcash.Security.Ledger.Model.balanceSubset_measure_le
-assert_axioms Zcash.Security.Ledger.Model.valueConservation_measure_le
-assert_axioms Zcash.Security.Ledger.Model.balanceValue_measure_le
+assert_axioms Zcash.Security.Ledger.Model.balanceConservation_measure_le
+assert_axioms Zcash.Security.Ledger.Model.shieldedBalanceCap_measure_le
 assert_axioms Zcash.Security.Ledger.Model.spendAuthority_measure_le
 
 /-! ## The deployed discrete-log-relation discharges

--- a/book/src/formal-verification/security-definitions.md
+++ b/book/src/formal-verification/security-definitions.md
@@ -74,7 +74,7 @@ flowchart TD
   KS --->|"<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Snark/Soundness/AGM/Capstone.lean'>AGM heuristic +<br/>independent<br/>hash-to-curve bases</a>"| DL
   KS -->|"<a target='_blank' href='https://github.com/zcash/ironwood/tree/main/Zcash/Snark/Soundness/Forking'>Fiat–Shamir<br/>heuristic</a>"| ROM
   MC --> SDLR
-  CUS --->|"<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Security/Common/Birthday.lean'>birthday counting<br/>q(q-1)/r,<br/>no assumption</a>"| ROM
+  CUS --->|"<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Security/Common/Birthday.lean'>birthday counting<br/>q(q-1)/|F|,<br/>no assumption</a>"| ROM
   NFC -->|"<a target='_blank' href='https://github.com/zcash/ironwood/blob/main/Zcash/Security/Ledger/Nullifier.lean'>distinct-note openings<br/>compute</a>"| SDLR
   SAF --> RDSA["RedDSA unforgeability,<br/>±-randomized keys"]
   RDSA -->|"re-rand reduction<br/><a target='_blank' href='https://eprint.iacr.org/2015/395'>[FKMSSS2016]</a> +<br/>forking extraction"| DL
@@ -193,7 +193,7 @@ circuit soundness proof.
 <div class="grp">Key binding — ZIP 2005 theorem (ROM)</div>
 <div class="g"><div class="g-head"><span class="term">key binding</span><span class="anchor">Security.KeyBinding.KB</span></div><div class="def">A verifying Recovery-Statement witness pins its key components — <code>ak</code> (up to y-sign), <code>nk</code>, and the <code>qk</code>/<code>sk</code> branch with its key — to <code>ivk</code>, unless a break is exhibited (<a href="https://zips.z.cash/zip-2005#thm-key-binding-rom">ZIP 2005 key-binding theorem</a>). Factors as <code>KB = KBOpening ∧ KBDerivation</code>: the <code>Commit^ivk</code> opening and the derivation constraints.</div></div>
 <div class="g"><div class="g-head"><span class="term">commit_scalar_pm</span><span class="anchor">KeyBinding.commit_scalar_pm · OpeningBreak</span></div><div class="def">Algebraic core: two openings of the same <code>Commitivk</code> value force their Pedersen scalars equal or negated. An <code>OpeningBreak</code> (two valid openings differing in the opening data) is the break structure the games layer produces.</div></div>
-<div class="g"><div class="g-head"><span class="term">reduces to an RO collision</span><span class="anchor">CollisionUpToSign.ofBreak · Birthday.birthday_closed_form</span></div><div class="def">The reduction computes a <code>±</code>-collision of the <code>rivk</code>-derivation random oracle at distinct derivation queries from a break (Layer B). Producing that collision within <code>q</code> queries is bounded by the birthday bound <code>ε_kb ≤ q(q-1)/r</code> (Layer C).</div></div>
+<div class="g"><div class="g-head"><span class="term">reduces to an RO collision</span><span class="anchor">CollisionUpToSign.ofBreak · Birthday.birthday_closed_form</span></div><div class="def">The reduction computes a <code>±</code>-collision of the <code>rivk</code>-derivation random oracle at distinct derivation queries from a break (Layer B). Producing that collision within <code>q</code> queries is bounded by the birthday bound <code>ε_kb ≤ q(q-1)/|RIVK|</code>, which is <code>q(q-1)/r_ℙ</code> at the intended Pallas instantiation (Layer C).</div></div>
 </section>
 
 <section>


### PR DESCRIPTION
Documentation and naming changes only — nothing proven changes. Splitting these out keeps them from distracting from the substance of the probability-bounds PR that follows on top of them.

## Overclaim fix

The `DeployedCapstone.lean` module doc and reduction docstring, and the `TrustBoundary.lean` census note, had described an event-level discharge of the capstone's named ε hypotheses — and a composition with the abstract Balance-subset probability bound — as if it had already been realized, when the file contained only the deterministic reduction. This rewords all three to the deterministic present state; the discharge itself lands in the follow-up PR. The other discharge modules did not overclaim.

## Key-binding numeric-bound scoping

The birthday bound's denominator is the cardinality of the abstract randomness type: `q(q-1)/|RIVK|`, and nothing in scope pins `|RIVK|` to the Pallas scalar order. The KeyBinding module docs and the book's security-definitions page wrote `|RIVK| = r` and `q(q-1)/r` outright; they now scope the concrete level to the intended Pallas instantiation. The theorems are parametric, and an undersized instantiation makes them vacuous rather than falsely secure. (This addresses the one actionable finding of an AI-driven analysis report; its remaining observations restate the disclosed-open capstone wiring and the deliberate abstract-parameter design.)

## Naming clarification

Renames, no change in behaviour:

- value-conservation → **Balance-conservation** (`balanceConservation*`): the identity that the shielded and transparent pools sum to issuance.
- Balance-value → **shielded-balance cap** (`shieldedBalanceCap*`): the upper bound `pool ≤ issuance`, named for the balance it caps rather than the vague "value".
- `KeyBinding.Pool.Break` → **`CommitIvkCollision`**: distinct from the oracle-model `KeyBinding.Break` structure and the interface `Break` predicate, which the shared name kept conflating.
- `poolValueBalance` → **`shieldedPoolBalance`**: names the pool it measures.
- the per-transaction value premiss → the **transaction-balance premiss** (`valueBreakEvent` → `txBalanceBreakEvent`, `allValueOrBreak` → `allConservedOrBreak`).
- `balanceOrBreak` → **`balanceIntegrityOrBreak`**: matches the Balance-integrity property it proves.
- `ValueShape.balanceOrBreak` → **`ValueShape.capOrBreak`**: pairs with `shieldedBalanceCapOrBreak`, which it instantiates.
- `εvb` → **`ε_conservation`** / **`ε_cap`** in the two probabilistic capstones.

## Balance module docs

The Balance module doc's argument-shape sentence and the balance-integrity docstring become bulleted lists; the balance-integrity docstring relates the property to the ZIP 209 turnstile rules (the cryptographic guarantees are what make a turnstile violation impossible, so those rules only reinforce them); and docstrings name `BalanceBreak` where they said "a break".

## OrchardCapstone rename

`DeployedCapstone.lean` becomes `OrchardCapstone.lean`, with `orchard*` identifiers: `OrchardAnnotated`, `OrchardBalanceRelation`, and `orchardBalanceSubsetOrRelation`. These are the instantiations that use the Orchard-protocol bases and parameters, and the previous "deployed" naming did not say which protocol. The sibling DLR modules' comments and the census discharge block say "Orchard-protocol" rather than "deployed" for the same reason; comments where "deployed" carries deployment status — the deployed Action statement as against the ZIP 2005 Recovery Statement, deployed constants and gadgets — keep it, as do deployed-named declarations outside the Ledger tree.

Full build green at every commit.

🤖 Claude Fable 5
