### PR TITLE
Retitle the README and document the build and CI checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Ironwood $\small\gets \text{Setup}(1^\lambda)$
+# Formalizing Ironwood
 
 $\textsf{Ironwood}$ is a project to deploy a new shielded pool, built to restore
 confidence for all Zcash'rs in the supply integrity of Zcash.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ and accurately document the scope of what is and is not formally verified.
 
 The formalization is a Lean 4 development over Mathlib, and building it
 re-elaborates every proof — a successful build *is* the verification. The single
-command is `lake build`, with two one-time prerequisites: install
+command is `lake build --wfail`, with two one-time prerequisites: install
 [`elan`](https://github.com/leanprover/elan) (the Lean toolchain manager, which
 reads [`lean-toolchain`](lean-toolchain) and installs the pinned toolchain
 automatically), then, from the repository root, fetch Mathlib's prebuilt
@@ -20,8 +20,12 @@ artifacts so it need not be recompiled from source:
 
 ```sh
 lake exe cache get   # one-time: download prebuilt Mathlib artifacts
-lake build           # verify everything (exactly what CI runs)
+lake build --wfail   # verify every proof; --wfail makes warnings fail, as CI does
 ```
+
+CI runs the same build plus source-level consistency checks — census coverage,
+fixture digests, and regeneration diffs — documented in
+[Build and CI Checks](https://zcash.github.io/ironwood/formal-verification/ci-checks.html).
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ lake build           # verify everything (exactly what CI runs)
 
 ## Documentation
 
-- [The Ironwood Book](https://zcash.github.io/ironwood/)
+- <a href="https://zcash.github.io/ironwood/" class="raleway">The Ironwood Book</a>
 
 ## License
 

--- a/book/custom.css
+++ b/book/custom.css
@@ -432,6 +432,12 @@ em {
     font-size: 0.83em !important;
 }
 
+.raleway {
+    font-family: 'raleway', Arial, 'Helvetica Neue', Helvetica, sans-serif !important;
+    font-style: normal !important;
+    font-weight: 500 !important;
+}
+
 /* Headings and the book title in upright Raleway (body text stays the theme font).
    The menu title shares the font but must not share the headings' top margin:
    a margin inside the fixed-height menu bar makes the bar taller than

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -21,6 +21,7 @@
   - [Reference]()
     - [Definitions](formal-verification/definitions.md)
     - [Source Map](formal-verification/source-map.md)
+    - [Build and CI Checks](formal-verification/ci-checks.md)
   - [Working Notes](formal-verification/working-notes.md)
     - [The Clean Boundary](formal-verification/clean-boundary.md)
     - [Clean Circuit Framework Improvements](formal-verification/clean-improvements.md)

--- a/book/src/formal-verification/ci-checks.md
+++ b/book/src/formal-verification/ci-checks.md
@@ -1,0 +1,101 @@
+# Build and CI checks
+
+Building the Lean development re-elaborates every proof reachable from the build
+targets — a successful build *is* the verification. This page lists what CI runs on
+top of that build, and what each additional check guards. The workflow files under
+`.github/workflows/` are the mechanism; the substance of what they do is described
+here.
+
+## The build
+
+CI builds with
+
+```sh
+lake build --wfail Zcash FixtureCheck CircuitCheck MetaCheck SecurityCheck CensusCheck
+```
+
+The named targets are exactly the lakefile's default set, so `lake build --wfail`
+is equivalent. The `--wfail` treats warnings as errors. `sorry` elaborates with a
+warning, so among other things this causes any use of `sorry` to fail CI even where
+no census entry reaches it.
+
+The targets:
+
+* **`Zcash`** — the library: everything reachable from `Zcash.lean`, which imports
+  `Zcash.TrustBoundary`, the library-wide axiom census. Building this target enforces
+  every census entry in that file.
+* **`FixtureCheck`** — the captured fixtures, the knowledge soundness capstones, and
+  the keygen certificate. The fixture-local trust boundaries and the `native_decide`
+  fingerprint faithfulness checks run here; this target is separate because the
+  captures are large and slow.
+* **`CircuitCheck`** — `Zcash.Circuits.Tests`: comparisons of the pinned verifying-key
+  and layout dumps against the Lean circuit model.
+* **`MetaCheck`** — tests of `Zcash.Meta.AxiomCheck` itself: forged axioms exercising
+  its rejection paths, kept out of the production import graph.
+* **`SecurityCheck`** — `Zcash.Security.Ledger.BridgeTests`: regression checks
+  guarding the protocol distinctions a type-correct refinement could silently erase.
+* **`CensusCheck`** — the endpoint census enforced a second time, from the elaborated
+  environment: every endpoint-named declaration in the census files' import closure
+  must carry a direct pin.
+
+The build also re-elaborates proofs in the CompElliptic library that it depends on,
+but *not* necessarily every proof in that library, and *not* CompElliptic's
+[additional CI checks](https://github.com/daira/CompElliptic/blob/main/.github/workflows/ci.yml).
+
+## Source-level checks
+
+Each of these is a standalone script under `scripts/`, run by CI on every
+Lean-relevant change. All of them can be run locally from the repository root.
+
+* **`check_build_coverage.sh`** — CI and the lakefile agree on the target list, and
+  every Lean module is reachable from it. A module no target reaches is not elaborated
+  at all: its `sorry`s, its axiom drift, and even a failure to compile would be
+  invisible to a green build.
+* **`check_endpoint_census.sh`** — every deliverable soundness endpoint is named in a
+  census pin. The census commands traverse a declaration's *dependencies*, so an
+  endpoint that nothing pinned depends on would otherwise be invisible to every census
+  entry.
+* **`check_csimp_census.sh`** — every `@[csimp]` replacement lemma has its own
+  `assert_axioms` entry. The compiler applies a csimp substitution in all downstream
+  compiled code, but the lemma's own axioms are not propagated into downstream
+  `native_decide` axiom tracking
+  ([lean4#7463](https://github.com/leanprover/lean4/issues/7463)).
+* **`check_costed_group_work_census.sh`** — the staged Vesta work model's host
+  callbacks (`pure`/`map` payloads) carry non-group computation at no charge to the
+  group-work counter. The cost language is shallow, so Lean cannot check that an
+  opaque payload performs no Vesta group law; each such definition is therefore
+  pinned, and a new one must join the census to be reviewed against that condition.
+* **`check_no_umbrella_imports.sh`** — no Lean file imports a Mathlib umbrella module.
+  `import Mathlib` pulls in all of Mathlib, and several such processes in a parallel
+  build create severe memory pressure.
+* **`check_fixture_manifest.sh`** — every machine-generated capture artifact matches
+  its recorded digest and provenance entry in `Zcash/Snark/Fixtures/MANIFEST.tsv`.
+  This binds the committed artifacts to their provenance on every run, with no Rust
+  toolchain needed.
+
+## Fixture regeneration
+
+**`scripts/regenerate-fingerprint-fixtures.sh`** proves the committed captures
+regenerate byte-for-byte from their sources: it clones the pinned Orchard release,
+asserts the tag and its published lockfile checksums, regenerates every capture family
+plus the proof-byte siblings, and diffs each committed artifact. CI runs the full
+regeneration when a fixture-relevant path changes; on every other run, the manifest
+check above still binds the artifacts to their recorded digests.
+
+The circuit-side layout dumps have no regeneration pipeline: their generator is
+unpublished one-off instrumentation in local halo2/orchard checkouts
+(`Zcash/Circuits/Fixtures/PROVENANCE.md` records the lineage). This should not be
+confused with the *verifier-fingerprint* exporter above, which is published and
+pinned. Publishing the layout instrumentation is
+[#207](https://github.com/zcash/ironwood/issues/207). CI instead pins the bytes of
+the layout dumps: `SHA256SUMS` must list exactly the committed dumps, each digest
+must match, and the `Stamp.lean` rendering of those pins —which carries a fixture
+change into Lake's import graph— must be current.
+
+## Book checks
+
+The book workflow validates the proof-journey page's graph data before building:
+`book/validate-proof-journey.py` checks the recorded edges against the checked-out
+Lean tree, so a renamed or deleted anchor fails CI rather than silently pointing at
+nothing. The book itself is then built with `mdbook`, which resolves every included
+file and internal link.


### PR DESCRIPTION
README and build-documentation changes:

- Retitle to "Formalizing Ironwood". The previous title "Ironwood ← Setup(1<sup>λ</sup>)" borrowed the security-parameter argument from asymptotic security definitions, where it makes the setup polynomial-time in λ. This development is a concrete-security analysis of fixed curves and hashes, so the device does not apply. It is also misleading: it suggests a fresh setup, while Ironwood reuses a URS fixed when Orchard was designed — the point from which attacks against it could begin, as the Security Models page describes. The new title deliberately reads as an ongoing process.
- Set "The Ironwood Book" link in Raleway where styles apply. The book includes the README as its landing page, so the link picks up the book's Raleway face at the intended weight via a stylesheet class. GitHub strips the attribute and renders a plain link (confirmed on the branch).
- Correct the verification command. `lake build` was described as "exactly what CI runs", but CI treats warnings as errors and runs source-level consistency checks besides. The README now recommends `lake build --wfail` — which builds every Lean file CI builds — and links a new "Build and CI Checks" reference page in the book documenting the build targets, the check scripts, fixture regeneration and byte-pinning, the book workflow's proof-journey validation, and what is not covered of the CompElliptic dependency's own checks.

🤖 Filed with Claude Code (Fable 5)
