### PR TITLE
chore(fv): pin the instance-construction and generic-verifier audit floors

### DIFF
--- a/Zcash/Circuits.lean
+++ b/Zcash/Circuits.lean
@@ -88,8 +88,8 @@ import Zcash.Circuits.Action.SelectorCoherence
 import Zcash.Circuits.Integration
 
 /-!
-# Ironwood circuits
+# Orchard-protocol circuits
 
-Aggregator for the Ironwood (halo2-native) circuit modules. Ironwood is kept separate
-from the main `Clean` library export and can be built with `lake build Zcash`.
+Aggregator for the Orchard-protocol (halo2-native) circuit modules. These are kept
+separate from the main `Clean` library export and can be built with `lake build Zcash`.
 -/

--- a/Zcash/Circuits.lean
+++ b/Zcash/Circuits.lean
@@ -81,6 +81,7 @@ import Zcash.Circuits.Action.Circuit
 import Zcash.Circuits.Action.Bundle
 import Zcash.Circuits.Action.RealBases
 import Zcash.Circuits.Action.Spec
+import Zcash.Circuits.Action.Separation
 import Clean.Halo2.TopLevel
 import Zcash.Circuits.Action.TopLevel
 import Zcash.Circuits.Action.SelectorCoherence

--- a/Zcash/Circuits/Action/Bundle.lean
+++ b/Zcash/Circuits/Action/Bundle.lean
@@ -1,4 +1,4 @@
-import Zcash.Circuits.Action.CircuitPreIronwood
+import Zcash.Circuits.Action.CircuitPreNU63
 
 /-!
 # The Orchard Action circuit: bundle contract (spec / extract / elaborated)
@@ -142,16 +142,16 @@ theorem synthNotes_regionCount (G : Generators) (B : Bases) (W : Witnesses Fp)
 stage, the 91-region note stage — 394. -/
 theorem synthesize_regionCount (G : Generators) (B : Bases) (W : Witnesses Fp)
     (cfg : Config) (i : RegionIndex) :
-    Operations.regionCount ((CircuitPreIronwood.synthesize G B W cfg).operations i)
+    Operations.regionCount ((CircuitPreNU63.synthesize G B W cfg).operations i)
       = 394 := by
