### PR TITLE
chore(fv): census the compiled surface, not just the axiom footprint

### DIFF
--- a/Zcash/Arithmetic/FastMsm.lean
+++ b/Zcash/Arithmetic/FastMsm.lean
@@ -20,7 +20,9 @@ statement surface and the kernel-level meaning of `evalNat` are untouched. This 
 the proven-equality counterpart of `implemented_by`, which is forbidden here because it
 is unchecked — a ban the trusted-base census enforces rather than leaves to convention:
 `Zcash.Meta.assert_axioms` and `Zcash.Meta.assert_computable` fail the build on any
-`@[implemented_by]` or `@[extern]` outside the toolchain's own ambient surface.
+`@[implemented_by]` or `@[extern]` outside the toolchain's own ambient surface, anywhere in
+the import closure of the module the census entry sits in. `Zcash.TrustBoundary` records
+which modules that leaves uncovered.
 -/
 
 namespace Zcash.Arithmetic.Msm

--- a/Zcash/Arithmetic/FastMsm.lean
+++ b/Zcash/Arithmetic/FastMsm.lean
@@ -17,8 +17,10 @@ registered with `@[csimp]`:
 the compiler substitutes the fast implementation at every subsequently compiled call
 site — in particular inside the fixtures' `native_decide` auxiliaries — while the
 statement surface and the kernel-level meaning of `evalNat` are untouched. This is
-the proven-equality counterpart of `implemented_by` (which is forbidden here because
-it is unchecked).
+the proven-equality counterpart of `implemented_by`, which is forbidden here because it
+is unchecked — a ban the trusted-base census enforces rather than leaves to convention:
+`Zcash.Meta.assert_axioms` and `Zcash.Meta.assert_computable` fail the build on any
+`@[implemented_by]` or `@[extern]` outside the toolchain's own ambient surface.
 -/
 
 namespace Zcash.Arithmetic.Msm

--- a/Zcash/Arithmetic/FastMsm.lean
+++ b/Zcash/Arithmetic/FastMsm.lean
@@ -20,9 +20,10 @@ statement surface and the kernel-level meaning of `evalNat` are untouched. This 
 the proven-equality counterpart of `implemented_by`, which is forbidden here because it
 is unchecked — a ban the trusted-base census enforces rather than leaves to convention:
 `Zcash.Meta.assert_axioms` and `Zcash.Meta.assert_computable` fail the build on any
-`@[implemented_by]` or `@[extern]` outside the toolchain's own ambient surface, anywhere in
-the import closure of the module the census entry sits in. `Zcash.TrustBoundary` records
-which modules that leaves uncovered.
+`@[implemented_by]` or `@[extern]` outside the ambient roots
+(`Zcash.Meta.ambientPackageRoots` — the toolchain *and* the pinned dependency stack, not
+the toolchain alone), anywhere in the import closure of the module the census entry sits
+in. `Zcash.TrustBoundary` records which modules that leaves uncovered.
 -/
 
 namespace Zcash.Arithmetic.Msm

--- a/Zcash/Meta/AxiomCheck.lean
+++ b/Zcash/Meta/AxiomCheck.lean
@@ -1,6 +1,9 @@
 import Lean.Util.CollectAxioms
 import Lean.Elab.Command
 import Lean.DeclarationRange
+import Lean.Compiler.ImplementedByAttr
+import Lean.Compiler.ExternAttr
+import Lean.Compiler.CSimpAttr
 import Mathlib.Util.AssertNoSorry
 
 /-!
@@ -13,6 +16,12 @@ hard-code the pretty-printed axiom list, so it stays green across toolchain bump
 declared tier (a `sorry`, an unexpected axiom, or `native_decide` where none was permitted).
 
 The `#guard_msgs`-pinned form remains the right tool when the *exact* axiom set is the claim.
+
+Both commands also police the *compiled* side of the trusted base: an axiom footprint says nothing
+about what compiled code runs, and the fixtures' faithfulness certificates are `native_decide`
+proofs that run it. Two sections below cover the two ways compiled behaviour comes apart from kernel
+meaning — a substituted body (`@[implemented_by]`, `@[extern]`) and a `partial` declaration inside a
+certificate's evaluated term.
 
 Scope: these commands catch *inadvertent* drift — an entry silently reaching more than it
 claims. They are not a full defense against a deliberately deceptive author. The provenance
@@ -43,6 +52,118 @@ namespace Zcash.Meta
 
 /-- The standard axioms of Lean's trusted base — the whole budget for a general theorem. -/
 def standardAxioms : Array Name := #[``propext, ``Classical.choice, ``Quot.sound]
