### PR TITLE
feat(fv): split the Lean CI cache into layered dependency and build caches

### DIFF
--- a/.github/workflows/fixtures.yml
+++ b/.github/workflows/fixtures.yml
@@ -55,6 +55,16 @@ jobs:
           persist-credentials: false
       # Regeneration is expensive (real k=11 Orchard proofs + verifier runs), so only run
       # it when a committed capture artifact or the pins change.
+      #
+      # Deliberately absent from the list: the captures' Lean-side import surface
+      # (`Zcash/Snark.lean`, `Zcash/Snark/Core/Vesta.lean`, the lakefile globs), which the
+      # cache and import restructuring moved. Regeneration cannot observe it — the
+      # `import Zcash.Snark` header and the data under it both come from the pinned Rust
+      # exporter, so a Lean-side move emits byte-identical output and the diff would be a
+      # guaranteed pass bought with a full k=11 proving run. The risk it does carry is that
+      # the emitted header stops resolving, and that is caught where the captures elaborate:
+      # `FixtureCheck`, in `lean.yml`. Anything that changes what the exporter emits must
+      # move the pinned script, which IS filtered.
       - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         id: filter
         with:

--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -114,7 +114,10 @@ jobs:
       #    and manifest pins alone — not the commit. Between dependency bumps
       #    every PR and push reuses ONE stable entry, which stays LRU-fresh
       #    and is never re-uploaded (the save step is skipped on an exact
-      #    key hit).
+      #    key hit). Caveat: entries saved from a pull_request run are scoped
+      #    to that PR's merge ref, so after a bump each open PR cold-builds
+      #    its own entry until the first post-merge push to main publishes
+      #    the shared main-scoped one — merge bumps promptly.
       #  * Project build (`.lake/build`, ~0.7 GB compressed): keyed per
       #    commit and restored by key prefix from the most recent entry.
       #    Entries are small enough that the quota holds ~10 of them next to
@@ -188,7 +191,12 @@ jobs:
       #    cleanup, so partial progress from an interrupted build warms the
       #    next attempt. Cache entries are immutable, but this layer's keys
       #    are per-commit, so a partial entry is superseded as soon as the
-      #    next push builds further.
+      #    next push builds further. The restore step must itself have
+      #    COMPLETED, though: a cancellation landing mid-untar would
+      #    otherwise save the truncated tree, and since restore-keys resolve
+      #    to the most recently created prefix match, every subsequent run
+      #    would warm-start from the gutted entry and re-publish it under
+      #    its own key.
       #  * Dependencies: only if the build step actually succeeded. This
       #    layer's key is shared and stable until the next dependency bump,
       #    and the exact-key-hit guard (needed to avoid futile duplicate-key
@@ -199,7 +207,7 @@ jobs:
       #    the previous entry (restore-keys above) until its first green run
       #    publishes a complete one.
       - name: Save project build cache
-        if: always() && steps.restore-build.outputs.cache-hit != 'true'
+        if: always() && steps.restore-build.outcome == 'success' && steps.restore-build.outputs.cache-hit != 'true'
         uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: .lake/build

--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -187,16 +187,31 @@ jobs:
       #
       # The two layers save under different conditions, deliberately:
       #
-      #  * Project build: `always()`, which also runs during cancellation
-      #    cleanup, so partial progress from an interrupted build warms the
-      #    next attempt. Cache entries are immutable, but this layer's keys
-      #    are per-commit, so a partial entry is superseded as soon as the
-      #    next push builds further. The restore step must itself have
-      #    COMPLETED, though: a cancellation landing mid-untar would
-      #    otherwise save the truncated tree, and since restore-keys resolve
-      #    to the most recently created prefix match, every subsequent run
-      #    would warm-start from the gutted entry and re-publish it under
-      #    its own key.
+      #  * Project build: saved whenever the build step FINISHED, green or
+      #    red. A red build's `lake` process exited on its own, so its writes
+      #    are whole, and letting a failed run warm the next attempt is the
+      #    big win for a PR under active iteration. Cache entries are
+      #    immutable, but this layer's keys are per-commit, so a partial
+      #    entry is superseded as soon as the next push builds further.
+      #
+      #    Cancelled runs deliberately do NOT save. A cancellation can kill
+      #    `lake` between an artifact write and its trace bookkeeping, and
+      #    whether the resulting tree is safe to restore then rests on lake's
+      #    write ordering: if an intact, input-matching trace can outlive a
+      #    truncated olean, lake skips rebuilding the corrupt file. Since
+      #    restore-keys resolve to the most recently created prefix match and
+      #    every run re-saves under its own key, one torn artifact would
+      #    propagate into every descendant entry until something loaded it
+      #    and failed — curable only by manually evicting the caches. The
+      #    partial progress given up is largely redundant with the prefix
+      #    restore of the last complete entry anyway. `always()` still leads
+      #    the expression because an `if` with no status-check function gets
+      #    an implicit `success()` prepended, which would stop failed runs
+      #    from saving at all.
+      #
+      #    The restore step must also have COMPLETED: a cancellation landing
+      #    mid-untar would otherwise save the truncated tree it had just
+      #    started unpacking, with the same propagation.
       #  * Dependencies: only if the build step actually succeeded. This
       #    layer's key is shared and stable until the next dependency bump,
       #    and the exact-key-hit guard (needed to avoid futile duplicate-key
@@ -207,7 +222,7 @@ jobs:
       #    the previous entry (restore-keys above) until its first green run
       #    publishes a complete one.
       - name: Save project build cache
-        if: always() && steps.restore-build.outcome == 'success' && steps.restore-build.outputs.cache-hit != 'true'
+        if: always() && (steps.lake.outcome == 'success' || steps.lake.outcome == 'failure') && steps.restore-build.outcome == 'success' && steps.restore-build.outputs.cache-hit != 'true'
         uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: .lake/build

--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -77,9 +77,11 @@ jobs:
       # native_decide axiom tracking (lean4#7463).
       - name: Verify csimp lemmas are axiom-censused
         run: scripts/check_csimp_census.sh
-      # No Lean file may import the Mathlib umbrella module: `import Mathlib` peaks around
-      # 6.5 GB RSS per Lean process, and nothing else fails when it creeps back in — builds
-      # just quietly get slow again. Import the specific Mathlib modules instead.
+      # No Lean file may import the Mathlib umbrella modules: `import Mathlib` peaks around
+      # 6.5 GB RSS per Lean process, and `import Mathlib.Tactic` costs ~+1.6 s import-load
+      # and ~+1.3 GB RSS per process over the narrow tactic modules (issue #153). Nothing
+      # else fails when either creeps back in — builds just quietly get slow again. Import
+      # the specific Mathlib modules instead.
       - name: Verify no Mathlib umbrella imports
         run: scripts/check_no_umbrella_imports.sh
       # Every deliverable soundness endpoint must use a censused protocol prefix or the semantic

--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -91,6 +91,13 @@ jobs:
       # such a leaf, but not a stray native_decide or other unexpected axiom; the pin does.
       - name: Verify soundness endpoints are axiom-censused
         run: scripts/check_endpoint_census.sh
+      # Every module file must be reachable from the lakefile's defaultTargets — a module
+      # outside that set is not elaborated at all, and nothing else fails when one falls out.
+      # Coverage stopped being a pure import-reachability property when `Zcash/Snark.lean`
+      # ceased re-exporting `Soundness/` (issue #153); the subtree is pinned by an explicit
+      # lakefile glob, and this check asserts the end-to-end property for the whole package.
+      - name: Verify build coverage of every module
+        run: scripts/check_build_coverage.sh
       # ── Caching (issue #153) ─────────────────────────────────────────────
       # lean-action's built-in cache is disabled below: it archives the entire
       # `.lake` directory (~2.6 GB compressed) under a per-commit key, so the

--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -91,9 +91,58 @@ jobs:
       # such a leaf, but not a stray native_decide or other unexpected axiom; the pin does.
       - name: Verify soundness endpoints are axiom-censused
         run: scripts/check_endpoint_census.sh
+      # ── Caching (issue #153) ─────────────────────────────────────────────
+      # lean-action's built-in cache is disabled below: it archives the entire
+      # `.lake` directory (~2.6 GB compressed) under a per-commit key, so the
+      # repository's 10 GB Actions cache quota holds only ~3 entries. Any few
+      # concurrent PRs plus a couple of pushes evict each other's entries, and
+      # an evicted entry means a ~35 min cold rebuild (~135 CPU-min of Lean on
+      # a 4-vCPU runner). The cache is instead split into two layers with
+      # different lifetimes:
+      #
+      #  * Dependencies (`.lake/packages`, ~2 GB compressed): checkouts and
+      #    build artifacts of all Lake dependencies, keyed on the toolchain
+      #    and manifest pins alone — not the commit. Between dependency bumps
+      #    every PR and push reuses ONE stable entry, which stays LRU-fresh
+      #    and is never re-uploaded (the save step is skipped on an exact
+      #    key hit).
+      #  * Project build (`.lake/build`, ~0.7 GB compressed): keyed per
+      #    commit and restored by key prefix from the most recent entry.
+      #    Entries are small enough that the quota holds ~10 of them next to
+      #    the dependency layer, so eviction pressure lands on old per-commit
+      #    entries instead of the expensive shared state.
+      #
+      # On a dependency bump, the restore-keys prefix warm-starts from the
+      # previous dependency entry: Lake re-materializes only the bumped
+      # checkouts, `lake exe cache get` (run by lean-action) refreshes the
+      # mathlib-ecosystem oleans in ~2 min, and only the source-built deps
+      # that actually changed (Clean, CompElliptic, CompPoly — ~16 CPU-min
+      # all told) rebuild. The prefix is scoped to the toolchain hash so a
+      # toolchain bump starts from a clean slate rather than dragging
+      # incompatible-format oleans into the fresh entry forever (stale
+      # artifacts restored under the same toolchain are trace-checked and
+      # inert — they cost entry size, not correctness).
+      - name: Restore dependency cache
+        id: restore-deps
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: .lake/packages
+          key: lake-deps-${{ runner.os }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}
+          restore-keys: |
+            lake-deps-${{ runner.os }}-${{ hashFiles('lean-toolchain') }}-
+      - name: Restore project build cache
+        id: restore-build
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: .lake/build
+          key: lake-build-${{ runner.os }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}-${{ github.sha }}
+          restore-keys: |
+            lake-build-${{ runner.os }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}-
+            lake-build-${{ runner.os }}-${{ hashFiles('lean-toolchain') }}-
       # Installs the toolchain from lean-toolchain, fetches the Mathlib olean cache, and runs
       # `lake build --wfail`, which rejects all warnings and builds the lakefile's
