### PR TITLE
chore(fv): census pin hardening

### DIFF
--- a/Zcash/Meta/AxiomCheck.lean
+++ b/Zcash/Meta/AxiomCheck.lean
@@ -30,8 +30,9 @@ at all — the assertion then reads as covering one theorem while checking anoth
 CompElliptic has a sibling `CompElliptic/Meta/AxiomCheck.lean`, but the two have diverged: this
 version is a strict superset, adding the `+native(D₁, …)` owner list (upstream takes a bare
 `+native`, so it cannot state *which* certificate it trusts), the marker parsing and
-owner/module/range provenance checks, `checkFullyQualified`, the exact-set staleness check, and
-the negative regression suite. Ironwood re-checks every inherited axiom itself, so the census here
+owner/module/range provenance checks, `checkFullyQualified`, the exact-set staleness check, the
+`assert_computable` definition-safety check, and the negative regression suite. Ironwood re-checks
+every inherited axiom itself, so the census here
 does not depend on the upstream version's strength; porting this file upstream is tracked
 separately. Improvements made here should be considered for upstream, not assumed present there.
 -/
@@ -199,11 +200,11 @@ elab "assert_axioms " n:ident native:(nativeFlag)? : command => do
     throwError "{n} depends on unexpected axiom(s): {unexpected.toList}"
 
 /--
-`assert_computable foo` fails the build unless `foo` is a plain `def` — an actual
-definition, not marked `noncomputable` — depending on no axioms beyond `propext` / `Quot.sound`.
-This is the breaks-as-computed-data check: the data is genuinely computed, and with
-`Classical.choice` excluded it cannot have been conjured from mere propositional existence even
-in erased positions.
+`assert_computable foo` fails the build unless `foo` is a plain `def` — an actual definition,
+marked neither `unsafe`/`partial` nor `noncomputable` — depending on no axioms beyond
+`propext` / `Quot.sound`. This is the breaks-as-computed-data check: the data is genuinely
+computed, and with `Classical.choice` excluded it cannot have been conjured from mere
+propositional existence even in erased positions.
 
 `assert_computable foo +choice` additionally permits `Classical.choice`. Together with the
 plain-`def` check this asserts choice enters only through erased `Prop` fields: had it touched the
@@ -212,15 +213,25 @@ the named declarations' `native_decide` compiler-trust axioms.
 
 The plain-`def` check guards a gap in "computability is compiler-enforced": marking a reduction
 `noncomputable` later would still build, silently voiding the convention; this assertion catches
-it.
+it. The definition-safety check closes the same gap from the other side. An `unsafe` def is a
+`.defnInfo` like any other and is not `noncomputable`, so neither the kind check nor
+`isNoncomputable` sees it — yet `unsafe` lifts the termination check, so such a definition can
+inhabit its result type by bare self-reference (`unsafe def r : Break := r`) while computing
+nothing. The kernel does refuse to let a safe declaration depend on an unsafe one, which confines
+the forgery to a reduction no safe proof consumes; that is exactly the shape of a deliverable
+endpoint reduction, which is why the assertion checks safety itself rather than leaning on the
+kernel. `Zcash.Meta.Tests.AxiomCheck.ComputableSafety` pins the rejection.
 -/
 elab "assert_computable " n:ident choice:("+choice")? native:(nativeFlag)? : command => do
   let name ← liftCoreM <| realizeGlobalConstNoOverloadWithInfo n
   checkFullyQualified n name
   let env ← getEnv
-  let info ← liftCoreM <| getConstInfo name
-  unless info matches .defnInfo _ do
-    throwError "{n} is not a def"
+  let .defnInfo val ← liftCoreM <| getConstInfo name
+    | throwError "{n} is not a def"
+  match val.safety with
+  | .safe => pure ()
+  | .unsafe => throwError "{n} is marked unsafe"
+  | .partial => throwError "{n} is marked partial"
   if Lean.isNoncomputable env name then
     throwError "{n} is marked noncomputable"
   let axs ← collectAxioms name

--- a/Zcash/Meta/Tests/AxiomCheck.lean
+++ b/Zcash/Meta/Tests/AxiomCheck.lean
@@ -1,12 +1,13 @@
 import Zcash.Meta.AxiomCheck
 
 /-!
-# Regression tests for native-axiom provenance
+# Regression tests for `Zcash.Meta.AxiomCheck`
 