+
+/-! ## Compiled-body overrides
+
+`@[implemented_by f]` and `@[extern "sym"]` instruct the compiler to run a *different body* than the
+one the kernel reduces, and Lean checks no relation between the two (`@[csimp]` is the checked
+counterpart: it demands a proof that the replacement equals the original). Neither attribute changes
+the safety flag, the `noncomputable` flag, or the axiom footprint, so nothing the rest of this file
+inspects can see the substitution: a censused `def` can carry `@[implemented_by doctored]` and
+`assert_computable` will still call it genuinely computed data while the executed value is the
+attacker's. That matters here because the fixtures' faithfulness certificates are `native_decide`
+proofs, which *run the compiled bodies* — a doctored capture makes the certificate report a match
+that the kernel value refutes.
+
+The check below is deliberately not cone-scoped. `collectAxioms` no longer walks imported bodies
+(it reads a per-module precomputed footprint), so a transitive walk over a fixture's cone would be
+the expensive traversal Lean stopped doing — and what it would mostly find is the *ambient* surface:
+at the pinned toolchain, `Init`/`Std`/`Lean`/`Mathlib` carry on the order of a thousand of these
+attributes between them, all of them compiled code every `native_decide` in existence already runs.
+So the census splits the two rather than walking terms. On the ambient surface it claims nothing
+new. Outside it, it enumerates *every* override in the import closure, reachable or not: the
+attribute extensions are indexed by declaring module, so this is a scan of the module list rather
+than of any term, and it catches an override before the commit that puts it in a cone. Stating it
+over the whole closure is sound because `ParametricAttribute`'s `add` refuses a declaration from an
+imported module (`Lean.Attributes`, `throwAttrDeclInImportedModule`) — a commit can only attach
+either attribute inside the module that declares the constant, so every override a commit here can
+introduce lives in a module this repository owns, and none of them can hide behind an ambient
+root. -/
+
+/-- Package roots whose compiled-body overrides are *ambient*: the Lean toolchain and the pinned
+mathlib stack, whose compiled code every `native_decide` runs no matter what this repository does,
+and which a commit here cannot add an override to (attributes cannot be attached to an imported
+declaration). Everything else is censused, so a *new* dependency fails the build until its root is
+classified — a new package in the import closure is a trusted-base change, unlike a version bump of
+one already listed. This is where the `@[extern]` `Task.spawn` / `Task.get` reached through
+`List.parMap` land; the kernel sees their reference bodies, `List.parMap_eq_map` closes by `rfl`,
+and `Zcash.TrustBoundary` discloses what the task runtime widens the compiled surface to. -/
+def ambientPackageRoots : Array Name :=
+  #[`Init, `Lean, `Std, `Lake, `Batteries, `Mathlib, `Aesop, `Qq, `Plausible, `ProofWidgets,
+    `ImportGraph, `LeanSearchClient, `Cli]
+
+/-- The attribute substituting `decl`'s compiled body, if any. -/
+def compiledBodyOverride? (env : Environment) (decl : Name) : Option Name :=
+  if (Lean.Compiler.getImplementedBy? env decl).isSome then some `implemented_by
+  else if Lean.isExtern env decl then some `extern
+  else none
+
+/-- Compiled-body overrides the census has examined and admitted, each of which must be justified by
+a disclosure in `Zcash.TrustBoundary` saying why the substituted body is trusted. Empty: the
+repository has none, and `Zcash.Arithmetic.FastMsm` records the convention that the proven-equality
+`@[csimp]` is used instead. An entry here is a deliberate widening of the trusted base, so it should
+be as hard to add unnoticed as any other census line. -/
+def allowedCompiledBodyOverrides : Array Name := #[]
+
+/-- Every declaration outside `ambientPackageRoots` that carries a compiled-body override and is not
+on the allowlist, paired with the attribute responsible.
+
+Imported declarations are read off the two attribute extensions' per-module entry arrays — the same
+arrays `ParametricAttribute.getParam?`, and hence the compiler, reads, so an override the compiler
+acts on cannot be invisible here. The entry arrays are fetched first and the module root classified
+only for the few modules that have any, so the scan costs a pair of array lookups per imported
+module. Declarations of the module currently being elaborated have no module index, so they are read
+from stage 2 of the constant map — exactly the current module's constants — through
+`compiledBodyOverride?`, which is that same compiler-facing query. -/
+def undisclosedCompiledBodyOverrides (env : Environment) : Array (Name × Name) := Id.run do
+  let mods := env.header.moduleNames
+  let mut found : Array (Name × Name) := #[]
+  for i in [0:mods.size] do
+    let idx : ModuleIdx := i
+    let impls := Lean.Compiler.implementedByAttr.ext.getModuleEntries env idx
+    let externs := Lean.externAttr.ext.getModuleEntries env idx
+    unless impls.isEmpty && externs.isEmpty do
+      unless ambientPackageRoots.contains mods[i]!.getRoot do
+        found := impls.foldl (fun acc (d, _) => acc.push (d, `implemented_by)) found
+        found := externs.foldl (fun acc (d, _) => acc.push (d, `extern)) found
+  found := env.constants.foldStage2 (fun acc d _ =>
+    match compiledBodyOverride? env d with
+    | some attr => acc.push (d, attr)
+    | none => acc) found
+  -- Sorted: the current module's constants come out of a hash map, so the report — which is pinned
+  -- by `#guard_msgs` in the regression suite — would otherwise have no fixed order. The attribute
+  -- breaks ties, since a declaration can in principle carry both and sorting on the name alone
+  -- would leave those two rows unordered.
+  return (found.filter fun (d, _) => !allowedCompiledBodyOverrides.contains d).qsort
+    (fun a b => Name.lt a.1 b.1 || (a.1 == b.1 && Name.lt a.2 b.2))
+
+/-- Render `(declaration, attribute)` pairs as the text of the offending attributes. -/
+def overridesText (overrides : Array (Name × Name)) : String :=
+  ", ".intercalate (overrides.toList.map fun (d, attr) => s!"{d} (@[{attr}])")
+
+/-- The censused declaration must not have its own compiled body substituted. Checked even for an
+ambient-root target, because here the substitution is not background compiler trust but the entry's
+own subject: everything the census goes on to verify is about the kernel term, which for such a
+declaration is not what runs. -/
+def checkNoCompiledBodyOverride (n : Ident) (name : Name) : CommandElabM Unit := do
+  if allowedCompiledBodyOverrides.contains name then return
+  if let some attr := compiledBodyOverride? (← getEnv) name then
+    throwError "{n} carries '@[{attr}]', so its compiled body is not the body the kernel reduces \
+      and Lean checks no relation between the two. Nothing this census verifies about the kernel \
+      term constrains what compiled code — a `native_decide` over it in particular — computes."
+
+/-- No declaration in the census's own scope may have its compiled body substituted. This is a
+property of the whole import closure rather than of `n`, so it fails every entry in the file at
+once; that is the intent — an override anywhere is undisclosed compiler trust that the census, as
+the artifact's statement of its trusted base, must not certify around. -/
+def checkCompiledBodyDisclosure (n : Ident) : CommandElabM Unit := do
+  let overrides := undisclosedCompiledBodyOverrides (← getEnv)
+  unless overrides.isEmpty do
+    throwError "{n} cannot be censused: {overridesText overrides} \
+      substitute(s) a compiled body Lean never checks against the kernel body, so the value the \
+      compiler runs is unconstrained by anything proved about it. Use the proven-equality \
+      `@[csimp]` instead, or — if the substitution really belongs in the trusted base — disclose it \
+      in `Zcash.TrustBoundary` and add it to `Zcash.Meta.allowedCompiledBodyOverrides`."
 
 /-- The declaration an alleged `native_decide` axiom names as its owner. The compiler-generated
 name has an `_native.native_decide` marker after the owning declaration; only the tail after that
@@ -160,6 +281,93 @@ def checkNativeAllowance (n : Ident) (axs : Array Name) (allowed : Option (Array
       throwError "{n}: '+native' names {allowedL} but the native_decide axiom(s) present \
         are owned by {owners}; write '+native({ownersText owners})'"
 
+/-! ## `partial` inside a native certificate
+
+The other shape of compiled-versus-kernel divergence, and the one the attribute sweep above cannot
+see. `partial def f` elaborates to an `opaque` constant plus an `unsafe` `f._unsafe_rec` that the
+compiler substitutes for it: the kernel gets a constant it will not unfold and no equation relating
+it to anything, while the compiled body is unsafe code with the termination check lifted — the
+`unsafe def r : Break := r` shape `assert_computable`'s safety check rejects, re-entering through a
+declaration that is neither `unsafe` nor a `def`. A `native_decide` over such a constant is an
+assertion about something the kernel could not have evaluated even in principle.
+
+`assert_computable` rejects a `partial` target already (it is not a `def`), but the entry that
+launders one is the `assert_axioms` on the certificate *consuming* it, whose own declaration is
+clean. So this is checked where it bites: inside what a `native_decide` certificate actually
+evaluated. That surface is exact and cheap, because a `native_decide` auxiliary axiom is
+`@Eq Bool e Bool.true` with `e` the closed term the compiler ran (`Lean.Meta.nativeEqTrue`) —
+walking `e` walks the data, not the proof.
+
+`e` is the term as the *kernel* records it, though, and the compiler does not run it verbatim: a
+`@[csimp]` lemma replaces a constant wholesale in compiled code, so where `e` says `evalNat` the
+compiled certificate ran `evalNatFast`. The walk therefore follows those replacements. Without that
+step a `partial` reachable only through a replacement target would be invisible here, and this
+repository redirects the fixtures' hot path exactly that way (`Zcash.Arithmetic.FastMsm`).
+
+Plain `opaque` is deliberately not reported. Its compiled body *is* its declared body, so it cannot
+make a certificate disagree with the source; and the sealed-subtype barriers this repository uses
+(`opaque h : {x // x = source} := ⟨source, rfl⟩`, as in `Zcash.Circuits.Action.TopLevel` and
+`ActionGateCoherence`) keep the value kernel-recoverable through the type. An `opaque` that *is*
+body-substituted carries `@[implemented_by]` and is caught by the sweep above. -/
+
+/-- Whether `decl` is the `opaque` constant a `partial def` leaves behind, recognised by the
+`_unsafe_rec` implementation the compiler substitutes for it (`Lean.Compiler.mkUnsafeRecName`). -/
+def isPartialDecl (env : Environment) (decl : Name) : Bool :=
+  env.find? decl matches some (.opaqueInfo _) &&
+    env.contains (Lean.Compiler.mkUnsafeRecName decl)
+
+/-- `partial` declarations outside `ambientPackageRoots` that a `native_decide` certificate
+evaluated. Walks the auxiliary axioms' types, which are the terms that ran, following the
+`@[csimp]` replacements the compiler applies to them. -/
+def nativeEvaluatedPartials (env : Environment) (nativeAxioms : Array Name) : Array Name := Id.run do
+  let mods := env.header.moduleNames
+  let csimp := (Lean.Compiler.CSimp.ext.getState env).map
+  let mut seen : Std.HashSet Name := {}
+  let mut found : Array Name := #[]
+  let mut todo := nativeAxioms
+  while todo.size > 0 do
+    let c := todo.back!
+    todo := todo.pop
+    unless seen.contains c do
+      seen := seen.insert c
+      if let some info := env.find? c then
+        let ambient := match env.getModuleIdxFor? c with
+          | some idx => ambientPackageRoots.contains mods[idx.toNat]!.getRoot
+          | none => false
+        if !ambient && isPartialDecl env c then
+          found := found.push c
+        -- An axiom contributes only its type: for a native auxiliary that type *is* the evaluated
+        -- term. A theorem contributes only its type too — its proof is erased before compilation,
+        -- so a `partial` reachable only through one is never run. Everything else contributes its
+        -- value, which is what evaluation unfolds into.
+        todo := todo ++ info.type.getUsedConstants
+        unless info matches .axiomInfo _ | .thmInfo _ do
+          todo := todo ++ (info.value?.map Expr.getUsedConstants).getD #[]
+        -- An inductive's constructors, as `Lean.CollectAxioms.collect` does: they carry no value,
+        -- but reaching them keeps the traversal's notion of "mentioned" the same as the census's.
+        if let .inductInfo v := info then
+          todo := todo ++ v.ctors.toArray
+        -- `@[csimp]` replaces `c` with `e.toDeclName` in compiled code, so where the kernel term
+        -- says `c` the compiler runs the replacement's body. Following it is what makes this a
+        -- walk of what actually ran rather than of what the axiom's statement mentions.
+        if let some e := csimp.find? c then
+          todo := todo.push e.toDeclName
+  return found.qsort Name.lt
+
+/-- A `native_decide` certificate must not have evaluated a `partial` declaration: the auxiliary
+axiom asserts that the compiler's evaluation is the kernel's, and here the kernel has no body to
+have evaluated — for a fixture capture, that turns the fingerprint into a statement about an
+abstract constant backed by an unsafe implementation. -/
+def checkNativeEvaluatedSurface (n : Ident) (axs : Array Name) : CommandElabM Unit := do
+  let nativeAxioms := axs.filter isNativeDecideAxiom
+  if nativeAxioms.isEmpty then return
+  let partials := nativeEvaluatedPartials (← getEnv) nativeAxioms
+  unless partials.isEmpty do
+    throwError "{n}: the native_decide certificate evaluated the `partial` declaration(s) \
+      {partials.toList}, whose compiled body is an unsafe implementation the kernel never sees and \
+      whose kernel constant has no body at all. Nothing relates what ran to what the certificate \
+      says. Give the evaluated data an ordinary `def`."
+
 /-- The `+native(A, B)` flag: the parenthesized, comma-separated owner list is required. -/
 syntax nativeFlag := "+native" "(" ident,+ ")"
 
@@ -187,17 +395,25 @@ def resolveNativeAnnotation (native : Option (TSyntax ``nativeFlag)) :
 exactly those owned by the named declarations, written fully qualified. The axiom names' tails are
 toolchain-dependent, so entries name the owning declarations rather than the axioms themselves.
 Any other axiom (including `sorryAx`) is still rejected, as is a stale or incomplete list.
+
+Independently of the axiom budget, the entry fails if `foo` or any censused-scope declaration
+carries a compiled-body override (`checkCompiledBodyDisclosure`), or if a permitted certificate
+evaluated a `partial` declaration (`checkNativeEvaluatedSurface`); `Zcash.Meta.Tests.NativeSurface`
+pins the latter.
 -/
 elab "assert_axioms " n:ident native:(nativeFlag)? : command => do
   let name ← liftCoreM <| realizeGlobalConstNoOverloadWithInfo n
   checkFullyQualified n name
+  checkNoCompiledBodyOverride n name
   let axs ← collectAxioms name
   let allowed ← resolveNativeAnnotation native
   checkNativeAllowance n axs allowed
+  checkNativeEvaluatedSurface n axs
   let unexpected := axs.filter fun ax =>
     !standardAxioms.contains ax && !(allowed.isSome && isNativeDecideAxiom ax)
   unless unexpected.isEmpty do
     throwError "{n} depends on unexpected axiom(s): {unexpected.toList}"
+  checkCompiledBodyDisclosure n
 
 /--
 `assert_computable foo` fails the build unless `foo` is a plain `def` — an actual definition,
@@ -224,6 +440,11 @@ nothing. The kernel does refuse to let a safe declaration depend on an unsafe on
 the forgery to a reduction no safe proof consumes; that is exactly the shape of a deliverable
 endpoint reduction, which is why the assertion checks safety itself rather than leaning on the
 kernel. `Zcash.Meta.Tests.AxiomCheck.ComputableSafety` pins the rejection.
+
+"Genuinely computed" is a claim about the *compiled* body, which none of the checks above can see,
+so the assertion additionally rejects a definition whose compiled body is substituted and any
+censused-scope declaration that substitutes one (`checkNoCompiledBodyOverride`,
+`checkCompiledBodyDisclosure`); `Zcash.Meta.Tests.CompiledOverride` pins both rejections.
 -/
 elab "assert_computable " n:ident choice:("+choice")? native:(nativeFlag)? : command => do
   let name ← liftCoreM <| realizeGlobalConstNoOverloadWithInfo n
@@ -237,17 +458,20 @@ elab "assert_computable " n:ident choice:("+choice")? native:(nativeFlag)? : com
   | .partial => throwError "{n} is marked partial"
   if Lean.isNoncomputable env name then
     throwError "{n} is marked noncomputable"
+  checkNoCompiledBodyOverride n name
   let axs ← collectAxioms name
   let allowChoice := choice.isSome
   if allowChoice && !axs.contains ``Classical.choice then
     throwError "{n} does not depend on Classical.choice; drop the '+choice' flag"
   let allowed ← resolveNativeAnnotation native
   checkNativeAllowance n axs allowed
+  checkNativeEvaluatedSurface n axs
   let unexpected := axs.filter fun ax =>
     !(ax == ``propext || ax == ``Quot.sound
       || (allowChoice && ax == ``Classical.choice)
       || (allowed.isSome && isNativeDecideAxiom ax))
   unless unexpected.isEmpty do
     throwError "{n} depends on unexpected axiom(s): {unexpected.toList}"
+  checkCompiledBodyDisclosure n
 
 end Zcash.Meta

--- a/Zcash/Meta/AxiomCheck.lean
+++ b/Zcash/Meta/AxiomCheck.lean
@@ -98,15 +98,16 @@ def compiledBodyOverride? (env : Environment) (decl : Name) : Option Name :=
   else if Lean.isExtern env decl then some `extern
   else none
 
-/-- Compiled-body overrides the census has examined and admitted, each of which must be justified by
-a disclosure in `Zcash.TrustBoundary` saying why the substituted body is trusted. Empty: the
-repository has none, and `Zcash.Arithmetic.FastMsm` records the convention that the proven-equality
-`@[csimp]` is used instead. An entry here is a deliberate widening of the trusted base, so it should
-be as hard to add unnoticed as any other census line. -/
-def allowedCompiledBodyOverrides : Array Name := #[]
+/-- Every declaration outside `ambientPackageRoots` that carries a compiled-body override, paired
+with the attribute responsible.
 
-/-- Every declaration outside `ambientPackageRoots` that carries a compiled-body override and is not
-on the allowlist, paired with the attribute responsible.
+There is deliberately no allowlist to sit alongside `ambientPackageRoots`, because the two would not
+be the same kind of thing. `ambientPackageRoots` is trust inherited by using Lean at all — no commit
+in this repository can add to it, since an attribute cannot be attached to an imported declaration —
+whereas an admitted override would be trust this repository chose to add, which is exactly what the
+prohibition is about. A substitution in a declaration this repository owns is therefore rejected
+outright rather than admitted with a disclosure, and `Zcash.Arithmetic.FastMsm` records the
+convention that the proven-equality `@[csimp]` is used instead.
 
 Imported declarations are read off the two attribute extensions' per-module entry arrays — the same
 arrays `ParametricAttribute.getParam?`, and hence the compiler, reads, so an override the compiler
@@ -134,8 +135,7 @@ def undisclosedCompiledBodyOverrides (env : Environment) : Array (Name × Name) 
   -- by `#guard_msgs` in the regression suite — would otherwise have no fixed order. The attribute
   -- breaks ties, since a declaration can in principle carry both and sorting on the name alone
   -- would leave those two rows unordered.
-  return (found.filter fun (d, _) => !allowedCompiledBodyOverrides.contains d).qsort
-    (fun a b => Name.lt a.1 b.1 || (a.1 == b.1 && Name.lt a.2 b.2))
+  return found.qsort (fun a b => Name.lt a.1 b.1 || (a.1 == b.1 && Name.lt a.2 b.2))
 
 /-- Render `(declaration, attribute)` pairs as the text of the offending attributes. -/
 def overridesText (overrides : Array (Name × Name)) : String :=
@@ -146,7 +146,6 @@ ambient-root target, because here the substitution is not background compiler tr
 own subject: everything the census goes on to verify is about the kernel term, which for such a
 declaration is not what runs. -/
 def checkNoCompiledBodyOverride (n : Ident) (name : Name) : CommandElabM Unit := do
-  if allowedCompiledBodyOverrides.contains name then return
   if let some attr := compiledBodyOverride? (← getEnv) name then
     throwError "{n} carries '@[{attr}]', so its compiled body is not the body the kernel reduces \
       and Lean checks no relation between the two. Nothing this census verifies about the kernel \
@@ -161,9 +160,8 @@ def checkCompiledBodyDisclosure (n : Ident) : CommandElabM Unit := do
   unless overrides.isEmpty do
     throwError "{n} cannot be censused: {overridesText overrides} \
       substitute(s) a compiled body Lean never checks against the kernel body, so the value the \
-      compiler runs is unconstrained by anything proved about it. Use the proven-equality \
-      `@[csimp]` instead, or — if the substitution really belongs in the trusted base — disclose it \
-      in `Zcash.TrustBoundary` and add it to `Zcash.Meta.allowedCompiledBodyOverrides`."
+      compiler runs is unconstrained by anything proved about it. If you must, use `@[csimp]` \
+      instead, but be aware that `@[csimp]` still substantially increases the trust surface."
 
 /-- The declaration an alleged `native_decide` axiom names as its owner. The compiler-generated
 name has an `_native.native_decide` marker after the owning declaration; only the tail after that
@@ -302,7 +300,9 @@ walking `e` walks the data, not the proof.
 `@[csimp]` lemma replaces a constant wholesale in compiled code, so where `e` says `evalNat` the
 compiled certificate ran `evalNatFast`. The walk therefore follows those replacements. Without that
 step a `partial` reachable only through a replacement target would be invisible here, and this
-repository redirects the fixtures' hot path exactly that way (`Zcash.Arithmetic.FastMsm`).
+repository redirects the fixtures' hot path exactly that way (`Zcash.Arithmetic.FastMsm`). That step
+is owed entirely to `@[csimp]` being permitted: prohibiting it retires the replacement map, and the
+walk collapses back to following the term the axiom states.
 
 Plain `opaque` is deliberately not reported. Its compiled body *is* its declared body, so it cannot
 make a certificate disagree with the source; and the sealed-subtype barriers this repository uses

--- a/Zcash/Meta/AxiomCheck.lean
+++ b/Zcash/Meta/AxiomCheck.lean
@@ -102,12 +102,13 @@ def compiledBodyOverride? (env : Environment) (decl : Name) : Option Name :=
 with the attribute responsible.
 
 There is deliberately no allowlist to sit alongside `ambientPackageRoots`, because the two would not
-be the same kind of thing. `ambientPackageRoots` is trust inherited by using Lean at all — no commit
-in this repository can add to it, since an attribute cannot be attached to an imported declaration —
-whereas an admitted override would be trust this repository chose to add, which is exactly what the
-prohibition is about. A substitution in a declaration this repository owns is therefore rejected
-outright rather than admitted with a disclosure, and `Zcash.Arithmetic.FastMsm` records the
-convention that the proven-equality `@[csimp]` is used instead.
+be the same kind of thing. `ambientPackageRoots` is trust inherited from the toolchain and the
+pinned dependency stack — no commit here can add to it, since an attribute cannot be attached to an
+imported declaration — whereas an admitted override would be trust this repository chose to add,
+which is exactly what the prohibition is about. A substitution in a declaration this repository owns
+is therefore rejected outright rather than admitted with a disclosure, and
+`Zcash.Arithmetic.FastMsm` records the convention that the proven-equality `@[csimp]` is used
+instead.
 
 Imported declarations are read off the two attribute extensions' per-module entry arrays — the same
 arrays `ParametricAttribute.getParam?`, and hence the compiler, reads, so an override the compiler

--- a/Zcash/Meta/Tests/CompiledOverride.lean
+++ b/Zcash/Meta/Tests/CompiledOverride.lean
@@ -37,12 +37,12 @@ assert_axioms Zcash.Meta.Tests.CompiledOverride.cleanTheorem
 
 /-! ## An ambient-package target
 
-The disclosure sweep exempts the toolchain's own overrides — `Nat.add` is `@[extern]`, as are most
-of the arithmetic and container primitives whose compiled code every `native_decide` runs
-regardless. Censusing one *directly* is a different claim, though: there the substitution is the
-entry's own subject rather than background compiler trust, and `assert_computable`'s "genuinely
-computed" would be asserted of a body that never runs. The per-declaration check therefore applies
-to any target. -/
+The disclosure sweep exempts the ambient roots — the toolchain and the pinned dependency stack, not
+the toolchain alone. `Nat.add` is `@[extern]`, as are most of the arithmetic and container
+primitives whose compiled code every `native_decide` runs regardless. Censusing one *directly* is a
+different claim, though: there the substitution is the entry's own subject rather than background
+compiler trust, and `assert_computable`'s "genuinely computed" would be asserted of a body that
+never runs. The per-declaration check therefore applies to any target. -/
 
 /-- error: Nat.add carries '@[extern]', so its compiled body is not the body the kernel reduces and Lean checks no relation between the two. Nothing this census verifies about the kernel term constrains what compiled code — a `native_decide` over it in particular — computes. -/
 #guard_msgs (whitespace := lax) in

--- a/Zcash/Meta/Tests/CompiledOverride.lean
+++ b/Zcash/Meta/Tests/CompiledOverride.lean
@@ -78,7 +78,7 @@ Pinning the doctored data is only half the bypass: the entry that actually laund
 reaches is a compiled body, which no axiom footprint records — so it is caught by the closure-wide
 disclosure check, naming the declaration responsible. -/
 
-/-- error: Zcash.Meta.Tests.CompiledOverride.fingerprintMatch cannot be censused: Zcash.Meta.Tests.CompiledOverride.capturedData (@[implemented_by]) substitute(s) a compiled body Lean never checks against the kernel body, so the value the compiler runs is unconstrained by anything proved about it. Use the proven-equality `@[csimp]` instead, or — if the substitution really belongs in the trusted base — disclose it in `Zcash.TrustBoundary` and add it to `Zcash.Meta.allowedCompiledBodyOverrides`. -/
+/-- error: Zcash.Meta.Tests.CompiledOverride.fingerprintMatch cannot be censused: Zcash.Meta.Tests.CompiledOverride.capturedData (@[implemented_by]) substitute(s) a compiled body Lean never checks against the kernel body, so the value the compiler runs is unconstrained by anything proved about it. If you must, use `@[csimp]` instead, but be aware that `@[csimp]` still substantially increases the trust surface. -/
 #guard_msgs (whitespace := lax) in
 assert_axioms Zcash.Meta.Tests.CompiledOverride.fingerprintMatch +native(
   Zcash.Meta.Tests.CompiledOverride.fingerprintMatch)
@@ -88,7 +88,7 @@ artifact's trusted base, and an unchecked compiled body inside it is undisclosed
 wherever it sits; scoping the check to each entry's dependency cone would let the same commit that
 adds the override keep every unrelated entry green. -/
 
-/-- error: Zcash.Meta.Tests.CompiledOverride.honestCaptured cannot be censused: Zcash.Meta.Tests.CompiledOverride.capturedData (@[implemented_by]) substitute(s) a compiled body Lean never checks against the kernel body, so the value the compiler runs is unconstrained by anything proved about it. Use the proven-equality `@[csimp]` instead, or — if the substitution really belongs in the trusted base — disclose it in `Zcash.TrustBoundary` and add it to `Zcash.Meta.allowedCompiledBodyOverrides`. -/
+/-- error: Zcash.Meta.Tests.CompiledOverride.honestCaptured cannot be censused: Zcash.Meta.Tests.CompiledOverride.capturedData (@[implemented_by]) substitute(s) a compiled body Lean never checks against the kernel body, so the value the compiler runs is unconstrained by anything proved about it. If you must, use `@[csimp]` instead, but be aware that `@[csimp]` still substantially increases the trust surface. -/
 #guard_msgs (whitespace := lax) in
 assert_computable Zcash.Meta.Tests.CompiledOverride.honestCaptured
 
@@ -103,7 +103,7 @@ nothing at all is known. Both checks report it exactly as they report `@[impleme
 #guard_msgs (whitespace := lax) in
 assert_computable Zcash.Meta.Tests.CompiledOverride.externData
 
-/-- error: Zcash.Meta.Tests.CompiledOverride.cleanTheorem cannot be censused: Zcash.Meta.Tests.CompiledOverride.capturedData (@[implemented_by]), Zcash.Meta.Tests.CompiledOverride.externData (@[extern]) substitute(s) a compiled body Lean never checks against the kernel body, so the value the compiler runs is unconstrained by anything proved about it. Use the proven-equality `@[csimp]` instead, or — if the substitution really belongs in the trusted base — disclose it in `Zcash.TrustBoundary` and add it to `Zcash.Meta.allowedCompiledBodyOverrides`. -/
+/-- error: Zcash.Meta.Tests.CompiledOverride.cleanTheorem cannot be censused: Zcash.Meta.Tests.CompiledOverride.capturedData (@[implemented_by]), Zcash.Meta.Tests.CompiledOverride.externData (@[extern]) substitute(s) a compiled body Lean never checks against the kernel body, so the value the compiler runs is unconstrained by anything proved about it. If you must, use `@[csimp]` instead, but be aware that `@[csimp]` still substantially increases the trust surface. -/
 #guard_msgs (whitespace := lax) in
 assert_axioms Zcash.Meta.Tests.CompiledOverride.cleanTheorem
 

--- a/Zcash/Meta/Tests/CompiledOverride.lean
+++ b/Zcash/Meta/Tests/CompiledOverride.lean
@@ -1,0 +1,110 @@
+import Zcash.Meta.AxiomCheck
+
+/-!
+# Regression tests for the compiled-body-override checks
+
+`@[implemented_by]` and `@[extern]` swap the body the compiler runs while the kernel keeps
+reducing the original, and Lean checks no relation between the two. A declaration carrying either
+is still a `.safe` `.defnInfo`, is not `noncomputable`, and introduces no axiom, so every other
+check in `Zcash.Meta.AxiomCheck` passes it — which is what makes this the one census bypass that
+reaches a *value*: the faithfulness fingerprints are `native_decide` proofs, so a doctored capture
+makes the certificate report a match against data the kernel refutes.
+
+The declarations here are deliberately doctored, so they live in this test-only library, out of the
+production `Zcash` import graph, alongside the forged axioms of `Zcash.Meta.Tests.AxiomCheck` —
+and in a module of their own, because `checkCompiledBodyDisclosure` is a property of the whole
+import closure: once an override exists here, every later census entry in this module fails, which
+is exactly the third case below but would swamp the unrelated entries of the sibling file.
+
+The order of this file is therefore load-bearing: the clean entries come first, while the module
+still has nothing to report.
+-/
+
+namespace Zcash.Meta.Tests.CompiledOverride
+
+/-! ## Clean module
+
+Both commands pass while nothing in the closure substitutes a compiled body — so the rejections
+below are not passing vacuously, and the disclosure check is not simply always-on. -/
+
+def cleanReduction (n : Nat) : Nat := n + 1
+
+assert_computable Zcash.Meta.Tests.CompiledOverride.cleanReduction
+
+theorem cleanTheorem : (2 : Nat) + 2 = 4 := rfl
+
+assert_axioms Zcash.Meta.Tests.CompiledOverride.cleanTheorem
+
+/-! ## An ambient-package target
+
+The disclosure sweep exempts the toolchain's own overrides — `Nat.add` is `@[extern]`, as are most
+of the arithmetic and container primitives whose compiled code every `native_decide` runs
+regardless. Censusing one *directly* is a different claim, though: there the substitution is the
+entry's own subject rather than background compiler trust, and `assert_computable`'s "genuinely
+computed" would be asserted of a body that never runs. The per-declaration check therefore applies
+to any target. -/
+
+/-- error: Nat.add carries '@[extern]', so its compiled body is not the body the kernel reduces and Lean checks no relation between the two. Nothing this census verifies about the kernel term constrains what compiled code — a `native_decide` over it in particular — computes. -/
+#guard_msgs (whitespace := lax) in
+assert_computable Nat.add
+
+/-! ## The bypass
+
+`capturedData` stands in for a fixture capture: `assert_computable` sees a plain safe `def` whose
+axioms are empty, `native_decide` evaluates the *compiled* body and certifies the match, and the
+kernel disagrees — `refutesAtKernel` proves the negation of what `fingerprintMatch` proves, both
+about the same constant. Every check that predates this file accepts the pair. -/
+
+def honestCaptured : List Nat := [1, 2, 3]
+
+unsafe def doctoredImpl : List Nat := [9, 9, 9]
+
+@[implemented_by doctoredImpl] def capturedData : List Nat := honestCaptured
+
+def target : List Nat := [9, 9, 9]
+
+theorem fingerprintMatch : capturedData = target := by native_decide
+
+theorem refutesAtKernel : capturedData ≠ target := by decide
+
+/-- error: Zcash.Meta.Tests.CompiledOverride.capturedData carries '@[implemented_by]', so its compiled body is not the body the kernel reduces and Lean checks no relation between the two. Nothing this census verifies about the kernel term constrains what compiled code — a `native_decide` over it in particular — computes. -/
+#guard_msgs (whitespace := lax) in
+assert_computable Zcash.Meta.Tests.CompiledOverride.capturedData
+
+/-! ## The certificate that consumes it
+
+Pinning the doctored data is only half the bypass: the entry that actually launders it is the
+`assert_axioms` on the `native_decide` certificate, whose own declaration is clean. What that entry
+reaches is a compiled body, which no axiom footprint records — so it is caught by the closure-wide
+disclosure check, naming the declaration responsible. -/
+
+/-- error: Zcash.Meta.Tests.CompiledOverride.fingerprintMatch cannot be censused: Zcash.Meta.Tests.CompiledOverride.capturedData (@[implemented_by]) substitute(s) a compiled body Lean never checks against the kernel body, so the value the compiler runs is unconstrained by anything proved about it. Use the proven-equality `@[csimp]` instead, or — if the substitution really belongs in the trusted base — disclose it in `Zcash.TrustBoundary` and add it to `Zcash.Meta.allowedCompiledBodyOverrides`. -/
+#guard_msgs (whitespace := lax) in
+assert_axioms Zcash.Meta.Tests.CompiledOverride.fingerprintMatch +native(
+  Zcash.Meta.Tests.CompiledOverride.fingerprintMatch)
+
+/-! An entry with no connection at all to the doctored declaration fails too. The census states the
+artifact's trusted base, and an unchecked compiled body inside it is undisclosed compiler trust
+wherever it sits; scoping the check to each entry's dependency cone would let the same commit that
+adds the override keep every unrelated entry green. -/
+
+/-- error: Zcash.Meta.Tests.CompiledOverride.honestCaptured cannot be censused: Zcash.Meta.Tests.CompiledOverride.capturedData (@[implemented_by]) substitute(s) a compiled body Lean never checks against the kernel body, so the value the compiler runs is unconstrained by anything proved about it. Use the proven-equality `@[csimp]` instead, or — if the substitution really belongs in the trusted base — disclose it in `Zcash.TrustBoundary` and add it to `Zcash.Meta.allowedCompiledBodyOverrides`. -/
+#guard_msgs (whitespace := lax) in
+assert_computable Zcash.Meta.Tests.CompiledOverride.honestCaptured
+
+/-! ## `@[extern]`
+
+The same swap without an `unsafe` helper: the compiled body becomes a foreign symbol, about which
+nothing at all is known. Both checks report it exactly as they report `@[implemented_by]`. -/
+
+@[extern "zcash_meta_tests_doctored_symbol"] def externData : List Nat := honestCaptured
+
+/-- error: Zcash.Meta.Tests.CompiledOverride.externData carries '@[extern]', so its compiled body is not the body the kernel reduces and Lean checks no relation between the two. Nothing this census verifies about the kernel term constrains what compiled code — a `native_decide` over it in particular — computes. -/
+#guard_msgs (whitespace := lax) in
+assert_computable Zcash.Meta.Tests.CompiledOverride.externData
+
+/-- error: Zcash.Meta.Tests.CompiledOverride.cleanTheorem cannot be censused: Zcash.Meta.Tests.CompiledOverride.capturedData (@[implemented_by]), Zcash.Meta.Tests.CompiledOverride.externData (@[extern]) substitute(s) a compiled body Lean never checks against the kernel body, so the value the compiler runs is unconstrained by anything proved about it. Use the proven-equality `@[csimp]` instead, or — if the substitution really belongs in the trusted base — disclose it in `Zcash.TrustBoundary` and add it to `Zcash.Meta.allowedCompiledBodyOverrides`. -/
+#guard_msgs (whitespace := lax) in
+assert_axioms Zcash.Meta.Tests.CompiledOverride.cleanTheorem
+
+end Zcash.Meta.Tests.CompiledOverride

--- a/Zcash/Meta/Tests/NativeSurface.lean
+++ b/Zcash/Meta/Tests/NativeSurface.lean
@@ -1,0 +1,106 @@
+import Zcash.Meta.AxiomCheck
+
+/-!
+# Regression tests for the native-certificate evaluated surface
+
+A `native_decide` auxiliary axiom asserts that the compiler's evaluation of a closed `Bool` term is
+the kernel's. `partial def` breaks the premise: the kernel constant is `opaque` with no body, and
+what the compiler runs in its place is an `unsafe` implementation with the termination check lifted.
+A certificate over such a constant therefore says nothing about anything the kernel could have
+checked — and the entry that would launder it is the `assert_axioms` on the certificate, whose own
+declaration is clean, so no per-declaration check reaches it.
+
+These declarations live in the test-only library for the same reason as
+`Zcash.Meta.Tests.AxiomCheck` and `Zcash.Meta.Tests.CompiledOverride`: the production `Zcash`
+import graph must never reach them. This is a module of its own so the closure-wide compiled-body
+sweep, which the sibling file deliberately trips, does not mask the checks pinned here.
+-/
+
+namespace Zcash.Meta.Tests.NativeSurface
+
+/-! ## The honest shape
+
+A certificate over ordinary `def` data passes, so the rejections below are not vacuous and the
+check is not simply refusing every `+native` entry. -/
+
+def honestCaptured : List Nat := [1, 2, 3]
+
+theorem honestMatch : honestCaptured = [1, 2, 3] := by native_decide
+
+assert_axioms Zcash.Meta.Tests.NativeSurface.honestMatch +native(
+  Zcash.Meta.Tests.NativeSurface.honestMatch)
+
+/-! ## `partial` data under a certificate
+
+`capturedPartial` needs a parameter only because `partial` requires a function type; the compiled
+body still ignores it and returns the attacker's list. The kernel cannot confirm the certificate,
+and — unlike the `@[implemented_by]` bypass, where the kernel value refutes the compiled one — it
+cannot refute it either, because there is no kernel value at all. -/
+
+partial def capturedPartial (_ : Unit) : List Nat :=
+  if 0 = 0 then [9, 9, 9] else capturedPartial ()
+
+def target : List Nat := [9, 9, 9]
+
+theorem partialMatch : capturedPartial () = target := by native_decide
+
+/-- error: Zcash.Meta.Tests.NativeSurface.partialMatch: the native_decide certificate evaluated the `partial` declaration(s) [Zcash.Meta.Tests.NativeSurface.capturedPartial], whose compiled body is an unsafe implementation the kernel never sees and whose kernel constant has no body at all. Nothing relates what ran to what the certificate says. Give the evaluated data an ordinary `def`. -/
+#guard_msgs (whitespace := lax) in
+assert_axioms Zcash.Meta.Tests.NativeSurface.partialMatch +native(
+  Zcash.Meta.Tests.NativeSurface.partialMatch)
+
+/-! The data itself was already rejected — a `partial def` is not a `def` — which is what makes the
+certificate entry the one that has to catch this. Pinned so the two halves stay distinguishable. -/
+
+/-- error: Zcash.Meta.Tests.NativeSurface.capturedPartial is not a def -/
+#guard_msgs (whitespace := lax) in
+assert_computable Zcash.Meta.Tests.NativeSurface.capturedPartial
+
+/-! ## A sealed `opaque` is not reported
+
+The reduction-barrier idiom this repository uses (`Zcash.Circuits.Action.TopLevel.actionCircuit`,
+`Zcash.Circuits.Integration.ActionGateCoherence.configureHandle`): the opaque's *type* carries the
+equation to its source, so the kernel can recover the value, and its compiled body is the declared
+one. The certificate below is therefore honest, and the check leaves it alone. -/
+
+def sealedSource : List Nat := [1, 2, 3]
+
+opaque sealed : { xs : List Nat // xs = sealedSource } := ⟨sealedSource, rfl⟩
+
+theorem sealedMatch : sealed.val = [1, 2, 3] := by rw [sealed.property]; native_decide
+
+assert_axioms Zcash.Meta.Tests.NativeSurface.sealedMatch +native(
+  Zcash.Meta.Tests.NativeSurface.sealedMatch)
+
+/-! ## `partial` behind a `@[csimp]` replacement
+
+The auxiliary axiom records the term as the *kernel* sees it, and `@[csimp]` replaces a constant
+wholesale in compiled code — so the certificate below runs `csimpFast` where its own statement says
+`csimpSlow`, and a walk of the statement alone would never reach `hiddenBehindCsimp`. This is not a
+hypothetical routing: `Zcash.Arithmetic.FastMsm` redirects the fixtures' MSM hot path exactly this
+way, so the replacement target's cone is where a `partial` would sit unnoticed.
+
+The csimp lemma stays at the end of the file: a replacement applies to code compiled after it, and
+the honest certificates above must be elaborated without it to keep their own coverage meaningful. -/
+
+partial def hiddenBehindCsimp (_ : Unit) : Nat := hiddenBehindCsimp ()
+
+def csimpSlow (n : Nat) : Nat := n
+
+/-- Equal to `csimpSlow` — the `partial` call sits in an argument the body discards, which is what
+lets the replacement be *proved* while still putting `hiddenBehindCsimp` in the compiled cone. -/
+def csimpFast (n : Nat) : Nat := (fun _ => n) (hiddenBehindCsimp ())
+
+@[csimp] theorem csimpSlow_eq_csimpFast : @csimpSlow = @csimpFast := by
+  funext n; rfl
+
+assert_axioms Zcash.Meta.Tests.NativeSurface.csimpSlow_eq_csimpFast
+
+theorem csimpCert : csimpSlow 7 = 7 := by native_decide
+
+/-- error: Zcash.Meta.Tests.NativeSurface.csimpCert: the native_decide certificate evaluated the `partial` declaration(s) [Zcash.Meta.Tests.NativeSurface.hiddenBehindCsimp], whose compiled body is an unsafe implementation the kernel never sees and whose kernel constant has no body at all. Nothing relates what ran to what the certificate says. Give the evaluated data an ordinary `def`. -/
+#guard_msgs (whitespace := lax) in
+assert_axioms Zcash.Meta.Tests.NativeSurface.csimpCert +native(
+  Zcash.Meta.Tests.NativeSurface.csimpCert)
+
+end Zcash.Meta.Tests.NativeSurface

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -101,6 +101,13 @@ proven-equality `@[csimp]` is used instead (`Zcash.Arithmetic.FastMsm`). The amb
 boundary is the compiler trust every `native_decide` carries, including the `@[extern]` `Task.spawn`
 / `Task.get` that `List.parMap` reaches, discussed under `@[csimp]` below.
 
+That bound reaches as far as the census entries do, which is not the same as every module built. The
+compiled-body sweep is stated over an entry's whole import closure rather than its dependency cone,
+so one entry covers far more than it depends on — but it still runs *from* entries, and a module that
+neither holds one nor is imported by one is outside every closure the sweep is stated over.
+`Zcash.Circuits.Tests` (the `CircuitCheck` target) is where that currently bites: its `#eval` VK and
+layout comparisons run compiled code, and no census entry reaches them.
+
 Both commands are built on `Lean.collectAxioms`, which walks a declaration's transitive
 *dependencies*. Coverage therefore flows downwards only: a declaration that nothing censused
 depends on is checked by nothing, however prominent it is. Deliverable endpoints are exactly the

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -93,13 +93,13 @@ Two commands from `Zcash.Meta.AxiomCheck`, per the breaks-as-computed-data disci
 
 Axioms bound what the *kernel* was asked to believe; they say nothing about what compiled code runs,
 and the fixtures' faithfulness certificates are `native_decide` proofs that run it. Both commands
-therefore also bound the compiled surface, and the bound is the same everywhere in this repository:
-outside the Lean toolchain and the pinned mathlib stack, nothing may substitute a compiled body
-(`@[implemented_by]`, `@[extern]`) and no `partial` declaration may appear in what a `native_decide`
-certificate evaluated. `Zcash.Meta.allowedCompiledBodyOverrides` is the disclosure list for the
-first, and it is empty: the proven-equality `@[csimp]` is used instead (`Zcash.Arithmetic.FastMsm`).
-The ambient side of that boundary is the compiler trust every `native_decide` carries, including the
-`@[extern]` `Task.spawn` / `Task.get` that `List.parMap` reaches, discussed under `@[csimp]` below.
+therefore also bound the compiled surface: outside the Lean toolchain and the pinned mathlib stack,
+nothing may substitute a compiled body (`@[implemented_by]`, `@[extern]`) and no `partial`
+declaration may appear in what a `native_decide` certificate evaluated. There is no disclosure list
+for the first — a substitution in a declaration this repository owns is rejected outright, and the
+proven-equality `@[csimp]` is used instead (`Zcash.Arithmetic.FastMsm`). The ambient side of that
+boundary is the compiler trust every `native_decide` carries, including the `@[extern]` `Task.spawn`
+/ `Task.get` that `List.parMap` reaches, discussed under `@[csimp]` below.
 
 Both commands are built on `Lean.collectAxioms`, which walks a declaration's transitive
 *dependencies*. Coverage therefore flows downwards only: a declaration that nothing censused

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -93,7 +93,8 @@ Two commands from `Zcash.Meta.AxiomCheck`, per the breaks-as-computed-data disci
 
 Axioms bound what the *kernel* was asked to believe; they say nothing about what compiled code runs,
 and the fixtures' faithfulness certificates are `native_decide` proofs that run it. Both commands
-therefore also bound the compiled surface: outside the Lean toolchain and the pinned mathlib stack,
+therefore also bound the compiled surface: outside the ambient roots
+(`Zcash.Meta.ambientPackageRoots`, the Lean toolchain and the pinned dependency stack),
 nothing may substitute a compiled body (`@[implemented_by]`, `@[extern]`) and no `partial`
 declaration may appear in what a `native_decide` certificate evaluated. There is no disclosure list
 for the first — a substitution in a declaration this repository owns is rejected outright, and the

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -91,6 +91,16 @@ Two commands from `Zcash.Meta.AxiomCheck`, per the breaks-as-computed-data disci
 * **Theorems** get `assert_axioms`, an upper bound at the standard tier
   (`propext` / `Classical.choice` / `Quot.sound`). Both commands reject `sorryAx`.
 
+Axioms bound what the *kernel* was asked to believe; they say nothing about what compiled code runs,
+and the fixtures' faithfulness certificates are `native_decide` proofs that run it. Both commands
+therefore also bound the compiled surface, and the bound is the same everywhere in this repository:
+outside the Lean toolchain and the pinned mathlib stack, nothing may substitute a compiled body
+(`@[implemented_by]`, `@[extern]`) and no `partial` declaration may appear in what a `native_decide`
+certificate evaluated. `Zcash.Meta.allowedCompiledBodyOverrides` is the disclosure list for the
+first, and it is empty: the proven-equality `@[csimp]` is used instead (`Zcash.Arithmetic.FastMsm`).
+The ambient side of that boundary is the compiler trust every `native_decide` carries, including the
+`@[extern]` `Task.spawn` / `Task.get` that `List.parMap` reaches, discussed under `@[csimp]` below.
+
 Both commands are built on `Lean.collectAxioms`, which walks a declaration's transitive
 *dependencies*. Coverage therefore flows downwards only: a declaration that nothing censused
 depends on is checked by nothing, however prominent it is. Deliverable endpoints are exactly the

--- a/_typos.toml
+++ b/_typos.toml
@@ -32,5 +32,6 @@ hsi = "hsi"  # hypothesis identifiers (`hsiN`) in Verifier/Assemble
 henc = "henc"  # hypothesis identifier (`henc`) in Circuits/Integration/ActionCopyWitness
 padd = "padd"  # projective point addition (`padd`) in Vendor/CompPoly/ScalarFftDefs
 Hom = "Hom"  # `RingHom`, `evalRingHom` — Mathlib's homomorphism naming
+thm = "thm"  # `.thmInfo` is Lean core's `ConstantInfo` constructor for theorems
 advices = "advices"
 colinear = "colinear"  # deliberate English spelling; we are not writing Latin

--- a/scripts/check_csimp_census.sh
+++ b/scripts/check_csimp_census.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Check that every `@[csimp]` declaration in the library is covered by an
-# `assert_axioms` entry in Zcash/TrustBoundary.lean. The compiler applies a
+# `assert_axioms` entry in some census file. The compiler applies a
 # csimp substitution in all downstream compiled code, but the axioms of the lemma's
 # own proof are not propagated into downstream `native_decide` axiom tracking (
 # lean4#7463), so a csimp lemma whose axioms go unchecked would be an
@@ -23,6 +23,22 @@ cd "$(dirname "$0")/.."
 # quoting rule).
 matches=$(grep -rn "csimp" Zcash/ --include="*.lean" || true)
 
+# Census entries that actually run, by final name component. Any census file counts, not just
+# Zcash/TrustBoundary.lean: entries are spread across the per-fixture boundaries and the test-only
+# libraries, and a lemma is pinned wherever its entry sits; requiring the main file would reject a
+# legitimate pin in a fixture boundary, and cannot be satisfied at all by a csimp lemma in a
+# test-only library that production must not import (`Zcash/Meta/Tests/`, the `MetaCheck` target).
+#
+# Widening the search to those files means excluding `#guard_msgs`-wrapped entries, which assert
+# that a census entry *fails* and so are the opposite of coverage. They sit at column 0 like real
+# entries -- the wrapper is the preceding line -- and `Zcash/Meta/Tests/` is full of them, so an
+# expected-to-fail entry would otherwise satisfy this check.
+censused=$(find Zcash -name "*.lean" -print0 | xargs -0 awk '
+  FNR == 1 { prev = "" }
+  /^assert_axioms / && prev !~ /^#guard_msgs/ { sub(/.*\./, "", $2); print $2 }
+  { prev = $0 }
+')
+
 status=0
 count=0
 while IFS=: read -r file lineno line; do
@@ -41,12 +57,9 @@ while IFS=: read -r file lineno line; do
     continue
   fi
   count=$((count + 1))
-  # Any census file counts, not just Zcash/TrustBoundary.lean. Census entries are spread across
-  # the per-fixture boundaries and the test-only libraries, and a lemma is pinned wherever its
-  # entry sits; requiring the main file would reject a legitimate pin in a fixture boundary, and
-  # cannot be satisfied at all by a csimp lemma in a test-only library that production must not
-  # import (`Zcash/Meta/Tests/`, the `MetaCheck` target).
-  if ! grep -rqE "^assert_axioms .*\.${name}( |\$)|^assert_axioms ${name}( |\$)" Zcash/ --include="*.lean"; then
+  # Herestring rather than a pipe: `grep -q` exits at the first match, which under `pipefail` would
+  # make a *successful* lookup fail the pipeline on the writer's SIGPIPE.
+  if ! grep -qxF "${name##*.}" <<< "$censused"; then
     echo "VIOLATION: csimp declaration ${name} ($file:$lineno) has no assert_axioms entry in any census file" >&2
     status=1
   fi

--- a/scripts/check_csimp_census.sh
+++ b/scripts/check_csimp_census.sh
@@ -41,8 +41,13 @@ while IFS=: read -r file lineno line; do
     continue
   fi
   count=$((count + 1))
-  if ! grep -qE "^assert_axioms .*\.${name}( |\$)|^assert_axioms ${name}( |\$)" Zcash/TrustBoundary.lean; then
-    echo "VIOLATION: csimp declaration ${name} ($file:$lineno) has no assert_axioms entry in Zcash/TrustBoundary.lean" >&2
+  # Any census file counts, not just Zcash/TrustBoundary.lean. Census entries are spread across
+  # the per-fixture boundaries and the test-only libraries, and a lemma is pinned wherever its
+  # entry sits; requiring the main file would reject a legitimate pin in a fixture boundary, and
+  # cannot be satisfied at all by a csimp lemma in a test-only library that production must not
+  # import (`Zcash/Meta/Tests/`, the `MetaCheck` target).
+  if ! grep -rqE "^assert_axioms .*\.${name}( |\$)|^assert_axioms ${name}( |\$)" Zcash/ --include="*.lean"; then
+    echo "VIOLATION: csimp declaration ${name} ($file:$lineno) has no assert_axioms entry in any census file" >&2
     status=1
   fi
 done <<< "$matches"


### PR DESCRIPTION
Pure hardening; makes the census check what the compiler actually runs, so nobody can slip in a fixture whose compiled value differs from the one the kernel proves things about. 