-      # `defaultTargets`: `Zcash`, `FixtureCheck`, `CircuitCheck`, and `MetaCheck`.
+      # `defaultTargets`: `Zcash`, `FixtureCheck`, `CircuitCheck`, `MetaCheck`, and
+      # `SecurityCheck`.
       #
       # `Zcash` imports the fixture-free top-level trust census. Concrete capstone census entries
       # live beside their captures and are built through `FixtureCheck`.
@@ -110,8 +159,48 @@ jobs:
       # `configure`/`synthesize` against the CS and layout fixtures dumped from the Rust
       # circuit, so a divergence between the Lean circuit model and the deployed VK fails here.
       - uses: leanprover/lean-action@38fbc41a8c28c4cbaec22d7f7de508ec2e7c0dd9 # v1.5.0
+        id: lake
         with:
           build-args: "--wfail"
+          # Caching is handled by the explicit layered restore/save steps
+          # around this action; see the caching comment above.
+          use-github-cache: "false"
+      # Both layers are saved explicitly rather than through the actions/cache
+      # post hook, because the post hook is gated on job *success*
+      # (`post-if: success()`): a failed build saved nothing, and — worse for
+      # a PR under active iteration — `cancel-in-progress: true` above meant a
+      # rapid push sequence cancelled each superseded run before its save, so
+      # the next run restarted from the last cache that survived, compounding
+      # the thrash.
+      #
+      # The two layers save under different conditions, deliberately:
+      #
+      #  * Project build: `always()`, which also runs during cancellation
+      #    cleanup, so partial progress from an interrupted build warms the
+      #    next attempt. Cache entries are immutable, but this layer's keys
+      #    are per-commit, so a partial entry is superseded as soon as the
+      #    next push builds further.
+      #  * Dependencies: only if the build step actually succeeded. This
+      #    layer's key is shared and stable until the next dependency bump,
+      #    and the exact-key-hit guard (needed to avoid futile duplicate-key
+      #    saves in the steady state) means whatever gets saved first under a
+      #    new key is FINAL for that key. An `always()` save here could pin
+      #    an interrupted, mostly-empty dependency build as the shared entry
+      #    for weeks; success-gating instead lets a bump PR warm-start from
+      #    the previous entry (restore-keys above) until its first green run
+      #    publishes a complete one.
+      - name: Save project build cache
+        if: always() && steps.restore-build.outputs.cache-hit != 'true'
+        uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: .lake/build
+          key: lake-build-${{ runner.os }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}-${{ github.sha }}
+      - name: Save dependency cache
+        if: always() && steps.lake.outcome == 'success' && steps.restore-deps.outputs.cache-hit != 'true'
+        uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: .lake/packages
+          key: lake-deps-${{ runner.os }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}
 
   lean-ci:
     # The single stable check to mark as a required status check. It always

--- a/Zcash.lean
+++ b/Zcash.lean
@@ -1,5 +1,17 @@
--- This module serves as the root of the `Zcash` library.
--- Import modules here that should be built as part of the library.
+-- This module serves as the root of the `Zcash` library: its sole import root, so
+-- `lake build Zcash` is exactly this file's transitive closure. No module imports it — it is a
+-- build entry point, not a re-export surface — and the line it draws is between the parametric
+-- library and anything pinned to a concrete capture, which lives in the `FixtureCheck`,
+-- `CircuitCheck`, `MetaCheck`, and `SecurityCheck` targets instead.
+--
+-- Import modules here that should be built as part of the library. Note that this list is not
+-- the whole story for the SNARK soundness stack: `Zcash/Snark.lean` deliberately does not
+-- re-export `Soundness/` or the rational-match tier (the byte-locked fixture
+-- captures must `import Zcash.Snark`, so whatever that umbrella re-exports lands on their build
+-- path). Those modules enter this closure through the census imports in `Zcash.TrustBoundary`,
+-- with a `lakefile.toml` glob as the backstop should that ever stop being true;
+-- `scripts/check_build_coverage.sh` asserts in CI that every module file in the package is
+-- reachable from some default target.
 
 import Zcash.Common
 import Zcash.Circuits

--- a/Zcash/Arithmetic/Msm.lean
+++ b/Zcash/Arithmetic/Msm.lean
@@ -1,4 +1,8 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.Abel
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Arithmetic.Group
 
 /-!

--- a/Zcash/Arithmetic/Msm.lean
+++ b/Zcash/Arithmetic/Msm.lean
@@ -1,3 +1,9 @@
+import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+import Mathlib.Algebra.Field.ZMod
+import Mathlib.Algebra.Module.NatInt
+import Mathlib.Data.Fintype.Basic
+import Mathlib.Data.Nat.Prime.Defs
+import Mathlib.Data.ZMod.Basic
 import Mathlib.Tactic.Abel
 import Mathlib.Tactic.FieldSimp
 import Mathlib.Tactic.Linarith

--- a/Zcash/Circuits/Ecc/AddIncompleteTheorems.lean
+++ b/Zcash/Circuits/Ecc/AddIncompleteTheorems.lean
@@ -1,7 +1,10 @@
 import Zcash.Circuits.Specs.Pallas
 import Zcash.Circuits.Ecc.Defs
 import Clean.Utils.Tactics
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 
 namespace Zcash.Circuits.Ecc
 

--- a/Zcash/Circuits/Ecc/AddTheorems.lean
+++ b/Zcash/Circuits/Ecc/AddTheorems.lean
@@ -1,7 +1,11 @@
 import Zcash.Circuits.Specs.Pallas
 import Zcash.Circuits.Ecc.Defs
 import Clean.Utils.Tactics
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.LinearCombination
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 
 namespace Zcash.Circuits.Ecc
 

--- a/Zcash/Circuits/Ecc/Defs.lean
+++ b/Zcash/Circuits/Ecc/Defs.lean
@@ -2,7 +2,10 @@ import Clean.Circuit
 import CompElliptic.CurveForms.ShortWeierstrass
 import Zcash.Circuits.Specs.Pallas
 import Clean.Utils.Tactics
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 
 /-
 Some definitions useful for circuits involving points

--- a/Zcash/Circuits/Integration/ActionPermutationDomain.lean
+++ b/Zcash/Circuits/Integration/ActionPermutationDomain.lean
@@ -2,6 +2,7 @@ import Zcash.Circuits.Integration.ActionPermutationDomainCompute
 import Zcash.Circuits.Integration.PermutationCompiler
 import Zcash.Circuits.Integration.TopLevelAssignment
 import Zcash.Circuits.Integration.TopLevelConstraintModel
+import Mathlib.Tactic.NormNum.Parity
 import Mathlib.Util.AssertNoSorry
 
 /-!

--- a/Zcash/Circuits/Integration/CircuitSatisfaction.lean
+++ b/Zcash/Circuits/Integration/CircuitSatisfaction.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Clean.Halo2.Operations
 import Zcash.Arithmetic
 

--- a/Zcash/Circuits/Specs/Bitrange.lean
+++ b/Zcash/Circuits/Specs/Bitrange.lean
@@ -1,4 +1,9 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Positivity
+import Mathlib.Tactic.Ring
+import Mathlib.Tactic.Set
 import Clean.Circuit.WitnessIRSugar
 import Zcash.Circuits.Specs.CompEllipticExtras
 

--- a/Zcash/Security/BindingSignature/Balance.lean
+++ b/Zcash/Security/BindingSignature/Balance.lean
@@ -1,3 +1,6 @@
+import Mathlib.Algebra.Field.ZMod
+import Mathlib.Data.Nat.Prime.Defs
+import Mathlib.Data.ZMod.Basic
 import Mathlib.Tactic.Abel
 import Mathlib.Tactic.FieldSimp
 import Mathlib.Tactic.Linarith

--- a/Zcash/Security/BindingSignature/Balance.lean
+++ b/Zcash/Security/BindingSignature/Balance.lean
@@ -1,4 +1,8 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.Abel
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Common.DiscreteLogRelation
 
 /-!

--- a/Zcash/Security/Common/Birthday.lean
+++ b/Zcash/Security/Common/Birthday.lean
@@ -1,3 +1,8 @@
+import Mathlib.Algebra.Field.Defs
+import Mathlib.Data.Fintype.Card
+import Mathlib.Data.Fintype.Prod
+import Mathlib.Data.NNRat.Order
+import Mathlib.Data.Nat.Choose.Cast
 import Mathlib.Tactic.FieldSimp
 import Mathlib.Tactic.GCongr
 import Mathlib.Tactic.Linarith

--- a/Zcash/Security/Common/Birthday.lean
+++ b/Zcash/Security/Common/Birthday.lean
@@ -1,4 +1,9 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.GCongr
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.LinearCombination
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Security.Common.RandomOracle
 
 /-!

--- a/Zcash/Security/Common/RandomOracle.lean
+++ b/Zcash/Security/Common/RandomOracle.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 
 /-!
 # Random-oracle collision vocabulary (classical ROM)

--- a/Zcash/Security/KeyBinding/Basic.lean
+++ b/Zcash/Security/KeyBinding/Basic.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Security.Common.RandomOracle
 
 /-!

--- a/Zcash/Security/KeyBinding/Basic.lean
+++ b/Zcash/Security/KeyBinding/Basic.lean
@@ -1,3 +1,9 @@
+import Mathlib.Algebra.Field.Defs
+import Mathlib.Algebra.Module.Defs
+import Mathlib.Algebra.NoZeroSMulDivisors.Defs
+import Mathlib.Algebra.Order.BigOperators.Group.Finset
+import Mathlib.Data.Fintype.Card
+import Mathlib.Data.Fintype.Prod
 import Mathlib.Tactic.FieldSimp
 import Mathlib.Tactic.Linarith
 import Mathlib.Tactic.NormNum