-The negative cases deliberately impersonate Lean's `native_decide` auxiliaries: most declare an
-axiom named like an auxiliary, and one instead names a *theorem* so that its own genuine auxiliary
-imitates the marker path. They live in this test-only library so the production `Zcash` library
-never imports them.
+Two rejection families. The native-axiom provenance cases deliberately impersonate Lean's
+`native_decide` auxiliaries: most declare an axiom named like an auxiliary, and one instead names a
+*theorem* so that its own genuine auxiliary imitates the marker path. The `assert_computable` cases
+pin the declaration checks that stand behind "the reduction data is genuinely computed". Both live
+in this test-only library so the production `Zcash` library never imports them.
 -/
 
 namespace Zcash.Meta.Tests.AxiomCheck
@@ -156,5 +157,39 @@ assert_axioms Zcash.Meta.Tests.AxiomCheck.AliasedOwner.target +native(
   Zcash.Meta.Tests.AxiomCheck.AliasedOwner.owner.native_decide.smuggled)
 
 end AliasedOwner
+
+namespace ComputableSafety
+
+/-! The `assert_computable` declaration checks. `unsafe` lifts the termination check, so the
+reduction below inhabits `False` by bare self-reference while computing nothing — and it is a
+`.defnInfo` that is not `noncomputable`, so the kind and computability checks both pass it. Only
+the definition-safety check rejects it. The kernel independently refuses to let a safe declaration
+depend on an unsafe one, so what the check has to catch is a reduction no safe proof consumes:
+precisely a deliverable endpoint, which the census pins directly for that same reason. -/
+
+unsafe def unsafeReduction : False := unsafeReduction
+
+/-- error: Zcash.Meta.Tests.AxiomCheck.ComputableSafety.unsafeReduction is marked unsafe -/
+#guard_msgs (whitespace := lax) in
+assert_computable Zcash.Meta.Tests.AxiomCheck.ComputableSafety.unsafeReduction
+
+/-! `partial def` elaborates to an `opaque` constant carrying an unsafe implementation, so it is
+rejected one check earlier — as not a `def` at all. Pinned so a toolchain that instead emits a
+`.defnInfo` with `partial` safety is caught by the safety check rather than passing silently. -/
+
+partial def partialReduction (n : Nat) : Nat :=
+  if n = 0 then 0 else partialReduction (n - 1)
+
+/-- error: Zcash.Meta.Tests.AxiomCheck.ComputableSafety.partialReduction is not a def -/
+#guard_msgs (whitespace := lax) in
+assert_computable Zcash.Meta.Tests.AxiomCheck.ComputableSafety.partialReduction
+
+/-! The positive case, so the rejections above are not passing vacuously. -/
+
+def safeReduction (n : Nat) : Nat := n + 1
+
+assert_computable Zcash.Meta.Tests.AxiomCheck.ComputableSafety.safeReduction
+
+end ComputableSafety
 
 end Zcash.Meta.Tests.AxiomCheck

--- a/Zcash/Security.lean
+++ b/Zcash/Security.lean
@@ -7,7 +7,6 @@ import Zcash.Security.BindingSignature.Sapling
 import Zcash.Security.Ledger.Merkle
 import Zcash.Security.Ledger.Pool
 import Zcash.Security.Ledger.Bridge
-import Zcash.Security.Ledger.BridgeTests
 import Zcash.Security.Ledger.SinsemillaDLR
 import Zcash.Security.Ledger.Statement
 import Zcash.Security.Ledger.Model