-  simp only [CircuitPreIronwood.synthesize, synthesizeBase, circuit_norm,
+  simp only [CircuitPreNU63.synthesize, synthesizeBase, circuit_norm,
     Circuit.operations_bind, Circuit.operations_pure, Operations.regionCount_append]
   rw [synthWitness_regionCount, synthChecks_regionCount, synthNotes_regionCount]
 
 /-- The base Action synthesis with its one fixed hint-backed witness program. -/
 def main (G : Generators) (B : Bases) (cfg : Config) :
     Var unit Fp → Circuit Fp (Var AddressPoints Fp) := fun _ =>
-  CircuitPreIronwood.synthesize G B hintWitnesses cfg
+  CircuitPreNU63.synthesize G B hintWitnesses cfg
 
 theorem main_regionCount (G : Generators) (B : Bases) (cfg : Config)
     (input : Var unit Fp) (i : RegionIndex) :
@@ -351,8 +351,8 @@ def SpecBase (G : Generators) (B : Bases) (wit : ActionData) : Prop :=
   wit.vOld * (1 - wit.enableSpend) = 0 ∧
   wit.vNew * (1 - wit.enableOutput) = 0
 
-/-- The pre-ironwood bundle's contract: the base statement, plus the output cells
-carrying the four witnessed address points (what the ironwood cross-address stage
+/-- The pre-NU6.3 bundle's contract: the base statement, plus the output cells
+carrying the four witnessed address points (what the post-NU6.3 cross-address stage
 consumes). -/
 def Spec (G : Generators) (B : Bases)
     (_ : Value unit Fp) (out : Value AddressPoints Fp) (wit : ActionData) :
@@ -776,7 +776,7 @@ instance elaborated (G : Generators) (B : Bases) (cfg : Config) :
   regionCount _ := 394
   output_eq := by
     intro _ i₀
-    simp only [main, CircuitPreIronwood.synthesize, synthesizeBase,
+    simp only [main, CircuitPreNU63.synthesize, synthesizeBase,
       Circuit.output_bind, Circuit.output_pure,
       synthWitness_output, synthWitness_nextRegionIndex, synthChecks_output,
       synthChecks_nextRegionIndex, synthNotes_output]
@@ -794,7 +794,7 @@ theorem soundness (G : Generators) (B : Bases) (cfg : Config) :
   let input_var_rivk := hintWitnesses.rivk
   let input_var_rcmOld := hintWitnesses.rcmOld
   let input_var_rcmNew := hintWitnesses.rcmNew
-  simp only [CircuitPreIronwood.synthesize, synthesizeBase, circuit_norm] at hc
+  simp only [CircuitPreNU63.synthesize, synthesizeBase, circuit_norm] at hc
   have hW := hc.1
   have hCk := hc.2.1
   have hN := hc.2.2
@@ -1212,7 +1212,7 @@ theorem completeness (G : Generators) (B : Bases) (cfg : Config) :
   let input_var_rcmNew := hintWitnesses.rcmNew
   let input_var_merkleSib := hintWitnesses.merkleSib
   let input_var_merkleSwap := hintWitnesses.merkleSwap
-  simp only [CircuitPreIronwood.synthesize, synthesizeBase,
+  simp only [CircuitPreNU63.synthesize, synthesizeBase,
     circuit_norm] at hwit ⊢
   have hWw := hwit.1
   have hWc := hwit.2.1
@@ -1913,7 +1913,7 @@ def baseCircuit (G : Generators) (B : Bases) :
   soundness := soundness G B
   completeness := completeness G B
 
-/-! ## The ironwood (post-NU 6.3) circuit bundle
+/-! ## The post-NU6.3 circuit bundle
 
 The main circuit: the proven base circuit called as a subcircuit, then the
 `"post-NU 6.3 cross-address checks"` region on its output cells. -/
@@ -1925,7 +1925,7 @@ private theorem aafi_output (instCol : Column .instance) (r : ℕ)
 
 derive_contract_bridges base (G : Generators) (B : Bases) := baseCircuit G B
 
-/-- The deployed ironwood synthesis: the fixed hint-backed Action witness program,
+/-- The deployed post-NU6.3 synthesis: the fixed hint-backed Action witness program,
 followed by the cross-address region. The verifier-visible input is `unit`; prover
 choices enter only through `hintWitnesses` and the runtime `ProverHint`. -/
 def mainPost (G : Generators) (B : Bases) (cfg : Config) :
@@ -2005,7 +2005,7 @@ def extractPost (cfg : Config) (_ : Var unit Fp) (i : RegionIndex)
       env.env.get cfg.primary (DISABLE_CROSS_ADDRESS : ℤ) :=
   rfl
 
-/-- The ironwood Action statement: the base §4.17.4 statement, plus the post-NU 6.3
+/-- The post-NU6.3 Action statement: the base §4.17.4 statement, plus the post-NU6.3
 cross-address binding — a nonzero `DISABLE_CROSS_ADDRESS` instance row forces the new
 note's diversified address to equal the old note's. -/
 def SpecPost (G : Generators) (B : Bases)
@@ -2013,7 +2013,7 @@ def SpecPost (G : Generators) (B : Bases)
   SpecBase G B wit ∧
   (wit.disableCrossAddress ≠ 0 → wit.gdOld = wit.gdNew ∧ wit.pkdOld = wit.pkdNew)
 
-/-- Honest-prover preconditions for the ironwood circuit: the base preconditions, and
+/-- Honest-prover preconditions for the post-NU6.3 circuit: the base preconditions, and
 the cross-address rows hold at the honest values (the flag is off, or the addresses
 coincide). -/
 def ProverAssumptionsPost (G : Generators) (B : Bases)
@@ -2241,9 +2241,9 @@ theorem completenessPost
       · rw [w7, w1]
         ring
 
-/-- Rust `impl Circuit for Circuit` on the ironwood branch (post-NU 6.3) as a
-proof-carrying bundle: the e2e Orchard Action statement (§4.17.4 + cross-address
-binding, breaks-as-data) over the extracted primary-instance rows and witness data. -/
+/-- Rust post-NU6.3 `impl Circuit for Circuit` as a proof-carrying bundle: the e2e
+Orchard Action statement (§4.17.4 + cross-address binding, breaks-as-data) over the
+extracted primary-instance rows and witness data. -/
 def circuit (G : Generators) (B : Bases) :
     FormalCircuit Fp Unit Config unit unit where
   name := "OrchardAction"

--- a/Zcash/Circuits/Action/Circuit.lean
+++ b/Zcash/Circuits/Action/Circuit.lean
@@ -11,7 +11,7 @@ import Zcash.Circuits.Action.SpendAuthority
 import Zcash.Circuits.Action.AddressIntegrity
 
 /-!
-# The Orchard Action circuit (Ironwood): configure
+# The Orchard-protocol Action circuit: configure
 
 Reference (ported from actual Rust, not memory):
 `orchard@0.14.0/src/circuit.rs`, `impl plonk::Circuit for Circuit` —
@@ -438,7 +438,7 @@ def synthNotes (G : Generators) (B : Bases) (W : Witnesses Fp) (cfg : Config)
     (orchardGate cfg.qOrchard cfg.advices).enable 0)
   pure { gdNew, pkdNew }
 
-/-- Rust `AddressPoints` (ironwood `circuit.rs`): the old/new-note diversified-address
+/-- Rust `AddressPoints` (orchard `circuit.rs`): the old/new-note diversified-address
 points the cross-address stage compares — the base circuit's output. -/
 structure AddressPoints (F : Type) where
   gdOld : Point F
@@ -447,7 +447,7 @@ structure AddressPoints (F : Type) where
   pkdNew : Point F
 deriving ProvableStruct
 
-/-- Ironwood `Circuit::synthesize_cross_address_checks` (`circuit.rs:920-1035`): the
+/-- The post-NU6.3 `Circuit::synthesize_cross_address_checks` (`circuit.rs:920-1035`): the
 `"post-NU 6.3 cross-address checks"` region — one row per address coordinate, reusing
 the `q_orchard` gate as `disableCrossAddress − 0 = disableCrossAddress · 1` (value
 row), `disableCrossAddress · (old − new) = 0` (root/anchor row), with both enable
@@ -478,8 +478,8 @@ def synthCrossAddressChecks (cfg : Config) (pts : Var AddressPoints Fp) :
 
 /-- Rust `Circuit::synthesize_base` (`circuit.rs:461-828`): the staged witness /
 integrity-check / note-commitment composition, returning the `AddressPoints` the
-ironwood cross-address stage reads. This alone is the pre-ironwood (fixed post-NU 6.2)
-circuit — see `Action/CircuitPreIronwood.lean`. -/
+post-NU6.3 cross-address stage reads. This alone is the pre-NU6.3 (fixed post-NU6.2)
+circuit — see `Action/CircuitPreNU63.lean`. -/
 def synthesizeBase (G : Generators) (B : Bases) (W : Witnesses Fp) (cfg : Config) :
     Circuit Fp (Var AddressPoints Fp) := do
   let wc ← synthWitness G W cfg
@@ -487,8 +487,8 @@ def synthesizeBase (G : Generators) (B : Bases) (W : Witnesses Fp) (cfg : Config
   let nc ← synthNotes G B W cfg wc cc
   pure { gdOld := wc.gdOld, pkdOld := cc.pkdOld, gdNew := nc.gdNew, pkdNew := nc.pkdNew }
 
-/-- The ironwood (post-NU 6.3) `Circuit::synthesize` — THE top-level circuit this repo
-targets: the base stages plus the cross-address checks region. -/
+/-- The post-NU6.3 `Circuit::synthesize` — the base stages plus the cross-address
+checks region. -/
 def synthesize (G : Generators) (B : Bases) (W : Witnesses Fp) (cfg : Config) :
     Circuit Fp Unit := do
   let pts ← synthesizeBase G B W cfg

--- a/Zcash/Circuits/Action/CircuitPreNU63.lean
+++ b/Zcash/Circuits/Action/CircuitPreNU63.lean
@@ -1,17 +1,17 @@
 import Zcash.Circuits.Action.Circuit
 
 /-!
-# The pre-ironwood Orchard Action circuit (fixed post-NU 6.2)
+# The pre-NU6.3 Orchard Action circuit (fixed post-NU6.2)
 
 The historical/current-network circuit: `Circuit::synthesize_base` alone — the staged
 composition of the witness, integrity-check, and note-commitment stages, WITHOUT the
-ironwood `"post-NU 6.3 cross-address checks"` region. The ironwood circuit (this
-repo's main target) is `Action.Circuit.synthesize`; both share `configure` (the
-constraint system is version-independent — `Config::configure` on the ironwood
-branch), all three stages, and therefore all VK CS fixtures.
+`"post-NU 6.3 cross-address checks"` region. The post-NU6.3 circuit (this repo's main
+target) is `Action.Circuit.synthesize`; both share `configure` (the constraint system
+is version-independent — `Config::configure` on orchard's `ironwood` branch), all three
+stages, and therefore all VK CS fixtures.
 -/
 
-namespace Zcash.Circuits.Action.CircuitPreIronwood
+namespace Zcash.Circuits.Action.CircuitPreNU63
 
 open Halo2
 open Specs.Sinsemilla (Generators)
@@ -24,4 +24,4 @@ def synthesize (G : Generators) (B : Bases) (W : Witnesses Fp) (cfg : Config) :
     Circuit Fp (Var AddressPoints Fp) :=
   synthesizeBase G B W cfg
 
-end Zcash.Circuits.Action.CircuitPreIronwood
+end Zcash.Circuits.Action.CircuitPreNU63

--- a/Zcash/Circuits/Action/DeriveNullifier.lean
+++ b/Zcash/Circuits/Action/DeriveNullifier.lean
@@ -8,14 +8,14 @@ import Zcash.Circuits.Poseidon.Hash
 import Zcash.Circuits.Utilities.AddChip
 
 /-!
-# Orchard nullifier derivation (Ironwood)
+# Orchard-protocol nullifier derivation
 
 Reference (ported from actual Rust, not memory):
 `orchard@0.14.0/src/circuit/gadget.rs::derive_nullifier` (lines 154-206):
 `nf = extract_p(cm + [poseidon_hash(nk, rho) + psi] NullifierK)` — four layouter pieces
 in source order:
 1. `PoseidonHash::init` + `hash([nk, rho])` (`ConstantLength<2>` on the Pow5 chip; the
-   Ironwood `Poseidon.hash` bundle at capacity `2·2⁶⁴`);
+   Orchard-protocol `Poseidon.hash` bundle at capacity `2·2^{64}`);
 2. `add_chip.add(hash, psi)` (region `"c = a + b"`, `add_chip.rs:71-91`);
 3. `FixedPointBaseField::from_inner(NullifierK).mul(scalar)` (the
    `Ecc.MulFixed.BaseFieldElem` bundle);
@@ -41,10 +41,10 @@ structure Input (F : Type) where
   cm : Point F
 deriving ProvableStruct
 
-/-- The `ConstantLength<2>` hash value is the one-padded-block hash at capacity `2·2⁶⁴`:
-the message is exactly one rate-2 block, so the donor scheduler's fold is a single
-absorb/permute step — the value-level bridge onto the Ironwood `Poseidon.hash` bundle's
-`HashPaddedBlock` contract. -/
+/-- The `ConstantLength<2>` hash value is the one-padded-block hash at capacity
+`2·2^{64}`: the message is exactly one rate-2 block, so the donor scheduler's fold
+is a single absorb/permute step — the value-level bridge onto the Orchard-protocol
+`Poseidon.hash` bundle's `HashPaddedBlock` contract. -/
 theorem constantLength_value_two (a b : Fp) :
     Hash.ConstantLength.value #v[a, b]
       = Hash.HashPaddedBlock.value roundConstants (Hash.ConstantLength.capacity 2)

--- a/Zcash/Circuits/Action/Separation.lean
+++ b/Zcash/Circuits/Action/Separation.lean
@@ -1,0 +1,83 @@
+import Mathlib.Util.AssertNoSorry
+import Zcash.Circuits.Action.CircuitPreIronwood
+import Zcash.Circuits.Action.Spec
+
+/-!
+# The pre-ironwood contract omits the cross-address policy
+
+The NU 6.3 upgrade adds exactly one clause to the Action statement: the cross-address
+binding.  This file pins that localization, machine-checked at the deployed generators and
+bases:
+
+* `preIronwood_synthesize_eq_base` — the pre-ironwood circuit is *definitionally*
+  `synthesizeBase` alone: it never runs the `synthCrossAddressChecks` region the ironwood
+  `synthesize` appends (`Circuit.lean`).
+* `specPost_iff_base_and_crossAddress` — the ironwood contract `SpecPost` is exactly the
+  base statement `SpecBase` conjoined with the cross-address clause, so the two differ in
+  precisely that clause.
+* `preIronwood_spec_omits_crossAddress` — the pre-ironwood contract `Spec` guarantees only
+  `SpecBase` (plus its output-carrying rows), never the cross-address clause.
+* `crossAddressBinding_nontrivial` — that clause is a genuine restriction: a witness with the
+  flag set and distinct old/new diversified bases falsifies it.
+
+Together these localize the entire post-NU 6.3 policy to the one clause the old key cannot
+enforce; height-based key selection is the deployed obligation that keeps the old key from
+being chosen after activation (`book/src/design/action-circuit.md`).
+
+Not established here: a *satisfying* pre-ironwood witness that violates the clause — i.e.
+`¬ ∀ wit, SpecBase G B wit → crossAddressBinding wit`.  A concrete such witness must open the
+honest `Commit^ivk`/note/nullifier chains, whose `[ivk]·g_d` and Poseidon-scalar terms are
+~255-bit `nsmul`s that `native_decide` cannot evaluate; that separation is left as the
+remaining step.
+-/
+
+namespace Zcash.Circuits.Action.Separation
+
+open Halo2
+open Circuit
+open Specs.Sinsemilla (Generators)
+
+variable (G : Generators) (B : Bases) (W : Witnesses Fp) (cfg : Config)
+
+/-- **The pre-ironwood circuit is `synthesizeBase` alone.**  Definitionally equal — the ironwood
+`synthCrossAddressChecks` region is absent, so no constraint of the pre-NU 6.3 key depends on
+`disableCrossAddress`. -/
+theorem preIronwood_synthesize_eq_base :
+    CircuitPreIronwood.synthesize G B W cfg = synthesizeBase G B W cfg := rfl
+
+/-- The post-NU 6.3 cross-address binding, as a standalone clause: a nonzero
+`disableCrossAddress` forces both new-note address components to equal the old note's. -/
+def crossAddressBinding (wit : ActionData) : Prop :=
+  wit.disableCrossAddress ≠ 0 → wit.gdOld = wit.gdNew ∧ wit.pkdOld = wit.pkdNew
+
+/-- **The ironwood contract is the base contract plus exactly the cross-address clause.**  The two
+statements separate in precisely this conjunct. -/
+theorem specPost_iff_base_and_crossAddress (wit : ActionData) :
+    SpecPost G B () () wit ↔ SpecBase G B wit ∧ crossAddressBinding wit := Iff.rfl
+
+/-- **The pre-ironwood contract omits the cross-address clause.**  Its guarantee is `SpecBase`
+(with the output-carrying rows); nothing in it constrains the cross-address relation, so a prover
+bound only by the old key is free on it. -/
+theorem preIronwood_spec_omits_crossAddress
+    (out : Value AddressPoints Fp) (wit : ActionData)
+    (h : Spec G B () out wit) : SpecBase G B wit := h.1
+
+/-- **The cross-address clause is a real restriction.**  A witness carrying `disableCrossAddress = 1`
+with distinct old/new diversified bases falsifies it — so conjoining it in `SpecPost` genuinely
+narrows the accepted set relative to `SpecBase`.  (`merkleQ`/`ivkQ` are two distinct deployed
+domain points, used here only as a convenient pair of unequal on-curve points.) -/
+theorem crossAddressBinding_nontrivial :
+    ∃ wit : ActionData, wit.disableCrossAddress ≠ 0 ∧ ¬ crossAddressBinding wit := by
+  refine ⟨{ (default : ActionData) with
+      disableCrossAddress := 1, gdOld := orchardBases.merkleQ, gdNew := orchardBases.ivkQ },
+    one_ne_zero, ?_⟩
+  intro hbind
+  have hne : orchardBases.merkleQ ≠ orchardBases.ivkQ := by native_decide
+  exact hne (hbind one_ne_zero).1
+
+assert_no_sorry preIronwood_synthesize_eq_base
+assert_no_sorry specPost_iff_base_and_crossAddress
+assert_no_sorry preIronwood_spec_omits_crossAddress
+assert_no_sorry crossAddressBinding_nontrivial
+
+end Zcash.Circuits.Action.Separation

--- a/Zcash/Circuits/Action/Separation.lean
+++ b/Zcash/Circuits/Action/Separation.lean
@@ -1,34 +1,32 @@
-import Mathlib.Util.AssertNoSorry
-import Zcash.Circuits.Action.CircuitPreIronwood
+import Zcash.Circuits.Action.CircuitPreNU63
 import Zcash.Circuits.Action.Spec
 
 /-!
-# The pre-ironwood contract omits the cross-address policy
+# The pre- and post-NU6.3 circuits differ exactly by same-address enforcement
 
-The NU 6.3 upgrade adds exactly one clause to the Action statement: the cross-address
-binding.  This file pins that localization, machine-checked at the deployed generators and
-bases:
+The circuit used after the NU6.3 upgrade adds exactly one clause to the Action statement:
+the cross-address binding. This file pins that fact, machine-checked at the deployed
+generators and bases:
 
-* `preIronwood_synthesize_eq_base` — the pre-ironwood circuit is *definitionally*
-  `synthesizeBase` alone: it never runs the `synthCrossAddressChecks` region the ironwood
-  `synthesize` appends (`Circuit.lean`).
-* `specPost_iff_base_and_crossAddress` — the ironwood contract `SpecPost` is exactly the
+* `preNU63_synthesize_eq_base` — the pre-NU6.3 circuit is definitionally `synthesizeBase`
+  alone: it never runs the `synthCrossAddressChecks` region the NU6.3 `synthesize` appends
+  (`Circuit.lean`).
+* `specPost_iff_base_and_crossAddress` — the post-NU6.3 contract `SpecPost` is exactly the
   base statement `SpecBase` conjoined with the cross-address clause, so the two differ in
   precisely that clause.
-* `preIronwood_spec_omits_crossAddress` — the pre-ironwood contract `Spec` guarantees only
-  `SpecBase` (plus its output-carrying rows), never the cross-address clause.
-* `crossAddressBinding_nontrivial` — that clause is a genuine restriction: a witness with the
-  flag set and distinct old/new diversified bases falsifies it.
+* `preNU63_spec_omits_crossAddress` — the pre-NU6.3 contract `Spec` guarantees only
+  `SpecBase` (plus its output-carrying rows), without the cross-address clause.
+* `crossAddressBinding_nontrivial` — that clause is a genuine restriction: a witness with
+  the flag set and distinct old/new diversified bases falsifies it.
 
-Together these localize the entire post-NU 6.3 policy to the one clause the old key cannot
-enforce; height-based key selection is the deployed obligation that keeps the old key from
-being chosen after activation (`book/src/design/action-circuit.md`).
-
-Not established here: a *satisfying* pre-ironwood witness that violates the clause — i.e.
-`¬ ∀ wit, SpecBase G B wit → crossAddressBinding wit`.  A concrete such witness must open the
-honest `Commit^ivk`/note/nullifier chains, whose `[ivk]·g_d` and Poseidon-scalar terms are
-~255-bit `nsmul`s that `native_decide` cannot evaluate; that separation is left as the
-remaining step.
+Not established here:
+* That consensus nodes correctly implement the rules specifying which verifying key is
+  used before and after NU6.3 activation.
+* A *satisfying* pre-NU6.3 witness that violates the clause — i.e.
+  `¬ ∀ wit, SpecBase G B wit → crossAddressBinding wit`. A concrete such witness must
+  open the honest `Commit^ivk`/note/nullifier chains, whose `[ivk] g_d` and
+  Poseidon-scalar terms are ~255-bit `nsmul`s that `native_decide` cannot evaluate; that
+  separation is left as the remaining step.
 -/
 
 namespace Zcash.Circuits.Action.Separation
@@ -39,26 +37,26 @@ open Specs.Sinsemilla (Generators)
 
 variable (G : Generators) (B : Bases) (W : Witnesses Fp) (cfg : Config)
 
-/-- **The pre-ironwood circuit is `synthesizeBase` alone.**  Definitionally equal — the ironwood
-`synthCrossAddressChecks` region is absent, so no constraint of the pre-NU 6.3 key depends on
+/-- **The pre-NU6.3 circuit is `synthesizeBase` alone.**  Definitionally equal — the NU6.3
+`synthCrossAddressChecks` region is absent, so no constraint of the pre-NU6.3 key depends on
 `disableCrossAddress`. -/
-theorem preIronwood_synthesize_eq_base :
-    CircuitPreIronwood.synthesize G B W cfg = synthesizeBase G B W cfg := rfl
+theorem preNU63_synthesize_eq_base :
+    CircuitPreNU63.synthesize G B W cfg = synthesizeBase G B W cfg := rfl
 
-/-- The post-NU 6.3 cross-address binding, as a standalone clause: a nonzero
+/-- The post-NU6.3 cross-address binding, as a standalone clause: a nonzero
 `disableCrossAddress` forces both new-note address components to equal the old note's. -/
 def crossAddressBinding (wit : ActionData) : Prop :=
   wit.disableCrossAddress ≠ 0 → wit.gdOld = wit.gdNew ∧ wit.pkdOld = wit.pkdNew
 
-/-- **The ironwood contract is the base contract plus exactly the cross-address clause.**  The two
+/-- **The NU6.3 contract is the base contract plus exactly the cross-address clause.**  The two
 statements separate in precisely this conjunct. -/
 theorem specPost_iff_base_and_crossAddress (wit : ActionData) :
     SpecPost G B () () wit ↔ SpecBase G B wit ∧ crossAddressBinding wit := Iff.rfl
 
-/-- **The pre-ironwood contract omits the cross-address clause.**  Its guarantee is `SpecBase`
+/-- **The pre-NU6.3 contract omits the cross-address clause.**  Its guarantee is `SpecBase`
 (with the output-carrying rows); nothing in it constrains the cross-address relation, so a prover
 bound only by the old key is free on it. -/
-theorem preIronwood_spec_omits_crossAddress
+theorem preNU63_spec_omits_crossAddress
     (out : Value AddressPoints Fp) (wit : ActionData)
     (h : Spec G B () out wit) : SpecBase G B wit := h.1
 
@@ -74,10 +72,5 @@ theorem crossAddressBinding_nontrivial :
   intro hbind
   have hne : orchardBases.merkleQ ≠ orchardBases.ivkQ := by native_decide
   exact hne (hbind one_ne_zero).1
-
-assert_no_sorry preIronwood_synthesize_eq_base
-assert_no_sorry specPost_iff_base_and_crossAddress
-assert_no_sorry preIronwood_spec_omits_crossAddress
-assert_no_sorry crossAddressBinding_nontrivial
 
 end Zcash.Circuits.Action.Separation

--- a/Zcash/Circuits/Action/SpendAuthority.lean
+++ b/Zcash/Circuits/Action/SpendAuthority.lean
@@ -7,7 +7,7 @@ import Zcash.Circuits.Ecc.MulFixed.FullWidth
 import Clean.Halo2.CircuitTypeDeriving
 
 /-!
-# Orchard spend authority (Ironwood)
+# Orchard-protocol spend authority
 
 Reference (ported from actual Rust, not memory):
 `orchard@0.14.0/src/circuit.rs`, the `Spend authority` block in `Circuit::synthesize`

--- a/Zcash/Circuits/Action/TopLevel.lean
+++ b/Zcash/Circuits/Action/TopLevel.lean
@@ -22,7 +22,7 @@ theorem initialGeneratorTableIdx_mem
     List.append_nil]
   apply List.mem_append_left
   rw [FormalCircuit.call_operations]
-  simp only [baseCircuit, main, CircuitPreIronwood.synthesize, synthesizeBase,
+  simp only [baseCircuit, main, CircuitPreNU63.synthesize, synthesizeBase,
     Circuit.operations_bind, Circuit.operations_pure, List.append_nil]
   apply List.mem_append_left
   simp only [synthWitness, Circuit.operations_bind, Circuit.operations_pure,

--- a/Zcash/Circuits/Action/ValueCommit.lean
+++ b/Zcash/Circuits/Action/ValueCommit.lean
@@ -8,7 +8,7 @@ import Clean.Halo2.CircuitTypeDeriving
 import Zcash.Circuits.Ecc.MulFixed.Short
 
 /-!
-# Orchard value commitment (Ironwood)
+# Orchard-protocol value commitment
 
 Reference (ported from actual Rust, not memory):
 `orchard@0.14.0/src/circuit/gadget.rs::value_commit_orchard` (lines 115-148):

--- a/Zcash/Circuits/CommitIvk/MainBundle.lean
+++ b/Zcash/Circuits/CommitIvk/MainBundle.lean
@@ -31,7 +31,7 @@ private theorem short_output (b : ℕ) (cfg : LookupRangeCheck.Config 10)
 
 /-! ## Value-level infrastructure -/
 
-/-- The Ironwood `Chain.PieceChunks` is the donor's, verbatim. -/
+/-- The ironwood `Chain.PieceChunks` is the donor's, verbatim. -/
 private theorem pieceChunks_donor_iff :
     ∀ (ms : List ℕ) (pieces : Vector Fp ms.length) (chunks : List ℕ),
       Sinsemilla.Chain.PieceChunks ms pieces chunks ↔
@@ -49,7 +49,7 @@ private theorem pieceChunks_donor_iff :
     · rintro ⟨msf, h1, h2, tailChunks, h3, h4⟩
       exact ⟨msf, h1, h2, tailChunks, h3, (ih _ _).mpr h4⟩
 
-/-- The Ironwood `Chain.ZsFacts` is the donor's, verbatim. -/
+/-- The ironwood `Chain.ZsFacts` is the donor's, verbatim. -/
 private theorem zsFacts_donor_iff :
     ∀ (ms : List ℕ) (chunks : List ℕ)
       (zs : Sinsemilla.HVec (Sinsemilla.Chain.zLengths ms) Fp),

--- a/Zcash/Circuits/Ecc/Chip.lean
+++ b/Zcash/Circuits/Ecc/Chip.lean
@@ -8,7 +8,7 @@ import Zcash.Circuits.Ecc.MulFixed.Short
 import Zcash.Circuits.Ecc.MulFixed.BaseFieldElem
 
 /-!
-# ECC chip configure (Ironwood)
+# Orchard-protocol ECC chip configure
 
 The aggregate ECC configuration, in VK-exact registration order: witness point, incomplete
 addition, complete addition, variable-base mul, the shared `mul_fixed` core, then the

--- a/Zcash/Circuits/Ecc/MulAssignTheorems.lean
+++ b/Zcash/Circuits/Ecc/MulAssignTheorems.lean
@@ -49,7 +49,7 @@ natural-number value. `chainNat` mirrors `z ↦ 2z + bit` over `ℕ`.
 
 The chain/canonicity lemmas of this file (`chainNat_*`, `chain_cast`, `accScalar_closed`,
 `nsmul_step`, `neg_add_nsmul`, `k_canonical`, `m_bounds`, `cells_kNat`, `z0_cell_value`,
-`overflow_spec_honest`) are public: the Ironwood region-level port
+`overflow_spec_honest`) are public: the ironwood region-level port
 (`Clean/Ironwood/Ecc/Mul.lean`) consumes them directly. -/
 
 /-- The running sum continued from `zin` by `b` steps of `z ↦ 2z + bit`. -/

--- a/Zcash/Circuits/Fixtures/PROVENANCE.md
+++ b/Zcash/Circuits/Fixtures/PROVENANCE.md
@@ -32,8 +32,8 @@ the `SimpleFloorPlanner` exactly as `keygen_vk` does.
 | Fact | Status |
 |---|---|
 | halo2_proofs version | 0.3.2 (github.com/zcash/halo2) — recorded in `Layout.lean` |
-| Base (pre-NU 6.3) circuit | orchard 0.14.0 — the `actionBase` dump is byte-identical to the 0.14.0 circuit, verified on the ironwood branch (`TestVkLayoutActionBase.lean`) |
-| Post (NU 6.3 / ironwood) circuit | the orchard ironwood branch (`Circuit::synthesize` with `synthesize_cross_address_checks`) |
+| Pre-NU6.3 circuit | orchard 0.14.0 — the `actionBase` dump is byte-identical to the 0.14.0 circuit (`TestVkLayoutActionBase.lean`) |
+| Post-NU6.3 circuit | orchard 0.15.0 (`Circuit::synthesize` with `synthesize_cross_address_checks`) |
 | Instrumented halo2 / orchard commit hashes | Not pinned to a public commit. The `dump_lean` / `layout_dump` / `dump_layout_action` instrumentation is one-off tooling in local checkouts of halo2/orchard — it exists only to emit these fixtures for the VK-match tests, is not production code, and by decision is not being upstreamed to main. So there is no public commit to pin and no byte-for-byte regeneration from public sources. |
 
 Note that zcash/halo2#922 does **not** close this: it concerns the *separate*
@@ -97,16 +97,16 @@ instrumented checkouts of the actual `zcash/halo2` (halo2_proofs 0.3.2) and
 `zcash/orchard` code: the dump tooling (`halo2_proofs::plonk::dump_lean`,
 `layout_dump`) hooks the real `Circuit::configure` / `keygen_vk` path and serializes
 the real constraint system, selector-compression map, permutation σ, and fixed cells.
-They are not hand-written and not from a reimplementation. For the post-NU 6.3
-circuit there is no deployed source in any case — the orchard ironwood branch *is*
-the circuit-in-development, and that is what was dumped.
+They are not hand-written and not from a reimplementation. The post-NU6.3 circuit is
+now released in orchard 0.15.0, but these dumps were taken earlier, from an
+instrumented pre-release commit rather than from the 0.15.0 release — a commit that
+was never recorded (see *What's missing*).
 
 **What's missing.** Any machine-checkable proof of that lineage. The instrumented
 forks were never published and their commit hashes never recorded, so the generation
-cannot currently be re-run to confirm the checked-in bytes correspond to
-orchard 0.14.0 / the ironwood branch as claimed. Those claims exist only as prose in
-test docstrings. This file therefore marks the fork commits **UNKNOWN**
-rather than inventing pins.
+cannot currently be re-run to confirm the checked-in bytes correspond to orchard
+0.14.0 / 0.15.0 as claimed. Those claims exist only as prose in test docstrings.
+This file therefore marks the fork commits **UNKNOWN** rather than inventing pins.
 
 **What limits the damage.** Two independent corroborations:
 
@@ -128,7 +128,7 @@ rather than inventing pins.
   checked-in bytes — the circuit-side analogue of what `fixtures.yml` already does
   for the `Zcash/Snark/Fixtures/` verifier-fingerprint captures (see
   `Zcash/Snark/Fixtures/PROVENANCE.md`).
-- For the base (pre-NU 6.3) circuit, a stronger check is available: verify the
+- For the pre-NU6.3 circuit, a stronger check is available: verify the
   dumped constraint system against the actual mainnet Orchard verifying key — a
   fixed public artifact — tying the chain to the deployed network rather than to
   any checkout.

--- a/Zcash/Circuits/Integration/README.md
+++ b/Zcash/Circuits/Integration/README.md
@@ -1,4 +1,4 @@
-# Clean-to-Ironwood integration boundary
+# Clean-to-ironwood integration boundary
 
 This directory is the designated implementation boundary between Clean formal
 circuits and ironwood's verifier and soundness development.

--- a/Zcash/Circuits/Integration/TopLevelBridge.lean
+++ b/Zcash/Circuits/Integration/TopLevelBridge.lean
@@ -6,7 +6,7 @@ import Zcash.Circuits.Integration.TopLevelCircuit
 # Circuit-derived full bridge assembly
 
 This module is the generic join between the circuit-derived gate and lookup
-adapters and Ironwood's `FullCircuitBridge`. It keeps the verifier and soundness
+adapters and ironwood's `FullCircuitBridge`. It keeps the verifier and soundness
 layers in their native polynomial language: Clean-specific reconstruction is
 finished here before the resulting bridge is handed to the semantic endpoint.
 -/

--- a/Zcash/Circuits/Integration/TopLevelConstraintModel.lean
+++ b/Zcash/Circuits/Integration/TopLevelConstraintModel.lean
@@ -5,7 +5,7 @@ import Zcash.Snark.Soundness.Canonical.ConstraintModel
 # Circuit-derived canonical constraint models
 
 This module closes the domain-law boundary between a Clean top-level circuit and
-Ironwood's verifier-native canonical constraint model. Arbitrary verification
+ironwood's verifier-native canonical constraint model. Arbitrary verification
 keys still require an explicit proof that their blinding rows fit the domain;
 a key derived from `TopLevelCircuit` carries that fact by construction.
 -/

--- a/Zcash/Circuits/Integration/TopLevelCorrectness.lean
+++ b/Zcash/Circuits/Integration/TopLevelCorrectness.lean
@@ -5,7 +5,7 @@ import Zcash.Circuits.Integration.TopLevelAssignment
 /-!
 # Top-level circuit correctness interface
 
-This module packages the named Clean/Ironwood representation boundaries consumed
+This module packages the named Clean/ironwood representation boundaries consumed
 by the generic soundness terminal.  It deliberately contains no final circuit
 statement and no opaque encoding implication.
 -/

--- a/Zcash/Circuits/Integration/VerifierCS.lean
+++ b/Zcash/Circuits/Integration/VerifierCS.lean
@@ -6,7 +6,7 @@ import Clean.Halo2.TopLevel
 /-!
 # Circuit-owned verifier data
 
-`Halo2.TopLevelCircuit.verifierCS` is the single Ironwood-native projection of a
+`Halo2.TopLevelCircuit.verifierCS` is the single ironwood-native projection of a
 closed Clean circuit. It translates the circuit's pinned expressions and permutation
 columns into the types consumed by the verifier, without introducing proof parameters,
 commitments, or a second source of circuit configuration.
@@ -23,7 +23,7 @@ variable
 
 /--
 The circuit-owned verifier constraint system: Clean's pinned circuit data
-translated once into Ironwood's expression and column-reference types.
+translated once into ironwood's expression and column-reference types.
 -/
 def verifierCS
     (top : TopLevelCircuit F Config PublicInput) :

--- a/Zcash/Circuits/NoteCommit/Canonicity.lean
+++ b/Zcash/Circuits/NoteCommit/Canonicity.lean
@@ -2,7 +2,7 @@ import Zcash.Circuits.NoteCommit.Gates
 import Zcash.Circuits.NoteCommit.CanonicityTheorems
 
 /-!
-Reference (ported from actual Rust, not memory):
+Reference (ported from Rust):
 `orchard@0.14.0/src/circuit/note_commit.rs` — the input-canonicity `assign` regions
 (`"NoteCommit input value"` 994-1035: pure copies of `value`/`d_2`/`d_3 = z1_d`/`e_0`).
 
@@ -10,7 +10,7 @@ The semantic contracts are the phase-1 gate specs (`Clean/Orchard/Action/Canonic
 verbatim; the heavyweight canonicity value arguments are REUSED wholesale via the
 donor-replay bridge: the donor `Gate.circuit` is a main-Clean `FormalAssertion` over the
 same field equations, so applying its `soundness` at offset 0, a trivial environment and
-const-lifted inputs turns the Ironwood-landed equations into the donor `Spec`.
+const-lifted inputs turns the ironwood-landed equations into the donor `Spec`.
 -/
 
 namespace Zcash.Circuits.NoteCommit

--- a/Zcash/Circuits/NoteCommit/Main.lean
+++ b/Zcash/Circuits/NoteCommit/Main.lean
@@ -9,7 +9,7 @@ import Zcash.Circuits.NoteCommit.MainTheorems
 import Clean.Halo2.CircuitTypeDeriving
 
 /-!
-# NoteCommit main circuit (Ironwood)
+# Orchard-protocol NoteCommit main circuit
 
 Reference (ported from actual Rust, not memory):
 `orchard@0.14.0/src/circuit/note_commit.rs` — `NoteCommitChip::commit` (lines 1596-1798).

--- a/Zcash/Circuits/NoteCommit/MainBundle.lean
+++ b/Zcash/Circuits/NoteCommit/MainBundle.lean
@@ -87,7 +87,7 @@ private theorem prefixRows_ns_3 : Sinsemilla.Chain.prefixRows ns 3 = 51 := rfl
 private theorem prefixRows_ns_5 : Sinsemilla.Chain.prefixRows ns 5 = 58 := rfl
 private theorem prefixRows_ns_6 : Sinsemilla.Chain.prefixRows ns 6 = 83 := rfl
 
-/-- The Ironwood `Chain.PieceChunks` is the donor's, verbatim — the bridge unlocks the
+/-- The ironwood `Chain.PieceChunks` is the donor's, verbatim — the bridge unlocks the
 donor's piece-value/chunk-equality connectors. -/
 private theorem pieceChunks_donor_iff :
     ∀ (ms : List ℕ) (pieces : Vector Fp ms.length) (chunks : List ℕ),
@@ -166,7 +166,7 @@ private theorem peelGates (cfg : Config) (input : Var Inputs Fp)
     decomposeD_output, decomposeG_output, decomposeH_output] at h
   exact h
 
-/-- The Ironwood `Chain.ZsFacts` is the donor's, verbatim. -/
+/-- The ironwood `Chain.ZsFacts` is the donor's, verbatim. -/
 private theorem zsFacts_donor_iff :
     ∀ (ms : List ℕ) (chunks : List ℕ)
       (zs : Sinsemilla.HVec (Sinsemilla.Chain.zLengths ms) Fp),
@@ -518,7 +518,7 @@ private theorem yc_lsb_witness (w : WitgenIR Fp 1)
   simp only [Nat.add_assoc, Nat.reduceAdd] at hlsb ⊢
   exact hlsb
 
-/-- The Ironwood `Chain.PieceBounds`/`honestChunks` are the donor's, verbatim. -/
+/-- The ironwood `Chain.PieceBounds`/`honestChunks` are the donor's, verbatim. -/
 private theorem pieceBounds_donor_iff :
     ∀ (ms : List ℕ) (pieces : Vector Fp ms.length),
       Sinsemilla.Chain.PieceBounds ms pieces ↔

--- a/Zcash/Circuits/Tests/TestFloorPlanner.lean
+++ b/Zcash/Circuits/Tests/TestFloorPlanner.lean
@@ -33,7 +33,7 @@ open Halo2 Fixtures Halo2.FloorPlanner
 #guard SimpleFloorPlanner.starts Test.Layout.ops
   = (mulLayout.regions.filter (·.name ≠ "table_idx")).map (·.start)
 
-/-! ## V1: the full Action circuit (ironwood + pre-ironwood base)
+/-! ## V1: the full Action circuit (post-NU6.3 + pre-NU6.3 base)
 
 The derived starts / constants are checked against the JSON fixtures at `#eval` time; the
 fixtures are loaded by name through their SHA-256 pins (see `Fixtures/Json.lean`). Orchard's

--- a/Zcash/Circuits/Tests/TestVkLayoutAction.lean
+++ b/Zcash/Circuits/Tests/TestVkLayoutAction.lean
@@ -1,7 +1,7 @@
 import Zcash.Circuits.Fixtures.ActionSelMap
 import Zcash.Circuits.Fixtures.Json
 import Zcash.Circuits.Action.RealBases
-import Zcash.Circuits.Action.CircuitPreIronwood
+import Zcash.Circuits.Action.CircuitPreNU63
 import Zcash.Circuits.Fixtures.Layout
 import Zcash.Circuits.Action.Circuit
 
@@ -58,17 +58,17 @@ def aW : Action.Circuit.Witnesses Fp :=
     merkleSib := fun _ => .native fun _ => #v[(0 : Fp)],
     merkleSwap := fun _ _ => false }
 
-/-- THE REAL ironwood (post-NU 6.3) circuit, at the REAL certified bases. -/
+/-- THE REAL post-NU6.3 circuit, at the REAL certified bases. -/
 def aProgram : Circuit Fp Unit :=
   Action.Circuit.synthesize aG Action.orchardBases aW aCfg
 
-/-- The real pre-ironwood (fixed post-NU 6.2) circuit, at the same bases. -/
+/-- The real pre-NU6.3 (fixed post-NU6.2) circuit, at the same bases. -/
 def aProgramBase : Circuit Fp Unit := do
-  let _ ← Action.CircuitPreIronwood.synthesize aG
+  let _ ← Action.CircuitPreNU63.synthesize aG
     Action.orchardBases aW aCfg
   pure ()
 
-/-! ## The reconstructed layout products vs the ported Action stack (ironwood)
+/-! ## The reconstructed layout products vs the ported Action stack (post-NU6.3)
 
 All checks live in ONE `#eval` so the shared reconstruction (ops → regions → copy list →
 σ → fixed) evaluates exactly once; the fixture is loaded by name through its SHA-256 pin

--- a/Zcash/Circuits/Tests/TestVkLayoutActionBase.lean
+++ b/Zcash/Circuits/Tests/TestVkLayoutActionBase.lean
@@ -1,13 +1,12 @@
 import Zcash.Circuits.Tests.TestVkLayoutAction
 
 /-!
-# VK-layout test: the pre-ironwood (fixed post-NU 6.2) Action circuit
+# VK-layout test: the pre-NU6.3 (fixed post-NU6.2) Action circuit
 
 The base-circuit counterpart of `TestVkLayoutAction`: the same mirror WITHOUT the
-cross-address stage (`aProgramBase`), against the `actionBase` dump (byte-identical to
-the 0.14.0 circuit — verified on the ironwood branch), loaded from
-`actionBaseLayout.json` at `#eval` time. The constraint system (and so the SelMap) is
-shared between the two versions.
+cross-address stage (`aProgramBase`), against the `actionBase` dump (byte-identical
+to the 0.14.0 circuit), loaded from `actionBaseLayout.json` at `#eval` time. The
+constraint system (and so the SelMap) is shared between the two versions.
 -/
 
 namespace Zcash.Circuits.Fixtures.Test.LayoutActionBase

--- a/Zcash/Circuits/Tests/TestVkMatchAction.lean
+++ b/Zcash/Circuits/Tests/TestVkMatchAction.lean
@@ -10,7 +10,7 @@ import Zcash.Circuits.Action.Circuit
 Projects the `ConstraintSystem` produced by the ported `Action.Circuit.configure` to the
 `CsFixture` shape — via the Rust-dumped selector map applied mechanically — and checks it
 EQUAL to the fixture dumped from the actual Rust circuit after `compress_selectors`
-(`actionPost.json`). `configure` is version-independent (post-NU 6.2 and 6.3 share the
+(`actionPost.json`). `configure` is version-independent (post-NU6.2 and 6.3 share the
 CS), so this single test covers both top-level circuits.
 
 The fixtures are JSON data files loaded by name at `#eval` time (see `Fixtures/Json.lean`

--- a/Zcash/Circuits/Tests/TestVkMatchAdd.lean
+++ b/Zcash/Circuits/Tests/TestVkMatchAdd.lean
@@ -22,7 +22,7 @@ approach — two leaf gadgets, each with both sides: Add (this file + `TestVkLay
 the minimal example) and Mul (`TestVkMatchMul` + `TestVkLayoutMul`; the LOOKUP and
 selector-compression example). The check that the real circuit is correct is the
 top-level suite: `TestVkMatchAction` (configure, both versions) + `TestVkLayoutAction`
-(ironwood synthesize) + `TestVkLayoutActionBase` (pre-ironwood synthesize) — the other
+(post-NU6.3 synthesize) + `TestVkLayoutActionBase` (pre-NU6.3 synthesize) — the other
 per-gadget tests were subsumed by those and retired (see git history).
 -/
 

--- a/Zcash/Circuits/Utilities/LookupRangeCheck.lean
+++ b/Zcash/Circuits/Utilities/LookupRangeCheck.lean
@@ -114,7 +114,7 @@ Packaging decision: a plain `def load … : Circuit Fp Unit` emitting the single
 op, plus a standalone table-contents theorem proven from its `Constraints`. We do NOT wrap
 it in a `FormalCircuit` (the design sketch's suggestion): the layouter-level formal-circuit
 `call`/forward-lemma machinery is not yet ported (only `FormalRegionCircuit` proofs exist
-in the Ironwood tree, and `FormalCircuit` has no `_iff` helpers landed), and the loader's
+in the ironwood tree, and `FormalCircuit` has no `_iff` helpers landed), and the loader's
 sole content IS the table-contents fact, which the theorem below states directly from the
 `loadTable` `Constraints`. This keeps the loader usable by consumers today with no
 dependence on unported layouter-level formal-circuit plumbing. -/

--- a/Zcash/Meta/AxiomCheck.lean
+++ b/Zcash/Meta/AxiomCheck.lean
@@ -36,15 +36,6 @@ Both commands require their argument to be written fully qualified (`checkFullyQ
 an unqualified name resolves through the census file's `open`s, so a same-base-name cousin in
 an opened namespace can silently capture an entry meant for a declaration that is not in scope
 at all — the assertion then reads as covering one theorem while checking another.
-
-CompElliptic has a sibling `CompElliptic/Meta/AxiomCheck.lean`, but the two have diverged: this
-version is a strict superset, adding the `+native(D₁, …)` owner list (upstream takes a bare
-`+native`, so it cannot state *which* certificate it trusts), the marker parsing and
-owner/module/range provenance checks, `checkFullyQualified`, the exact-set staleness check, the
-`assert_computable` definition-safety check, and the negative regression suite. Ironwood re-checks
-every inherited axiom itself, so the census here
-does not depend on the upstream version's strength; porting this file upstream is tracked
-separately. Improvements made here should be considered for upstream, not assumed present there.
 -/
 
 open Lean Elab Command

--- a/Zcash/Security/BindingSignature/Balance.lean
+++ b/Zcash/Security/BindingSignature/Balance.lean
@@ -13,8 +13,9 @@ import Zcash.Common.DiscreteLogRelation
 
 This module formalizes the algebraic heart of the Zcash binding-signature *balance* argument
 (Zcash protocol specification §4.13 Sapling / §4.14 Orchard), abstracted over an arbitrary
-`F`-module `M` so that it applies to both the Pallas (Orchard, Ironwood) and Jubjub (Sapling)
-value-commitment groups. Here `F` will be instantiated with the scalar field `ZMod r`.
+`F`-module `M` so that it applies to both the Pallas (Orchard-protocol) and Jubjub
+(Sapling-protocol) value-commitment groups. Here `F` will be instantiated with the scalar
+field `ZMod r`.
 
 ## The setting
 

--- a/Zcash/Security/KeyBinding/Basic.lean
+++ b/Zcash/Security/KeyBinding/Basic.lean
@@ -11,7 +11,7 @@ import Mathlib.Tactic.Ring
 import Zcash.Security.Common.RandomOracle
 
 /-!
-# Key binding (Orchard / Ironwood)
+# Orchard-protocol Key binding
 
 The deterministic layer of the
 [ZIP 2005 key-binding theorem (ROM)](https://zips.z.cash/zip-2005#thm-key-binding-rom): a

--- a/Zcash/Snark/Capstones/Action.lean
+++ b/Zcash/Snark/Capstones/Action.lean
@@ -59,7 +59,12 @@ rather than proved, with its known strengthening named where one exists:
   (`AdaptiveStatementModel.lean`, *Intended instantiation*).
 * *Acceptance* — `DeployedAccepts` starts at typed, post-decode values and prices one proof
   bundle; byte encoding and halo2's optional `BatchVerifier` sit outside the formalized
-  verifier (`Fingerprint/Match.lean`, *What remains external*).
+  verifier (`Fingerprint/Match.lean`, *What remains external*).  The deployment record pins the
+  call shape behind that boundary: exact ten-row instance columns — Lagrange commitment
+  zero-padding makes a shorter column verify as its zero-padding
+  (`assembleNonInteractiveInstances?_padColumns`), aliasing a missing trailing row to
+  `disableCrossAddress = 0` — and a positive per-bundle action count
+  (`instanceColumnsExact`, `numProofs_pos`).
 
 The bounds these endpoints prove are exact inside that model. The machine-readable shape for a
 deployed interpretation is `ActionDeploymentInstantiation`

--- a/Zcash/Snark/Fixtures/MultiAction/Honest/TrustBoundary.lean
+++ b/Zcash/Snark/Fixtures/MultiAction/Honest/TrustBoundary.lean
@@ -923,6 +923,8 @@ assert_axioms Zcash.Snark.Fixture2.derivedInstanceCommitment
 -- Cross-capture provenance (`Fixtures/PostNu63.lean`): the point-level equalities that transport
 -- the single-action keygen certificate to this capture, and the URS record equality assembled
 -- from them.
+assert_axioms Zcash.Snark.PostNu63Fixture.captures_urs_point_references_in_bounds +native(
+  Zcash.Snark.PostNu63Fixture.captures_urs_point_references_in_bounds)
 assert_axioms Zcash.Snark.PostNu63Fixture.captures_use_same_ursG +native(
   Zcash.Snark.PostNu63Fixture.captures_use_same_ursG)
 assert_axioms Zcash.Snark.PostNu63Fixture.captures_use_same_wu +native(

--- a/Zcash/Snark/Fixtures/PostNu63.lean
+++ b/Zcash/Snark/Fixtures/PostNu63.lean
@@ -5,14 +5,14 @@ import Mathlib.Util.AssertNoSorry
 /-!
 # Post-NU6.3 fixture provenance
 
-Cross-capture checks for the canonical Post-NU6.3 Orchard/Ironwood verifying key and URS. During
-fixture generation, Orchard first compares the exact `PinnedVerificationKey` debug representation
-against its checked-in `circuit_description_post_nu6_3`; Halo2 then derives and emits the transcript
-representation below from that same verified key object.
+Cross-capture checks for the canonical Post-NU6.3 Orchard-protocol verifying key and URS. During
+fixture generation, the `orchard` implementation first compares the exact `PinnedVerificationKey`
+debug representation against its checked-in `circuit_description_post_nu6_3`; `halo2` then derives
+and emits the transcript representation below from that same verified key object.
 
-Lean does not reimplement Halo2's `Debug` serialization or BLAKE2b derivation. The hand-pinned scalar
-here makes fixture drift visible in this repository, while the Rust regeneration assertion binds it
-to the full canonical pinned key.
+Lean does not reimplement `halo2`'s `Debug` serialization or BLAKE2b derivation. The hand-pinned
+scalar here makes fixture drift visible in this repository, while the Rust regeneration assertion
+binds it to the full canonical pinned key.
 
 The point-level equalities below identify the two captures' URS and verifying-key commitment
 points; the multi-action verifying-key certificate (`Fixtures/MultiAction/Honest/VkCertificate.lean`)

--- a/Zcash/Snark/Fixtures/PostNu63.lean
+++ b/Zcash/Snark/Fixtures/PostNu63.lean
@@ -66,6 +66,14 @@ theorem multiAction_uses_canonicalVk :
     Fixture2.capturedVkTranscriptRepr = canonicalVkTranscriptRepr := by
   native_decide
 
+/-- Every `capturedPoint` reference used to build either captured augmented URS is backed by its
+point table.  The `2^k` generators occupy indices `0, ..., 2^k - 1`, followed by `w` and `u`; this
+separately guards the inner `capturedPoints.getD` from silently substituting the identity. -/
+theorem captures_urs_point_references_in_bounds :
+    2 ^ Fixture.shape.k + 2 ≤ Fixture.capturedPoints.length ∧
+      2 ^ Fixture2.shape.k + 2 ≤ Fixture2.capturedPoints.length := by
+  native_decide
+
 /-- Both captures use the same deterministic Halo2 URS (`g`, then `w` and `u` occupy the first
 `2^11 + 2` entries in each generated concrete-point table).
 

--- a/Zcash/Snark/Keygen/Pipeline.lean
+++ b/Zcash/Snark/Keygen/Pipeline.lean
@@ -275,14 +275,14 @@ theorem toVerifierKey_permutationCommonCommitment
       top.instanceQueryLayout := by
   simp only [toVerifierKey]
 
-/-- The derived key uses the circuit's Ironwood-native gate expressions. -/
+/-- The derived key uses the circuit's ironwood-native gate expressions. -/
 @[simp] theorem toVerifierKey_gates
     (top : TopLevelCircuit Fp Config PublicInput)
     (urs : URS G) :
     (top.toVerifierKey urs).gates = top.verifierCS.gates := by
   simp only [toVerifierKey]
 
-/-- The derived key uses the circuit's Ironwood-native permutation chunks. -/
+/-- The derived key uses the circuit's ironwood-native permutation chunks. -/
 @[simp] theorem toVerifierKey_permutationChunks
     (top : TopLevelCircuit Fp Config PublicInput)
     (urs : URS G) :
@@ -290,7 +290,7 @@ theorem toVerifierKey_permutationCommonCommitment
       top.verifierCS.permutationChunks := by
   simp only [toVerifierKey]
 
-/-- The derived key uses the circuit's Ironwood-native lookup input expressions. -/
+/-- The derived key uses the circuit's ironwood-native lookup input expressions. -/
 @[simp] theorem toVerifierKey_lookupInputExprs
     (top : TopLevelCircuit Fp Config PublicInput)
     (urs : URS G)
@@ -299,7 +299,7 @@ theorem toVerifierKey_permutationCommonCommitment
       top.verifierCS.lookupInputExprs lookup := by
   simp only [toVerifierKey]
 
-/-- The derived key uses the circuit's Ironwood-native lookup table expressions. -/
+/-- The derived key uses the circuit's ironwood-native lookup table expressions. -/
 @[simp] theorem toVerifierKey_lookupTableExprs
     (top : TopLevelCircuit Fp Config PublicInput)
     (urs : URS G)

--- a/Zcash/Snark/Soundness/Action/DeploymentRecord.lean
+++ b/Zcash/Snark/Soundness/Action/DeploymentRecord.lean
@@ -27,6 +27,8 @@ namespace Zcash.Snark
 open Zcash.Common
 
 open scoped ENNReal
+open Halo2
+open Zcash.Circuits.Action
 
 local instance deploymentRecordVestaInhabited : Inhabited VestaG := ⟨0⟩
 
@@ -41,7 +43,10 @@ is the GroupHash-as-random-oracle idealization, permanent up to the encoding-dis
 groundwork.  `vkDigestAgreesOnCanonical` binds the family's opaque digest to the deployed one at
 the canonical key only — the capstones claim no cross-key binding.  `acceptsFaithful` is the
 typed post-decode boundary: the byte-level verifier model stays open work
-(`Fingerprint/Match.lean`, *What remains external*). `dlogAdvantageAgrees` prevents the record from
+(`Fingerprint/Match.lean`, *What remains external*).  `instanceColumnsExact` and `numProofs_pos`
+pin the shape of each deployed call behind that boundary: exact ten-row instance columns
+(excluding the trailing-zero commitment alias) and one invocation per present bundle carrying
+its positive action count. `dlogAdvantageAgrees` prevents the record from
 carrying an unrelated advantage function: it must be the one used by `profile`.  Its concrete
 security interpretation remains the permanent external estimate. -/
 structure ActionDeploymentInstantiation {T : Type*} [DecidableEq T] (pp : ProofParams)
@@ -86,6 +91,28 @@ structure ActionDeploymentInstantiation {T : Type*} [DecidableEq T] (pp : ProofP
   /-- Deployed acceptance agrees with the model's checked acceptance — capture faithfulness at
   the typed, post-decode boundary. -/
   acceptsFaithful : ∀ basis O, deployedTypedAccepts basis O ↔ family.accepts basis O
+  /-- The raw instance columns each deployed verifier call supplies, per action. -/
+  deployedInstanceColumns :
+    (AugmentedIndex (2 ^ (AdaptiveActionStatementShape pp).k) → VestaG) →
+      family.Coins → Fin pp.numProofs → List (List Fp)
+  /-- Every action's supplied raw instance is exactly the full ten-row column serializing its
+  typed public inputs (`actionCircuit_publicInputRows_zero`).  This pins the instance
+  construction behind the typed boundary `acceptsFaithful` prices: Halo2's Lagrange commitment
+  zero-pads columns, so a shorter column commits — and verifies — identically to its zero-padding
+  (`commitInstance_append_replicate_zero`, `assembleNonInteractiveInstances?_padColumns`); in
+  particular a nine-row column aliases the ten-row column ending in `disableCrossAddress = 0`.
+  Row-count validation cannot exclude the alias; supplying exact rows does. -/
+  instanceColumnsExact : ∀ basis O (p : Fin pp.numProofs),
+    deployedInstanceColumns basis O p =
+      List.ofFn fun column : Fin (AdaptiveActionStatementShape pp).numInstanceColumns =>
+        actionCircuit.publicInputRows ((family.runOutput basis O).inputs p)
+          (⟨column⟩ : Column .instance)
+  /-- The verifier is invoked once per present Orchard bundle, with the proof count equal to the
+  bundle's action count.  Zero models an absent bundle, never an empty verifier invocation
+  (`book/src/formal-verification/source-map.md`), so a deployment record prices a positive
+  count; that the count equals the deployed bundle's action count is part of the same
+  identification. -/
+  numProofs_pos : 0 < pp.numProofs
   /-- Maximum number of distinct challenge points visited by the complete knowledge-failure
   experiment. -/
   challengeQueryBound : ℕ

--- a/Zcash/Snark/Soundness/Canonical/InstanceCommitment.lean
+++ b/Zcash/Snark/Soundness/Canonical/InstanceCommitment.lean
@@ -263,6 +263,20 @@ theorem commitInstance_eq {urs : URS G} {omega : Fp}
   simpa [commitInstance, instanceCoefficients, instanceRowPolynomial] using
     key.commitRows_eq (zeroPaddedRows (n := 2 ^ urs.k) values) blind
 
+/-- Trailing zero rows do not change a committed instance column: the commitment zero-pads every
+column to the domain, so columns differing only by trailing zeros are indistinguishable at
+commitment level.  This is the collision behind the shorter-column alias — a column that stops
+before a trailing flag row commits exactly as the full column carrying that flag as `0`;
+`assembleNonInteractiveInstances?_padColumns` (`Verifier/Deployed.lean`) states the resulting
+acceptance invariance at the raw verifier entry. -/
+theorem commitInstance_append_replicate_zero {urs : URS G} {omega : Fp}
+    (key : LagrangeCommitmentKey urs omega)
+    (values : List Fp) (m : ℕ) (blind : Fp) :
+    key.commitInstance (values ++ List.replicate m 0) blind =
+      key.commitInstance values blind := by
+  unfold commitInstance
+  rw [zeroPaddedRows_append_replicate_zero]
+
 /--
 The full key made by `ofPrefix` commits any column contained in the certified prefix exactly as the
 finite-prefix implementation does.

--- a/Zcash/Snark/Soundness/Canonical/PolynomialEnvironment.lean
+++ b/Zcash/Snark/Soundness/Canonical/PolynomialEnvironment.lean
@@ -82,6 +82,18 @@ theorem rowPolynomial_natDegree_lt {n : ℕ}
 def zeroPaddedRows {n : ℕ} (values : List Fp) : Fin n → Fp :=
   fun i => values.getD (i : ℕ) 0
 
+/-- Appending trailing zero rows leaves the zero-padded row family unchanged: the suffix only
+replaces default zeros with explicit ones. -/
+theorem zeroPaddedRows_append_replicate_zero {n m : ℕ} (values : List Fp) :
+    zeroPaddedRows (n := n) (values ++ List.replicate m 0) = zeroPaddedRows values := by
+  funext i
+  simp only [zeroPaddedRows, List.getD_eq_getElem?_getD]
+  rcases lt_or_ge (i : ℕ) values.length with hi | hi
+  · rw [List.getElem?_append_left hi]
+  · rw [List.getElem?_append_right hi, List.getElem?_replicate,
+      List.getElem?_eq_none hi]
+    by_cases hj : (i : ℕ) - values.length < m <;> simp [hj]
+
 /-- The coefficient-form instance polynomial for a zero-padded public column. -/
 def instanceRowPolynomial (n : ℕ)
     (omega : Fp) (values : List Fp) : CPoly :=

--- a/Zcash/Snark/Soundness/Circuit/Terminal.lean
+++ b/Zcash/Snark/Soundness/Circuit/Terminal.lean
@@ -16,7 +16,7 @@ turns satisfaction of the verifier-native canonical constraint model into the
 circuit's own statement for every proof in the bundle, and binds that statement
 to the public inputs supplied to an accepting verifier.
 
-The Clean/Ironwood representation work remains exposed as named component
+The Clean/ironwood representation work remains exposed as named component
 conditions.  In particular, `TopLevelCircuitCorrectness` does not contain the
 desired statement or an opaque encoding implication.
 -/

--- a/Zcash/Snark/Soundness/Multiopen/ConstraintResolver.lean
+++ b/Zcash/Snark/Soundness/Multiopen/ConstraintResolver.lean
@@ -20,8 +20,8 @@ those two views:
   instantiation layer.
 
 The adapter is generic in the verification key and proof string. It does not select a concrete
-Ironwood verification key or duplicate the straight-line AGM argument that produces member-node
-binding.
+Action circuit verification key or duplicate the straight-line AGM argument that produces
+member-node binding.
 -/
 
 namespace Zcash.Snark

--- a/Zcash/Snark/Verifier/Assemble.lean
+++ b/Zcash/Snark/Verifier/Assemble.lean
@@ -45,7 +45,8 @@ def finFn {F : Type*} [Zero F] {n : ℕ} (f : Fin n → F) : ℕ → F :=
 /-- View a `Fin n`-indexed family of group elements as a total `ℕ`-indexed function (`default`
 out of range), like `finFn`. Caveat: an out-of-range index aliases `default` rather than erroring
 — the Vesta identity in the concrete fixtures, and `0` in abstract shape fixtures — so faithfulness
-rests on the VK's query indices being in range. -/
+rests on the VK's query indices being in range.  For the deployed key that is discharged, not
+assumed: see the degradation-site note on `VerifyingKey` (`Verifier/Key.lean`). -/
 def finFnG {G : Type*} [Inhabited G] {n : ℕ} (f : Fin n → G) : ℕ → G :=
   fun i => if h : i < n then f ⟨i, h⟩ else default
 

--- a/Zcash/Snark/Verifier/ConstraintSystem.lean
+++ b/Zcash/Snark/Verifier/ConstraintSystem.lean
@@ -10,7 +10,7 @@ integration boundary.
 
 namespace Zcash.Snark
 
-/-- The Ironwood-native constraint-system data consumed by the verifier. -/
+/-- The ironwood-native constraint-system data consumed by the verifier. -/
 structure VerifierCS (numLookups : ℕ) (F : Type*) where
   gates : List (Expr F)
   permutationChunks : List (List (ColumnRef × ℕ))

--- a/Zcash/Snark/Verifier/Deployed.lean
+++ b/Zcash/Snark/Verifier/Deployed.lean
@@ -60,4 +60,77 @@ theorem assembleNonInteractiveInstances?_eq_none_of_oversized_column
     assembleNonInteractiveInstances? fs vkHash vk instances commitColumn ps = none := by
   simp [assembleNonInteractiveInstances?, validateInstances?, hcount, hfit]
 
+/-- Zero-pad a raw instance column on the right to `n` rows (the identity on longer columns). -/
+def padColumn {F : Type*} [Zero F] (n : ℕ) (column : List F) : List F :=
+  column ++ List.replicate (n - column.length) 0
+
+/-- **Trailing-zero padding invariance.**  When the commitment operation ignores trailing zeros —
+Halo2's Lagrange commitment does (`commitInstance_append_replicate_zero`) — this raw verifier
+entry cannot distinguish a column from its zero-padding to any length inside the usable rows:
+both validate, commit, transcript-bind, and assemble identically.  At the Action circuit with
+`n = 10` this is the shorter-column alias stated exactly: a nine-row instance column is accepted
+iff the ten-row column extending it with `disableCrossAddress = 0` is.  Row-count validation
+cannot exclude the alias — supplying full ten-row columns is a deployed caller obligation,
+recorded as `ActionDeploymentInstantiation.instanceColumnsExact`. -/
+theorem assembleNonInteractiveInstances?_padColumns
+    {shape : Shape} {F G : Type*}
+    [Field F] [DecidableEq F] [DecidableEq G] [Inhabited G]
+    (fs : FiatShamir F G) (vkHash : VerifyingKey shape F G → F) (vk : VerifyingKey shape F G)
+    (instances : RawInstances shape F) (commitColumn : List F → G)
+    (ps : ProofString shape F G) (n : ℕ)
+    (hpad : ∀ column : List F, commitColumn (padColumn n column) = commitColumn column)
+    (hn : n ≤ instanceUsableRows vk)
+    (hcols : ∀ p, ∀ column ∈ instances p, column.length ≤ n) :
+    assembleNonInteractiveInstances? fs vkHash vk
+        (fun p => (instances p).map (padColumn n)) commitColumn ps =
+      assembleNonInteractiveInstances? fs vkHash vk instances commitColumn ps := by
+  by_cases hcount : InstancesHaveExpectedColumnCount instances
+  · have hcount' : InstancesHaveExpectedColumnCount
+        (fun p => (instances p).map (padColumn n)) := by
+      intro p
+      simpa [List.length_map] using hcount p
+    have hfit : InstanceColumnsFit vk instances := fun p column =>
+      le_trans (hcols p _ (List.get_mem _ _)) hn
+    have hfit' : InstanceColumnsFit vk (fun p => (instances p).map (padColumn n)) := by
+      intro p column
+      have hlt : (column : ℕ) < (instances p).length := by
+        simpa [List.length_map] using column.isLt
+      have hle : ((instances p)[(column : ℕ)]'hlt).length ≤ n :=
+        hcols p _ (List.getElem_mem hlt)
+      have hget : ((instances p).map (padColumn n)).get column
+          = padColumn n ((instances p)[(column : ℕ)]'hlt) := by
+        simp [List.get_eq_getElem]
+      rw [hget]
+      have hlen : (padColumn n ((instances p)[(column : ℕ)]'hlt)).length = n := by
+        simp only [padColumn, List.length_append, List.length_replicate]
+        omega
+      rw [hlen]
+      exact hn
+    have hcommit : ∀ p (column : ℕ),
+        commitColumn (((instances p).map (padColumn n)).getD column []) =
+          commitColumn ((instances p).getD column []) := by
+      intro p column
+      rcases lt_or_ge column (instances p).length with hcol | hcol
+      · simp only [List.getD_eq_getElem?_getD, List.getElem?_map,
+          List.getElem?_eq_getElem hcol, Option.map_some, Option.getD_some]
+        exact hpad _
+      · rw [List.getD_eq_default _ _ (by simpa using hcol),
+          List.getD_eq_default _ _ hcol]
+    have hfun : ValidatedInstances.commitments
+        (vk := vk) ⟨fun p => (instances p).map (padColumn n), hcount', hfit'⟩ commitColumn =
+        ValidatedInstances.commitments ⟨instances, hcount, hfit⟩ commitColumn := by
+      funext p column
+      exact hcommit p column
+    simp only [assembleNonInteractiveInstances?, validateInstances?,
+      dif_pos hcount, dif_pos hfit, dif_pos hcount', dif_pos hfit']
+    rw [hfun]
+  · have hcount' : ¬ InstancesHaveExpectedColumnCount
+        (fun p => (instances p).map (padColumn n)) := by
+      intro h
+      exact hcount fun p => by simpa [List.length_map] using h p
+    rw [assembleNonInteractiveInstances?_eq_none_of_wrong_column_count
+        fs vkHash vk _ commitColumn ps hcount',
+      assembleNonInteractiveInstances?_eq_none_of_wrong_column_count
+        fs vkHash vk instances commitColumn ps hcount]
+
 end Zcash.Snark

--- a/Zcash/Snark/Verifier/Key.lean
+++ b/Zcash/Snark/Verifier/Key.lean
@@ -47,7 +47,27 @@ computes it per proof from the public instances (`commit_lagrange`) rather than 
 VK, and supplies it to the assembly as a separate argument (`instanceCommitment` of
 `assembleQueries`/`assemble`). This keeps the VK a faithful image of the pinned Rust key.
 
-Two conventions hold for the deployed key but are not enforced by this structure:
+The structure deliberately does not force its lists to agree with the shape's counts, mirroring
+halo2, which upholds those agreements by construction (one evaluation read per query; chunks built
+by `chunks(chunk_len)`).  Where the Lean split makes disagreement representable, the assembly
+degrades rather than rejects — `columnQueries` zips truncate, `finFn`/`finFnG` alias out-of-range
+indices to `0`/`default`, and `subProofPermSets.zip vk.permutationChunks` drops unmatched sets —
+so the soundness layers consume the agreements as named facts of the deployed key:
+* query-layout lengths equal the shape's query counts — premises of `Soundness/Canonical/
+  Terminal.lean`, discharged by the `toVerifierKey_*QueryCount` lemmas (`Keygen/Pipeline.lean`);
+* `permutationChunks.length` equals the shape's permutation-set count — the
+  `ResolverPermutationDomain.chunkCount` field, discharged by the `chunkCount` theorem of
+  `Integration/ActionPermutationDomain.lean` and, at the captured key,
+  `permutation_chunks_match_shape` (`Fixtures/*/Faithfulness.lean`);
+* chunk widths and common-eval indices — `permutation_chunk_layout_regular` (ibid.) pins the
+  `chunkLen`-regular stride and in-order indices the δ-coset offsets need;
+* expression and chunk references in range — `vk_expression_refs_in_range` (ibid.) keeps the
+  `finFn`/`finFnG` alias branch unreachable; query-layout columns are consumed at the pinned
+  concrete layouts.
+A key supplied outside these agreements silently checks fewer constraints instead of failing, so
+any alternate key-loading or circuit-version path must re-establish them.
+
+Two further conventions hold for the deployed key but are not enforced by this structure:
 * `n` is both Halo2's `params.n` and the domain size; the fixture exporter checks their equality.
 * `permutationChunks` uses `chunkLen` as its stride, matching Halo2's `chunks(chunk_len)`; the
   captured key packs 7/7/1 columns with `chunkLen = 7`. -/

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -1,4 +1,5 @@
 import Zcash.Circuits.Action.RealBases
+import Zcash.Circuits.Action.Separation
 import Zcash.Security.Ledger.Bridge
 import Zcash.Security.Ledger.SinsemillaDLR
 import Zcash.Arithmetic.FastMsm
@@ -2642,3 +2643,27 @@ assert_axioms Zcash.Snark.ComputedStraightLineDeployedFSFamily.straightLineDeplo
 assert_axioms Zcash.Snark.ComputedStraightLineDeployedFSFamily.straightLineConstraintBadX_prob_le +native(CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
 assert_axioms Zcash.Snark.ComputedAdaptiveActionStatementFSFamily.statisticalSurfaceEvent_prob_le +native(Zcash.Snark.ActionPermutationDomain.numInstanceColumns_eq, CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt, CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt, Zcash.Circuits.Ecc.MulFixed.windowScalar_ne_zero, Zcash.Circuits.Ecc.MulFixed.Certs.commitIvkRCert_check, Zcash.Circuits.Ecc.MulFixed.Certs.noteCommitRCert_check, Zcash.Circuits.Ecc.MulFixed.Certs.nullifierKCert_check, Zcash.Circuits.Ecc.MulFixed.Certs.spendAuthGCert_check, Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitRCert_check, Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitVCert_check, Zcash.Circuits.Ecc.MulFixed.Short.windowScalar_ne_zero)
 assert_axioms Zcash.Snark.ComputedAdaptiveActionStatementFSFamily.adaptiveStatementKnowledgeFailure_prob_le +native(Zcash.Snark.actionConstantCellAddressFailures_eq_nil, Zcash.Snark.actionConstantSites_fit, Zcash.Snark.actionCopyActiveRowFailures_eq_nil, Zcash.Snark.actionCopyAddressFailures_eq_nil, Zcash.Snark.actionCopyBounds, Zcash.Snark.actionMissingConstantAllocations_eq_nil, CompElliptic.Fields.Pasta.pallasBase, Zcash.Snark.ActionFixedCoherence.queryCoverageFailures_eq_nil, Zcash.Snark.ActionFixedCoherence.realizationFailures_eq_nil, Zcash.Snark.ActionGateCoherence.adviceQueryColumnsAllocated, Zcash.Snark.ActionGateCoherence.domainExponent_lt, Zcash.Snark.ActionGateCoherence.gateData_eq, Zcash.Snark.ActionGateCoherence.selectorDegree, Zcash.Snark.ActionPermutationDomain.instanceQueryLayout_columns_lt, Zcash.Snark.ActionPermutationDomain.numInstanceColumns_eq, Zcash.Snark.ActionPermutationDomain.permutationColumnCount_eq, Zcash.Snark.ActionPermutationDomain.routingFailures_eq_nil, CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt, CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt, Zcash.Circuits.Ecc.MulFixed.windowScalar_ne_zero, Zcash.Circuits.Ecc.MulFixed.Certs.commitIvkRCert_check, Zcash.Circuits.Ecc.MulFixed.Certs.noteCommitRCert_check, Zcash.Circuits.Ecc.MulFixed.Certs.nullifierKCert_check, Zcash.Circuits.Ecc.MulFixed.Certs.spendAuthGCert_check, Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitRCert_check, Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitVCert_check, Zcash.Circuits.Ecc.MulFixed.Short.windowScalar_ne_zero)
+
+/-! ## Pre- and post-NU6.3 circuit separation
+
+`Zcash/Circuits/Action/Separation.lean` pins the structural fact that the NU6.3 upgrade
+adds exactly the cross-address clause to the Action statement. They are theorems, so they
+get `assert_axioms`. `preNU63_synthesize_eq_base` reaches the fixed-base construction and
+`crossAddressBinding_nontrivial` evaluates a deployed-base inequality, so both inherit the
+`native_decide` compiler-trust axioms; the other two stay at the standard tier. -/
+
+assert_axioms Zcash.Circuits.Action.Separation.preNU63_synthesize_eq_base +native(
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt,
+  Zcash.Circuits.Ecc.MulFixed.windowScalar_ne_zero,
+  Zcash.Circuits.Ecc.MulFixed.Short.windowScalar_ne_zero)
+assert_axioms Zcash.Circuits.Action.Separation.specPost_iff_base_and_crossAddress
+assert_axioms Zcash.Circuits.Action.Separation.preNU63_spec_omits_crossAddress
+assert_axioms Zcash.Circuits.Action.Separation.crossAddressBinding_nontrivial +native(
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt,
+  Zcash.Circuits.Action.Separation.crossAddressBinding_nontrivial,
+  Zcash.Circuits.Ecc.MulFixed.Certs.commitIvkRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.noteCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.nullifierKCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.spendAuthGCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitRCert_check,
+  Zcash.Circuits.Ecc.MulFixed.Certs.valueCommitVCert_check)

--- a/book/src/formal-verification/source-map.md
+++ b/book/src/formal-verification/source-map.md
@@ -184,7 +184,7 @@ less silent. This subtree is the `FixtureCheck` lake target, kept out of `lake b
 captures are large, generated, and slow) but built by CI.
 `Shared/ScheduleMarker` re-encodes captured Fiat–Shamir schedules into the model's marker form;
 `Shared/TamperSweep` is the shared mutation vocabulary of the per-slot negative sweeps; `PostNu63` pins
-the canonical post-NU 6.3 verifying key and URS so fixture drift is visible here, and
+the canonical post-NU6.3 verifying key and URS so fixture drift is visible here, and
 `PostNu63Random` extends the same point equalities to the random captures — kept separate so the
 honest lane does not depend on compiling the random data modules. (The join between the captured
 instance commitments and the circuit-derived family lives in `Keygen/InstanceCapture`.)
@@ -444,7 +444,7 @@ them as data (`SpecOrBreak`) rather than assuming them away.
   decompositions, the gate set, the canonicity checks, and the assembled `Main`/`MainBundle`
   contract at the extracted window scalar.
 - **`Action/`** — the top-level Orchard Action circuit. `Circuit` is the ironwood `configure`
-  and `synthesize` in exact region-creation order; `CircuitPreIronwood` is the post-NU 6.2
+  and `synthesize` in exact region-creation order; `CircuitPreNU63` is the post-NU6.2
   circuit without the cross-address region (both share `configure`);
   `RealBases` instantiates everything at the actual deployed constants; `PublicInput` declares the
   public instance-cell layout and splits the semantic witness into public and private halves;


### PR DESCRIPTION
Appending some low-hanging hardenings from this [audit list](https://gist.github.com/ebfull/b36e1c85af75f744fcc6b0e12212d3ae) — nothing exploitable, just pinning down boundaries we’d already flagged. Not all of the listed findings are valid: several are invalid, and several others describe documented idealizations of the model. This PR pins only the genuine boundaries.

- the nine/ten-row instance collision is now a named theorem, and exact-column / positive-count is pinned as `ActionDeploymentInstantiation` fields.
- documented the generic-verifier degradation sites and the certified-key facts that discharge them (docs only — nothing needed fixing).
- structural pre-NU6.3 separation — the old circuit is definitionally `synthesizeBase`, and `SpecPost = SpecBase ∧ cross-clause`.
- both honest capture point tables are checked to cover every `g`, `w`, and `u` index used by the augmented URS, preventing `getD` from silently substituting the identity.

The last two commits are naming and census follow-ups (the first is a broad terminology sweep, ~35 files):

- **Rename `CircuitPreIronwood` to `CircuitPreNU63` and normalize NU6.3 naming.** The Action circuit is selected by consensus branch, not by pool: the post-NU6.3 circuit serves both the Orchard and Ironwood pools. Renames the module and every reference; normalizes `NU 6.x` to `NU6.x` (keeping the verbatim `"post-NU 6.3 cross-address checks"` region label); replaces `ironwood`/`pre-ironwood` circuit-version labels with `post-`/`pre-NU6.3`, and `Ironwood` (for the halo2-native circuit development) with `Orchard-protocol`, keeping genuine references (the orchard `ironwood` git branch, `zcash/ironwood`, the project name); and records the post-NU6.3 circuit as released in orchard 0.15.0, correcting the fixture provenance in `PROVENANCE.md`. The auto-generated fixed-base and generator tables keep their `ironwood-branch` provenance headers, to be fixed in the unpublished generator.
- **Census the pre-/post-NU6.3 separation facts.** Moves `Separation.lean`'s inline `assert_no_sorry` checks to `assert_axioms` pins in `Zcash/TrustBoundary.lean`, so the facts join the library census.