--- a/Zcash/Security/Ledger/Balance.lean
+++ b/Zcash/Security/Ledger/Balance.lean
@@ -1,3 +1,5 @@
+import Mathlib.Algebra.Order.BigOperators.Group.List
+import Mathlib.Algebra.Order.BigOperators.Group.Multiset
 import Mathlib.Tactic.FieldSimp
 import Mathlib.Tactic.Linarith
 import Mathlib.Tactic.NormNum

--- a/Zcash/Security/Ledger/Balance.lean
+++ b/Zcash/Security/Ledger/Balance.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Mathlib.Data.List.GetD
 import Zcash.Security.Ledger.Effects
 

--- a/Zcash/Security/Ledger/Capstone.lean
+++ b/Zcash/Security/Ledger/Capstone.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Mathlib.Probability.Distributions.Uniform
 import Zcash.Security.Ledger.Balance
 import Zcash.Security.Ledger.SpendAuthority

--- a/Zcash/Security/Ledger/Completeness.lean
+++ b/Zcash/Security/Ledger/Completeness.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Security.Ledger.Balance
 import Zcash.Security.Ledger.Spendability
 

--- a/Zcash/Security/Ledger/Effects.lean
+++ b/Zcash/Security/Ledger/Effects.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Security.Ledger.Model
 
 /-!

--- a/Zcash/Security/Ledger/Effects.lean
+++ b/Zcash/Security/Ledger/Effects.lean
@@ -1,3 +1,4 @@
+import Mathlib.Algebra.BigOperators.Group.Multiset.Basic
 import Mathlib.Tactic.FieldSimp
 import Mathlib.Tactic.Linarith
 import Mathlib.Tactic.NormNum

--- a/Zcash/Security/Ledger/ExtractionArm.lean
+++ b/Zcash/Security/Ledger/ExtractionArm.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Mathlib.Probability.Distributions.Uniform
 import Zcash.Security.Ledger.Capstone
 import Zcash.Security.Ledger.Value

--- a/Zcash/Security/Ledger/ExtractionKappaArm.lean
+++ b/Zcash/Security/Ledger/ExtractionKappaArm.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Security.Ledger.ExtractionArm
 import Zcash.Security.RedDSA.KnowledgeError
 import Zcash.Security.KeyBinding.Probability

--- a/Zcash/Security/Ledger/KeyBindingArm.lean
+++ b/Zcash/Security/Ledger/KeyBindingArm.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Security.KeyBinding.Instance
 import Zcash.Security.Ledger.Balance
 import Zcash.Security.Ledger.SpendAuthority

--- a/Zcash/Security/Ledger/KeyBindingDLR.lean
+++ b/Zcash/Security/Ledger/KeyBindingDLR.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Security.Ledger.Pool
 import Zcash.Security.Ledger.SinsemillaDLR
 

--- a/Zcash/Security/Ledger/Merkle.lean
+++ b/Zcash/Security/Ledger/Merkle.lean
@@ -1,3 +1,4 @@
+import Mathlib.Data.Fin.Tuple.Basic
 import Mathlib.Tactic.FieldSimp
 import Mathlib.Tactic.Linarith
 import Mathlib.Tactic.NormNum

--- a/Zcash/Security/Ledger/Merkle.lean
+++ b/Zcash/Security/Ledger/Merkle.lean
@@ -1,4 +1,8 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
+import Mathlib.Tactic.Set
 import Zcash.Security.Common.RandomOracle
 
 /-!

--- a/Zcash/Security/Ledger/MerkleDLR.lean
+++ b/Zcash/Security/Ledger/MerkleDLR.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Security.Common.RandomOracle
 import Zcash.Security.Ledger.Pool
 import Zcash.Security.Ledger.SinsemillaDLR

--- a/Zcash/Security/Ledger/Model.lean
+++ b/Zcash/Security/Ledger/Model.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Security.Ledger.Statement
 
 /-!

--- a/Zcash/Security/Ledger/NoteCommitDLR.lean
+++ b/Zcash/Security/Ledger/NoteCommitDLR.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Security.Ledger.Statement
 import Zcash.Security.Ledger.Pool
 import Zcash.Security.Ledger.SinsemillaDLR

--- a/Zcash/Security/Ledger/Nullifier.lean
+++ b/Zcash/Security/Ledger/Nullifier.lean
@@ -1,4 +1,8 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.Abel
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Security.Ledger.Spendability
 import Zcash.Common.DiscreteLogRelation
 

--- a/Zcash/Security/Ledger/OrchardCapstone.lean
+++ b/Zcash/Security/Ledger/OrchardCapstone.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Security.Ledger.Capstone
 import Zcash.Security.Ledger.ExtractionArm
 import Zcash.Security.Ledger.KeyBindingDLR

--- a/Zcash/Security/Ledger/SpendAuthority.lean
+++ b/Zcash/Security/Ledger/SpendAuthority.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Security.Ledger.Model
 
 /-!

--- a/Zcash/Security/Ledger/Spendability.lean
+++ b/Zcash/Security/Ledger/Spendability.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Security.Ledger.Balance
 
 /-!

--- a/Zcash/Security/Ledger/Statement.lean
+++ b/Zcash/Security/Ledger/Statement.lean
@@ -1,3 +1,5 @@
+import Mathlib.Algebra.Module.Defs
+import Mathlib.Algebra.NoZeroSMulDivisors.Defs
 import Mathlib.Tactic.FieldSimp
 import Mathlib.Tactic.Linarith
 import Mathlib.Tactic.NormNum

--- a/Zcash/Security/Ledger/Statement.lean
+++ b/Zcash/Security/Ledger/Statement.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Security.Ledger.Merkle
 
 /-!

--- a/Zcash/Security/Ledger/Value.lean
+++ b/Zcash/Security/Ledger/Value.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Security.Ledger.Balance
 import Zcash.Security.BindingSignature.Balance
 

--- a/Zcash/Security/RedDSA/Basic.lean
+++ b/Zcash/Security/RedDSA/Basic.lean
@@ -1,3 +1,5 @@
+import Mathlib.Algebra.Module.Defs
+import Mathlib.Algebra.NoZeroSMulDivisors.Defs
 import Mathlib.Tactic.FieldSimp
 import Mathlib.Tactic.Linarith
 import Mathlib.Tactic.NormNum

--- a/Zcash/Security/RedDSA/Basic.lean
+++ b/Zcash/Security/RedDSA/Basic.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 
 /-!
 # RedDSA, abstractly

--- a/Zcash/Security/RedDSA/Extraction.lean
+++ b/Zcash/Security/RedDSA/Extraction.lean
@@ -1,4 +1,8 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.LinearCombination
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Security.RedDSA.Basic
 import Zcash.Snark.Soundness.AGM.Adapter
 

--- a/Zcash/Snark.lean
+++ b/Zcash/Snark.lean
@@ -65,14 +65,10 @@ import Zcash.Snark.Verifier.Deployed
 import Zcash.Snark.Verifier.Parametric
 import Zcash.Snark.Verifier.GroupingRef
 import Zcash.Snark.Fingerprint.Match