--- a/Zcash/Snark/Fixtures/MultiAction/TrustBoundary.lean
+++ b/Zcash/Snark/Fixtures/MultiAction/TrustBoundary.lean
@@ -625,6 +625,18 @@ assert_axioms Zcash.Snark.Fixture2.straightLineInterface_nonempty_at_captured_sh
 assert_axioms Zcash.Snark.Fixture2.adaptiveInterface_nonempty_at_captured_shape +native(
   CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
 
+-- The consensus-maximum work-factor packages (`Zcash.Snark.FixtureMax`, reached through
+-- `ActionCapstone`'s import of `StraightLineMaxShapeBounds`). These are the profiled endpoints the
+-- book's proof journey cites by name, and they are top-level leaves: nothing censused depends on
+-- them, so without these entries nothing bounds their trusted base. Unlike the captured-key
+-- knowledge-error endpoints, they take the static checks and the `x`-squeeze schedule as
+-- hypotheses rather than discharging them from the capture, so they reach no fixture native
+-- certificate — only the Vesta point count, through the `Fp`-module structure on the curve.
+assert_axioms Zcash.Snark.FixtureMax.straightLine_consensus_2pow123_workFactor_generatorRO +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_axioms Zcash.Snark.FixtureMax.straightLine_consensus_2pow122_workFactor_generatorRO +native(
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+
 -- `whitespace := lax` collapses all whitespace, so the pin is insensitive to how
 -- `#print axioms` line-wraps the list (a formatting artifact of the axiom-name lengths).
 /-- info: 'Zcash.Snark.Fixture2.fingerprint_matches' depends on axioms: [propext, Classical.choice, Quot.sound, Zcash.Snark.Fixture2.fingerprint_matches._native.native_decide.ax_1_1] -/

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -69,10 +69,10 @@ Two commands from `Zcash.Meta.AxiomCheck`, per the breaks-as-computed-data disci
 `Zcash.Security.RandomOracle`):
 
 * **Computed break reductions** get `assert_computable`: the declaration is a plain `def` — not a
-  theorem, not marked `noncomputable` — with axioms bounded by `propext` / `Quot.sound`.
-  `+choice` additionally permits `Classical.choice`; with the plain-`def` check this asserts
-  choice enters only through erased `Prop` certificate fields, so the break data cannot have been
-  conjured from mere propositional existence.
+  theorem, marked neither `unsafe`/`partial` nor `noncomputable` — with axioms bounded by
+  `propext` / `Quot.sound`. `+choice` additionally permits `Classical.choice`; with the
+  plain-`def` check this asserts choice enters only through erased `Prop` certificate fields, so
+  the break data cannot have been conjured from mere propositional existence.
 * **Theorems** get `assert_axioms`, an upper bound at the standard tier
   (`propext` / `Classical.choice` / `Quot.sound`). Both commands reject `sorryAx`.
 

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,7 +1,7 @@
 name = "Zcash"
 version = "0.1.0"
 keywords = ["cryptography", "math", "protocols"]
-defaultTargets = ["Zcash", "FixtureCheck", "CircuitCheck", "MetaCheck"]
+defaultTargets = ["Zcash", "FixtureCheck", "CircuitCheck", "MetaCheck", "SecurityCheck"]
 
 [leanOptions]
 pp.unicode.fun = true # pretty-prints `fun a ↦ b`
@@ -67,3 +67,15 @@ globs = [
 [[lean_lib]]
 name = "CircuitCheck"
 globs = ["Zcash.Circuits.Tests.+"]
+
+# `Zcash/Security/Ledger/BridgeTests.lean` — the regression checks guarding the protocol
+# distinctions a type-correct refinement can silently erase (signed value semantics, scalar
+# randomization, raw Merkle encodings, the dummy-spend guard, the three-valued cross-address flag).
+# Same reason as `MetaCheck`: a check module is where a smoke lemma stated too strongly, or an
+# axiom added to reproduce a bug, is least likely to draw review, so it does not belong in the
+# production `Zcash` import graph that downstream users get. It is not reached from `Zcash.Security`
+# (nothing outside the file references its declarations), and its own `assert_axioms` entries pin
+# its trusted base either way; this target keeps the default build running them.
+[[lean_lib]]
+name = "SecurityCheck"
+globs = ["Zcash.Security.Ledger.BridgeTests"]

--- a/scripts/check_endpoint_census.sh
+++ b/scripts/check_endpoint_census.sh
@@ -33,8 +33,14 @@ cd "$(dirname "$0")/.."
 # A declaration is a deliverable endpoint when its base name matches this pattern. These are the
 # capstone families: the verifier-soundness rungs (`orchard_verifier_*`), the composed Action
 # probability endpoints (`orchard_action_*`), the captured knowledge-error endpoints
-# (`orchard_deployed_*`), and the concrete-statement terminals (`*bundleStatement_or_relation*`).
-ENDPOINT_RE="^(orchard_verifier_|orchard_action_|orchard_deployed_)|bundleStatement_or_relation"
+# (`orchard_deployed_*`), the concrete-statement terminals (`*bundleStatement_or_relation*`), and
+# the profiled work-factor packages (`*workFactor*`), whose consensus-maximum forms are named for
+# the shape rather than for a capstone family and so match none of the prefixes above.
+#
+# `orchard_verifier_*` currently matches nothing: those rungs were retired with the legacy rewind
+# paths. It is retained as a guard, so a reintroduced name in that family is demanded rather than
+# silently unpinned.
+ENDPOINT_RE="^(orchard_verifier_|orchard_action_|orchard_deployed_)|bundleStatement_or_relation|workFactor"
 
 # Sources scanned for endpoint declarations. `Zcash/Meta/Tests/` is excluded: it holds forged
 # adversarial declarations that exercise the rejection paths of the census macros themselves.


### PR DESCRIPTION
The way we enforce trust census pins with regex is fragile, because a new theorem that falls outside our semi-standard naming convention (like these top-level capstones) doesn't get pinned. This widens the regex, but i'll separately do a pass at standardizing our naming conventions and hardening the regex.