--- The quantified random match — the sample space, the good event's enumerated
--- denominator factors, and the rational-representation walk of the assembled coefficients.
-import Zcash.Snark.Fingerprint.SampleSpace
-import Zcash.Snark.Fingerprint.Rational.GoodEvent
-import Zcash.Snark.Fingerprint.Rational.Representation
-import Zcash.Snark.Fingerprint.Rational.ConstraintWalk
-import Zcash.Snark.Fingerprint.Rational.GroupingTable
-import Zcash.Snark.Fingerprint.Rational.IpaWalk
-import Zcash.Snark.Fingerprint.Rational.OpeningWalk
-import Zcash.Snark.Fingerprint.Rational.Capstone
-import Zcash.Snark.Fingerprint.Epsilon
+-- The quantified random match — the sample space, the good event's enumerated denominator
+-- factors, and the rational-representation walk (`Fingerprint/SampleSpace`, `Fingerprint/
+-- Rational/`, `Fingerprint/Epsilon`) — is deliberately NOT re-exported, for the same reason
+-- as `Soundness/` above: the captures reference none of it, and its `Rational/Capstone`
+-- chain (~4 min) sat on every capture lane's build path through this umbrella. Its
+-- consumers (each random family's `Epsilon.lean`, and the census files through them)
+-- import it directly, and the `FixtureCheck` glob keeps it in the default build.

--- a/Zcash/Snark.lean
+++ b/Zcash/Snark.lean
@@ -16,7 +16,13 @@
 --   challenge bad sets and `Relation/` says what constraint satisfaction buys. Above those,
 --   `AGM/`, `StraightLine/`, and `Composition/` carry extraction and composition from the
 --   acceptance predicate (`Soundness/Main.lean`), instantiated at Vesta
---   (`Soundness/Deployed/Vesta.lean`).
+--   (`Soundness/Deployed/Vesta.lean`). Deliberately NOT re-exported by this umbrella: the
+--   byte-locked fixture captures must `import Zcash.Snark` (the header halo2's
+--   `dump_vesta_lean_fixture` emits), and re-exporting the soundness argument here put the
+--   whole `Soundness/` subtree on every capture lane's build path — most of the cold-build
+--   critical path (issue #153). Import `Soundness` modules directly. They stay in the
+--   default build through the `Zcash.Snark.Soundness.+` glob on the `Zcash` target, and
+--   `scripts/check_build_coverage.sh` asserts the closure property in CI.
 -- * `Fixtures/` — concrete Orchard captures and the boundary checks they license, split by
 --   capture kind. The namespaces (`Fixture`, `Fixture2`, `FixtureRandom`, `FixtureRandom2`) are
 --   emitted by halo2's `dump_vesta_lean_fixture` and cannot be renamed here: the fixture CI
@@ -27,7 +33,10 @@
 --   that proves them: the straight-line knowledge errors beside their capture, the
 --   consensus work factors in `Soundness/AGM/`.
 --
--- Import modules here that should be built as part of the library.
+-- Import modules here that this umbrella should re-export. Build coverage does not depend on
+-- this list: every module under `Zcash/` must be reachable from some default target, which
+-- `scripts/check_build_coverage.sh` enforces (the `Soundness/` subtree, for instance, is
+-- carried by a lakefile glob instead of an import here).
 
 -- The arithmetic tier the verifier is stated over. The umbrella also re-exports `Fp` and `URS`
 -- at the `Zcash` root, which is how they resolve unqualified across the repository.
@@ -39,6 +48,11 @@ import Zcash.Arithmetic.FastMsm
 import Zcash.Snark.Core
 import Zcash.Snark.Core.ProofString
 import Zcash.Snark.Core.Challenges
+-- The deployed verifier group. The captures state their points in `VestaG` (and open the
+-- CompElliptic Pasta namespaces this module carries), so the umbrella must supply it; it was
+-- hoisted out of `Soundness/Decoded/Vesta.lean` exactly so that supplying it does not pull
+-- the soundness stack back onto the capture lanes (issue #153).
+import Zcash.Snark.Core.Vesta
 import Zcash.Snark.Fingerprint.SchwartzZippel
 import Zcash.Snark.Verifier.Ipa
 import Zcash.Snark.Verifier.Checks
@@ -62,95 +76,3 @@ import Zcash.Snark.Fingerprint.Rational.IpaWalk
 import Zcash.Snark.Fingerprint.Rational.OpeningWalk
 import Zcash.Snark.Fingerprint.Rational.Capstone
 import Zcash.Snark.Fingerprint.Epsilon
-import Zcash.Snark.Soundness.Argument.GrandProduct
-import Zcash.Snark.Soundness.Argument.Lookup
-import Zcash.Snark.Soundness.Argument.Permutation
-import Zcash.Snark.Soundness.Argument.PermutationConstruction
-import Zcash.Snark.Soundness.Argument.RunningProduct
-import Zcash.Snark.Soundness.Argument.GrandProductBridge
-import Zcash.Snark.Soundness.Argument.LookupAssembly
-import Zcash.Snark.Soundness.Argument.PermutationRows
-import Zcash.Snark.Soundness.Relation.ConstraintRelations
-import Zcash.Snark.Soundness.Pricing.ChallengePricing
-import Zcash.Snark.Soundness.Ipa.InnerProduct
-import Zcash.Snark.Soundness.Ipa.Halves
-import Zcash.Snark.Soundness.Constraint.Constraints
-import Zcash.Snark.Soundness.Constraint.FoldSplit
-import Zcash.Snark.Soundness.Ipa.CommitFold
-import Zcash.Snark.Soundness.Ipa.Consistency
-import Zcash.Snark.Soundness.Relation.KnowledgeSoundness
-import Zcash.Snark.Soundness.Ipa.IpaSoundness
--- Verifier-native semantic models used by the Clean integration boundary.  These
--- belong to the core SNARK library even when no capstone imports them incidentally.
-import Zcash.Snark.Soundness.Canonical.ConstraintSatisfaction
-import Zcash.Snark.Soundness.Canonical.ConstraintModel
-import Zcash.Snark.Soundness.Canonical.InstanceCommitment
--- Deployed halo2-verifier algebra and binding reductions.
-import Zcash.Snark.Soundness.Deployed.Binding
-import Zcash.Snark.Soundness.Deployed.Fold
-import Zcash.Snark.Soundness.Deployed.Verification
--- The reusable Fiat–Shamir oracle kernel and its represented adversary model: random-oracle
--- lemmas, deployed transcript ordering, closed-form IPA assembly, and the bounded
--- querying-adversary reduction.
-import Zcash.Snark.Soundness.Oracle.Model
-import Zcash.Snark.Soundness.FiatShamir.Assembly
-import Zcash.Snark.Soundness.FiatShamir.Ordering
-import Zcash.Snark.Soundness.FiatShamir.Execution
-import Zcash.Snark.Soundness.FiatShamir.Adversary
-import Zcash.Snark.Soundness.Main
--- Multiopen decode reconstruction: bind the IPA witness to real verifier columns recovered from
--- the represented `x₄` power batch (`Multiopen.Decode`, `Multiopen.Deployed`), the MSM evaluation
--- spine (`Multiopen.Compat`), and the explicit opened/member interfaces (`Multiopen.Opened`).
--- Schwartz–Zippel good-challenge budgets and production (kills `hgood` at the `_xgood` rungs).
-import Zcash.Snark.Soundness.Pricing.GoodChallenge
-import Zcash.Snark.Soundness.Multiopen.Decode
-import Zcash.Snark.Soundness.Multiopen.Compat
-import Zcash.Snark.Soundness.Multiopen.Deployed
-import Zcash.Snark.Soundness.Multiopen.Opened
-import Zcash.Snark.Soundness.Multiopen.RPoly
-import Zcash.Snark.Soundness.Multiopen.CanonicalRelation
-import Zcash.Snark.Soundness.Canonical.Terminal
-import Zcash.Snark.Soundness.Circuit.Terminal
-import Zcash.Snark.Soundness.Decoded.Vesta
--- AGM binding reduction: consume computed deployed relations through the programmed-basis
--- discrete-log adapter and representation-carrying algebraic-prover model.
-import Zcash.Snark.Soundness.AGM.Adapter
-import Zcash.Snark.Soundness.AGM.Probability
-import Zcash.Snark.Soundness.AGM.ProbabilityVesta
-import Zcash.Snark.Soundness.AGM.Peel
-import Zcash.Snark.Soundness.AGM.BindingSignature
--- Rewind-free deployed multiopen decoding and additive pinned-root composition.
-import Zcash.Snark.Soundness.Composition.DeployedRootContainment
--- The straight-line AGM route: staged IPA representations, fixed-call deployed constraint
--- extraction, and an explicit finite-security DLOG work profile.
-import Zcash.Snark.Soundness.AGM.StraightLineFiniteSecurity
--- The constraint-level and straight-line family interfaces are inhabited at the witness shape.
-import Zcash.Snark.Soundness.Composition.StraightLineWitness
--- The zero-data keystone and the constant zero prover family, at any shape.
-import Zcash.Snark.Soundness.AGM.ZeroFamily
--- The zero family's deployed root layer: six staged root events at any shape.
-import Zcash.Snark.Soundness.AGM.ZeroFamilyRoots
--- The straight-line deployed interface, inhabited with live IPA rounds at any instance-free shape.
-import Zcash.Snark.Soundness.Composition.ZeroStraightLine
--- The direct-coordinate postprocessing carries an explicit polynomial total-cost model.
--- The Action-level semantic challenge exclusions, priced and summed.
--- A rewind-free decode presented through the opened-batch interface the Action terminal takes.
-import Zcash.Snark.Soundness.AGM.DecodeToOpened
-import Zcash.Snark.Soundness.Composition.SemanticChallengeRemainder
-import Zcash.Snark.Soundness.Composition.StraightLineDecodeSupply
-import Zcash.Snark.Soundness.Composition.SequentialLift
-import Zcash.Snark.Soundness.Composition.DirectPathCost
--- Circuit soundness specializations consume the Clean/Ironwood integration
--- boundary; they do not belong to that boundary's import graph.
-import Zcash.Snark.Soundness.StraightLine.Terminal
-import Zcash.Snark.Soundness.StraightLine.Event
-import Zcash.Snark.Soundness.Action.StraightLineTerminal
-import Zcash.Snark.Soundness.Action.StraightLineEvent
-import Zcash.Snark.Soundness.Action.AdaptiveStatementModel
-import Zcash.Snark.Soundness.Action.AdaptiveStatementAccounting
-import Zcash.Snark.Soundness.Action.AdaptiveStatementTerminal
-import Zcash.Snark.Soundness.Action.AdaptiveStatementEvent
-import Zcash.Snark.Soundness.Action.AdaptiveStatementCapstone
-import Zcash.Snark.Soundness.Action.AdaptiveStatementKnowledge
-import Zcash.Snark.Soundness.Action.AdaptiveStatementProfile
-import Zcash.Snark.Soundness.Action.AdaptiveStatementReads

--- a/Zcash/Snark/Core/Challenges.lean
+++ b/Zcash/Snark/Core/Challenges.lean
@@ -1,3 +1,4 @@
+import Mathlib.Data.Fintype.Basic
 import Mathlib.Tactic.FieldSimp
 import Mathlib.Tactic.Linarith
 import Mathlib.Tactic.NormNum

--- a/Zcash/Snark/Core/Challenges.lean
+++ b/Zcash/Snark/Core/Challenges.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 
 /-!
 # The verifier's challenges

--- a/Zcash/Snark/Core/Shape.lean
+++ b/Zcash/Snark/Core/Shape.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 
 /-!
 # Circuit and proof shapes

--- a/Zcash/Snark/Core/Vesta.lean
+++ b/Zcash/Snark/Core/Vesta.lean
@@ -1,0 +1,49 @@
+import Mathlib.Algebra.Module.ZMod
+import Mathlib.GroupTheory.OrderOfElement
+import CompElliptic.Curves.Pasta
+import CompElliptic.Curves.PastaOrder
+import Zcash.Arithmetic
+
+/-!
+# The deployed verifier group
+
+This module pins the verifier group to the actual Vesta curve: the type `VestaG`, its
+group order (every point is `p`-torsion for `p = scalarFieldOrder`, derived from
+CompElliptic's pinned point count), and the resulting `Fp`-module structure.
+
+Housed in `Core/`, not `Soundness/Decoded/`, deliberately: the byte-locked fixture
+captures state their points in `VestaG` and evaluate the verifier over its `Fp`-module
+instance, and the only import halo2's `dump_vesta_lean_fixture` emits is
+`Zcash.Snark` — so this vocabulary must be reachable from the umbrella without
+dragging the soundness stack into every capture's build path (issue #153). The
+soundness-facing Vesta bridges (concrete-to-abstract MSM evaluation, the IPA witness
+identities) remain in `Soundness/Decoded/Vesta.lean`, which imports this module.
+-/
+
+namespace Zcash.Snark
+
+open Zcash.Arithmetic (scalarFieldOrder)
+open CompElliptic.Curves.Pasta CompElliptic.CurveForms.ShortWeierstrass
+  CompElliptic.CurveOrder
+
+/-- The deployed verifier group `E_q`, concretely the points of `y² = x³ + 5`. -/
+abbrev VestaG := SWPoint Vesta.curve
+
+/-- Every Vesta point is `p`-torsion for `p = scalarFieldOrder`. -/
+abbrev VestaOrder : Prop := ∀ P : VestaG, (scalarFieldOrder : ℕ) • P = 0
+
+/-- Derive the Vesta group order from CompElliptic's pinned point count. -/
+theorem vestaOrder : VestaOrder := by
+  intro P
+  have hcard : Nat.card VestaG = scalarFieldOrder := Vesta.card_eq
+  rw [← hcard]
+  exact addOrderOf_dvd_iff_nsmul_eq_zero.mp (addOrderOf_dvd_natCard P)
+
+/-- Install the proved Vesta order for the `Fp`-module instance. -/
+instance : Fact VestaOrder := ⟨vestaOrder⟩
+
+/-- Give Vesta its scalar-field module structure. -/
+instance vestaFpModule [h : Fact VestaOrder] : Module Fp VestaG :=
+  AddCommGroup.zmodModule h.out
+
+end Zcash.Snark

--- a/Zcash/Snark/Fingerprint/Epsilon.lean
+++ b/Zcash/Snark/Fingerprint/Epsilon.lean
@@ -1,4 +1,9 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.GCongr
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
+import Mathlib.Tactic.Set
 import Zcash.Snark.Fingerprint.SchwartzZippel
 import Zcash.Snark.Fingerprint.Rational.Family
 

--- a/Zcash/Snark/Fingerprint/Match.lean
+++ b/Zcash/Snark/Fingerprint/Match.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Arithmetic.Msm
 import Zcash.Snark.Fingerprint.SchwartzZippel
 import Zcash.Snark.Verifier.Assemble

--- a/Zcash/Snark/Fingerprint/Rational/Capstone.lean
+++ b/Zcash/Snark/Fingerprint/Rational/Capstone.lean
@@ -1,4 +1,8 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
+import Mathlib.Tactic.Set
 import Zcash.Snark.Fingerprint.Rational.OtherCoefficients
 import Zcash.Snark.Fingerprint.Rational.ConstraintWalk
 import Zcash.Snark.Fingerprint.Rational.IpaWalk

--- a/Zcash/Snark/Fingerprint/Rational/ConstraintWalk.lean
+++ b/Zcash/Snark/Fingerprint/Rational/ConstraintWalk.lean
@@ -1,4 +1,8 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
+import Mathlib.Tactic.Set
 import Zcash.Snark.Fingerprint.Rational.Representation
 import Zcash.Snark.Soundness.Pricing.DegreeWalk
 

--- a/Zcash/Snark/Fingerprint/Rational/Family.lean
+++ b/Zcash/Snark/Fingerprint/Rational/Family.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Snark.Fingerprint.Rational.Representation
 
 /-!

--- a/Zcash/Snark/Fingerprint/Rational/GoodEvent.lean
+++ b/Zcash/Snark/Fingerprint/Rational/GoodEvent.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Mathlib.Algebra.MvPolynomial.SchwartzZippel
 import Zcash.Snark.Fingerprint.SampleSpace
 

--- a/Zcash/Snark/Fingerprint/Rational/GroupingTable.lean
+++ b/Zcash/Snark/Fingerprint/Rational/GroupingTable.lean
@@ -1,4 +1,8 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
+import Mathlib.Tactic.Set
 import Zcash.Snark.Verifier.GroupingRef
 import Zcash.Snark.Fingerprint.Rational.GoodEvent
 

--- a/Zcash/Snark/Fingerprint/Rational/IpaWalk.lean
+++ b/Zcash/Snark/Fingerprint/Rational/IpaWalk.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Snark.Fingerprint.Rational.ConstraintWalk
 import Zcash.Snark.Soundness.Deployed.Fold
 import Zcash.Snark.Soundness.FiatShamir.Assembly

--- a/Zcash/Snark/Fingerprint/Rational/OpeningWalk.lean
+++ b/Zcash/Snark/Fingerprint/Rational/OpeningWalk.lean
@@ -1,4 +1,8 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
+import Mathlib.Tactic.Set
 import Zcash.Snark.Fingerprint.Rational.ConstraintWalk
 import Zcash.Snark.Fingerprint.Rational.GroupingTable
 

--- a/Zcash/Snark/Fingerprint/Rational/OtherCoefficients.lean
+++ b/Zcash/Snark/Fingerprint/Rational/OtherCoefficients.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Snark.Fingerprint.Rational.GroupingTable
 import Zcash.Snark.Fingerprint.Rational.OpeningWalk
 

--- a/Zcash/Snark/Fingerprint/Rational/Representation.lean
+++ b/Zcash/Snark/Fingerprint/Rational/Representation.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Snark.Fingerprint.Rational.GoodEvent
 
 /-!

--- a/Zcash/Snark/Fingerprint/SampleSpace.lean
+++ b/Zcash/Snark/Fingerprint/SampleSpace.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Arithmetic
 import Zcash.Arithmetic.Msm
 import Zcash.Snark.Verifier.Assemble

--- a/Zcash/Snark/Fingerprint/SampleSpace.lean
+++ b/Zcash/Snark/Fingerprint/SampleSpace.lean
@@ -1,3 +1,4 @@
+import Mathlib.Tactic.DeriveFintype
 import Mathlib.Tactic.FieldSimp
 import Mathlib.Tactic.Linarith
 import Mathlib.Tactic.NormNum

--- a/Zcash/Snark/Fingerprint/SchwartzZippel.lean
+++ b/Zcash/Snark/Fingerprint/SchwartzZippel.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Mathlib.Algebra.MvPolynomial.SchwartzZippel
 import Zcash.Arithmetic
 

--- a/Zcash/Snark/Fixtures/Shared/TamperSweep.lean
+++ b/Zcash/Snark/Fixtures/Shared/TamperSweep.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 
 /-!
 # Tamper combinators for the fixture sensitivity sweeps

--- a/Zcash/Snark/Soundness/Argument/GrandProduct.lean
+++ b/Zcash/Snark/Soundness/Argument/GrandProduct.lean
@@ -1,4 +1,8 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
+import Mathlib.Tactic.Set
 import CompPoly.Univariate.ToPoly
 import Zcash.Common.CPolynomial
 

--- a/Zcash/Snark/Soundness/Argument/GrandProductBridge.lean
+++ b/Zcash/Snark/Soundness/Argument/GrandProductBridge.lean
@@ -1,4 +1,8 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
+import Mathlib.Tactic.Set
 import CompPoly.Bivariate.ToPoly
 import Zcash.Snark.Soundness.Argument.GrandProduct
 import Zcash.Snark.Soundness.Argument.RunningProduct

--- a/Zcash/Snark/Soundness/Argument/Lookup.lean
+++ b/Zcash/Snark/Soundness/Argument/Lookup.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Snark.Soundness.Argument.GrandProduct
 
 /-!

--- a/Zcash/Snark/Soundness/Argument/LookupAssembly.lean
+++ b/Zcash/Snark/Soundness/Argument/LookupAssembly.lean
@@ -1,4 +1,8 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.LinearCombination
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Snark.Soundness.Argument.Lookup
 import Zcash.Snark.Soundness.Argument.GrandProductBridge
 import Zcash.Snark.Soundness.Argument.PermutationRows

--- a/Zcash/Snark/Soundness/Argument/Permutation.lean
+++ b/Zcash/Snark/Soundness/Argument/Permutation.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Snark.Soundness.Argument.GrandProduct
 
 /-!

--- a/Zcash/Snark/Soundness/Argument/PermutationConstruction.lean
+++ b/Zcash/Snark/Soundness/Argument/PermutationConstruction.lean
@@ -1,4 +1,8 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
+import Mathlib.Tactic.Set
 import Zcash.Snark.Soundness.Argument.Permutation
 
 /-!

--- a/Zcash/Snark/Soundness/Argument/RunningProduct.lean
+++ b/Zcash/Snark/Soundness/Argument/RunningProduct.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Snark.Soundness.Argument.GrandProduct
 
 /-!

--- a/Zcash/Snark/Soundness/Canonical/ConstraintSatisfaction.lean
+++ b/Zcash/Snark/Soundness/Canonical/ConstraintSatisfaction.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Snark.Soundness.Constraint.Constraints
 import Zcash.Snark.Soundness.Constraint.FoldSplit
 import Zcash.Snark.Soundness.Relation.KnowledgeSoundness

--- a/Zcash/Snark/Soundness/Canonical/LookupInstantiation.lean
+++ b/Zcash/Snark/Soundness/Canonical/LookupInstantiation.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Snark.Soundness.Canonical.LookupRows
 import Zcash.Snark.Verifier.Parametric
 

--- a/Zcash/Snark/Soundness/Canonical/LookupRows.lean
+++ b/Zcash/Snark/Soundness/Canonical/LookupRows.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Snark.Soundness.Canonical.ConstraintSatisfaction
 import Zcash.Snark.Soundness.Argument.LookupAssembly
 import Zcash.Snark.Soundness.Argument.PermutationRows

--- a/Zcash/Snark/Soundness/Constraint/Constraints.lean
+++ b/Zcash/Snark/Soundness/Constraint/Constraints.lean
@@ -1,4 +1,8 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.GCongr
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Arithmetic
 import Zcash.Common.CPolynomial
 import Zcash.Snark.Verifier.Expressions

--- a/Zcash/Snark/Soundness/Constraint/FoldSplit.lean
+++ b/Zcash/Snark/Soundness/Constraint/FoldSplit.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Snark.Soundness.Constraint.Constraints
 
 /-!

--- a/Zcash/Snark/Soundness/Decoded/Vesta.lean
+++ b/Zcash/Snark/Soundness/Decoded/Vesta.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Snark.Core.Vesta
 import Zcash.Snark.Soundness.Main
 import Zcash.Snark.Soundness.Multiopen.Deployed

--- a/Zcash/Snark/Soundness/Decoded/Vesta.lean
+++ b/Zcash/Snark/Soundness/Decoded/Vesta.lean
@@ -1,19 +1,17 @@
 import Mathlib.Tactic
+import Zcash.Snark.Core.Vesta
 import Zcash.Snark.Soundness.Main
 import Zcash.Snark.Soundness.Multiopen.Deployed
-import CompElliptic.Curves.Pasta
-import CompElliptic.Curves.PastaOrder
 
 /-!
-# Vesta support for the deployed verifier
+# Vesta support for the straight-line soundness stack
 
-This module pins the verifier group to the actual Vesta curve and supplies the
-concrete-to-abstract MSM bridge and IPA witness identities used by the
-straight-line soundness stack.
-
-The only structure the `Fp` action needs that the curve does not already carry
-is the Vesta group order: every point is `p`-torsion for
-`p = scalarFieldOrder`. `CompElliptic` supplies the pinned point-count result.
+The Vesta pinning itself — `VestaG`, its group order, the `Fp`-module structure — lives
+in `Zcash/Snark/Core/Vesta.lean`, where the byte-locked fixture captures can reach it
+through the `Zcash.Snark` umbrella without importing the soundness stack (issue #153).
+This module supplies what sits on top for the soundness development: the
+concrete-to-abstract MSM bridge and the IPA witness identities used by the
+straight-line extraction.
 -/
 
 namespace Zcash.Snark
@@ -21,26 +19,6 @@ namespace Zcash.Snark
 open Zcash.Arithmetic (Msm Msm.evalNat_eq_eval scalarFieldOrder)
 open CompElliptic.Curves.Pasta CompElliptic.CurveForms.ShortWeierstrass
   CompElliptic.CurveOrder
-
-/-- The deployed verifier group `E_q`, concretely the points of `y² = x³ + 5`. -/
-abbrev VestaG := SWPoint Vesta.curve
-
-/-- Every Vesta point is `p`-torsion for `p = scalarFieldOrder`. -/
-abbrev VestaOrder : Prop := ∀ P : VestaG, (scalarFieldOrder : ℕ) • P = 0
-
-/-- Derive the Vesta group order from CompElliptic's pinned point count. -/
-theorem vestaOrder : VestaOrder := by
-  intro P
-  have hcard : Nat.card VestaG = scalarFieldOrder := Vesta.card_eq
-  rw [← hcard]
-  exact addOrderOf_dvd_iff_nsmul_eq_zero.mp (addOrderOf_dvd_natCard P)
-
-/-- Install the proved Vesta order for the `Fp`-module instance. -/
-instance : Fact VestaOrder := ⟨vestaOrder⟩
-
-/-- Give Vesta its scalar-field module structure. -/
-instance vestaFpModule [h : Fact VestaOrder] : Module Fp VestaG :=
-  AddCommGroup.zmodModule h.out
 
 /-- Natural-scalar MSM evaluation agrees with the module-theoretic evaluation
 used by the soundness development. -/

--- a/Zcash/Snark/Soundness/Ipa/CommitFold.lean
+++ b/Zcash/Snark/Soundness/Ipa/CommitFold.lean
@@ -1,4 +1,8 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.Abel
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Snark.Soundness.Ipa.InnerProduct
 import Zcash.Common.DiscreteLogRelation
 

--- a/Zcash/Snark/Soundness/Ipa/Halves.lean
+++ b/Zcash/Snark/Soundness/Ipa/Halves.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 
 /-!
 # Splitting a power-of-two vector into halves

--- a/Zcash/Snark/Soundness/Ipa/InnerProduct.lean
+++ b/Zcash/Snark/Soundness/Ipa/InnerProduct.lean
@@ -1,4 +1,8 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.Abel
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Arithmetic
 
 /-!

--- a/Zcash/Snark/Soundness/Ipa/IpaSoundness.lean
+++ b/Zcash/Snark/Soundness/Ipa/IpaSoundness.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Snark.Soundness.Ipa.CommitFold
 import Zcash.Snark.Soundness.Ipa.Halves
 

--- a/Zcash/Snark/Soundness/Main.lean
+++ b/Zcash/Snark/Soundness/Main.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Snark.Verifier.Assemble
 import Zcash.Snark.Soundness.Deployed.Verification
 

--- a/Zcash/Snark/Soundness/Multiopen/Compat.lean
+++ b/Zcash/Snark/Soundness/Multiopen/Compat.lean
@@ -1,4 +1,8 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.Abel
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Snark.Soundness.Main
 import Zcash.Snark.Soundness.Pricing.UniformMeasure
 import Zcash.Snark.Soundness.Multiopen.Decode

--- a/Zcash/Snark/Soundness/Multiopen/Decode.lean
+++ b/Zcash/Snark/Soundness/Multiopen/Decode.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Snark.Soundness.Ipa.IpaSoundness
 import Zcash.Snark.Soundness.Relation.KnowledgeSoundness
 import Zcash.Snark.Verifier.Assemble

--- a/Zcash/Snark/Soundness/Multiopen/Deployed.lean
+++ b/Zcash/Snark/Soundness/Multiopen/Deployed.lean
@@ -1,4 +1,8 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.Abel
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Snark.Soundness.Main
 import Zcash.Snark.Soundness.Multiopen.Decode
 import Zcash.Snark.Soundness.Multiopen.Compat

--- a/Zcash/Snark/Soundness/Multiopen/Opened.lean
+++ b/Zcash/Snark/Soundness/Multiopen/Opened.lean
@@ -1,4 +1,8 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
+import Mathlib.Tactic.Set
 import Zcash.Snark.Soundness.Main
 import Zcash.Snark.Soundness.Multiopen.Decode
 import Zcash.Snark.Soundness.Multiopen.Deployed

--- a/Zcash/Snark/Soundness/Multiopen/RPoly.lean
+++ b/Zcash/Snark/Soundness/Multiopen/RPoly.lean
@@ -1,4 +1,8 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
+import Mathlib.Tactic.Set
 import Mathlib.LinearAlgebra.Lagrange
 import Zcash.Snark.Soundness.Main
 import Zcash.Snark.Soundness.Multiopen.Deployed

--- a/Zcash/Snark/Soundness/Multiopen/ValueCheck.lean
+++ b/Zcash/Snark/Soundness/Multiopen/ValueCheck.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Snark.Soundness.Multiopen.RPoly
 
 /-!

--- a/Zcash/Snark/Soundness/Multiopen/ValueCheckDeployed.lean
+++ b/Zcash/Snark/Soundness/Multiopen/ValueCheckDeployed.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Snark.Soundness.Multiopen.ValueCheck
 import Zcash.Snark.Soundness.Multiopen.Deployed
 import Zcash.Snark.Soundness.Multiopen.Opened

--- a/Zcash/Snark/Soundness/Pricing/ChallengePricing.lean
+++ b/Zcash/Snark/Soundness/Pricing/ChallengePricing.lean
@@ -1,4 +1,10 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.GCongr
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.LinearCombination
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
+import Mathlib.Tactic.Set
 import Zcash.Snark.Soundness.Pricing.GoodChallenge
 import Zcash.Snark.Soundness.Constraint.FoldSplit
 import Zcash.Snark.Soundness.Argument.GrandProductBridge

--- a/Zcash/Snark/Soundness/Pricing/GoodChallenge.lean
+++ b/Zcash/Snark/Soundness/Pricing/GoodChallenge.lean
@@ -1,4 +1,8 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.GCongr
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Snark.Soundness.Constraint.Constraints
 import Zcash.Snark.Soundness.Oracle.Model
 

--- a/Zcash/Snark/Soundness/Pricing/UniformMeasure.lean
+++ b/Zcash/Snark/Soundness/Pricing/UniformMeasure.lean
@@ -1,4 +1,9 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.GCongr
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
+import Mathlib.Tactic.Set
 import Mathlib.Algebra.Order.Chebyshev
 import Mathlib.Probability.Distributions.Uniform
 

--- a/Zcash/Snark/Soundness/Relation/ConstraintRelations.lean
+++ b/Zcash/Snark/Soundness/Relation/ConstraintRelations.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Snark.Soundness.Relation.KnowledgeSoundness
 import Zcash.Snark.Soundness.Argument.PermutationRows
 import Zcash.Snark.Soundness.Argument.LookupAssembly

--- a/Zcash/Snark/Soundness/Relation/KnowledgeSoundness.lean
+++ b/Zcash/Snark/Soundness/Relation/KnowledgeSoundness.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Snark.Soundness.Ipa.InnerProduct
 import Zcash.Snark.Soundness.Constraint.Constraints
 import Zcash.Snark.Soundness.Ipa.CommitFold

--- a/Zcash/Snark/Verifier/Assemble.lean
+++ b/Zcash/Snark/Verifier/Assemble.lean
@@ -1,4 +1,8 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
+import Mathlib.Tactic.Set
 import Mathlib.Data.List.GetD
 import Zcash.Snark.Core.ProofString
 import Zcash.Snark.Core.Challenges

--- a/Zcash/Snark/Verifier/Checks.lean
+++ b/Zcash/Snark/Verifier/Checks.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Arithmetic
 import Zcash.Arithmetic.Msm
 

--- a/Zcash/Snark/Verifier/Expressions.lean
+++ b/Zcash/Snark/Verifier/Expressions.lean
@@ -1,4 +1,8 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
+import Mathlib.Tactic.Set
 import Zcash.Common.Expr
 import Zcash.Snark.Core.ProofString
 

--- a/Zcash/Snark/Verifier/FiatShamir.lean
+++ b/Zcash/Snark/Verifier/FiatShamir.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Snark.Core.ProofString
 import Zcash.Snark.Core.Challenges
 import Zcash.Snark.Verifier.Assemble

--- a/Zcash/Snark/Verifier/GroupingRef.lean
+++ b/Zcash/Snark/Verifier/GroupingRef.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Snark.Verifier.Assemble
 
 /-!

--- a/Zcash/Snark/Verifier/Ipa.lean
+++ b/Zcash/Snark/Verifier/Ipa.lean
@@ -1,4 +1,8 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.Abel
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Arithmetic
 import Zcash.Arithmetic.Msm
 

--- a/Zcash/Snark/Verifier/Queries.lean
+++ b/Zcash/Snark/Verifier/Queries.lean
@@ -1,4 +1,7 @@
-import Mathlib.Tactic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Zcash.Snark.Verifier.Checks
 import Zcash.Snark.Core.ProofString
 

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -290,14 +290,14 @@ The honest construction is computable data (the wallet's own algorithm, includin
 authentication data recovered from the defined tree); the two completeness endpoints
 are theorems over it. The Spendability capstone is a computed reduction: the
 roadblock branch decides nullifier membership and searches out the revealing action.
-Its `+choice` is the erased-positions tier — choice arrives with proof terms in
-`Prop` positions, never the data path. -/
+It carries no `+choice`: neither the decision nor the search reaches for choice, and
+no choice-bearing proof term survives in its erased `Prop` positions either. -/
 
 assert_computable Zcash.Security.Ledger.Model.honestTx
 assert_computable Zcash.Security.Ledger.Model.HonestAction.withDummySpend
 assert_axioms Zcash.Security.Ledger.Model.HonestAction.satisfied
 assert_axioms Zcash.Security.Ledger.Model.honestTx_valid
-assert_computable Zcash.Security.Ledger.Model.spendabilityOrBreak +choice
+assert_computable Zcash.Security.Ledger.Model.spendabilityOrBreak
 
 /-! ## Probabilistic capstones
 

--- a/book/src/formal-verification.md
+++ b/book/src/formal-verification.md
@@ -140,8 +140,9 @@ boundary theorems, documenting precisely *which*
 compiler-trust axiom `native_decide` adds — on this toolchain a per-declaration axiom
 (`…_native.native_decide.ax_1_1`), where older Lean versions used the global `Lean.ofReduceBool` —
 because for a captured fingerprint match the exact axiom set *is* the claim, the case
-`Zcash.Meta.AxiomCheck` reserves the pinned form for. CI builds `Zcash` and `FixtureCheck` as
-default targets, and each `fingerprint_matches`'s `native_decide` compiles and runs
+`Zcash.Meta.AxiomCheck` reserves the pinned form for. CI builds all five default targets —
+`Zcash`, `FixtureCheck`, `CircuitCheck`, `MetaCheck`, and `SecurityCheck` — and each
+`fingerprint_matches`'s `native_decide` compiles and runs
 the verifier, so anything `noncomputable` on the assembled-verifier path fails the build.
 
 What the fixture captures actually *check* is the statement of record in each family's

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -24,15 +24,28 @@ name = "mathlib"
 scope = "leanprover-community"
 rev = "v4.30.0"
 
-# The root glob alone would build only what `Zcash.lean` transitively imports. Since
-# `Zcash/Snark.lean` stopped re-exporting `Soundness/` (issue #153: the byte-locked fixture
-# captures must `import Zcash.Snark`, and re-exporting the soundness argument there put the
-# whole subtree on every capture lane's build path), the Soundness modules reach the root
-# closure only through the census imports in `Zcash/TrustBoundary.lean` — real but fragile
-# coverage, gone the moment a census entry is refactored. The explicit glob pins the whole
-# subtree into the default build regardless of what the import graph does;
-# `scripts/check_build_coverage.sh` (CI) asserts the same end-to-end property for every
-# module in the package.
+# `Zcash.lean` is this library's only import root, so the root glob alone builds exactly its
+# transitive closure. Since `Zcash/Snark.lean` stopped re-exporting `Soundness/` (the
+# byte-locked fixture captures must `import Zcash.Snark`, and re-exporting the soundness
+# argument there put the whole subtree on every capture lane's build path), the `Soundness/`
+# modules reach that closure only through the census imports in `Zcash/TrustBoundary.lean`.
+#
+# That is real coverage, but incidental: `TrustBoundary` imports those modules in order to NAME
+# their declarations in `assert_axioms`/`assert_computable` pins, not to use their contents. So
+# retiring a pin or moving an endpoint to another module would change which files get elaborated
+# at all — a strange thing for an audit file to control, and silent when it happens.
+#
+# The `Soundness.+` glob is a backstop against precisely that, and it is honest to say it is not
+# what is doing the work today: at the time of writing every `Soundness/` module is already
+# reachable from the default targets without it, and dropping it leaves `lake build`'s job count
+# unchanged (it adds six jobs to a bare `lake build Zcash` — the capstone- and test-adjacent
+# modules that otherwise arrive only via `FixtureCheck` and `MetaCheck`).
+#
+# Listing those modules in `Zcash.lean` instead would put coverage back on imports, but at the
+# cost of a hand-maintained list that every new `Soundness/` module must be added to — the
+# maintenance the globs on `FixtureCheck`, `MetaCheck`, and `CircuitCheck` exist to avoid.
+# Either way `scripts/check_build_coverage.sh` (CI) asserts the end-to-end property: every
+# module file in the package is reachable from some default target.
 [[lean_lib]]
 name = "Zcash"
 globs = ["Zcash", "Zcash.Snark.Soundness.+"]

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -24,8 +24,18 @@ name = "mathlib"
 scope = "leanprover-community"
 rev = "v4.30.0"
 
+# The root glob alone would build only what `Zcash.lean` transitively imports. Since
+# `Zcash/Snark.lean` stopped re-exporting `Soundness/` (issue #153: the byte-locked fixture
+# captures must `import Zcash.Snark`, and re-exporting the soundness argument there put the
+# whole subtree on every capture lane's build path), the Soundness modules reach the root
+# closure only through the census imports in `Zcash/TrustBoundary.lean` — real but fragile
+# coverage, gone the moment a census entry is refactored. The explicit glob pins the whole
+# subtree into the default build regardless of what the import graph does;
+# `scripts/check_build_coverage.sh` (CI) asserts the same end-to-end property for every
+# module in the package.
 [[lean_lib]]
 name = "Zcash"
+globs = ["Zcash", "Zcash.Snark.Soundness.+"]
 
 # Test-only adversarial declarations for `Zcash.Meta.AxiomCheck`. This is a separate library so
 # forged axioms used to exercise the rejection paths never enter the production `Zcash` import

--- a/scripts/check_build_coverage.sh
+++ b/scripts/check_build_coverage.sh
@@ -66,6 +66,11 @@ find Zcash -name '*.lean' -print | sort | awk '
   }
 
   # ── *.lean files: the module universe and its internal import edges ─────────
+  # Imports are recorded only from the file HEADER (Lean permits them nowhere
+  # else): edge scanning stops at the first line that is not blank, a comment,
+  # `module`/`prelude`, or an import. Without this, an import-shaped line inside
+  # a block comment or docstring would create a phantom edge — and a phantom
+  # edge lets the guard pass for a module `lake build` never elaborates.
   {
     if (!(FILENAME in seen)) {
       seen[FILENAME] = 1
@@ -76,13 +81,30 @@ find Zcash -name '*.lean' -print | sort | awk '
       order[nuniv++] = mod
       filemod[mod] = FILENAME
       curmod = mod
+      hdrdone = 0
+      cdepth = 0
     }
+    if (hdrdone) next
     line = $0
+    if (cdepth > 0) {                     # inside a (possibly nested) block comment
+      cdepth += gsub(/\/-/, "/-", line) - gsub(/-\//, "-/", line)
+      next
+    }
+    if (line ~ /^[ \t]*$/) next           # blank
+    if (line ~ /^[ \t]*--/) next          # line comment
+    if (line ~ /^[ \t]*\/-/) {            # block comment or docstring opens
+      cdepth += gsub(/\/-/, "/-", line) - gsub(/-\//, "-/", line)
+      next
+    }
     sub(/^public[ \t]+/, "", line)
+    sub(/^meta[ \t]+/, "", line)
     if (line ~ /^import[ \t]+/) {
       split(line, parts, /[ \t]+/)
       adj[curmod] = adj[curmod] " " parts[2]
+      next
     }
+    if (line ~ /^(module|prelude)[ \t]*$/) next
+    hdrdone = 1                           # first real command: the header is over
   }
 
   END {

--- a/scripts/check_build_coverage.sh
+++ b/scripts/check_build_coverage.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Check that every Lean module is built by `lake build` (the lakefile's defaultTargets).
+#
+# `lake build` compiles exactly the modules reachable from the default targets: each
+# `lean_lib`'s glob roots plus everything they transitively import. A module outside that
+# set is not elaborated at all — its `sorry`s, its axiom drift, even a failure to compile
+# are invisible to CI while the build stays green. Reachability is fragile precisely when
+# imports are being *trimmed*: issue #153 made `Zcash/Snark.lean` stop re-exporting the
+# `Soundness/` subtree (so the byte-locked fixture captures, which must `import Zcash.Snark`,
+# no longer serialize behind it), which moved Soundness coverage from "reachable by import"
+# to an explicit `Zcash.Snark.Soundness.+` glob on the `Zcash` target. This script asserts
+# the end-to-end property those globs exist to maintain: EVERY module file in the package
+# is covered by some default target, however the import graph shifts under future trims.
+#
+# The check mirrors Lake's own semantics (Lake.Glob, v4.30.0):
+#   * `"A.B"`   selects exactly the module A.B;
+#   * `"A.B.+"` selects all submodules of A.B (the files under A/B/), not A.B itself;
+#   * `"A.B.*"` selects A.B and all submodules;
+#   * a `lean_lib` with no `globs` field defaults to its root module (`Glob.one name`);
+# and only libraries named in `defaultTargets` count — a library outside it is not built
+# by plain `lake build`, so coverage that lives there is no coverage at all.
+#
+# `find` rather than `git ls-files`, matching check_endpoint_census.sh: a not-yet-staged
+# module is still checked. Run from the repository root; exits non-zero on violation.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+find Zcash -name '*.lean' -print | sort | awk '
+  # The found files arrive on stdin as a LIST; they become awk input files via ARGV,
+  # so FILENAME-based dispatch below sees each one. Lean module paths contain no
+  # whitespace, so line-based reading is exact.
+  BEGIN {
+    nuniv = 0
+    ARGV[ARGC++] = "lakefile.toml"
+    # The package root module is not under Zcash/ but is a module like any other.
+    ARGV[ARGC++] = "Zcash.lean"
+    while ((getline f < "/dev/stdin") > 0) ARGV[ARGC++] = f
+  }
+
+  # ── lakefile.toml: defaultTargets and each [[lean_lib]] name/globs ──────────
+  FILENAME == "lakefile.toml" {
+    if ($0 ~ /^defaultTargets[ \t]*=/) {
+      line = $0
+      while (match(line, /"[^"]+"/)) {
+        targets[substr(line, RSTART + 1, RLENGTH - 2)] = 1
+        line = substr(line, RSTART + RLENGTH)
+      }
+    }
+    if ($0 ~ /^\[\[lean_lib\]\]/) { inlib = 1; libname = ""; next }
+    if ($0 ~ /^\[/) { inlib = 0; inglobs = 0; next }
+    if (inlib && match($0, /^name[ \t]*=[ \t]*"[^"]+"/)) {
+      line = $0; match(line, /"[^"]+"/)
+      libname = substr(line, RSTART + 1, RLENGTH - 2)
+      next
+    }
+    if (inlib && $0 ~ /^globs[ \t]*=/) inglobs = 1
+    if (inlib && inglobs) {
+      line = $0
+      while (match(line, /"[^"]+"/)) {
+        libglobs[libname] = libglobs[libname] " " substr(line, RSTART + 1, RLENGTH - 2)
+        line = substr(line, RSTART + RLENGTH)
+      }
+      if ($0 ~ /\]/) inglobs = 0
+    }
+    next
+  }
+
+  # ── *.lean files: the module universe and its internal import edges ─────────
+  {
+    if (!(FILENAME in seen)) {
+      seen[FILENAME] = 1
+      mod = FILENAME
+      sub(/\.lean$/, "", mod)
+      gsub(/\//, ".", mod)
+      univ[mod] = 1
+      order[nuniv++] = mod
+      filemod[mod] = FILENAME
+      curmod = mod
+    }
+    line = $0
+    sub(/^public[ \t]+/, "", line)
+    if (line ~ /^import[ \t]+/) {
+      split(line, parts, /[ \t]+/)
+      adj[curmod] = adj[curmod] " " parts[2]
+    }
+  }
+
+  END {
+    status = 0
+    # Expand the default targets globs into the BFS root set.
+    for (lib in targets) {
+      globs = (lib in libglobs) ? libglobs[lib] : lib
+      n = split(globs, g, / +/)
+      for (i = 1; i <= n; i++) {
+        if (g[i] == "") continue
+        hit = 0
+        if (g[i] ~ /\.\+$/ || g[i] ~ /\.\*$/) {
+          pre = substr(g[i], 1, length(g[i]) - 2)      # strip ".+" / ".*"
+          withroot = (g[i] ~ /\.\*$/)
+          for (j = 0; j < nuniv; j++) {
+            m = order[j]
+            if (index(m, pre ".") == 1 || (withroot && m == pre)) {
+              queue[nq++] = m; hit = 1
+            }
+          }
+        } else if (g[i] in univ) {
+          queue[nq++] = g[i]; hit = 1
+        }
+        if (!hit) {
+          printf "VIOLATION: default target %s glob %s matches no module file\n", lib, g[i] > "/dev/stderr"
+          status = 1
+        }
+      }
+    }
+    # BFS over the in-package import edges.
+    for (q = 0; q < nq; q++) {
+      m = queue[q]
+      if (m in covered) continue
+      covered[m] = 1
+      n = split(adj[m], deps, / +/)
+      for (i = 1; i <= n; i++)
+        if (deps[i] in univ && !(deps[i] in covered))
+          queue[nq++] = deps[i]
+    }
+    ncov = 0
+    for (j = 0; j < nuniv; j++) {
+      m = order[j]
+      if (m in covered) { ncov++; continue }
+      printf "VIOLATION: %s (%s) is not built by any default target — add it to a lakefile glob or import it from a covered module\n", m, filemod[m] > "/dev/stderr"
+      status = 1
+    }
+    if (status == 0)
+      printf "build coverage: %d module(s), all covered by the default targets.\n", ncov
+    exit status
+  }
+'

--- a/scripts/check_no_umbrella_imports.sh
+++ b/scripts/check_no_umbrella_imports.sh
@@ -22,7 +22,10 @@
 # Run from the repository root; exits non-zero on violation.
 set -euo pipefail
 
-violations=$(git ls-files '*.lean' | xargs grep -nE '^import Mathlib(\.Tactic)?([[:space:]]|$)' || true)
+# One-or-more whitespace after `import` (not exactly one space), and optional
+# `public`/`meta` modifiers, so spacing variants and module-system prefixes
+# cannot slip a banned umbrella past the anchor.
+violations=$(git ls-files '*.lean' | xargs grep -nE '^(public[[:space:]]+)?(meta[[:space:]]+)?import[[:space:]]+Mathlib(\.Tactic)?([[:space:]]|$)' || true)
 
 if [ -n "$violations" ]; then
   echo "::error::bare 'import Mathlib' / 'import Mathlib.Tactic' umbrella imports are not allowed; import the specific Mathlib modules instead (see scripts/check_no_umbrella_imports.sh):"

--- a/scripts/check_no_umbrella_imports.sh
+++ b/scripts/check_no_umbrella_imports.sh
@@ -1,25 +1,31 @@
 #!/usr/bin/env bash
-# Check that no Lean file imports the Mathlib umbrella module.
+# Check that no Lean file imports the Mathlib umbrella modules.
 #
 # `import Mathlib` pulls in all of Mathlib, which peaks around 6.5 GB RSS per Lean process.
 # During a parallel Lake build several such processes create severe memory and GC pressure —
 # one observed `PermutationInstantiation` build took 648 seconds despite compiling in about
 # five seconds in isolation. PR #144 replaced every umbrella import with `Mathlib.Tactic` or
-# narrower module imports; this script keeps the umbrella from creeping back in, since nothing
-# else fails when it does — builds just quietly get slow again.
+# narrower module imports.
 #
-# The rule: no tracked `.lean` file may contain a bare `import Mathlib` (with or without a
-# trailing comment). Submodule imports such as `import Mathlib.Tactic` are fine — that is the
-# accepted broad-import compromise. If an umbrella import is ever legitimately needed, extend
-# this script with an explicit allowlist rather than deleting the check.
+# `import Mathlib.Tactic` is the same failure mode at smaller scale: it transitively pulls a
+# large slice of Mathlib's theory (measured for issue #153 at roughly +1.6 s import-load time
+# and +1.3 GB RSS per Lean process against the narrow tactic modules a file actually needs).
+# It was the accepted broad-import compromise until issue #153 swept the last 83 uses; the
+# sweep holds only if the umbrella cannot creep back in, since nothing else fails when it
+# does — builds just quietly get slow again.
+#
+# The rule: no tracked `.lean` file may contain a bare `import Mathlib` or a bare
+# `import Mathlib.Tactic` (with or without a trailing comment). Specific submodule imports
+# such as `import Mathlib.Tactic.Ring` are fine. If an umbrella import is ever legitimately
+# needed, extend this script with an explicit allowlist rather than deleting the check.
 #
 # Run from the repository root; exits non-zero on violation.
 set -euo pipefail
 
-violations=$(git ls-files '*.lean' | xargs grep -nE '^import Mathlib([[:space:]]|$)' || true)
+violations=$(git ls-files '*.lean' | xargs grep -nE '^import Mathlib(\.Tactic)?([[:space:]]|$)' || true)
 
 if [ -n "$violations" ]; then
-  echo "::error::bare 'import Mathlib' umbrella imports are not allowed; import the specific Mathlib modules instead (see scripts/check_no_umbrella_imports.sh):"
+  echo "::error::bare 'import Mathlib' / 'import Mathlib.Tactic' umbrella imports are not allowed; import the specific Mathlib modules instead (see scripts/check_no_umbrella_imports.sh):"
   echo "$violations"
   exit 1
 fi


### PR DESCRIPTION
Closes https://github.com/zcash/ironwood/issues/153. Cold starts are the same as before, but cold starts happen less often then before with more clever caching. One prudent way to reduce CI times is to bump our runners up from 4 cores (there are diminishing returns at some point, but going from 4 to 8 alone would more than halve CI times).

----------

**1. `lean.yml` caching rework** (`019a0b19`)

- Disabled lean-action's built-in cache (one 2.65 GB `.lake` blob per commit — only ~3 fit in the 10 GB quota, so concurrent PRs constantly evicted each other → ~35 min cold rebuilds).
- Split it into two explicit layers:
  - **Deps** (`.lake/packages`, ~2 GB): keyed on toolchain + manifest hashes only; one stable entry reused by all PRs between dependency bumps; saved only after a green build so a partial build can never become the shared entry.
  - **Project build** (`.lake/build`, ~0.7 GB): per-commit key with prefix restore of the newest entry; saved with `always()`, so failed and cancelled runs now warm the next attempt (previously saves were skipped on both — `actions/cache` saves via a post hook gated on `post-if: success()`, and `cancel-in-progress: true` cancels every superseded push).
  - Mathlib oleans stay out of GitHub's cache on bumps — `lake exe cache get` refills them in ~2 min.

**2. Fixture lanes decoupled from the soundness stack** (`51464e2e`)

The byte-locked captures must `import Zcash.Snark`, and the umbrella re-exported all of `Soundness/` — 24.9 min of the ~36 min cold build was this one serial chain. The umbrella stops re-exporting `Soundness/`; the captures' one real dependency (`VestaG` + its `Fp`-module structure) is hoisted into the new `Core/Vesta.lean` with all names unchanged. Coverage is pinned twice: an explicit `Zcash.Snark.Soundness.+` lakefile glob, and the new `scripts/check_build_coverage.sh` in CI asserting every module file is reachable from some default target. Verified locally with a full `lake build --wfail` (3,835 jobs); generated fixtures byte-untouched. Critical path: **24.9 → 15.5 min**.

**3. Rational-match tier trimmed from the umbrella** (`d5b73ced`)

The quantified-random-match tier (`SampleSpace`, `Rational/`, `Epsilon`) also leaves the umbrella: the captures reference none of it, its consumers already import it directly, and its ~4 min `Rational/Capstone` chain sat on every capture lane's build path. Fixture spine: **~15.5 → ~11.5 min**, leaving the Soundness spine (~14.9 min) as the binding critical path.

**4. `Mathlib.Tactic` umbrella swept** (`28e75190`)

All 83 bare `import Mathlib.Tactic` uses (measured at ~+1.6 s import-load and +1.3 GB RSS per Lean process vs. narrow imports) replaced with `Mathlib.Tactic.{Ring, NormNum, FieldSimp, Linarith}` plus modules for tactics each file demonstrably uses. `check_no_umbrella_imports.sh` now bans the bare `Mathlib.Tactic` alongside `import Mathlib` so it cannot creep back.

Commits 3 and 4 are guard-verified (build coverage, umbrella, csimp and endpoint censuses, zizmor) but await this PR's CI build for full elaboration — narrow-import fallout, if any, surfaces as unknown identifiers fixable by adding the named import.