### PR TITLE
fv: the circuit-to-ledger Action witness bridge

### DIFF
--- a/Zcash/Circuits/Integration/TopLevelCircuit.lean
+++ b/Zcash/Circuits/Integration/TopLevelCircuit.lean
@@ -1,6 +1,7 @@
 import Clean.Halo2.TopLevel
 import Zcash.Circuits.Integration.CircuitIntegration
 import Zcash.Common.RelationWitness
+import Zcash.Common.Satisfying
 
 /-!
 # Generic SNARK-to-top-level-circuit endpoint
@@ -36,15 +37,16 @@ theorem topLevelSoundness
 
 end FullCircuitSatisfaction
 
-/-- Type-valued semantic evidence for a top-level circuit.  Unlike
-`TopLevelCircuit.Statement`, this retains the private witness as executable data. -/
-structure TopLevelSemanticWitness
+/-- Type-valued semantic evidence for a top-level circuit: the private witness as
+executable data, together with its specification proof — `Zcash.Common.Satisfying`
+at the circuit's own specification.  Unlike `TopLevelCircuit.Statement`, nothing is
+truncated. -/
+abbrev TopLevelSemanticWitness
     {Config : Type} {PublicInput : TypeMap}
     [ProvableType PublicInput]
     (top : TopLevelCircuit Fp Config PublicInput)
-    (publicInput : PublicInput Fp) where
-  privateWitness : top.PrivateWitness
-  valid : top.Spec publicInput privateWitness
+    (publicInput : PublicInput Fp) : Type :=
+  Zcash.Common.Satisfying top.Spec publicInput
 
 namespace TopLevelSemanticWitness
 
@@ -56,7 +58,7 @@ theorem statement
     {publicInput : PublicInput Fp}
     (witness : TopLevelSemanticWitness top publicInput) :
     top.Statement publicInput :=
-  ⟨witness.privateWitness, witness.valid⟩
+  ⟨witness.w, witness.satisfied⟩
 
 end TopLevelSemanticWitness
 
@@ -130,9 +132,8 @@ def semanticWitness_or_bad
     TopLevelSemanticWitness top
       (top.extractPublicInput (top.environment assignment)) ⊕' Bad :=
   bindOrRelationWitness witness.bridge.satisfaction_or_bad fun hsatisfied =>
-    { privateWitness :=
-        top.extractPrivateWitness (top.placedEnvironment assignment)
-      valid := top.soundness assignment
+    { w := top.extractPrivateWitness (top.placedEnvironment assignment)
+      satisfied := top.soundness assignment
         (by
           rw [witness.operations_eq]
           exact FullCircuitSatisfaction.constraints

--- a/Zcash/Circuits/Integration/TopLevelCircuit.lean
+++ b/Zcash/Circuits/Integration/TopLevelCircuit.lean
@@ -39,7 +39,7 @@ end FullCircuitSatisfaction
 
 /-- Type-valued semantic evidence for a top-level circuit: the private witness as
 executable data, together with its specification proof — `Zcash.Common.Satisfying`
-at the circuit's own specification.  Unlike `TopLevelCircuit.Statement`, nothing is
+at the circuit's own specification. Unlike `TopLevelCircuit.Statement`, nothing is
 truncated. -/
 abbrev TopLevelSemanticWitness
     {Config : Type} {PublicInput : TypeMap}

--- a/Zcash/Circuits/Integration/TopLevelCorrectness.lean
+++ b/Zcash/Circuits/Integration/TopLevelCorrectness.lean
@@ -109,11 +109,11 @@ def of_publicInputEncoding
       pp.numProofs proofIndex :=
     { polynomial := poly }
   refine
-    { privateWitness := (witness proofIndex).privateWitness
-      valid := ?_ }
+    { w := (witness proofIndex).w
+      satisfied := ?_ }
   rw [← assignment.extractPublicInput_eq
     (inputs proofIndex) (hencoding proofIndex)]
-  exact (witness proofIndex).valid
+  exact (witness proofIndex).satisfied
 
 /-- Forget the retained decoded witnesses and recover the ordinary bundle statement. -/
 theorem statement

--- a/Zcash/Common/Satisfying.lean
+++ b/Zcash/Common/Satisfying.lean
@@ -2,7 +2,7 @@
 # A satisfying witness, as data
 
 `Satisfying R x` bundles a witness with the proof that it satisfies the relation `R`
-at the instance `x`.  It is Type-valued: under Curry–Howard the witness is data, and
+at the instance `x`. It is Type-valued: under Curry–Howard the witness is data, and
 that is what keeps knowledge-soundness statements constructive — `Classical.choice`
 can conjure the truncated `∃ w, R x w` from mere soundness, but not this structure.
 
@@ -10,7 +10,7 @@ Modelled on `Satisfying` in zcash-lean's `Zcash/Proofs/Relations.lean`
 (<https://github.com/daira/zcash-lean/blob/9065c356416e802a3b57cc54b26c8ac9b4165e4c/Zcash/Proofs/Relations.lean>),
 which develops refinements between relations, with completeness, soundness, and
 knowledge soundness as properties of the refinements rather than of individual
-relations.  Divergences a reader of that file should expect here: the instance and
+relations. Divergences a reader of that file should expect here: the instance and
 witness types are universe-polymorphic rather than fixed at `Type`; the relation is a
 curried `I → W → Prop` rather than Mathlib's `Rel`; and this development's
 knowledge-soundness maps are fallible — they conclude `Satisfying … ⊕' Break` with

--- a/Zcash/Common/Satisfying.lean
+++ b/Zcash/Common/Satisfying.lean
@@ -1,0 +1,33 @@
+/-!
+# A satisfying witness, as data
+
+`Satisfying R x` bundles a witness with the proof that it satisfies the relation `R`
+at the instance `x`.  It is Type-valued: under Curry–Howard the witness is data, and
+that is what keeps knowledge-soundness statements constructive — `Classical.choice`
+can conjure the truncated `∃ w, R x w` from mere soundness, but not this structure.
+
+Modelled on `Satisfying` in zcash-lean's `Zcash/Proofs/Relations.lean`
+(<https://github.com/daira/zcash-lean/blob/9065c356416e802a3b57cc54b26c8ac9b4165e4c/Zcash/Proofs/Relations.lean>),
+which develops refinements between relations, with completeness, soundness, and
+knowledge soundness as properties of the refinements rather than of individual
+relations.  Divergences a reader of that file should expect here: the instance and
+witness types are universe-polymorphic rather than fixed at `Type`; the relation is a
+curried `I → W → Prop` rather than Mathlib's `Rel`; and this development's
+knowledge-soundness maps are fallible — they conclude `Satisfying … ⊕' Break` with
+the break carried as computed data and priced by a hardness assumption, rather than
+being total functions between satisfying witnesses.
+-/
+
+namespace Zcash.Common
+
+universe u v
+
+/-- A witness together with the proof that it satisfies the relation at the given
+instance. -/
+structure Satisfying {I : Type u} {W : Type v} (R : I → W → Prop) (x : I) where
+  /-- The witness. -/
+  w : W
+  /-- The relation is satisfied by this witness at the given instance. -/
+  satisfied : R x w
+
+end Zcash.Common

--- a/Zcash/Security/Ledger/ActionBundleBridge.lean
+++ b/Zcash/Security/Ledger/ActionBundleBridge.lean
@@ -5,12 +5,12 @@ import Zcash.Snark.Soundness.Action.AdaptiveStatementKnowledge
 /-!
 # The bundle-level Action-to-ledger bridge
 
-Lift the per-Action data bridge across an accepted bundle.  Each extracted member
+Lift the per-Action data bridge across an accepted bundle. Each extracted member
 witness (`TopLevelSemanticWitness`) is a satisfying witness of the circuit-facing
 `ActionSpec` (`Zcash.Common.Satisfying`), and `actionSpecToLedgerData` refines it to
 the member's ledger data —the full extracted witness together with its refined
 ledger action— or the computed discrete-log relation of its first Sinsemilla
-escape.  The bundle traversal returns every member's data or the first escape
+escape. The bundle traversal returns every member's data or the first escape
 (`finForallOrRelationWitness`): knowledge soundness composed at the reduction layer,
 with everything carried as data.
 -/
@@ -84,7 +84,7 @@ variable {pp : ProofParams} (family : ComputedAdaptiveActionStatementFSFamily pp
 /-- The ledger-level outcome of one adaptive-statement run: every member's ledger data, a
 ledger Sinsemilla escape, or the circuit-side algebraic relation over the run's own basis.
 `none` is exactly the runs on which the shared knowledge outcome is undefined
-(`actionLedgerOutcome_isSome_iff`).  The routing is deliberate: circuit-side relations
+(`actionLedgerOutcome_isSome_iff`). The routing is deliberate: circuit-side relations
 stay in their own arm —on accepting runs, that arm and `none` together are the
 knowledge-failure event that the knowledge-error endpoint bounds— and only the
 bridge's Sinsemilla escapes surface as ledger breaks. -/

--- a/Zcash/Security/Ledger/ActionBundleBridge.lean
+++ b/Zcash/Security/Ledger/ActionBundleBridge.lean
@@ -1,0 +1,74 @@
+import Zcash.Common.Satisfying
+import Zcash.Security.Ledger.SinsemillaDLR
+import Zcash.Snark.Soundness.Action.StraightLineTerminal
+
+/-!
+# The bundle-level Action-to-ledger bridge
+
+Lift the per-Action data bridge across an accepted bundle.  Each extracted member
+witness (`TopLevelSemanticWitness`) is a satisfying witness of the circuit-facing
+`ActionSpec` (`Zcash.Common.Satisfying`), and `actionSpecToLedgerData` refines it to
+the member's ledger data —the full extracted witness together with its refined
+ledger action— or the computed discrete-log relation of its first Sinsemilla
+escape.  The bundle traversal returns every member's data or the first escape
+(`finForallOrRelationWitness`): knowledge soundness composed at the reduction layer,
+with everything carried as data.
+-/
+
+namespace Zcash.Security.Ledger.ActionBundleBridge
+
+open Zcash.Circuits
+open Zcash.Circuits.Action
+open Zcash.Common
+open Zcash.Security.Concrete
+open Zcash.Security.Ledger.Bridge
+open Zcash.Snark
+open Zcash.Snark.ActionTerminal
+
+variable {MSG SIG : Type*}
+
+/-- An extracted bundle member as a satisfying witness of the circuit-facing
+`ActionSpec`: the private witness transported across the circuit boundary, with its
+specification proof. -/
+def memberSatisfying {input : PublicInputs Fp}
+    (w : TopLevelSemanticWitness actionCircuit input) :
+    Satisfying ActionSpec input where
+  w := actionCircuit_privateWitness_eq ▸ w.w
+  satisfied := by
+    rw [actionCircuit_spec_iff]
+    simp only [eqRec_eq_cast, cast_cast, cast_eq]
+    exact w.satisfied
+
+/-- The ledger data of one accepted bundle member. -/
+structure MemberLedgerData
+    (spendAuthVerify bindingVerify : PallasGroup → MSG → SIG → Prop)
+    (input : PublicInputs Fp) where
+  /-- The member's extracted private witness — the chain's genuinely free value,
+  carried in full. -/
+  wit : PrivateWitness
+  /-- The member's refined ledger action. -/
+  success : ActionLedgerSuccess spendAuthVerify bindingVerify (combine input wit)
+
+/-- Refine one extracted bundle member to its ledger data, or the computed
+discrete-log relation of its first Sinsemilla escape. -/
+def memberLedgerData
+    (spendAuthVerify bindingVerify : PallasGroup → MSG → SIG → Prop)
+    {input : PublicInputs Fp}
+    (w : TopLevelSemanticWitness actionCircuit input) :
+    MemberLedgerData spendAuthVerify bindingVerify input ⊕' ActionDLBreak :=
+  let sat := memberSatisfying w
+  bindOrRelationWitness
+    (actionSpecToLedgerData spendAuthVerify bindingVerify input sat.w sat.satisfied)
+    fun success => { wit := sat.w, success := success }
+
+/-- Refine every member of an accepted bundle, or return the first member's computed
+escape relation. -/
+def bundleLedgerData
+    (spendAuthVerify bindingVerify : PallasGroup → MSG → SIG → Prop)
+    {numProofs : ℕ} {inputs : Fin numProofs → PublicInputs Fp}
+    (witness : ActionBundleWitness inputs) :
+    (∀ i, MemberLedgerData spendAuthVerify bindingVerify (inputs i)) ⊕' ActionDLBreak :=
+  finForallOrRelationWitness fun i =>
+    memberLedgerData spendAuthVerify bindingVerify (witness i)
+
+end Zcash.Security.Ledger.ActionBundleBridge

--- a/Zcash/Security/Ledger/ActionBundleBridge.lean
+++ b/Zcash/Security/Ledger/ActionBundleBridge.lean
@@ -1,6 +1,6 @@
 import Zcash.Common.Satisfying
 import Zcash.Security.Ledger.SinsemillaDLR
-import Zcash.Snark.Soundness.Action.StraightLineTerminal
+import Zcash.Snark.Soundness.Action.AdaptiveStatementKnowledge
 
 /-!
 # The bundle-level Action-to-ledger bridge
@@ -70,5 +70,56 @@ def bundleLedgerData
     (∀ i, MemberLedgerData spendAuthVerify bindingVerify (inputs i)) ⊕' ActionDLBreak :=
   finForallOrRelationWitness fun i =>
     memberLedgerData spendAuthVerify bindingVerify (witness i)
+
+section Extraction
+
+open Zcash.Arithmetic (scalarFieldOrder)
+
+variable {pp : ProofParams} (family : ComputedAdaptiveActionStatementFSFamily pp)
+  (hchar : ∀ basis O, deployedX4PairCount (adaptiveActionStatementVk pp basis)
+    (adaptiveActionStatementInstanceCommitment pp basis (family.runOutput basis O).inputs)
+    (family.runProof basis O).proof.1 (family.runRecord basis O) < scalarFieldOrder)
+  (spendAuthVerify bindingVerify : PallasGroup → MSG → SIG → Prop)
+
+/-- The ledger-level outcome of one adaptive-statement run: every member's ledger data, a
+ledger Sinsemilla escape, or the circuit-side algebraic relation over the run's own basis.
+`none` is exactly the runs on which the shared knowledge outcome is undefined
+(`actionLedgerOutcome_isSome_iff`).  The routing is deliberate: circuit-side relations
+stay in their own arm —on accepting runs, that arm and `none` together are the
+knowledge-failure event that the knowledge-error endpoint bounds— and only the
+bridge's Sinsemilla escapes surface as ledger breaks. -/
+def actionLedgerOutcome
+    (basis : AugmentedIndex (2 ^ (AdaptiveActionStatementShape pp).k) → VestaG)
+    (O : family.Coins) :
+    Option ((∀ i, MemberLedgerData spendAuthVerify bindingVerify
+        ((family.runOutput basis O).inputs i))
+      ⊕ (ActionDLBreak ⊕ AlgebraicRelationWitness (F := Fp) basis)) :=
+  (family.adaptiveStatementKnowledgeOutcome hchar basis O).map fun
+    | Sum.inl witness =>
+        match bundleLedgerData spendAuthVerify bindingVerify witness with
+        | PSum.inl members => Sum.inl members
+        | PSum.inr dlb => Sum.inr (Sum.inl dlb)
+    | Sum.inr relation => Sum.inr (Sum.inr relation)
+
+/-- The composed ledger-level extractor: every member's ledger data, on the runs
+where the witness extraction succeeds and no member escapes. -/
+def actionLedgerExtractor
+    (basis : AugmentedIndex (2 ^ (AdaptiveActionStatementShape pp).k) → VestaG)
+    (O : family.Coins) :
+    Option (∀ i, MemberLedgerData spendAuthVerify bindingVerify
+      ((family.runOutput basis O).inputs i)) :=
+  match actionLedgerOutcome family hchar spendAuthVerify bindingVerify basis O with
+  | some (Sum.inl members) => some members
+  | _ => none
+
+/-- The ledger outcome is defined exactly where the shared knowledge outcome is:
+the composition adds no new failure. -/
+theorem actionLedgerOutcome_isSome_iff (basis) (O) :
+    (actionLedgerOutcome family hchar spendAuthVerify bindingVerify basis O).isSome ↔
+      (family.adaptiveStatementKnowledgeOutcome hchar basis O).isSome := by
+  unfold actionLedgerOutcome
+  simp
+
+end Extraction
 
 end Zcash.Security.Ledger.ActionBundleBridge

--- a/Zcash/Security/Ledger/ActionBundleBridge.lean
+++ b/Zcash/Security/Ledger/ActionBundleBridge.lean
@@ -120,6 +120,43 @@ theorem actionLedgerOutcome_isSome_iff (basis) (O) :
   unfold actionLedgerOutcome
   simp
 
+/-- The computed ledger escape of one run: the discrete-log relation data of the first
+member's Sinsemilla escape, on the runs where the extracted bundle escapes the bridge. -/
+def actionLedgerEscapeFinder
+    (basis : AugmentedIndex (2 ^ (AdaptiveActionStatementShape pp).k) → VestaG)
+    (O : family.Coins) : Option ActionDLBreak :=
+  match actionLedgerOutcome family hchar spendAuthVerify bindingVerify basis O with
+  | some (Sum.inr (Sum.inl dlb)) => some dlb
+  | _ => none
+
+/-- The composed `actionLedgerExtractor` fails iff either:
+* the shared knowledge outcome carries no witness — i.e. on its undefined and relation arms; or
+* a member of the extracted bundle escapes the bridge (`actionLedgerEscapeFinder` returns
+  something). -/
+theorem actionLedgerExtractor_eq_none_iff (basis) (O) :
+    actionLedgerExtractor family hchar spendAuthVerify bindingVerify basis O = none ↔
+      (family.adaptiveStatementKnowledgeExtractor hchar basis O = none ∨
+        (actionLedgerEscapeFinder family hchar spendAuthVerify bindingVerify
+          basis O).isSome) := by
+  rw [ComputedAdaptiveActionStatementFSFamily.adaptiveStatementKnowledgeExtractor_eq_none_iff]
+  have houtEq : actionLedgerOutcome family hchar spendAuthVerify bindingVerify basis O =
+      (family.adaptiveStatementKnowledgeOutcome hchar basis O).map _ := rfl
+  unfold actionLedgerExtractor actionLedgerEscapeFinder
+  rw [houtEq]
+  cases houtcome : family.adaptiveStatementKnowledgeOutcome hchar basis O with
+  | none => simp
+  | some outcome =>
+      cases outcome with
+      | inl witness =>
+          cases hb : bundleLedgerData spendAuthVerify bindingVerify witness with
+          | inl members =>
+              refine iff_of_false (by simp [hb]) ?_
+              rintro (hforall | hesc)
+              · exact hforall witness rfl
+              · simp [hb] at hesc
+          | inr dlb => simp [hb]
+      | inr relation => simp
+
 end Extraction
 
 end Zcash.Security.Ledger.ActionBundleBridge

--- a/Zcash/Security/Ledger/Bridge.lean
+++ b/Zcash/Security/Ledger/Bridge.lean
@@ -476,13 +476,12 @@ theorem classify_none_defined {wit : ActionData} (h : classifyAction wit = none)
         exact ⟨⟨Bi, hashToPointB_inl hivk⟩, ⟨Bo, hashToPointB_inl hold⟩,
           ⟨Bn, hashToPointB_inl hnew⟩, classifyMerkle_none_defined h⟩
 
-/-- **The Prop-level break and the computed classifier cannot diverge, at the consumer
-boundary either**: an exhibited `ActionBreak` holds exactly when the classifier reports
-an escape.  A consumer landing in the break arm of `actionSpec_to_ledger` can
-therefore pass to `classifyAction`'s (and hence `classifyRelation`'s) computed data
-without reconstructing the glue: forward, each break constructor's
-`hashToPointB … = .inr` equation contradicts the defined hashes of a `none` verdict;
-backward is classifier soundness. -/
+/-- **The Prop-level break and the computed classifier cannot diverge**: an exhibited
+`ActionBreak` holds exactly when the classifier reports an escape.  This is what lets
+the data bridge's success branch (`ActionLedgerSuccess.ofSpec`) turn the classifier's
+`none` verdict into the absence of every Prop-level break: forward, each break
+constructor's `hashToPointB … = .inr` equation contradicts the defined hashes of a
+`none` verdict; backward is classifier soundness. -/
 theorem actionBreak_iff_classify_isSome {wit : ActionData} :
     ActionBreak wit ↔ (classifyAction wit).isSome := by
   constructor
@@ -536,51 +535,74 @@ theorem CommitIvkSuccess.ivk_ne {wit : ActionData} {ivk : Fp}
     rfl
   exact Point.ne_zero_of_onCurve hpkd hzero
 
-/-- Convert the successful `Commit^ivk` branch into the exact deployed Orchard
-key-binding witness used by the ledger statement.  The returned equations keep
-the affine Action points available in their Pallas-wrapper form for the final
-address and spend-authority fields. -/
-theorem commitIvkSuccess_to_ledger {wit : ActionData}
-    (hgd : wit.gdOld.OnCurve) (hak : wit.akP.OnCurve)
-    (hpkd : wit.pkdOld.OnCurve) (h : CommitIvkSuccess wit) :
-    ∃ (ivk : Fp) (kw : KeyBinding.Pool.Witness Fq PallasGroup Fp),
-      Pool.keyBinding.KB kw ∧
-      Pool.keyBinding.ivk kw ≠ 0 ∧
-      Pool.keyBinding.ivk kw = ivk ∧
-      Pool.keyBinding.nk kw = wit.nk ∧
-      Pool.keyBinding.akP kw = PallasGroup.ofPoint wit.akP (.inl hak) ∧
+/-- A successful `Commit^ivk` opening makes the ledger's own hash primitive defined
+on the witnessed key material. -/
+theorem CommitIvkSuccess.hash_isSome {wit : ActionData} (h : CommitIvkSuccess wit) :
+    (Pool.commitIvkHash wit.akP.x wit.nk).isSome := by
+  obtain ⟨ivk, bp, hbp, -, -⟩ := h
+  exact Option.isSome_iff_exists.mpr ⟨_, commitIvkHash_of_action_hash hbp⟩
+
+/-- The exact deployed Orchard key-binding witness of a successful `Commit^ivk`
+opening, computed through the ledger's own primitives: the hash point is the defined
+value of `Pool.commitIvkHash`, and the incoming viewing key is the extraction the
+interface's opening equation demands, so that equation holds by construction. -/
+def commitIvkWitness (wit : ActionData) (hak : wit.akP.OnCurve)
+    (hdef : (Pool.commitIvkHash wit.akP.x wit.nk).isSome) :
+    KeyBinding.Pool.Witness Fq PallasGroup Fp :=
+  { ivk := Pool.extract ((Pool.commitIvkHash wit.akP.x wit.nk).get hdef +
+      wit.rivk.2 • PallasGroup.ofPoint Ecc.MulFixed.Certs.commitIvkR.point
+        (Or.inl Ecc.MulFixed.Certs.commitIvkR.onCurve)),
+    akP := PallasGroup.ofPoint wit.akP (.inl hak),
+    nk := wit.nk,
+    rivk := wit.rivk.2,
+    hashPoint := (Pool.commitIvkHash wit.akP.x wit.nk).get hdef }
+
+@[simp] theorem commitIvkWitness_nk (wit : ActionData) (hak : wit.akP.OnCurve)
+    (hdef : (Pool.commitIvkHash wit.akP.x wit.nk).isSome) :
+    (commitIvkWitness wit hak hdef).nk = wit.nk := rfl
+
+@[simp] theorem commitIvkWitness_akP (wit : ActionData) (hak : wit.akP.OnCurve)
+    (hdef : (Pool.commitIvkHash wit.akP.x wit.nk).isSome) :
+    (commitIvkWitness wit hak hdef).akP = PallasGroup.ofPoint wit.akP (.inl hak) := rfl
+
+/-- The computed key-binding witness satisfies the deployed opening relation, and its
+extracted key opens the witnessed address equation. -/
+theorem commitIvkWitness_kb {wit : ActionData}
+    (hgd : wit.gdOld.OnCurve) (hak : wit.akP.OnCurve) (hpkd : wit.pkdOld.OnCurve)
+    (hdef : (Pool.commitIvkHash wit.akP.x wit.nk).isSome)
+    (h : CommitIvkSuccess wit) :
+    Pool.keyBinding.KB (commitIvkWitness wit hak hdef) ∧
       PallasGroup.ofPoint wit.pkdOld (.inl hpkd) =
-        PallasGroup.embedFp (Pool.keyBinding.ivk kw) •
+        PallasGroup.embedFp (commitIvkWitness wit hak hdef).ivk •
           PallasGroup.ofPoint wit.gdOld (.inl hgd) := by
-  rcases h with ⟨ivk, bp, hbp, hivk, hpkdEq⟩
+  obtain ⟨ivk, bp, hbp, hivk, hpkdEq⟩ := h
   have hbpValid : bp.Valid :=
     hashToPoint_valid (Or.inl orchardBases.ivkQ_onCurve)
       (fun _ hm => chunksOf_mem_lt hm) hbp
-  let kw : KeyBinding.Pool.Witness Fq PallasGroup Fp :=
-    { ivk := ivk,
-      akP := PallasGroup.ofPoint wit.akP (.inl hak),
-      nk := wit.nk,
-      rivk := wit.rivk.2,
-      hashPoint := PallasGroup.ofPoint bp hbpValid }
+  have hsome : Pool.commitIvkHash wit.akP.x wit.nk =
+      some (PallasGroup.ofPoint bp hbpValid) :=
+    commitIvkHash_of_action_hash hbp
+  have hget : (Pool.commitIvkHash wit.akP.x wit.nk).get hdef =
+      PallasGroup.ofPoint bp hbpValid := by
+    simp only [hsome, Option.get_some]
   have hivk' : ivk =
       (bp + wit.rivk.2.val • Ecc.MulFixed.Certs.commitIvkR.point).x := by
     simpa [orchardBases, Ecc.MulFixed.FixedBase.scalarMul] using hivk
-  have hkb : Pool.keyBinding.KB kw := by
-    change KeyBinding.Pool.KB Pool.extract Pool.commitIvkHash
-      (PallasGroup.ofPoint Ecc.MulFixed.Certs.commitIvkR.point
-        (Or.inl Ecc.MulFixed.Certs.commitIvkR.onCurve)) kw
-    refine ⟨?_, ?_, ?_⟩
-    · dsimp [kw]
-      exact commitIvkHash_of_action_hash hbp
-    · dsimp [kw]
-      simpa only [Pool.extract, PallasGroup.toPoint_add,
-        PallasGroup.toPoint_smul, PallasGroup.toPoint_nsmul,
-        PallasGroup.toPoint_ofPoint] using hivk'
-    · dsimp [kw]
-      apply CommitIvkSuccess.ivk_ne hpkd
-      exact ⟨bp, hbp, hivk, hpkdEq⟩
-  refine ⟨ivk, kw, hkb, hkb.ivk_ne, rfl, rfl, rfl, ?_⟩
-  · exact ofPoint_eq_embed_smul (.inl hpkd) (.inl hgd) hpkdEq
+  have hivk_eq : (commitIvkWitness wit hak hdef).ivk = ivk := by
+    show Pool.extract _ = ivk
+    rw [hget, hivk']
+    simp only [Pool.extract, PallasGroup.toPoint_add, PallasGroup.toPoint_smul,
+      PallasGroup.toPoint_ofPoint]
+  refine ⟨⟨?_, rfl, ?_⟩, ?_⟩
+  · show Pool.commitIvkHash
+      (Pool.extract (PallasGroup.ofPoint wit.akP (.inl hak))) wit.nk =
+      some ((Pool.commitIvkHash wit.akP.x wit.nk).get hdef)
+    rw [hget]
+    simpa [Pool.extract, PallasGroup.toPoint_ofPoint] using hsome
+  · rw [hivk_eq]
+    exact CommitIvkSuccess.ivk_ne hpkd ⟨bp, hbp, hivk, hpkdEq⟩
+  · rw [hivk_eq]
+    exact ofPoint_eq_embed_smul (.inl hpkd) (.inl hgd) hpkdEq
 
 /-- Successful old-note Sinsemilla opening. -/
 def NoteCommitOldSuccess (wit : ActionData) : Prop :=
@@ -598,21 +620,16 @@ def NoteCommitNewSuccess (wit : ActionData) : Prop :=
         = some hashPoint ∧
     wit.cmx = (hashPoint + wit.rcmNew.2 • orchardBases.noteCommitR).x
 
-/-- Turn the successful output-note opening retained by the Action statement
-into the concrete ledger commitment.  Unlike the circuit public input, the
-ledger keeps the full commitment point; this lemma supplies that point together
-with the coordinate equation used for `cmx_new_eq`. -/
-theorem noteCommitNewSuccess_to_ledger (spendAuthVerify bindingVerify : PallasGroup → MSG → SIG → Prop)
-    {wit : ActionData}
+/-- A successful output-note opening makes the ledger's own commitment primitive
+defined on the witnessed new note.  Unlike the circuit public input, the ledger
+keeps the full commitment point; the defined value is that point. -/
+theorem NoteCommitNewSuccess.commit_isSome {wit : ActionData}
     (hgd : wit.gdNew.OnCurve) (hpkd : wit.pkdNew.OnCurve)
     (h : NoteCommitNewSuccess wit) :
-    ∃ (cmNewP : Point Fp) (hcmNewP : cmNewP.Valid),
-      cmNewP.x = wit.cmx ∧
-      (Pool.primitives spendAuthVerify bindingVerify).noteCommit wit.rcmNew.2
-        { gd := PallasGroup.ofPoint wit.gdNew (.inl hgd),
-          pkd := PallasGroup.ofPoint wit.pkdNew (.inl hpkd),
-          v := wit.vNew.val, ρ := wit.nfOld, ψ := wit.psiNew } =
-        some (PallasGroup.ofPoint cmNewP hcmNewP) := by
+    (Pool.noteCommit wit.rcmNew.2
+      { gd := PallasGroup.ofPoint wit.gdNew (.inl hgd),
+        pkd := PallasGroup.ofPoint wit.pkdNew (.inl hpkd),
+        v := wit.vNew.val, ρ := wit.nfOld, ψ := wit.psiNew }).isSome := by
   rcases h with ⟨bp, hbp, hcmx⟩
   have hbpValid : bp.Valid :=
     hashToPoint_valid (Or.inl orchardBases.noteQ_onCurve)
@@ -623,15 +640,48 @@ theorem noteCommitNewSuccess_to_ledger (spendAuthVerify bindingVerify : PallasGr
     dsimp [cmNewP]
     exact Point.valid_add hbpValid
       (Point.valid_nsmul (Or.inl Ecc.MulFixed.Certs.noteCommitR.onCurve) _)
-  refine ⟨cmNewP, hcmNewP, ?_, ?_⟩
-  · simpa [cmNewP, orchardBases, Ecc.MulFixed.FixedBase.scalarMul] using hcmx.symm
-  · change Pool.noteCommit wit.rcmNew.2
+  refine Option.isSome_iff_exists.mpr ⟨PallasGroup.ofPoint cmNewP hcmNewP, ?_⟩
+  apply noteCommit_of_action_hash hgd hpkd hcmNewP hbp
+  rfl
+
+/-- The defined new-note commitment extracts to the witnessed `cmx` coordinate. -/
+theorem NoteCommitNewSuccess.extract_get {wit : ActionData}
+    (hgd : wit.gdNew.OnCurve) (hpkd : wit.pkdNew.OnCurve)
+    (hdef : (Pool.noteCommit wit.rcmNew.2
+      { gd := PallasGroup.ofPoint wit.gdNew (.inl hgd),
+        pkd := PallasGroup.ofPoint wit.pkdNew (.inl hpkd),
+        v := wit.vNew.val, ρ := wit.nfOld, ψ := wit.psiNew }).isSome)
+    (h : NoteCommitNewSuccess wit) :
+    Pool.extract ((Pool.noteCommit wit.rcmNew.2
+      { gd := PallasGroup.ofPoint wit.gdNew (.inl hgd),
+        pkd := PallasGroup.ofPoint wit.pkdNew (.inl hpkd),
+        v := wit.vNew.val, ρ := wit.nfOld, ψ := wit.psiNew }).get hdef) = wit.cmx := by
+  rcases h with ⟨bp, hbp, hcmx⟩
+  have hbpValid : bp.Valid :=
+    hashToPoint_valid (Or.inl orchardBases.noteQ_onCurve)
+      (fun _ hm => chunksOf_mem_lt hm) hbp
+  let cmNewP : Point Fp :=
+    bp + wit.rcmNew.2.val • Ecc.MulFixed.Certs.noteCommitR.point
+  have hcmNewP : cmNewP.Valid := by
+    dsimp [cmNewP]
+    exact Point.valid_add hbpValid
+      (Point.valid_nsmul (Or.inl Ecc.MulFixed.Certs.noteCommitR.onCurve) _)
+  have hsome : Pool.noteCommit wit.rcmNew.2
       { gd := PallasGroup.ofPoint wit.gdNew (.inl hgd),
         pkd := PallasGroup.ofPoint wit.pkdNew (.inl hpkd),
         v := wit.vNew.val, ρ := wit.nfOld, ψ := wit.psiNew } =
-        some (PallasGroup.ofPoint cmNewP hcmNewP)
+        some (PallasGroup.ofPoint cmNewP hcmNewP) := by
     apply noteCommit_of_action_hash hgd hpkd hcmNewP hbp
     rfl
+  have hget : (Pool.noteCommit wit.rcmNew.2
+      { gd := PallasGroup.ofPoint wit.gdNew (.inl hgd),
+        pkd := PallasGroup.ofPoint wit.pkdNew (.inl hpkd),
+        v := wit.vNew.val, ρ := wit.nfOld, ψ := wit.psiNew }).get hdef =
+      PallasGroup.ofPoint cmNewP hcmNewP := by
+    simp only [hsome, Option.get_some]
+  rw [hget]
+  simp only [Pool.extract, PallasGroup.toPoint_ofPoint]
+  simpa [cmNewP, orchardBases, Ecc.MulFixed.FixedBase.scalarMul] using hcmx.symm
 
 /-- The successful Merkle outcome as consumed by the ledger refinement: the exact
 raw-encoding path together with every layer's hash landing in its defined branch,
@@ -778,18 +828,41 @@ theorem merkle_path_of_exact {wit : ActionData} {root : Fp}
     exact ⟨B.x, Pool.merkleCompress_eq_of_hashToPoint (by
       simpa [orchardBases, Zcash.Circuits.Action.merkleQ, Pool.merkleQ] using hB)⟩
 
-/-- The Action postcondition refines to either one of its explicitly exhibited
-Sinsemilla escapes or a fully satisfied concrete Orchard ledger action.  The ledger
-alternative additionally reports the spend/output enable gates as a side fact
-(`EnableFlagsSatisfied`), with their exact circuit semantics. -/
-theorem actionSpec_to_ledger (spendAuthVerify bindingVerify : PallasGroup → MSG → SIG → Prop)
+/-- The refined ledger action retained as data: the concrete instance and witness that
+annotate an accepted Action, together with the proofs that they satisfy the
+games-facing statement.  The structure is indexed by the full circuit witness, so no
+component of the extracted data is projected away: the Balance games consume
+`satisfied`, and other games may consume the index directly. -/
+structure ActionLedgerSuccess
+    (spendAuthVerify bindingVerify : PallasGroup → MSG → SIG → Prop)
+    (wit : ActionData) where
+  /-- The ledger instance: the five public values the games consume. -/
+  inst : ActionInstance PallasGroup Fp Fp
+  /-- The ledger witness: notes, commitments, the raw path, and the key-binding
+  opening. -/
+  w : LedgerWitness
+  /-- The instance projects the Action's own public inputs. -/
+  projection : PublicProjection wit inst
+  /-- The instance and witness satisfy the games-facing Action statement. -/
+  satisfied : ActionSatisfied (Pool.primitives spendAuthVerify bindingVerify)
+    Pool.keyBinding inst w
+  /-- The post-NU6.3 cross-address gate, with its exact circuit semantics. -/
+  crossAddress : CrossAddressSatisfied wit w
+  /-- The spend/output enable gates, with their exact circuit semantics: a disabled
+  flag forces the corresponding note value to zero. -/
+  enableFlags : EnableFlagsSatisfied wit w
+
+/-- Build the ledger success data for a satisfied Action statement all of whose
+Sinsemilla queries land in their defined branches.  The instance and witness are
+computed from the circuit witness through the ledger's own primitives
+(`commitIvkWitness`, `Pool.noteCommit`); the classifier's `none` verdict supplies
+the definedness each guarded clause needs. -/
+def ActionLedgerSuccess.ofSpec
+    (spendAuthVerify bindingVerify : PallasGroup → MSG → SIG → Prop)
     (input : PublicInputs Fp) (wit : PrivateWitness)
-    (h : ActionSpec input wit) :
-    ActionBreak (combine input wit) ∨
-      ∃ inst w, PublicProjection (combine input wit) inst ∧
-        ActionSatisfied (Pool.primitives spendAuthVerify bindingVerify) Pool.keyBinding inst w ∧
-        CrossAddressSatisfied (combine input wit) w ∧
-        EnableFlagsSatisfied (combine input wit) w := by
+    (h : ActionSpec input wit)
+    (hcl : classifyAction (combine input wit) = none) :
+    ActionLedgerSuccess spendAuthVerify bindingVerify (combine input wit) := by
   let wit' := combine input wit
   have hwit : combine input wit = wit' := rfl
   rw [hwit]
@@ -798,141 +871,143 @@ theorem actionSpec_to_ledger (spendAuthVerify bindingVerify : PallasGroup → MS
     simpa only [wit', PublicInputs.ofActionData, PrivateWitness.ofActionData,
       combine] using h
   have hPost := (actionSpec_ofActionData_iff_specPost wit').mp hData
-  rcases successes_or_break hData with hs | hbreak
-  · rcases hs with ⟨hivk, hold, hnew, hmerkle⟩
-    rcases hmerkle with ⟨root, hpath, hhash, hanchor⟩
-    rcases hPost.1 with ⟨hcmOld, hgdOld, hakP, hpkdOld, hgdNew, hpkdNew,
-      hvOld, hvNew, hvc, hnf, hrk, -, -, -, -, hvalue, hes, heo⟩
-    rcases hvc with ⟨hmag, hcv⟩
-    rcases hold with ⟨bold, hbold, hcmOldEq⟩
-    rcases commitIvkSuccess_to_ledger hgdOld hakP hpkdOld hivk with
-      ⟨ivk, kw, hkb, hivne, hkwivk, hkwNk, hkwAk, hpkdLedger⟩
-    have hkwNk' : kw.nk = wit'.nk := hkwNk
-    rcases noteCommitNewSuccess_to_ledger spendAuthVerify bindingVerify hgdNew hpkdNew hnew with
-      ⟨cmNewP, hcmNewP, hcmNewX, hcommitNew⟩
-    have hcmOldEq' : wit'.cmOld =
-        bold + wit'.rcmOld.2.val • Ecc.MulFixed.Certs.noteCommitR.point := by
-      simpa [orchardBases, Ecc.MulFixed.FixedBase.scalarMul] using hcmOldEq
-    have hnf' : wit'.nfOld =
-        (wit'.cmOld +
-          ((Poseidon.Hash.ConstantLength.value #v[wit'.nk, wit'.rhoOld] +
-            wit'.psiOld).val : Fq).val •
-            Ecc.MulFixed.Certs.nullifierK.point).x := by
-      simpa [orchardBases, Ecc.MulFixed.FixedBase.scalarMul] using hnf
-    have hcommitOld : Pool.noteCommit wit'.rcmOld.2
+  have hcl' : classifyAction wit' = none := hcl
+  have hno : ¬ ActionBreak wit' := fun hb =>
+    Option.ne_none_iff_isSome.mpr (actionBreak_iff_classify_isSome.mp hb) hcl'
+  obtain ⟨hivk, hold, hnew, hmerkle⟩ := successes_of_noBreak hData hno
+  rcases hPost.1 with ⟨hcmOld, hgdOld, hakP, hpkdOld, hgdNew, hpkdNew,
+    hvOld, hvNew, hvc, hnf, hrk, -, -, -, -, hvalue, hes, heo⟩
+  rcases hvc with ⟨hmag, hcv⟩
+  have hnf' : wit'.nfOld =
+      (wit'.cmOld +
+        ((Poseidon.Hash.ConstantLength.value #v[wit'.nk, wit'.rhoOld] +
+          wit'.psiOld).val : Fq).val •
+          Ecc.MulFixed.Certs.nullifierK.point).x := by
+    simpa [orchardBases, Ecc.MulFixed.FixedBase.scalarMul] using hnf
+  let path : Fin 32 → Pool.Encoding × Pool.Encoding := fun i =>
+    (⟨wit'.leftEncoding i, by
+        obtain ⟨root, hpath, -, -⟩ := hmerkle
+        rcases hpath with ⟨_, _, _, hsteps⟩
+        simpa only [merkleLeftEncoding_fin] using (hsteps i i.isLt).1⟩,
+     ⟨wit'.rightEncoding i, by
+        obtain ⟨root, hpath, -, -⟩ := hmerkle
+        rcases hpath with ⟨_, _, _, hsteps⟩
+        simpa only [merkleRightEncoding_fin] using (hsteps i i.isLt).2.1⟩)
+  have hkwDef : (Pool.commitIvkHash wit'.akP.x wit'.nk).isSome := hivk.hash_isSome
+  have hcmNewDef : (Pool.noteCommit wit'.rcmNew.2
+      { gd := PallasGroup.ofPoint wit'.gdNew (.inl hgdNew),
+        pkd := PallasGroup.ofPoint wit'.pkdNew (.inl hpkdNew),
+        v := wit'.vNew.val, ρ := wit'.nfOld, ψ := wit'.psiNew }).isSome :=
+    hnew.commit_isSome hgdNew hpkdNew
+  let inst : ActionInstance PallasGroup Fp Fp :=
+    { rt := wit'.anchor,
+      nf_old := wit'.nfOld,
+      rk := (Pool.primitives spendAuthVerify bindingVerify).randomizePublic wit'.alpha.2
+        (PallasGroup.ofPoint wit'.akP (.inl hakP)),
+      cv_net := (Pool.primitives spendAuthVerify bindingVerify).valueCommit
+        ((wit'.vOld.val : ℤ) - (wit'.vNew.val : ℤ)) wit'.rcv.2,
+      cmx_new := wit'.cmx }
+  let w : LedgerWitness :=
+    { path := path,
+      side := wit'.merkleSide,
+      note_old :=
         { gd := PallasGroup.ofPoint wit'.gdOld (.inl hgdOld),
           pkd := PallasGroup.ofPoint wit'.pkdOld (.inl hpkdOld),
-          v := wit'.vOld.val, ρ := wit'.rhoOld, ψ := wit'.psiOld } =
-        some (PallasGroup.ofPoint wit'.cmOld hcmOld) :=
-      noteCommit_of_action_hash hgdOld hpkdOld hcmOld hbold hcmOldEq'
-    let path : Fin 32 → Pool.Encoding × Pool.Encoding := fun i =>
-      (⟨wit'.leftEncoding i, by
-          rcases hpath with ⟨_, _, _, hsteps⟩
-          simpa only [merkleLeftEncoding_fin] using (hsteps i i.isLt).1⟩,
-       ⟨wit'.rightEncoding i, by
-          rcases hpath with ⟨_, _, _, hsteps⟩
-          simpa only [merkleRightEncoding_fin] using (hsteps i i.isLt).2.1⟩)
-    let inst : ActionInstance PallasGroup Fp Fp :=
-      { rt := wit'.anchor,
-        nf_old := wit'.nfOld,
-        rk := (Pool.primitives spendAuthVerify bindingVerify).randomizePublic wit'.alpha.2
-          (PallasGroup.ofPoint wit'.akP (.inl hakP)),
-        cv_net := (Pool.primitives spendAuthVerify bindingVerify).valueCommit
-          ((wit'.vOld.val : ℤ) - (wit'.vNew.val : ℤ)) wit'.rcv.2,
-        cmx_new := wit'.cmx }
-    let w : LedgerWitness :=
-      { path := path,
-        side := wit'.merkleSide,
-        note_old :=
-          { gd := PallasGroup.ofPoint wit'.gdOld (.inl hgdOld),
-            pkd := PallasGroup.ofPoint wit'.pkdOld (.inl hpkdOld),
-            v := wit'.vOld.val, ρ := wit'.rhoOld, ψ := wit'.psiOld },
-        note_new :=
-          { gd := PallasGroup.ofPoint wit'.gdNew (.inl hgdNew),
-            pkd := PallasGroup.ofPoint wit'.pkdNew (.inl hpkdNew),
-            v := wit'.vNew.val, ρ := wit'.nfOld, ψ := wit'.psiNew },
-        cm_old := PallasGroup.ofPoint wit'.cmOld hcmOld,
-        cm_new := PallasGroup.ofPoint cmNewP hcmNewP,
-        kw := kw,
-        α := wit'.alpha.2,
-        rcv := wit'.rcv.2,
-        rcm_old := wit'.rcmOld.2,
-        rcm_new := wit'.rcmNew.2 }
-    refine Or.inr ⟨inst, w, ?_, ?_, ?_, ?_⟩
-    · refine ⟨rfl, rfl, ?_, ?_, rfl⟩
-      · simpa [inst] using public_rk_eq_randomizePublic spendAuthVerify bindingVerify hakP hrk
-      · simpa [inst] using
-          public_cv_net_eq_valueCommit spendAuthVerify bindingVerify hvOld hvNew hmag hvalue hcv
-    · refine
-        { commit_old := ?_,
-          merkle_path := ?_,
-          nf_old_eq := ?_,
-          key_binding := ?_,
-          pkd_eq := ?_,
-          gd_ne := ?_,
-          rk_eq := ?_,
-          commit_new := ?_,
-          cmx_new_eq := ?_,
-          ρ_new_eq := ?_,
-          v_old_lt := ?_,
-          v_new_lt := ?_,
-          cv_net_eq := ?_ }
-      · simpa [w] using hcommitOld
-      · intro hv
-        have hv' : wit'.vOld ≠ 0 := by
-          intro hz
-          apply hv
-          dsimp [w]
-          simp [hz]
-        have hroot : root = wit'.anchor := by
-          have hz : root - wit'.anchor = 0 :=
-            (mul_eq_zero.mp hanchor).resolve_left hv'
-          exact sub_eq_zero.mp hz
-        have hp := merkle_path_of_exact hpath hhash
-        simpa [w, inst, path, Pool.extract, hroot] using hp
-      · simpa [inst, w, Pool.primitives, Pool.keyBinding,
-          KeyBinding.Pool.toInterface, hkwNk', Pool.deriveNullifier] using hnf'
-      · simpa [w] using hkb
-      · simpa [w, Pool.primitives, hkwivk] using hpkdLedger
-      · intro hzero
-        have hpzero : wit'.gdOld = 0 := by
-          have hz := congrArg PallasGroup.toPoint hzero
-          simpa [w] using hz
-        exact Point.ne_zero_of_onCurve hgdOld hpzero
-      · change (Pool.primitives spendAuthVerify bindingVerify).randomizePublic wit'.alpha.2
-            (PallasGroup.ofPoint wit'.akP (.inl hakP)) =
-          (Pool.primitives spendAuthVerify bindingVerify).randomizePublic wit'.alpha.2
-            (Pool.keyBinding.akP kw)
-        rw [hkwAk]
-      · simpa [w] using hcommitNew
-      · change wit'.cmx = cmNewP.x
-        exact hcmNewX.symm
-      · rfl
-      · exact hvOld
-      · exact hvNew
-      · rfl
-    · intro henabled
-      rcases hPost.2 henabled with ⟨hgd, hpkd⟩
-      change
-        PallasGroup.ofPoint wit'.gdOld (.inl hgdOld) =
-            PallasGroup.ofPoint wit'.gdNew (.inl hgdNew) ∧
-          PallasGroup.ofPoint wit'.pkdOld (.inl hpkdOld) =
-            PallasGroup.ofPoint wit'.pkdNew (.inl hpkdNew)
-      exact ⟨lift_eq_of_point_eq (.inl hgdOld) (.inl hgdNew) hgd,
-        lift_eq_of_point_eq (.inl hpkdOld) (.inl hpkdNew) hpkd⟩
-    · refine ⟨fun hv => ?_, fun hv => ?_⟩
-      · have hvOld0 : wit'.vOld ≠ 0 := by
-          intro hz
-          apply hv
-          dsimp [w]
-          simp [hz]
-        exact (sub_eq_zero.mp ((mul_eq_zero.mp hes).resolve_left hvOld0)).symm
-      · have hvNew0 : wit'.vNew ≠ 0 := by
-          intro hz
-          apply hv
-          dsimp [w]
-          simp [hz]
-        exact (sub_eq_zero.mp ((mul_eq_zero.mp heo).resolve_left hvNew0)).symm
-  · exact Or.inl hbreak
+          v := wit'.vOld.val, ρ := wit'.rhoOld, ψ := wit'.psiOld },
+      note_new :=
+        { gd := PallasGroup.ofPoint wit'.gdNew (.inl hgdNew),
+          pkd := PallasGroup.ofPoint wit'.pkdNew (.inl hpkdNew),
+          v := wit'.vNew.val, ρ := wit'.nfOld, ψ := wit'.psiNew },
+      cm_old := PallasGroup.ofPoint wit'.cmOld hcmOld,
+      cm_new := (Pool.noteCommit wit'.rcmNew.2
+        { gd := PallasGroup.ofPoint wit'.gdNew (.inl hgdNew),
+          pkd := PallasGroup.ofPoint wit'.pkdNew (.inl hpkdNew),
+          v := wit'.vNew.val, ρ := wit'.nfOld, ψ := wit'.psiNew }).get hcmNewDef,
+      kw := commitIvkWitness wit' hakP hkwDef,
+      α := wit'.alpha.2,
+      rcv := wit'.rcv.2,
+      rcm_old := wit'.rcmOld.2,
+      rcm_new := wit'.rcmNew.2 }
+  exact
+    { inst := inst
+      w := w
+      projection := by
+        refine ⟨rfl, rfl, ?_, ?_, rfl⟩
+        · simpa [inst] using
+            public_rk_eq_randomizePublic spendAuthVerify bindingVerify hakP hrk
+        · simpa [inst] using
+            public_cv_net_eq_valueCommit spendAuthVerify bindingVerify hvOld hvNew hmag
+              hvalue hcv
+      satisfied :=
+        { commit_old := by
+            rcases hold with ⟨bold, hbold, hcmOldEq⟩
+            have hcmOldEq' : wit'.cmOld =
+                bold + wit'.rcmOld.2.val • Ecc.MulFixed.Certs.noteCommitR.point := by
+              simpa [orchardBases, Ecc.MulFixed.FixedBase.scalarMul] using hcmOldEq
+            simpa [w] using
+              noteCommit_of_action_hash hgdOld hpkdOld hcmOld hbold hcmOldEq'
+          merkle_path := by
+            intro hv
+            obtain ⟨root, hpath, hhash, hanchor⟩ := hmerkle
+            have hv' : wit'.vOld ≠ 0 := by
+              intro hz
+              apply hv
+              dsimp [w]
+              simp [hz]
+            have hroot : root = wit'.anchor := by
+              have hz : root - wit'.anchor = 0 :=
+                (mul_eq_zero.mp hanchor).resolve_left hv'
+              exact sub_eq_zero.mp hz
+            have hp := merkle_path_of_exact hpath hhash
+            simpa [w, inst, path, Pool.extract, hroot] using hp
+          nf_old_eq := by
+            simpa [inst, w, Pool.primitives, Pool.keyBinding,
+              KeyBinding.Pool.toInterface, commitIvkWitness, Pool.deriveNullifier]
+              using hnf'
+          key_binding := by
+            simpa [w] using (commitIvkWitness_kb hgdOld hakP hpkdOld hkwDef hivk).1
+          pkd_eq := by
+            simpa [w, Pool.primitives, Pool.keyBinding, KeyBinding.Pool.toInterface]
+              using (commitIvkWitness_kb hgdOld hakP hpkdOld hkwDef hivk).2
+          gd_ne := by
+            intro hzero
+            have hpzero : wit'.gdOld = 0 := by
+              have hz := congrArg PallasGroup.toPoint hzero
+              simpa [w] using hz
+            exact Point.ne_zero_of_onCurve hgdOld hpzero
+          rk_eq := rfl
+          commit_new := by
+            simp [w, Pool.primitives]
+          cmx_new_eq := by
+            simpa [w, inst, Pool.primitives] using
+              (hnew.extract_get hgdNew hpkdNew hcmNewDef).symm
+          ρ_new_eq := rfl
+          v_old_lt := hvOld
+          v_new_lt := hvNew
+          cv_net_eq := rfl }
+      crossAddress := by
+        intro henabled
+        rcases hPost.2 henabled with ⟨hgd, hpkd⟩
+        change
+          PallasGroup.ofPoint wit'.gdOld (.inl hgdOld) =
+              PallasGroup.ofPoint wit'.gdNew (.inl hgdNew) ∧
+            PallasGroup.ofPoint wit'.pkdOld (.inl hpkdOld) =
+              PallasGroup.ofPoint wit'.pkdNew (.inl hpkdNew)
+        exact ⟨lift_eq_of_point_eq (.inl hgdOld) (.inl hgdNew) hgd,
+          lift_eq_of_point_eq (.inl hpkdOld) (.inl hpkdNew) hpkd⟩
+      enableFlags := by
+        refine ⟨fun hv => ?_, fun hv => ?_⟩
+        · have hvOld0 : wit'.vOld ≠ 0 := by
+            intro hz
+            apply hv
+            dsimp [w]
+            simp [hz]
+          exact (sub_eq_zero.mp ((mul_eq_zero.mp hes).resolve_left hvOld0)).symm
+        · have hvNew0 : wit'.vNew ≠ 0 := by
+            intro hz
+            apply hv
+            dsimp [w]
+            simp [hz]
+          exact (sub_eq_zero.mp ((mul_eq_zero.mp heo).resolve_left hvNew0)).symm }
 
 end Zcash.Security.Ledger.Bridge

--- a/Zcash/Security/Ledger/Bridge.lean
+++ b/Zcash/Security/Ledger/Bridge.lean
@@ -290,7 +290,7 @@ abbrev merkleQuery (wit : ActionData) (i : Fin 32) : List ℕ :=
 
 /-! The per-site hash abbreviations pin the deployed generator table and the site's
 domain point once, so the definedness facts and success predicates below spell each
-hash the same way.  `extractP` and the two `sinsemillaCommit…` steps name the
+hash the same way. `extractP` and the two `sinsemillaCommit…` steps name the
 spec-level operations the statements would otherwise spell out. -/
 
 /-- The `Commit^ivk` hash of the witness's exact query (`SinsemillaHashToPoint`,
@@ -313,15 +313,15 @@ abbrev noteNewHash (wit : ActionData) : Option (Point Fp) :=
 abbrev merkleHash (wit : ActionData) (i : Fin 32) : Option (Point Fp) :=
   hashToPoint orchardGenerators.S orchardBases.merkleQ (merkleQuery wit i)
 
-/-- `Extract_ℙ` (§5.4.9.7).  Not definitionally the `x`-projection: the spec maps
-`𝒪` to `0` and any other point to its affine `x`-coordinate.  It can be implemented
+/-- `Extract_ℙ` (§5.4.9.7). Not definitionally the `x`-projection: the spec maps
+`𝒪` to `0` and any other point to its affine `x`-coordinate. It can be implemented
 as `.x` here because this development represents `𝒪` as the off-curve coordinate
 pair `(0, 0)`. -/
 abbrev extractP (p : Point Fp) : Fp := p.x
 
 /-- The blinding step shared by the Sinsemilla commitments (§5.4.8.4): add the
-randomness term to the hash point.  Statements use this name so they do not depend
-on how `SinsemillaCommit` spells the blinding.  Generic over the point or group
+randomness term to the hash point. Statements use this name so they do not depend
+on how `SinsemillaCommit` spells the blinding. Generic over the point or group
 representation and the scalar type, so the circuit-level `Point` form and the
 ledger-level group form spell their blinding the same way. -/
 def sinsemillaCommitBlind {G R : Type*} [Add G] [SMul R G] (hp : G) (r : R)
@@ -519,7 +519,7 @@ theorem classify_none_defined {wit : ActionData} (h : classifyAction wit = none)
           classifyMerkle_none_defined h⟩
 
 /-- **The Prop-level break and the computed classifier cannot diverge**: an exhibited
-`ActionBreak` holds exactly when the classifier reports an escape.  This is what lets
+`ActionBreak` holds exactly when the classifier reports an escape. This is what lets
 the data bridge's success branch (`ActionLedgerSuccess.ofSpec`) turn the classifier's
 `none` verdict into the absence of every Prop-level break: forward, each break
 constructor's `hashToPointB … = .inr` equation contradicts the defined hashes of a
@@ -558,7 +558,7 @@ def commitIvkOf (wit : ActionData) (hdef : (ivkHash wit).isSome) : Fp :=
     Ecc.MulFixed.Certs.commitIvkR.point
 
 /-- Successful `Commit^ivk` information: the defined branch of the guarded
-`Commit^ivk` clause, on the witness's exact query.  The computed key
+`Commit^ivk` clause, on the witness's exact query. The computed key
 (`commitIvkOf`) opens the witnessed address equation. -/
 structure CommitIvkSuccess (wit : ActionData) : Prop where
   defined : (ivkHash wit).isSome
@@ -659,7 +659,7 @@ structure NoteCommitNewSuccess (wit : ActionData) : Prop where
     wit.rcmNew.2.val Ecc.MulFixed.Certs.noteCommitR.point
 
 /-- A successful output-note opening makes the ledger's own commitment primitive
-defined on the witnessed new note.  Unlike the circuit public input, the ledger
+defined on the witnessed new note. Unlike the circuit public input, the ledger
 keeps the full commitment point; the defined value is that point. -/
 theorem NoteCommitNewSuccess.commit_isSome {wit : ActionData}
     (hgd : wit.gdNew.OnCurve) (hpkd : wit.pkdNew.OnCurve)
@@ -731,7 +731,7 @@ def merkleRootOf (wit : ActionData) (hdef : (merkleHash wit 31).isSome) : Fp :=
 
 /-- The successful Merkle outcome as consumed by the ledger refinement: every layer's
 hash lands in its defined branch, the exact raw-encoding chain reaches the computed
-root (`merkleRootOf`), and the dummy-spend anchor gate holds at that root.  The raw
+root (`merkleRootOf`), and the dummy-spend anchor gate holds at that root. The raw
 child encodings are tied to these defined hashes before any `Merkle.Path` is
 constructed. -/
 structure MerkleSuccess (wit : ActionData) : Prop where
@@ -878,13 +878,13 @@ theorem merkle_path_of_exact {wit : ActionData} {root : Fp}
 
 /-- The refined ledger action retained as data: the concrete instance and witness that
 annotate an accepted Action, together with the proofs that they satisfy the
-games-facing statement.  The structure is indexed by the full circuit witness, so no
+games-facing statement. The structure is indexed by the full circuit witness, so no
 component of the extracted data is projected away: the Balance games consume
 `satisfied`, and other games may consume the index directly.
 
 The circuit witness is the chain's one genuinely free value; everything below it —
 the hash points, the computed viewing key, the Merkle root, and `inst`/`w`
-themselves — is computed from it.  That is why the per-site success predicates carry
+themselves — is computed from it. That is why the per-site success predicates carry
 only definedness facts (`isSome` fields, with `Option.get` recovering the values),
 and why `inst` and `w` are carried here as fields for the consumers' convenience
 rather than as free choices: `ofSpec` computes them. -/
@@ -908,7 +908,7 @@ structure ActionLedgerSuccess
   enableFlags : EnableFlagsSatisfied wit w
 
 /-- Build the ledger success data for a satisfied Action statement all of whose
-Sinsemilla queries land in their defined branches.  The instance and witness are
+Sinsemilla queries land in their defined branches. The instance and witness are
 computed from the circuit witness through the ledger's own primitives
 (`commitIvkWitness`, `Pool.noteCommit`); the classifier's `none` verdict supplies
 the definedness each guarded clause needs. -/

--- a/Zcash/Security/Ledger/Bridge.lean
+++ b/Zcash/Security/Ledger/Bridge.lean
@@ -468,12 +468,11 @@ theorem actionBreak_of_classifyMerkle {wit : ActionData} {br : ActionBreakData}
 /-- A `none` Merkle verdict leaves every layer's hash defined. -/
 theorem classifyMerkle_none_defined {wit : ActionData}
     (h : classifyMerkle wit = none) :
-    ∀ i : Fin 32, ∃ B, hashToPoint orchardGenerators.S orchardBases.merkleQ
-      (merkleQuery wit i) = some B := by
+    ∀ i : Fin 32, (merkleHash wit i).isSome := by
   intro i
   have hi := List.findSome?_eq_none_iff.mp h i (List.mem_finRange i)
   cases hb : hashToPointB orchardGenerators.S merkleQ (merkleQuery wit i) with
-  | inl B => exact ⟨B, hashToPointB_inl hb⟩
+  | inl B => exact Option.isSome_iff_exists.mpr ⟨B, hashToPointB_inl hb⟩
   | inr brd => simp [hb] at hi
 
 /-- **Classifier soundness**: a classified escape is an exhibited break of the
@@ -499,14 +498,8 @@ theorem actionBreak_of_classify {wit : ActionData} {br : ActionBreakData}
 the witness defined, so each guarded circuit clause lands in its successful
 branch. -/
 theorem classify_none_defined {wit : ActionData} (h : classifyAction wit = none) :
-    (∃ B, hashToPoint orchardGenerators.S orchardBases.ivkQ
-      (ivkQuery wit) = some B) ∧
-    (∃ B, hashToPoint orchardGenerators.S orchardBases.noteQ
-      (noteOldQuery wit) = some B) ∧
-    (∃ B, hashToPoint orchardGenerators.S orchardBases.noteQ
-      (noteNewQuery wit) = some B) ∧
-    ∀ i : Fin 32, ∃ B, hashToPoint orchardGenerators.S orchardBases.merkleQ
-      (merkleQuery wit i) = some B := by
+    (ivkHash wit).isSome ∧ (noteOldHash wit).isSome ∧ (noteNewHash wit).isSome ∧
+    ∀ i : Fin 32, (merkleHash wit i).isSome := by
   unfold classifyAction at h
   cases hivk : hashToPointB orchardGenerators.S ivkQ (ivkQuery wit) with
   | inr brd => simp [hivk] at h
@@ -520,8 +513,10 @@ theorem classify_none_defined {wit : ActionData} (h : classifyAction wit = none)
       | inr brd => simp [hnew] at h
       | inl Bn =>
         simp only [hnew] at h
-        exact ⟨⟨Bi, hashToPointB_inl hivk⟩, ⟨Bo, hashToPointB_inl hold⟩,
-          ⟨Bn, hashToPointB_inl hnew⟩, classifyMerkle_none_defined h⟩
+        exact ⟨Option.isSome_iff_exists.mpr ⟨Bi, hashToPointB_inl hivk⟩,
+          Option.isSome_iff_exists.mpr ⟨Bo, hashToPointB_inl hold⟩,
+          Option.isSome_iff_exists.mpr ⟨Bn, hashToPointB_inl hnew⟩,
+          classifyMerkle_none_defined h⟩
 
 /-- **The Prop-level break and the computed classifier cannot diverge**: an exhibited
 `ActionBreak` holds exactly when the classifier reports an escape.  This is what lets
@@ -536,7 +531,8 @@ theorem actionBreak_iff_classify_isSome {wit : ActionData} :
     cases hcl : classifyAction wit with
     | some _ => rfl
     | none =>
-      obtain ⟨⟨Bi, hBi⟩, ⟨Bo, hBo⟩, ⟨Bn, hBn⟩, hMk⟩ := classify_none_defined hcl
+      obtain ⟨hBi, hBo, hBn, hMk⟩ := classify_none_defined hcl
+      simp only [ivkHash, noteOldHash, noteNewHash, merkleHash] at hBi hBo hBn hMk
       cases hb with
       | commitIvk br heq _ =>
         rw [hashToPoint_of_inr heq] at hBi
@@ -548,46 +544,44 @@ theorem actionBreak_iff_classify_isSome {wit : ActionData} :
         rw [hashToPoint_of_inr heq] at hBn
         exact absurd hBn (by simp)
       | merkle i br heq _ =>
-        obtain ⟨B, hB⟩ := hMk i
+        have hB := hMk i
         rw [hashToPoint_of_inr heq] at hB
         exact absurd hB (by simp)
   · intro h
     obtain ⟨abr, habr⟩ := Option.isSome_iff_exists.mp h
     exact actionBreak_of_classify habr
 
+/-- The incoming viewing key computed from a defined `Commit^ivk` chain
+(§5.4.8.4). -/
+def commitIvkOf (wit : ActionData) (hdef : (ivkHash wit).isSome) : Fp :=
+  sinsemillaCommitBlindShort ((ivkHash wit).get hdef) wit.rivk.2.val
+    Ecc.MulFixed.Certs.commitIvkR.point
+
 /-- Successful `Commit^ivk` information: the defined branch of the guarded
-`Commit^ivk` clause, on the witness's exact query. -/
-def CommitIvkSuccess (wit : ActionData) : Prop :=
-  ∃ ivk : Fp, ∃ hashPoint : Point Fp,
-    hashToPoint orchardGenerators.S orchardBases.ivkQ
-      (commitIvkChunks wit.akP.x.val wit.nk.val) = some hashPoint ∧
-    ivk = (hashPoint + wit.rivk.2 • orchardBases.commitIvkR).x ∧
-    wit.pkdOld = ivk.val • wit.gdOld
+`Commit^ivk` clause, on the witness's exact query.  The computed key
+(`commitIvkOf`) opens the witnessed address equation. -/
+structure CommitIvkSuccess (wit : ActionData) : Prop where
+  defined : (ivkHash wit).isSome
+  pkd_eq : wit.pkdOld = (commitIvkOf wit defined).val • wit.gdOld
 
 /-- The successful incoming viewing key cannot be zero.  This is a circuit fact,
 not an additional ledger assumption: the address-integrity equation would otherwise
 make the witnessed, on-curve `pkdOld` the affine identity sentinel. -/
-theorem CommitIvkSuccess.ivk_ne {wit : ActionData} {ivk : Fp}
-    (hpkd : wit.pkdOld.OnCurve)
-    (h : ∃ hashPoint : Point Fp,
-      hashToPoint orchardGenerators.S orchardBases.ivkQ
-        (commitIvkChunks wit.akP.x.val wit.nk.val) = some hashPoint ∧
-      ivk = (hashPoint + wit.rivk.2 • orchardBases.commitIvkR).x ∧
-      wit.pkdOld = ivk.val • wit.gdOld) : ivk ≠ 0 := by
-  rcases h with ⟨_, _, _, hpkdEq⟩
+theorem CommitIvkSuccess.ivk_ne {wit : ActionData} (hpkd : wit.pkdOld.OnCurve)
+    (h : CommitIvkSuccess wit) : commitIvkOf wit h.defined ≠ 0 := by
   intro hiz
-  have hval : ivk.val = 0 := by simp [hiz]
+  have hval : (commitIvkOf wit h.defined).val = 0 := by simp [hiz]
   have hzero : wit.pkdOld = 0 := by
-    rw [hpkdEq, hval]
+    rw [h.pkd_eq, hval]
     rfl
   exact Point.ne_zero_of_onCurve hpkd hzero
 
 /-- A successful `Commit^ivk` opening makes the ledger's own hash primitive defined
 on the witnessed key material. -/
 theorem CommitIvkSuccess.hash_isSome {wit : ActionData} (h : CommitIvkSuccess wit) :
-    (Pool.commitIvkHash wit.akP.x wit.nk).isSome := by
-  obtain ⟨ivk, bp, hbp, -, -⟩ := h
-  exact Option.isSome_iff_exists.mpr ⟨_, commitIvkHash_of_action_hash hbp⟩
+    (Pool.commitIvkHash wit.akP.x wit.nk).isSome :=
+  Option.isSome_iff_exists.mpr
+    ⟨_, commitIvkHash_of_action_hash (Option.some_get h.defined).symm⟩
 
 /-- The exact deployed Orchard key-binding witness of a successful `Commit^ivk`
 opening, computed through the ledger's own primitives: the hash point is the defined
@@ -622,24 +616,23 @@ theorem commitIvkWitness_kb {wit : ActionData}
       PallasGroup.ofPoint wit.pkdOld (.inl hpkd) =
         PallasGroup.embedFp (commitIvkWitness wit hak hdef).ivk •
           PallasGroup.ofPoint wit.gdOld (.inl hgd) := by
-  obtain ⟨ivk, bp, hbp, hivk, hpkdEq⟩ := h
-  have hbpValid : bp.Valid :=
+  have hbp : ivkHash wit = some ((ivkHash wit).get h.defined) :=
+    (Option.some_get h.defined).symm
+  have hbpValid :=
     hashToPoint_valid (Or.inl orchardBases.ivkQ_onCurve)
       (fun _ hm => chunksOf_mem_lt hm) hbp
   have hsome : Pool.commitIvkHash wit.akP.x wit.nk =
-      some (PallasGroup.ofPoint bp hbpValid) :=
+      some (PallasGroup.ofPoint _ hbpValid) :=
     commitIvkHash_of_action_hash hbp
   have hget : (Pool.commitIvkHash wit.akP.x wit.nk).get hdef =
-      PallasGroup.ofPoint bp hbpValid := by
+      PallasGroup.ofPoint _ hbpValid := by
     simp only [hsome, Option.get_some]
-  have hivk' : ivk =
-      (bp + wit.rivk.2.val • Ecc.MulFixed.Certs.commitIvkR.point).x := by
-    simpa [orchardBases, Ecc.MulFixed.FixedBase.scalarMul] using hivk
-  have hivk_eq : (commitIvkWitness wit hak hdef).ivk = ivk := by
-    show Pool.extract _ = ivk
-    rw [hget, hivk']
+  have hivk_eq : (commitIvkWitness wit hak hdef).ivk = commitIvkOf wit h.defined := by
+    show Pool.extract _ = commitIvkOf wit h.defined
+    rw [hget]
     simp only [Pool.extract, PallasGroup.toPoint_add, PallasGroup.toPoint_smul,
       PallasGroup.toPoint_ofPoint]
+    rfl
   refine ⟨⟨?_, rfl, ?_⟩, ?_⟩
   · show Pool.commitIvkHash
       (Pool.extract (PallasGroup.ofPoint wit.akP (.inl hak))) wit.nk =
@@ -647,25 +640,23 @@ theorem commitIvkWitness_kb {wit : ActionData}
     rw [hget]
     simpa [Pool.extract, PallasGroup.toPoint_ofPoint] using hsome
   · rw [hivk_eq]
-    exact CommitIvkSuccess.ivk_ne hpkd ⟨bp, hbp, hivk, hpkdEq⟩
+    exact h.ivk_ne hpkd
   · rw [hivk_eq]
-    exact ofPoint_eq_embed_smul (.inl hpkd) (.inl hgd) hpkdEq
+    exact ofPoint_eq_embed_smul (.inl hpkd) (.inl hgd) h.pkd_eq
 
-/-- Successful old-note Sinsemilla opening. -/
-def NoteCommitOldSuccess (wit : ActionData) : Prop :=
-  ∃ hashPoint : Point Fp,
-    hashToPoint orchardGenerators.S orchardBases.noteQ
-      (NoteCommit.noteScalars wit.gdOld wit.pkdOld wit.vOld wit.rhoOld wit.psiOld).chunks
-        = some hashPoint ∧
-    wit.cmOld = hashPoint + wit.rcmOld.2 • orchardBases.noteCommitR
+/-- Successful old-note Sinsemilla opening: the commitment opens as the defined chain
+value plus the blinding term. -/
+structure NoteCommitOldSuccess (wit : ActionData) : Prop where
+  defined : (noteOldHash wit).isSome
+  cmOld_eq : wit.cmOld = sinsemillaCommitBlind ((noteOldHash wit).get defined)
+    wit.rcmOld.2.val Ecc.MulFixed.Certs.noteCommitR.point
 
-/-- Successful new-note Sinsemilla opening. -/
-def NoteCommitNewSuccess (wit : ActionData) : Prop :=
-  ∃ hashPoint : Point Fp,
-    hashToPoint orchardGenerators.S orchardBases.noteQ
-      (NoteCommit.noteScalars wit.gdNew wit.pkdNew wit.vNew wit.nfOld wit.psiNew).chunks
-        = some hashPoint ∧
-    wit.cmx = (hashPoint + wit.rcmNew.2 • orchardBases.noteCommitR).x
+/-- Successful new-note Sinsemilla opening: the public `cmx` is the extracted
+coordinate of the defined chain value plus the blinding term. -/
+structure NoteCommitNewSuccess (wit : ActionData) : Prop where
+  defined : (noteNewHash wit).isSome
+  cmx_eq : wit.cmx = sinsemillaCommitBlindShort ((noteNewHash wit).get defined)
+    wit.rcmNew.2.val Ecc.MulFixed.Certs.noteCommitR.point
 
 /-- A successful output-note opening makes the ledger's own commitment primitive
 defined on the witnessed new note.  Unlike the circuit public input, the ledger
@@ -677,7 +668,7 @@ theorem NoteCommitNewSuccess.commit_isSome {wit : ActionData}
       { gd := PallasGroup.ofPoint wit.gdNew (.inl hgd),
         pkd := PallasGroup.ofPoint wit.pkdNew (.inl hpkd),
         v := wit.vNew.val, ρ := wit.nfOld, ψ := wit.psiNew }).isSome := by
-  rcases h with ⟨bp, hbp, hcmx⟩
+  obtain ⟨bp, hbp⟩ := Option.isSome_iff_exists.mp h.defined
   have hbpValid : bp.Valid :=
     hashToPoint_valid (Or.inl orchardBases.noteQ_onCurve)
       (fun _ hm => chunksOf_mem_lt hm) hbp
@@ -703,7 +694,9 @@ theorem NoteCommitNewSuccess.extract_get {wit : ActionData}
       { gd := PallasGroup.ofPoint wit.gdNew (.inl hgd),
         pkd := PallasGroup.ofPoint wit.pkdNew (.inl hpkd),
         v := wit.vNew.val, ρ := wit.nfOld, ψ := wit.psiNew }).get hdef) = wit.cmx := by
-  rcases h with ⟨bp, hbp, hcmx⟩
+  obtain ⟨bp, hbp⟩ := Option.isSome_iff_exists.mp h.defined
+  have hcmx := h.cmx_eq
+  rw [show (noteNewHash wit).get h.defined = bp by simp [hbp]] at hcmx
   have hbpValid : bp.Valid :=
     hashToPoint_valid (Or.inl orchardBases.noteQ_onCurve)
       (fun _ hm => chunksOf_mem_lt hm) hbp
@@ -730,60 +723,63 @@ theorem NoteCommitNewSuccess.extract_get {wit : ActionData}
   simp only [Pool.extract, PallasGroup.toPoint_ofPoint]
   simpa [cmNewP, orchardBases, Ecc.MulFixed.FixedBase.scalarMul] using hcmx.symm
 
-/-- The successful Merkle outcome as consumed by the ledger refinement: the exact
-raw-encoding path together with every layer's hash landing in its defined branch,
-and the dummy-spend anchor gate.  The raw child encodings are tied to these defined
-hashes before any `Merkle.Path` is constructed. -/
-def MerkleSuccess (wit : ActionData) : Prop :=
-  ∃ root : Fp,
-    ExactMerklePathData wit root ∧
-    (∀ i : Fin 32, ∃ B, hashToPoint orchardGenerators.S orchardBases.merkleQ
-      (merkleChunks i.1 (wit.leftEncoding i) (wit.rightEncoding i)) = some B) ∧
-    wit.vOld * (root - wit.anchor) = 0
+/-- The Merkle root computed from the last layer's defined hash: the exact chain pins
+each running node by its own layer's hash, so the root is the final layer's extracted
+coordinate. -/
+def merkleRootOf (wit : ActionData) (hdef : (merkleHash wit 31).isSome) : Fp :=
+  extractP ((merkleHash wit 31).get hdef)
 
-/-- Split all four exceptional sites in the circuit statement at once, by running
-the classifier: either the witness's own queries compute an exhibited break, or
-every query is defined and each guarded clause of `ActionSpec` lands in its
-successful branch. -/
-theorem successes_or_break {wit : ActionData}
-    (h : ActionSpec (PublicInputs.ofActionData wit)
-      (PrivateWitness.ofActionData wit)) :
-    (CommitIvkSuccess wit ∧ NoteCommitOldSuccess wit ∧ NoteCommitNewSuccess wit ∧
-      MerkleSuccess wit) ∨ ActionBreak wit := by
-  have h := (actionSpec_ofActionData_iff_specPost wit).mp h
-  cases hcl : classifyAction wit with
-  | some br => exact Or.inr (actionBreak_of_classify hcl)
-  | none =>
-    obtain ⟨⟨Bi, hBi⟩, ⟨Bo, hBo⟩, ⟨Bn, hBn⟩, hMk⟩ := classify_none_defined hcl
-    rcases h.1 with ⟨_, _, _, _, _, _, _, _, _, _, _, ⟨ivk, hivk, hpkd⟩,
-      hold, hnew, ⟨root, hexact, hanchor⟩, _, _, _⟩
-    exact Or.inl ⟨⟨ivk, Bi, hBi, hivk Bi hBi, hpkd⟩,
-      ⟨Bo, hBo, hold Bo hBo⟩, ⟨Bn, hBn, hnew Bn hBn⟩,
-      ⟨root, hexact, hMk, hanchor⟩⟩
+/-- The successful Merkle outcome as consumed by the ledger refinement: every layer's
+hash lands in its defined branch, the exact raw-encoding chain reaches the computed
+root (`merkleRootOf`), and the dummy-spend anchor gate holds at that root.  The raw
+child encodings are tied to these defined hashes before any `Merkle.Path` is
+constructed. -/
+structure MerkleSuccess (wit : ActionData) : Prop where
+  defined : ∀ i : Fin 32, (merkleHash wit i).isSome
+  path : ExactMerklePathData wit (merkleRootOf wit (defined 31))
+  anchor : wit.vOld * (merkleRootOf wit (defined 31) - wit.anchor) = 0
 
-/-- If the caller rules out all four exhibited exceptional cases, the circuit's
-guarded clauses reduce to their successful openings.  The exact-Merkle export
-subsequently turns the final component into a ledger `Merkle.Path`. -/
-theorem successes_of_noBreak {wit : ActionData}
+/-- The exact chain's root is the computed root: the last layer's hash guard pins
+it. -/
+private theorem exactMerklePathData_root_eq {wit : ActionData} {root : Fp}
+    (hpath : ExactMerklePathData wit root)
+    (hdef : (merkleHash wit 31).isSome) :
+    root = merkleRootOf wit hdef := by
+  rcases hpath with ⟨nodes, -, hroot, hsteps⟩
+  have hB : hashToPoint orchardGenerators.S orchardBases.merkleQ
+      (merkleChunks (0 + 31) (merkleLeftEncoding wit 31) (merkleRightEncoding wit 31))
+        = some ((merkleHash wit 31).get hdef) := by
+    have h := (Option.some_get hdef).symm
+    rw [show merkleLeftEncoding wit 31 = wit.leftEncoding 31 from rfl,
+      show merkleRightEncoding wit 31 = wit.rightEncoding 31 from rfl, Nat.zero_add]
+    exact h
+  have hstep := (hsteps 31 (by norm_num)).2.2.2 _ hB
+  exact hroot.symm.trans hstep
+
+/-- The classifier's `none` verdict, on a satisfied Action statement, lands every
+guarded clause of `ActionSpec` in its successful branch: the four sites' success
+facts, with their data pinned to the computed values. -/
+theorem successes_of_classify_none {wit : ActionData}
     (h : ActionSpec (PublicInputs.ofActionData wit)
       (PrivateWitness.ofActionData wit))
-    (hno : ¬ ActionBreak wit) :
+    (hcl : classifyAction wit = none) :
     CommitIvkSuccess wit ∧ NoteCommitOldSuccess wit ∧ NoteCommitNewSuccess wit ∧
-      MerkleSuccess wit :=
-  (successes_or_break h).resolve_right hno
-
-/-- Recover the successful Sinsemilla hash underlying a defined Merkle
-compression: the converse direction of `Pool.merkleCompress_eq_of_hashToPoint`,
-used to turn a guard hypothesis `merkleCompress … = some b` back into the exact
-hash query that the exported chain pins. -/
-private theorem hashToPoint_of_merkleCompress {i : Fin 32}
-    {children : Pool.Encoding × Pool.Encoding} {b : Fp}
-    (h : Pool.merkleCompress i children = some b) :
-    ∃ B, hashToPoint orchardGenerators.S Pool.merkleQ
-      (merkleChunks i.1 children.1.1 children.2.1) = some B ∧ b = B.x := by
-  simp only [Pool.merkleCompress, Option.map_eq_some_iff] at h
-  obtain ⟨B, hB, hbx⟩ := h
-  exact ⟨B, hB, hbx.symm⟩
+      MerkleSuccess wit := by
+  have h := (actionSpec_ofActionData_iff_specPost wit).mp h
+  obtain ⟨hBi, hBo, hBn, hMk⟩ := classify_none_defined hcl
+  rcases h.1 with ⟨_, _, _, _, _, _, _, _, _, _, _, ⟨ivk, hivk, hpkd⟩,
+    hold, hnew, ⟨root, hexact, hanchor⟩, _, _, _⟩
+  have hivk_eq : ivk = commitIvkOf wit hBi := hivk _ (Option.some_get hBi).symm
+  have hroot_eq : root = merkleRootOf wit (hMk 31) :=
+    exactMerklePathData_root_eq hexact (hMk 31)
+  refine ⟨⟨hBi, ?_⟩, ⟨hBo, hold _ (Option.some_get hBo).symm⟩,
+    ⟨hBn, hnew _ (Option.some_get hBn).symm⟩, ⟨hMk, ?_, ?_⟩⟩
+  · rw [← hivk_eq]
+    exact hpkd
+  · rw [← hroot_eq]
+    exact hexact
+  · rw [← hroot_eq]
+    exact hanchor
 
 /-- The exact circuit Merkle chain, transferred into the ledger's guarded
 (⊥-model) path.  No definedness hypothesis is needed: each guarded clause is
@@ -809,7 +805,13 @@ theorem guardedPath_of_exact {wit : ActionData} {root : Fp}
       c.1.1 = wit.leftEncoding k → c.2.1 = wit.rightEncoding k →
       Pool.merkleCompress k c = some b → nodes (k.1 + 1) = b := by
     intro k c b hcl hcr hcomp
-    obtain ⟨B, hB, hbB⟩ := hashToPoint_of_merkleCompress hcomp
+    -- Recover the successful hash underlying the defined compression: the converse
+    -- direction of `Pool.merkleCompress_eq_of_hashToPoint`.
+    obtain ⟨B, hB, hbB⟩ : ∃ B, hashToPoint orchardGenerators.S Pool.merkleQ
+        (merkleChunks k.1 c.1.1 c.2.1) = some B ∧ b = B.x := by
+      simp only [Pool.merkleCompress, Option.map_eq_some_iff] at hcomp
+      obtain ⟨B, hB, hbx⟩ := hcomp
+      exact ⟨B, hB, hbx.symm⟩
     rw [hcl, hcr] at hB
     have hB' : hashToPoint orchardGenerators.S orchardBases.merkleQ
         (merkleChunks (0 + k.1) (merkleLeftEncoding wit k.1) (merkleRightEncoding wit k.1))
@@ -858,9 +860,7 @@ field element.  The proof is the guarded split: transfer the exact chain into th
 per-layer definedness supplied by `hhash`. -/
 theorem merkle_path_of_exact {wit : ActionData} {root : Fp}
     (hpath : ExactMerklePathData wit root)
-    (hhash : ∀ i : Fin 32, ∃ B,
-      hashToPoint orchardGenerators.S orchardBases.merkleQ
-        (merkleChunks i.1 (wit.leftEncoding i) (wit.rightEncoding i)) = some B) :
+    (hhash : ∀ i : Fin 32, (merkleHash wit i).isSome) :
     Merkle.Path Pool.merkle wit.cmOld.x root
       (fun i : Fin 32 =>
         (⟨wit.leftEncoding i, by
@@ -871,15 +871,23 @@ theorem merkle_path_of_exact {wit : ActionData} {root : Fp}
             simpa only [merkleRightEncoding_fin] using (hsteps i i.isLt).2.1⟩))
       wit.merkleSide :=
   Merkle.Path.of_guarded_of_defined (guardedPath_of_exact hpath) fun i => by
-    obtain ⟨B, hB⟩ := hhash i
-    exact ⟨B.x, Pool.merkleCompress_eq_of_hashToPoint (by
-      simpa [orchardBases, Zcash.Circuits.Action.merkleQ, Pool.merkleQ] using hB)⟩
+    obtain ⟨B, hB⟩ := Option.isSome_iff_exists.mp (hhash i)
+    exact Option.isSome_iff_exists.mpr
+      ⟨B.x, Pool.merkleCompress_eq_of_hashToPoint (by
+        simpa [orchardBases, Zcash.Circuits.Action.merkleQ, Pool.merkleQ] using hB)⟩
 
 /-- The refined ledger action retained as data: the concrete instance and witness that
 annotate an accepted Action, together with the proofs that they satisfy the
 games-facing statement.  The structure is indexed by the full circuit witness, so no
 component of the extracted data is projected away: the Balance games consume
-`satisfied`, and other games may consume the index directly. -/
+`satisfied`, and other games may consume the index directly.
+
+The circuit witness is the chain's one genuinely free value; everything below it —
+the hash points, the computed viewing key, the Merkle root, and `inst`/`w`
+themselves — is computed from it.  That is why the per-site success predicates carry
+only definedness facts (`isSome` fields, with `Option.get` recovering the values),
+and why `inst` and `w` are carried here as fields for the consumers' convenience
+rather than as free choices: `ofSpec` computes them. -/
 structure ActionLedgerSuccess
     (spendAuthVerify bindingVerify : PallasGroup → MSG → SIG → Prop)
     (wit : ActionData) where
@@ -919,9 +927,7 @@ def ActionLedgerSuccess.ofSpec
       combine] using h
   have hPost := (actionSpec_ofActionData_iff_specPost wit').mp hData
   have hcl' : classifyAction wit' = none := hcl
-  have hno : ¬ ActionBreak wit' := fun hb =>
-    Option.ne_none_iff_isSome.mpr (actionBreak_iff_classify_isSome.mp hb) hcl'
-  obtain ⟨hivk, hold, hnew, hmerkle⟩ := successes_of_noBreak hData hno
+  obtain ⟨hivk, hold, hnew, hmerkle⟩ := successes_of_classify_none hData hcl'
   rcases hPost.1 with ⟨hcmOld, hgdOld, hakP, hpkdOld, hgdNew, hpkdNew,
     hvOld, hvNew, hvc, hnf, hrk, -, -, -, -, hvalue, hes, heo⟩
   rcases hvc with ⟨hmag, hcv⟩
@@ -933,12 +939,10 @@ def ActionLedgerSuccess.ofSpec
     simpa [orchardBases, Ecc.MulFixed.FixedBase.scalarMul] using hnf
   let path : Fin 32 → Pool.Encoding × Pool.Encoding := fun i =>
     (⟨wit'.leftEncoding i, by
-        obtain ⟨root, hpath, -, -⟩ := hmerkle
-        rcases hpath with ⟨_, _, _, hsteps⟩
+        rcases hmerkle.path with ⟨_, _, _, hsteps⟩
         simpa only [merkleLeftEncoding_fin] using (hsteps i i.isLt).1⟩,
      ⟨wit'.rightEncoding i, by
-        obtain ⟨root, hpath, -, -⟩ := hmerkle
-        rcases hpath with ⟨_, _, _, hsteps⟩
+        rcases hmerkle.path with ⟨_, _, _, hsteps⟩
         simpa only [merkleRightEncoding_fin] using (hsteps i i.isLt).2.1⟩)
   have hkwDef : (Pool.commitIvkHash wit'.akP.x wit'.nk).isSome := hivk.hash_isSome
   have hcmNewDef : (Pool.noteCommit wit'.rcmNew.2
@@ -987,25 +991,24 @@ def ActionLedgerSuccess.ofSpec
               hvalue hcv
       satisfied :=
         { commit_old := by
-            rcases hold with ⟨bold, hbold, hcmOldEq⟩
-            have hcmOldEq' : wit'.cmOld =
-                bold + wit'.rcmOld.2.val • Ecc.MulFixed.Certs.noteCommitR.point := by
-              simpa [orchardBases, Ecc.MulFixed.FixedBase.scalarMul] using hcmOldEq
+            obtain ⟨bold, hbold⟩ := Option.isSome_iff_exists.mp hold.defined
+            have hcmOldEq := hold.cmOld_eq
+            rw [show (noteOldHash wit').get hold.defined = bold
+              by simp [hbold]] at hcmOldEq
             simpa [w] using
-              noteCommit_of_action_hash hgdOld hpkdOld hcmOld hbold hcmOldEq'
+              noteCommit_of_action_hash hgdOld hpkdOld hcmOld hbold hcmOldEq
           merkle_path := by
             intro hv
-            obtain ⟨root, hpath, hhash, hanchor⟩ := hmerkle
             have hv' : wit'.vOld ≠ 0 := by
               intro hz
               apply hv
               dsimp [w]
               simp [hz]
-            have hroot : root = wit'.anchor := by
-              have hz : root - wit'.anchor = 0 :=
-                (mul_eq_zero.mp hanchor).resolve_left hv'
+            have hroot : merkleRootOf wit' (hmerkle.defined 31) = wit'.anchor := by
+              have hz : merkleRootOf wit' (hmerkle.defined 31) - wit'.anchor = 0 :=
+                (mul_eq_zero.mp hmerkle.anchor).resolve_left hv'
               exact sub_eq_zero.mp hz
-            have hp := merkle_path_of_exact hpath hhash
+            have hp := merkle_path_of_exact hmerkle.path hmerkle.defined
             simpa [w, inst, path, Pool.extract, hroot] using hp
           nf_old_eq := by
             simpa [inst, w, Pool.primitives, Pool.keyBinding,

--- a/Zcash/Security/Ledger/Bridge.lean
+++ b/Zcash/Security/Ledger/Bridge.lean
@@ -270,21 +270,68 @@ the classifier, and the correctness theorems cannot silently drift apart.  The
 Merkle queries consume the raw 255-bit child encodings verbatim; a noncanonical
 representative is never reduced before hashing. -/
 
-/-- The exact `Commit^ivk` chunk query of a witness. -/
+/-- The exact `Commit^ivk` chunk query of a witness (§5.4.8.4). -/
 abbrev ivkQuery (wit : ActionData) : List ℕ :=
   commitIvkChunks wit.akP.x.val wit.nk.val
 
-/-- The exact old-note commitment chunk query. -/
+/-- The exact old-note commitment chunk query (`NoteCommit`, §5.4.8.4). -/
 abbrev noteOldQuery (wit : ActionData) : List ℕ :=
   (NoteCommit.noteScalars wit.gdOld wit.pkdOld wit.vOld wit.rhoOld wit.psiOld).chunks
 
-/-- The exact new-note commitment chunk query (`ρ_new = nf_old`). -/
+/-- The exact new-note commitment chunk query (`NoteCommit` with `ρ_new = nf_old`,
+§5.4.8.4). -/
 abbrev noteNewQuery (wit : ActionData) : List ℕ :=
   (NoteCommit.noteScalars wit.gdNew wit.pkdNew wit.vNew wit.nfOld wit.psiNew).chunks
 
-/-- The exact layer-`i` Merkle chunk query, over the raw 255-bit child encodings. -/
+/-- The exact layer-`i` Merkle chunk query, over the raw 255-bit child encodings
+(`MerkleCRH`, §5.4.1.4). -/
 abbrev merkleQuery (wit : ActionData) (i : Fin 32) : List ℕ :=
   merkleChunks i.1 (wit.leftEncoding i) (wit.rightEncoding i)
+
+/-! The per-site hash abbreviations pin the deployed generator table and the site's
+domain point once, so the definedness facts and success predicates below spell each
+hash the same way.  `extractP` and the two `sinsemillaCommit…` steps name the
+spec-level operations the statements would otherwise spell out. -/
+
+/-- The `Commit^ivk` hash of the witness's exact query (`SinsemillaHashToPoint`,
+§5.4.1.9, at the §5.4.8.4 domain). -/
+abbrev ivkHash (wit : ActionData) : Option (Point Fp) :=
+  hashToPoint orchardGenerators.S orchardBases.ivkQ (ivkQuery wit)
+
+/-- The old-note commitment hash of the witness's exact query
+(`SinsemillaHashToPoint`, §5.4.1.9, at the `NoteCommit` domain, §5.4.8.4). -/
+abbrev noteOldHash (wit : ActionData) : Option (Point Fp) :=
+  hashToPoint orchardGenerators.S orchardBases.noteQ (noteOldQuery wit)
+
+/-- The new-note commitment hash of the witness's exact query
+(`SinsemillaHashToPoint`, §5.4.1.9, at the `NoteCommit` domain, §5.4.8.4). -/
+abbrev noteNewHash (wit : ActionData) : Option (Point Fp) :=
+  hashToPoint orchardGenerators.S orchardBases.noteQ (noteNewQuery wit)
+
+/-- The layer-`i` Merkle hash of the witness's exact query (`SinsemillaHashToPoint`,
+§5.4.1.9, at the `MerkleCRH` domain, §5.4.1.4). -/
+abbrev merkleHash (wit : ActionData) (i : Fin 32) : Option (Point Fp) :=
+  hashToPoint orchardGenerators.S orchardBases.merkleQ (merkleQuery wit i)
+
+/-- `Extract_ℙ` (§5.4.9.7).  Not definitionally the `x`-projection: the spec maps
+`𝒪` to `0` and any other point to its affine `x`-coordinate.  It can be implemented
+as `.x` here because this development represents `𝒪` as the off-curve coordinate
+pair `(0, 0)`. -/
+abbrev extractP (p : Point Fp) : Fp := p.x
+
+/-- The blinding step shared by the Sinsemilla commitments (§5.4.8.4): add the
+randomness term to the hash point.  Statements use this name so they do not depend
+on how `SinsemillaCommit` spells the blinding.  Generic over the point or group
+representation and the scalar type, so the circuit-level `Point` form and the
+ledger-level group form spell their blinding the same way. -/
+def sinsemillaCommitBlind {G R : Type*} [Add G] [SMul R G] (hp : G) (r : R)
+    (base : G) : G :=
+  hp + r • base
+
+/-- The blinding-and-extraction step of the short Sinsemilla commitments
+(§5.4.8.4): `Extract_ℙ` of the blinded hash point. -/
+def sinsemillaCommitBlindShort (hp : Point Fp) (r : ℕ) (R : Point Fp) : Fp :=
+  extractP (sinsemillaCommitBlind hp r R)
 
 /-- The four circuit-facing exceptional outcomes, each tied to the witness's own
 exact Sinsemilla hash query via a `hashToPointB … = .inr br` equation and certified

--- a/Zcash/Security/Ledger/BridgeTests.lean
+++ b/Zcash/Security/Ledger/BridgeTests.lean
@@ -165,17 +165,15 @@ theorem path_iff_guarded_smoke
         ∀ i, ∃ b, Pool.merkle.compress i (children i) = some b :=
   Merkle.path_iff_guarded_defined
 
-/-- The circuit-level postcondition refines directly to the ledger action alternative. -/
-theorem actionSpec_bridge_smoke {MSG SIG : Type*}
+/-- The circuit-level postcondition refines directly to ledger action data or a computed
+discrete-log relation. -/
+def actionSpec_bridge_smoke {MSG SIG : Type*}
     (spendAuthVerify bindingVerify : PallasGroup → MSG → SIG → Prop)
     (input : PublicInputs Fp) (wit : PrivateWitness)
     (h : ActionSpec input wit) :
-    ActionBreak (combine input wit) ∨
-      ∃ inst w, PublicProjection (combine input wit) inst ∧
-        ActionSatisfied (Pool.primitives spendAuthVerify bindingVerify) Pool.keyBinding inst w ∧
-        CrossAddressSatisfied (combine input wit) w ∧
-        EnableFlagsSatisfied (combine input wit) w :=
-  actionSpec_to_ledger spendAuthVerify bindingVerify input wit h
+    ActionLedgerSuccess spendAuthVerify bindingVerify (combine input wit) ⊕'
+      ActionDLBreak :=
+  actionSpecToLedgerData spendAuthVerify bindingVerify input wit h
 
 open Zcash.Meta
 
@@ -218,7 +216,7 @@ assert_axioms Zcash.Security.Ledger.BridgeTests.or_break_iff_guarded_smoke +nati
 assert_axioms Zcash.Security.Ledger.BridgeTests.path_iff_guarded_smoke
 assert_axioms Zcash.Security.Ledger.Bridge.guardedPath_of_exact +native(
   CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt)
-assert_axioms Zcash.Security.Ledger.BridgeTests.actionSpec_bridge_smoke +native(
+assert_computable Zcash.Security.Ledger.BridgeTests.actionSpec_bridge_smoke +choice +native(
   CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt)
 
 -- The onward reduction from classified break data to the games-facing
@@ -232,6 +230,17 @@ assert_computable Zcash.Security.Ledger.Bridge.breakCoeffs +choice
 assert_computable Zcash.Security.Ledger.Bridge.relationOfBreakData +choice +native(
   CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt)
 assert_computable Zcash.Security.Ledger.Bridge.classifyRelation +choice +native(
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt)
+
+-- The full Action-to-ledger bridge is data end to end: the key-binding witness, the
+-- success construction, and the dispatching bridge are plain compiled `def`s, at the
+-- same budget as the classifiers they consume (`Classical.choice` and the Pallas
+-- point-count certificate enter only through erased `Prop` positions).
+assert_computable Zcash.Security.Ledger.Bridge.commitIvkWitness +choice +native(
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt)
+assert_computable Zcash.Security.Ledger.Bridge.ActionLedgerSuccess.ofSpec +choice +native(
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt)
+assert_computable Zcash.Security.Ledger.Bridge.actionSpecToLedgerData +choice +native(
   CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt)
 
 end Zcash.Security.Ledger.BridgeTests

--- a/Zcash/Security/Ledger/BridgeTests.lean
+++ b/Zcash/Security/Ledger/BridgeTests.lean
@@ -108,7 +108,7 @@ theorem path_layers_defined
     {B E : Type*} {P : Merkle.MerklePrimitives B E} {leaf root : B}
     {children : Fin P.depth → E × E} {side : Fin P.depth → Bool}
     (h : Merkle.Path P leaf root children side) (i : Fin P.depth) :
-    ∃ b, P.compress i (children i) = some b :=
+    (P.compress i (children i)).isSome :=
   Merkle.Path.compress_isSome h i
 
 /-- Flag zero leaves the post-NU6.3 address condition inert. -/
@@ -162,7 +162,7 @@ theorem path_iff_guarded_smoke
     (side : Fin Pool.merkle.depth → Bool) :
     Merkle.Path Pool.merkle leaf root children side ↔
       Merkle.GuardedPath Pool.merkle leaf root children side ∧
-        ∀ i, ∃ b, Pool.merkle.compress i (children i) = some b :=
+        ∀ i, (Pool.merkle.compress i (children i)).isSome :=
   Merkle.path_iff_guarded_defined
 
 /-- The circuit-level postcondition refines directly to ledger action data or a computed

--- a/Zcash/Security/Ledger/ExtractionArm.lean
+++ b/Zcash/Security/Ledger/ExtractionArm.lean
@@ -160,17 +160,30 @@ def extractFailEvent (S : ValueShape P) (B : BindingSigShape P S)
   {ω | ∃ e, balanceConservationOrBreak (issuance := issuance)
     (txBalancePremissFallible kv S B hr E ω) i = .inr (.inr e)}
 
-/-- Every sample of the extraction-failure arm exhibits a `RedDSA.ExtractionFailure`:
-the arm's named `κ` is a bound on the adversary's probability of beating the
-extractor, and nothing else. -/
-theorem extractFailEvent_failure (S : ValueShape P) (B : BindingSigShape P S)
+variable (kv) in
+/-- The extraction failure computed on a sample: the branch value of the conservation
+reduction, when it lands in the extraction-failure arm. -/
+def extractFailureOf (S : ValueShape P) (B : BindingSigShape P S)
+    (hr : maxActions * (P.valueBound - 1) + P.vBalanceBound < r)
+    (E : RedDSA.Extractor (ZMod r) G MSG)
+    (ω : ValidAnnotated P kv issuance maxActions) (i : ℕ) :
+    Option (RedDSA.ExtractionFailure B.sch E) :=
+  match balanceConservationOrBreak (issuance := issuance)
+    (txBalancePremissFallible kv S B hr E ω) i with
+  | .inr (.inr e) => some e
+  | _ => none
+
+/-- On the extraction-failure arm the computed failure is defined: the arm's named
+`κ` is a bound on the adversary's probability of beating the extractor, and nothing
+else. -/
+theorem extractFailureOf_isSome (S : ValueShape P) (B : BindingSigShape P S)
     (hr : maxActions * (P.valueBound - 1) + P.vBalanceBound < r)
     (E : RedDSA.Extractor (ZMod r) G MSG) (i : ℕ)
     {ω : ValidAnnotated P kv issuance maxActions}
     (hω : ω ∈ extractFailEvent kv S B hr E i) :
-    Nonempty (RedDSA.ExtractionFailure B.sch E) := by
-  obtain ⟨e, _⟩ := hω
-  exact ⟨e⟩
+    (extractFailureOf kv S B hr E ω i).isSome := by
+  obtain ⟨e, he⟩ := hω
+  simp only [extractFailureOf, he, Option.isSome_some]
 
 /-- The transaction-balance premiss arm splits into the relation arm and the
 extraction-failure arm. -/

--- a/Zcash/Security/Ledger/KeyBindingDLR.lean
+++ b/Zcash/Security/Ledger/KeyBindingDLR.lean
@@ -47,23 +47,20 @@ theorem commitIvkHash_isSome {a n : Fp} {g : PallasGroup}
   rcases Option.bind_eq_some_iff.mp h with ⟨p, hp, -⟩
   exact hp ▸ rfl
 
-/-- The chain a defined `commitIvkHash` hit names is valid, and the hit is its image. -/
-theorem commitIvkHash_get_spec {a n : Fp} {g : PallasGroup}
+/-- The chain a defined `commitIvkHash` hit names is valid. -/
+theorem commitIvkHash_get_valid {a n : Fp} {g : PallasGroup}
     (h : commitIvkHash a n = some g) :
-    ∃ hv : ((hashToPoint orchardGenerators.S ivkQ
-        (commitIvkChunks a.val n.val)).get (commitIvkHash_isSome h)).Valid,
-      g = PallasGroup.ofPoint _ hv := by
-  unfold commitIvkHash at h
-  rcases Option.bind_eq_some_iff.mp h with ⟨p, hp, hop⟩
-  have hget : (hashToPoint orchardGenerators.S ivkQ
-      (commitIvkChunks a.val n.val)).get (commitIvkHash_isSome h) = p := by
-    simp [hp]
-  rw [hget]
-  unfold PallasGroup.ofPoint? at hop
-  split at hop
-  · rename_i hv
-    exact ⟨hv, (Option.some_inj.mp hop).symm⟩
-  · exact absurd hop (by simp)
+    ((hashToPoint orchardGenerators.S ivkQ
+      (commitIvkChunks a.val n.val)).get (commitIvkHash_isSome h)).Valid :=
+  hashToPoint_valid (Or.inl ivkQ_onCurve) (fun _ hm => chunksOf_mem_lt hm)
+    (Option.some_get (commitIvkHash_isSome h)).symm
+
+/-- A defined `commitIvkHash` hit is the image of its chain. -/
+theorem commitIvkHash_get_eq {a n : Fp} {g : PallasGroup}
+    (h : commitIvkHash a n = some g) :
+    g = PallasGroup.ofPoint _ (commitIvkHash_get_valid h) :=
+  Option.some_inj.mp (h.symm.trans (commitIvkHash_eq_some_of_hashToPoint
+    (Option.some_get (commitIvkHash_isSome h)).symm (commitIvkHash_get_valid h)))
 
 /-- **The Orchard-protocol key-binding break computes a discrete-log relation.** Two
 valid `Commit^ivk` openings of the same `ivk` disagreeing on their opening projection:
@@ -82,16 +79,16 @@ def relationOfKeyBindingBreak
   relationOfChainPmEq (Q := ivkQ) (Or.inl ivkQ_onCurve) (W := commitIvkRpt)
     (fun _ hm => chunksOf_mem_lt hm) (fun _ hm => chunksOf_mem_lt hm)
     (by simp)
-    (Option.some_get hs₁).symm (commitIvkHash_get_spec b.kb₁.hash_eq).choose
-    (Option.some_get hs₂).symm (commitIvkHash_get_spec b.kb₂.hash_eq).choose
+    (Option.some_get hs₁).symm (commitIvkHash_get_valid b.kb₁.hash_eq)
+    (Option.some_get hs₂).symm (commitIvkHash_get_valid b.kb₂.hash_eq)
     (by
       have hx : extract (w₁.hashPoint + w₁.rivk • commitIvkRpt)
           = extract (w₂.hashPoint + w₂.rivk • commitIvkRpt) := by
         rw [← b.kb₁.ivk_eq, ← b.kb₂.ivk_eq]
         exact b.ivk_eq
       have hpm := (PallasGroup.toPoint_x_eq_iff _ _).mp hx
-      rwa [(commitIvkHash_get_spec b.kb₁.hash_eq).choose_spec,
-        (commitIvkHash_get_spec b.kb₂.hash_eq).choose_spec] at hpm)
+      rwa [commitIvkHash_get_eq b.kb₁.hash_eq,
+        commitIvkHash_get_eq b.kb₂.hash_eq] at hpm)
     (by simp)
     (by
       rintro ⟨hl, hr⟩

--- a/Zcash/Security/Ledger/Merkle.lean
+++ b/Zcash/Security/Ledger/Merkle.lean
@@ -119,7 +119,7 @@ evaluation at every height. -/
 theorem Path.compress_isSome {P : MerklePrimitives B E} {leaf root : B}
     {children : Fin P.depth → E × E} {side : Fin P.depth → Bool}
     (h : Path P leaf root children side) (i : Fin P.depth) :
-    ∃ b, P.compress i (children i) = some b := by
+    (P.compress i (children i)).isSome := by
   have hnode : node P leaf children i.succ = P.compress i (children i) := by
     simp [node, Fin.cases_succ]
   rcases Nat.lt_or_ge (i.1 + 1) P.depth with hlt | hge
@@ -128,14 +128,14 @@ theorem Path.compress_isSome {P : MerklePrimitives B E} {leaf root : B}
       simp [Fin.val_succ]
     have hstep := h.1 ⟨i.1 + 1, hlt⟩
     rw [hcast, hnode] at hstep
-    exact ⟨_, hstep⟩
+    exact hstep ▸ rfl
   · have heq : i.1 + 1 = P.depth := by have := i.isLt; omega
     have hlast : i.succ = Fin.last P.depth := by
       apply Fin.ext
       simp [Fin.val_succ, Fin.val_last, heq]
     have hroot := h.2
     rw [← hlast, hnode] at hroot
-    exact ⟨_, hroot⟩
+    exact hroot ▸ rfl
 
 /-! ## The guarded (⊥-model) path
 
@@ -174,7 +174,7 @@ theorem Path.toGuarded {P : MerklePrimitives B E} {leaf root : B}
 theorem Path.of_guarded_of_defined {P : MerklePrimitives B E} {leaf root : B}
     {children : Fin P.depth → E × E} {side : Fin P.depth → Bool}
     (hg : GuardedPath P leaf root children side)
-    (hdef : ∀ i, ∃ b, P.compress i (children i) = some b) :
+    (hdef : ∀ i, (P.compress i (children i)).isSome) :
     Path P leaf root children side := by
   -- Every running node is defined: index `0` is `some leaf`, and each successor
   -- index is a compression, defined by `hdef`.
@@ -183,7 +183,7 @@ theorem Path.of_guarded_of_defined {P : MerklePrimitives B E} {leaf root : B}
     induction k using Fin.cases with
     | zero => exact ⟨leaf, by simp [node]⟩
     | succ j =>
-        obtain ⟨b, hb⟩ := hdef j
+        obtain ⟨b, hb⟩ := Option.isSome_iff_exists.mp (hdef j)
         exact ⟨b, by simp [node, Fin.cases_succ, hb]⟩
   refine ⟨fun i => ?_, ?_⟩
   · -- Pin the defined running node with the guarded selected-child clause.
@@ -199,7 +199,7 @@ theorem path_iff_guarded_defined {P : MerklePrimitives B E} {leaf root : B}
     {children : Fin P.depth → E × E} {side : Fin P.depth → Bool} :
     Path P leaf root children side ↔
       GuardedPath P leaf root children side ∧
-        ∀ i, ∃ b, P.compress i (children i) = some b :=
+        ∀ i, (P.compress i (children i)).isSome :=
   ⟨fun h => ⟨h.toGuarded, h.compress_isSome⟩,
    fun ⟨hg, hdef⟩ => Path.of_guarded_of_defined hg hdef⟩
 

--- a/Zcash/Security/Ledger/NoteCommitDLR.lean
+++ b/Zcash/Security/Ledger/NoteCommitDLR.lean
@@ -55,26 +55,29 @@ theorem noteCommit_hash_isSome {rcm : Fq} {n : Note PallasGroup Fp Fp}
   rcases Option.bind_eq_some_iff.mp h with ⟨bp, hbp, -⟩
   exact hbp ▸ rfl
 
-/-- The chain a defined `noteCommit` hit names is valid, and the hit decomposes as
-the chain plus the blinding term. -/
-theorem noteCommit_get_spec {rcm : Fq} {n : Note PallasGroup Fp Fp}
+/-- The chain a defined `noteCommit` hit names is valid. -/
+theorem noteCommit_get_valid {rcm : Fq} {n : Note PallasGroup Fp Fp}
     {cm : PallasGroup} (h : noteCommit rcm n = some cm) :
-    ∃ hv : ((noteHash n).get (noteCommit_hash_isSome h)).Valid,
-      cm = PallasGroup.ofPoint _ hv + rcm • noteCommitRpt := by
-  unfold noteCommit at h
-  rcases Option.bind_eq_some_iff.mp h with ⟨bp, hbp, hop⟩
-  have hget : (noteHash n).get (noteCommit_hash_isSome h) = bp := by simp [hbp]
-  have hbpv : bp.Valid := hashToPoint_valid (Or.inl noteQ_onCurve)
-    (fun m hm => chunksOf_mem_lt hm) hbp
-  rw [hget]
-  refine ⟨hbpv, ?_⟩
-  unfold PallasGroup.ofPoint? at hop
-  split at hop
-  · rw [← Option.some_inj.mp hop]
-    rw [smul_eq_val_nsmul, noteCommitRpt, ← PallasGroup.ofPoint_nsmul,
-      ← PallasGroup.ofPoint_add hbpv
-        (Point.valid_nsmul (Or.inl Ecc.MulFixed.Certs.noteCommitR.onCurve) rcm.val)]
-  · exact absurd hop (by simp)
+    ((noteHash n).get (noteCommit_hash_isSome h)).Valid :=
+  hashToPoint_valid (Or.inl noteQ_onCurve) (fun _ hm => chunksOf_mem_lt hm)
+    (Option.some_get (noteCommit_hash_isSome h)).symm
+
+/-- A defined `noteCommit` hit decomposes as its chain plus the blinding term. -/
+theorem noteCommit_get_eq {rcm : Fq} {n : Note PallasGroup Fp Fp}
+    {cm : PallasGroup} (h : noteCommit rcm n = some cm) :
+    cm = sinsemillaCommitBlind (PallasGroup.ofPoint _ (noteCommit_get_valid h))
+      rcm noteCommitRpt := by
+  show cm = PallasGroup.ofPoint _ (noteCommit_get_valid h) + rcm • noteCommitRpt
+  have hval : ((noteHash n).get (noteCommit_hash_isSome h)
+      + rcm.val • Ecc.MulFixed.Certs.noteCommitR.point).Valid :=
+    Point.valid_add (noteCommit_get_valid h)
+      (Point.valid_nsmul (Or.inl Ecc.MulFixed.Certs.noteCommitR.onCurve) rcm.val)
+  have hsome := noteCommit_eq_some_of_hashToPoint
+    (Option.some_get (noteCommit_hash_isSome h)).symm rfl hval
+  rw [smul_eq_val_nsmul, noteCommitRpt, ← PallasGroup.ofPoint_nsmul,
+    ← PallasGroup.ofPoint_add (noteCommit_get_valid h)
+      (Point.valid_nsmul (Or.inl Ecc.MulFixed.Certs.noteCommitR.onCurve) rcm.val)]
+  exact Option.some_inj.mp (h.symm.trans hsome)
 
 /-- **The Orchard-protocol note-commitment break computes a discrete-log relation.** Two
 openings with distinct `(rcm, note)` pairs whose commitments share an extracted
@@ -89,13 +92,12 @@ def relationOfNoteCommitBreak {MSG SIG : Type*}
     (fun _ hm => chunksOf_mem_lt hm) (fun _ hm => chunksOf_mem_lt hm)
     (by simp [Pool.noteScalars])
     (Option.some_get (noteCommit_hash_isSome b.open₁)).symm
-    (noteCommit_get_spec b.open₁).choose
+    (noteCommit_get_valid b.open₁)
     (Option.some_get (noteCommit_hash_isSome b.open₂)).symm
-    (noteCommit_get_spec b.open₂).choose
+    (noteCommit_get_valid b.open₂)
     (by
       have hx : extract b.cm₁ = extract b.cm₂ := b.extract_eq
-      rw [(noteCommit_get_spec b.open₁).choose_spec,
-        (noteCommit_get_spec b.open₂).choose_spec] at hx
+      rw [noteCommit_get_eq b.open₁, noteCommit_get_eq b.open₂] at hx
       exact (PallasGroup.toPoint_x_eq_iff _ _).mp hx)
     (by simp [Pool.noteScalars])
     (by

--- a/Zcash/Security/Ledger/SinsemillaDLR.lean
+++ b/Zcash/Security/Ledger/SinsemillaDLR.lean
@@ -482,6 +482,24 @@ theorem classifyRelation_site {wit : ActionData} {dlb : ActionDLBreak}
   · exact absurd h (by simp)
   · next abr heq => exact ⟨abr, heq, by injection h with h'; rw [← h']⟩
 
+/-- **The computable Action-to-ledger bridge.**  Run the classifier on the combined
+circuit witness: an escape reduces onward to its computed discrete-log relation, and
+otherwise the refined ledger action — instance, witness, and the satisfaction
+proofs — is returned as data (`ActionLedgerSuccess.ofSpec`). -/
+def actionSpecToLedgerData {MSG SIG : Type*}
+    (spendAuthVerify bindingVerify : PallasGroup → MSG → SIG → Prop)
+    (input : PublicInputs Fp) (wit : PrivateWitness)
+    (h : ActionSpec input wit) :
+    ActionLedgerSuccess spendAuthVerify bindingVerify (combine input wit) ⊕'
+      ActionDLBreak :=
+  match hcl : classifyRelation (combine input wit) with
+  | some dlb => .inr dlb
+  | none => .inl (ActionLedgerSuccess.ofSpec spendAuthVerify bindingVerify input wit h
+      (Option.not_isSome_iff_eq_none.mp fun hs => by
+        have hrel := (classifyRelation_isSome_iff (combine input wit)).mpr hs
+        rw [hcl] at hrel
+        simp at hrel))
+
 /-! ## The chain-collision reducer
 
 Shared by every arm whose break compares two blinded Sinsemilla outputs: the

--- a/Zcash/Security/Ledger/SinsemillaDLR.lean
+++ b/Zcash/Security/Ledger/SinsemillaDLR.lean
@@ -473,14 +473,28 @@ theorem classifyRelation_isSome_iff (wit : ActionData) :
   unfold classifyRelation
   split <;> simp_all
 
+/-- The site of the classifier escape behind a successful reduction: the site of
+the computed `classifyAction` value, whose definedness is recovered through
+`classifyRelation_isSome_iff`. -/
+def classifierSiteOf (wit : ActionData) {dlb : ActionDLBreak}
+    (h : classifyRelation wit = some dlb) : BreakSite :=
+  ((classifyAction wit).get
+    ((classifyRelation_isSome_iff wit).mp
+      (Option.isSome_iff_exists.mpr ⟨dlb, h⟩))).site
+
 /-- The reduction reports the classifier's own site. -/
 theorem classifyRelation_site {wit : ActionData} {dlb : ActionDLBreak}
     (h : classifyRelation wit = some dlb) :
-    ∃ abr, classifyAction wit = some abr ∧ dlb.site = abr.site := by
-  unfold classifyRelation at h
-  split at h
-  · exact absurd h (by simp)
-  · next abr heq => exact ⟨abr, heq, by injection h with h'; rw [← h']⟩
+    dlb.site = classifierSiteOf wit h := by
+  obtain ⟨abr, heq, hsite⟩ :
+      ∃ abr, classifyAction wit = some abr ∧ dlb.site = abr.site := by
+    have h' := h
+    unfold classifyRelation at h'
+    split at h'
+    · exact absurd h' (by simp)
+    · next abr heq => exact ⟨abr, heq, by injection h' with h''; rw [← h'']⟩
+  rw [hsite]
+  simp [classifierSiteOf, heq]
 
 /-- **The computable Action-to-ledger bridge.**  Run the classifier on the combined
 circuit witness: an escape reduces onward to its computed discrete-log relation, and

--- a/Zcash/Security/Ledger/Statement.lean
+++ b/Zcash/Security/Ledger/Statement.lean
@@ -167,11 +167,11 @@ satisfy this interface (the latter enforces strictly more).
 
 This is the security-game statement — the abstract ledger meaning of a successful
 action — and it is deliberately separate from the circuit-facing `ActionSpec`:
-`Bridge.actionSpec_to_ledger` verifies that every `ActionSpec` case becomes either this
-statement or an exhibited `Bridge.ActionBreak`. The interface itself stays
-`Prop`-only; the breaks-as-computed-data pattern applies at the bridge
-(`Bridge.classifyAction`, reduced onward to the games-facing discrete-log-relation
-object by `Bridge.relationOfBreakData`), not here.
+`Bridge.actionSpecToLedgerData` turns every `ActionSpec` case into either a ledger
+action satisfying this statement (`Bridge.ActionLedgerSuccess`, with the instance and
+witness as data) or the computed discrete-log relation of a Sinsemilla escape
+(`Bridge.ActionDLBreak`). The interface itself stays `Prop`-only; the
+everything-as-computed-data pattern applies at the bridge, not here.
 
 TODO: Verify the exact Action interface the Balance and Spendability games consume.
 The NU6.3 flag conditions belong in the game instance rather than a circuit-facing

--- a/Zcash/Snark/Contract/Action.lean
+++ b/Zcash/Snark/Contract/Action.lean
@@ -28,7 +28,8 @@ That profile carries caller-supplied prover and reduction work labels; operation
 the separate `AdaptiveStatementAdversaryCostCertificate` and
 `CertifiedAdaptiveStatementDlogProfile` route consumed by
 `orchard_action_adaptiveStatement_certified_knowledge_error_bound`. The ledger continuation begins
-per Action at `Zcash.Security.Ledger.Bridge.actionSpec_to_ledger`; it is not part of this contract.
+per Action at `Zcash.Security.Ledger.Bridge.actionSpecToLedgerData`; it is not part of this
+contract.
 -/
 
 open scoped ENNReal

--- a/Zcash/Snark/Soundness/Action/AdaptiveStatementKnowledge.lean
+++ b/Zcash/Snark/Soundness/Action/AdaptiveStatementKnowledge.lean
@@ -246,6 +246,45 @@ abbrev adaptiveStatementKnowledgeExtractor {pp : ProofParams}
     (fun hrelation => family.semanticStageFacts_of_sourceFinder_none basis O
       (family.relationFinder_none_provenance hchar basis O hrelation).2.2.2.2.1)
 
+/-- The witness projection over one run view returns nothing exactly when the complete
+outcome carries no witness: on its undefined and relation arms. -/
+theorem adaptiveStatementKnowledgeExtractorV_eq_none_iff {pp : ProofParams}
+    (family : ComputedAdaptiveActionStatementFSFamily pp)
+    (basis : AugmentedIndex (2 ^ (AdaptiveActionStatementShape pp).k) → VestaG)
+    (view : RunView pp family basis)
+    (hcharV : deployedX4PairCount (adaptiveActionStatementVk pp basis)
+      (adaptiveActionStatementInstanceCommitment pp basis view.output.inputs)
+      view.output.toAlgebraicWfProof.proof.1
+      (chRecord (k := (AdaptiveActionStatementShape pp).k) view.pre view.rounds) <
+        scalarFieldOrder)
+    (finderResult : Option (AlgebraicRelationWitness (F := Fp) basis))
+    (hfacts : finderResult = none → family.SemanticStageFacts basis view) :
+    family.adaptiveStatementKnowledgeExtractorV basis view hcharV finderResult hfacts = none ↔
+      ∀ witness,
+        family.adaptiveStatementKnowledgeOutcomeV basis view hcharV finderResult hfacts ≠
+          some (Sum.inl witness) := by
+  unfold adaptiveStatementKnowledgeExtractorV
+  cases h : family.adaptiveStatementKnowledgeOutcomeV basis view hcharV finderResult hfacts with
+  | none => simp
+  | some outcome =>
+      cases outcome with
+      | inl witness => exact iff_of_false (by simp) (fun hne => hne witness rfl)
+      | inr relation => simp
+
+/-- The witness projection returns nothing exactly when the complete outcome carries no
+witness: on its undefined and relation arms. -/
+theorem adaptiveStatementKnowledgeExtractor_eq_none_iff {pp : ProofParams}
+    (family : ComputedAdaptiveActionStatementFSFamily pp)
+    (hchar : ∀ basis O, deployedX4PairCount (adaptiveActionStatementVk pp basis)
+      (adaptiveActionStatementInstanceCommitment pp basis (family.runOutput basis O).inputs)
+      (family.runProof basis O).proof.1 (family.runRecord basis O) < scalarFieldOrder)
+    (basis : AugmentedIndex (2 ^ (AdaptiveActionStatementShape pp).k) → VestaG)
+    (O : family.Coins) :
+    family.adaptiveStatementKnowledgeExtractor hchar basis O = none ↔
+      ∀ witness, family.adaptiveStatementKnowledgeOutcome hchar basis O ≠
+        some (Sum.inl witness) :=
+  family.adaptiveStatementKnowledgeExtractorV_eq_none_iff basis (runView family basis O) _ _ _
+
 /-- Acceptance for a selected statement with failure of the executable witness projection. -/
 def adaptiveStatementKnowledgeFailureEvent {pp : ProofParams}
     (family : ComputedAdaptiveActionStatementFSFamily pp)

--- a/Zcash/Snark/Soundness/Action/StraightLineTerminal.lean
+++ b/Zcash/Snark/Soundness/Action/StraightLineTerminal.lean
@@ -36,7 +36,7 @@ namespace ActionBundleWitness
 theorem statement
     {numProofs : ℕ} {inputs : Fin numProofs → PublicInputs Fp}
     (witness : ActionBundleWitness inputs) : BundleStatement inputs :=
-  fun proofIndex => (witness proofIndex).statement
+  fun proofIndex => TopLevelSemanticWitness.statement (witness proofIndex)
 
 end ActionBundleWitness
 

--- a/Zcash/Snark/Soundness/Action/StraightLineTerminal.lean
+++ b/Zcash/Snark/Soundness/Action/StraightLineTerminal.lean
@@ -23,7 +23,9 @@ open Zcash.Arithmetic (scalarFieldOrder)
 
 variable {G : Type} [AddCommGroup G] [Module Fp G] [DecidableEq G] [Inhabited G]
 
-local instance vestaInhabitedStraightLineActionTerminal : Inhabited VestaG := ⟨0⟩
+/-- The concrete inhabitant every straight-line module uses; public so importers
+composing with the terminal share the same instance term. -/
+instance vestaInhabitedStraightLineActionTerminal : Inhabited VestaG := ⟨0⟩
 
 /-- Type-valued private witnesses for every Action in the accepted bundle. -/
 abbrev ActionBundleWitness {numProofs : ℕ}

--- a/Zcash/Snark/Soundness/Relation/KnowledgeSoundness.lean
+++ b/Zcash/Snark/Soundness/Relation/KnowledgeSoundness.lean
@@ -31,14 +31,14 @@ open CompPoly.CPolynomial
 
 variable {G : Type*} [AddCommGroup G] [Module Fp G]
 
--- Decode gap (closed by the multiopen decode layer): the two conjuncts of `SnarkRelation` share
--- only the symbol `a`, so a free decode function feeding `circuitSatViaConstraints` could be
--- instantiated independently of `a` and `circuitSat a` would not constrain the extracted witness.
--- `DeployedConstraintWitness` closes that coupling for this payload by building both conjuncts
--- from one `DeployedAlgebraicDecode`. The Action capstones do not consume `SnarkRelation`; their
--- canonical and Action terminals instead consume that retained decode directly, via
--- `OpenedBatchOpenings` and `DeployedAlgebraicDecode.toMemberDecode`.
-/-- A witness that both opens the IPA commitment and satisfies the circuit predicate. -/
+/-- A witness that both opens the IPA commitment and satisfies the circuit predicate.
+
+Caution: The two conjuncts of `SnarkRelation` share only the symbol `a`, so a free decode function
+feeding `circuitSatViaConstraints` could be instantiated independently of `a`, and then `circuitSat a`
+would not constrain the extracted witness. `DeployedConstraintWitness` supplies that coupling for
+this payload by building both conjuncts from one `DeployedAlgebraicDecode`. The Action capstones do
+not consume `SnarkRelation`; their canonical and Action terminals instead consume that retained
+decode directly, via `OpenedBatchOpenings` and `DeployedAlgebraicDecode.toMemberDecode`. -/
 structure SnarkRelation (urs : URS G) (P : G) (b : Fin (2 ^ urs.k) → Fp) (v : Fp)
     (circuitSat : (Fin (2 ^ urs.k) → Fp) → Prop) (a : Fin (2 ^ urs.k) → Fp) : Prop where
   opens : IpaRelation urs P b v a

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -1888,7 +1888,8 @@ returns every member's data or the first escape (`bundleLedgerData`).
 satisfying witness of `ActionSpec`. Composed with the adaptive-statement knowledge
 outcome, one run yields every member's ledger data, a ledger Sinsemilla escape, or the
 circuit-side algebraic relation (`actionLedgerOutcome`), with `actionLedgerExtractor`
-its ledger projection; the composition adds no new undefinedness. Data end to end. -/
+its ledger projection and `actionLedgerEscapeFinder` its computed escape arm; the
+composition adds no new undefinedness. Data end to end. -/
 
 assert_computable Zcash.Security.Ledger.ActionBundleBridge.memberSatisfying +choice +native(
   CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt)
@@ -1901,6 +1902,10 @@ assert_computable Zcash.Security.Ledger.ActionBundleBridge.actionLedgerOutcome +
   CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt,
   CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
 assert_computable Zcash.Security.Ledger.ActionBundleBridge.actionLedgerExtractor +choice +native(
+  CompElliptic.Fields.Pasta.pallasBase,
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt,
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_computable Zcash.Security.Ledger.ActionBundleBridge.actionLedgerEscapeFinder +choice +native(
   CompElliptic.Fields.Pasta.pallasBase,
   CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt,
   CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -635,7 +635,8 @@ takes `εdlr + κ` in place of the opaque `ε_bindsig`. `+choice` is the erased-
 
 assert_computable Zcash.Security.Ledger.Model.ValueShape.premissOrBreakFallible +choice
 assert_computable Zcash.Security.Ledger.Model.txBalancePremissFallible +choice
-assert_axioms Zcash.Security.Ledger.Model.extractFailEvent_failure
+assert_computable Zcash.Security.Ledger.Model.extractFailureOf +choice
+assert_axioms Zcash.Security.Ledger.Model.extractFailureOf_isSome
 assert_axioms Zcash.Security.Ledger.Model.txBalanceBreakEvent_fallible_subset
 assert_axioms Zcash.Security.Ledger.Model.balanceConservation_measure_le_kerr
 assert_axioms Zcash.Security.Ledger.Model.shieldedBalanceCap_measure_le_kerr

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -1827,19 +1827,21 @@ assert_axioms Zcash.Circuits.Action.orchardActionCircuit +native(
 
 /-! ## The circuit → ledger bridge — exported refinement theorems
 
-The refinement from the Action circuit's postcondition to the games-facing ledger statement
-(`ActionBreak … ∨ ∃ inst w, …`), together with the two correctness directions of the
-break classifier `classifyAction`: an escape it returns is a break of the witness's own hash
-query, and a `none` return — no escape at any of the four sites — means every Sinsemilla query
-of the witness is defined. `actionBreak_iff_classify_isSome` packages both directions as the
-consumer-boundary equivalence. Same budget as the circuit layer above: standard tier plus only
+The refinement from the Action circuit's postcondition to the games-facing ledger statement,
+together with the two correctness directions of the break classifier `classifyAction`: an
+escape it returns is a break of the witness's own hash query, and a `none` return — no escape
+at any of the four sites — means every Sinsemilla query of the witness is defined.
+`actionBreak_iff_classify_isSome` packages both directions as the consumer-boundary
+equivalence. Same budget as the circuit layer above: standard tier plus only
 CompElliptic's Pallas point-count witness.
 
-`actionSpec_to_ledger` is the bridge's whole consumer surface: composition with circuit
-satisfaction lives on the Circuits side, where the `Constraints` predicate it would consume
-is actually produced. -/
+`actionSpecToLedgerData` is the bridge's whole consumer surface, and it returns data: the
+refined ledger action (`ActionLedgerSuccess`, carrying the instance and witness) or the
+computed discrete-log relation of the first Sinsemilla escape (`ActionDLBreak`). Composition
+with circuit satisfaction lives on the Circuits side, where the `Constraints` predicate it
+would consume is actually produced. -/
 
-assert_axioms Zcash.Security.Ledger.Bridge.actionSpec_to_ledger +native(
+assert_axioms Zcash.Security.Ledger.Bridge.actionSpecToLedgerData +native(
   CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt)
 assert_axioms Zcash.Security.Ledger.Bridge.actionBreak_of_classify +native(
   CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt)

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -1885,7 +1885,10 @@ private witness together with its refined ledger action— or the computed discr
 relation of its first Sinsemilla escape (`memberLedgerData`); the bundle traversal
 returns every member's data or the first escape (`bundleLedgerData`).
 `memberSatisfying` transports the extracted witness across the circuit boundary as a
-satisfying witness of `ActionSpec`. Data end to end, at the classifiers' budget. -/
+satisfying witness of `ActionSpec`. Composed with the adaptive-statement knowledge
+outcome, one run yields every member's ledger data, a ledger Sinsemilla escape, or the
+circuit-side algebraic relation (`actionLedgerOutcome`), with `actionLedgerExtractor`
+its ledger projection; the composition adds no new undefinedness. Data end to end. -/
 
 assert_computable Zcash.Security.Ledger.ActionBundleBridge.memberSatisfying +choice +native(
   CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt)
@@ -1893,6 +1896,14 @@ assert_computable Zcash.Security.Ledger.ActionBundleBridge.memberLedgerData +cho
   CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt)
 assert_computable Zcash.Security.Ledger.ActionBundleBridge.bundleLedgerData +choice +native(
   CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt)
+assert_computable Zcash.Security.Ledger.ActionBundleBridge.actionLedgerOutcome +choice +native(
+  CompElliptic.Fields.Pasta.pallasBase,
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt,
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
+assert_computable Zcash.Security.Ledger.ActionBundleBridge.actionLedgerExtractor +choice +native(
+  CompElliptic.Fields.Pasta.pallasBase,
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt,
+  CompElliptic.Curves.Pasta.Vesta.p_nsmul_Gpt)
 assert_axioms Zcash.Security.Ledger.Bridge.ofPoint_hashToPoint
 assert_axioms Zcash.Security.Ledger.Bridge.breakCoeffs_relation +native(
   CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt)

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -1861,9 +1861,9 @@ combination (`ofPoint_hashToPoint`), the coefficient vector is computed from the
 package that as a `NontrivialRelationOne` at the escaped site's domain point.
 
 `relationOfBreakData` and `classifyRelation` are asserted computable, per the
-breaks-as-computed-data convention. `+native` covers the deployed bases' on-curve certificates
-carried in their erased `Prop` fields; `+choice` is the same erased-positions tier the classifier
-itself sits at.
+breaks-as-computed-data convention. `+native` is the Pallas point-count witness that reaches
+their erased `Prop` fields through the group structure; `+choice` is the same erased-positions
+tier that the classifier itself sits at.
 
 `ofPoint_hashToPoint` and `breakCoeffs_nontrivial` stay at the standard tier: the chain
 combination reasons in `ℕ`-multiples of the lifted table, and nontriviality only in the scalar

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -2,6 +2,7 @@ import Zcash.Circuits.Action.RealBases
 import Zcash.Circuits.Action.Separation
 import Zcash.Security.Ledger.Bridge
 import Zcash.Security.Ledger.SinsemillaDLR
+import Zcash.Security.Ledger.ActionBundleBridge
 import Zcash.Arithmetic.FastMsm
 import Zcash.Security.KeyBinding.Instance
 import Zcash.Security.KeyBinding.Probability
@@ -1875,6 +1876,22 @@ assert_computable Zcash.Security.Ledger.Bridge.breakCoeffs +choice
 assert_computable Zcash.Security.Ledger.Bridge.relationOfBreakData +choice +native(
   CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt)
 assert_computable Zcash.Security.Ledger.Bridge.classifyRelation +choice +native(
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt)
+
+/-! ## The bundle-level Action-to-ledger bridge
+
+Every accepted bundle member's extracted witness refines to its ledger data —the full
+private witness together with its refined ledger action— or the computed discrete-log
+relation of its first Sinsemilla escape (`memberLedgerData`); the bundle traversal
+returns every member's data or the first escape (`bundleLedgerData`).
+`memberSatisfying` transports the extracted witness across the circuit boundary as a
+satisfying witness of `ActionSpec`. Data end to end, at the classifiers' budget. -/
+
+assert_computable Zcash.Security.Ledger.ActionBundleBridge.memberSatisfying +choice +native(
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt)
+assert_computable Zcash.Security.Ledger.ActionBundleBridge.memberLedgerData +choice +native(
+  CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt)
+assert_computable Zcash.Security.Ledger.ActionBundleBridge.bundleLedgerData +choice +native(
   CompElliptic.Curves.Pasta.Pallas.q_nsmul_Gpt)
 assert_axioms Zcash.Security.Ledger.Bridge.ofPoint_hashToPoint
 assert_axioms Zcash.Security.Ledger.Bridge.breakCoeffs_relation +native(

--- a/book/src/formal-verification/security-models.md
+++ b/book/src/formal-verification/security-models.md
@@ -31,14 +31,28 @@ A capstone is assembled from several sub-reductions, called "arms", each with it
 own bound. The composition happens at the **reduction layer** (Layer B), not the
 probability layer (Layer C).
 
-We use that approach because probability statements over *different* sample spaces
-don't combine straightforwardly — conditioning on a sub-event reweights the measure,
-and product measures and marginals get in the way. Computable reductions cause no
-such friction. A reduction is a total function from the adversary's output to a
-break, and so "run the adversary, then run the reduction" is just another machine
-(algebraic if both its components are) at an unchanged query count. Reductions
-compose by ordinary function composition —the path of least resistance that Lean's
-proof tactics handle well— and probability is taken *once*, at the end.
+We use that approach for two reasons:
+
+- Probability statements over *different* sample spaces don't combine
+  straightforwardly — conditioning on a sub-event reweights the measure, and product
+  measures and marginals get in the way.
+- Directly combining results expressed in terms of probability often results in an
+  unnecessarily loose reduction. The issue is that giving an adversary $n$ problems
+  in parallel, of which they only have to find one solution, *may or may not*
+  fundamentally help them depending on the detail of those problems. Black-box
+  reasoning using the probability bounds for the individual problems has to assume
+  the worst case, which loses a factor of $n$ in tightness (via a union bound).
+
+Composing at the level of computable reductions makes it easier to handle both issues.
+A reduction is a total function from the adversary's output to a break, and so "run
+the adversary, then run the reduction" is just another machine (algebraic if both its
+components are) at an unchanged query count. Reductions compose by ordinary function
+composition — the path of least resistance that Lean's proof tactics handle well. And
+the reduction has the *actual break data* from the adversary's solution to one of the
+source problems. The tightness loss, if any, that the reduction incurs to solve the
+target problem will depend on the particular case, but this approach avoids throwing
+away information that is likely to be needed to get the best available reduction. The
+overall probability bound is then taken *once* at the end.
 
 Three pieces of structure make that last step essentially mechanical:
 
@@ -57,14 +71,18 @@ Three pieces of structure make that last step essentially mechanical:
   lands in the event"; it preserves unions because $\exists$ distributes over
   $\lor$.
 
-So a composed bound is proved in two moves. First, a distribution-independent
-**set-level containment**: the bad event is contained in a union of per-arm
-events. This involves no probability over multiple sample spaces, so it is
-easily reusable. Second, lift to a probability, and sum:
+So a composed bound is proved like this:
 
-* monotonicity carries the containment into the sample space;
-* the join-homomorphism distributes it over the union;
-* subadditivity turns the union into the sum of the per-arm bounds.
+- First, a distribution-independent **set-level containment**: the bad event is
+  contained in a union of per-arm events. This involves no probability over
+  multiple sample spaces, so it is easily reusable.
+- At this point it might be possible to collapse together either multiple
+  possibilities for the same kind of event, or different events that rest on
+  the same or closely related cryptographic problems.
+- Finally, lift to a probability, and sum:
+  - monotonicity carries the containment into the sample space;
+  - the join-homomorphism distributes it over the union;
+  - subadditivity turns the union into the sum of the per-arm bounds.
 
 ### The Balance integrity argument as a worked example
 
@@ -73,17 +91,19 @@ shielded pool going negative, or the pools failing to sum to the minted
 issuance— is contained in the union of the three Balance-subset break arms
 (Merkle, note-commitment, key-binding) and the Balance conservation violation.
 That containment is `balanceIntegrityViolationBefore_subset_conservation`; it
-mentions no probabilities and holds at every prefix at once.
+mentions no probabilities and holds at every ledger prefix at once.
 
 Lifting it to the sample space through the join-homomorphism `sampledLedgerEvent`
 and applying subadditivity, gives the integrity experiment's bound as the sum
-of the non-negativity side and the conservation side. This is optimally tight
-and has no factor of the number of prefixes. The conservation side is reused
-wholesale — the conservation experiment is one arm dropped in as a black box.
-And at the Orchard instantiation, the three non-negativity arms collapse onto
-a single advantage, that of finding a nontrivial discrete-log relation among
-the fixed Sinsemilla bases. That is, each arm's break is routed through its
-deterministic reducer, so all three land in one event and are bounded once.
+of the non-negativity side and the conservation side. The conservation side is
+reused wholesale — the conservation experiment is one arm dropped in as a black
+box. And at the Orchard instantiation, the three non-negativity arms, at all
+possible prefixes at which they could occur, collapse onto a single advantage —
+that of finding a nontrivial discrete-log relation among the fixed Sinsemilla
+bases. That is, each arm's break is routed through its deterministic reducer,
+so all three land in one event and are bounded once. This gives a reduction for
+the `_idealizedks` capstones that is almost optimally tight — losing only a
+factor of $2$ in tightness, without any factor of the number of ledger prefixes.
 
 Naming the Boolean algebra, the subadditive measure, and the join-homomorphism
 is what turns per-composition plumbing into three reusable lemmas. This is an

--- a/scripts/check_endpoint_census.sh
+++ b/scripts/check_endpoint_census.sh
@@ -94,10 +94,40 @@ if [[ -z "$census" ]]; then
 fi
 
 # Every pinned name, fully qualified, one per line. An optional `_root_.` prefix is accepted by
-# the macros, so strip it here too.
-pins=$(echo "$census" | xargs grep -hE '^assert_(axioms|computable) ' \
-  | sed -E 's/^assert_(axioms|computable)[[:space:]]+//; s/^_root_\.//; s/[[:space:]].*$//' \
-  | sort -u)
+# the macros, so strip it here too. A pin may wrap its name onto the following line (the
+# assert command alone, then the indented name) to keep long names within the line-width
+# convention; accept both layouts.
+# A name that fails to parse (an empty continuation, or a token carrying syntax like
+# `+native(`) is reported as a violation rather than skipped: a silently dropped pin would
+# make a pinned endpoint read as unpinned — or, combined with a declaration-side parse gap,
+# read as nothing at all. The elaborated `CensusCheck` remains the backstop for the
+# declaration side.
+pins=$(echo "$census" | xargs awk '
+  /^assert_(axioms|computable)[[:space:]]+[^[:space:]]/ {
+    name = $2
+    sub(/^_root_\./, "", name)
+    if (name == "" || name ~ /[+(),]/) name = "PARSE_ERROR"
+    print name
+    next
+  }
+  /^assert_(axioms|computable)[[:space:]]*$/ { pending = 1; next }
+  pending {
+    name = $1
+    sub(/^_root_\./, "", name)
+    if (name == "" || name ~ /[+(),]/) name = "PARSE_ERROR"
+    print name
+    pending = 0
+  }
+  END { if (pending) print "PARSE_ERROR" }
+' | sort -u)
+
+# A herestring rather than a pipe: `grep -q` exits at the first match, and under
+# `pipefail` the SIGPIPE it sends a still-writing `echo` would turn a MATCH into a
+# failed pipeline, silently skipping this guard.
+if grep -q '^PARSE_ERROR$' <<< "$pins"; then
+  echo "VIOLATION: unparseable assert_axioms/assert_computable entry layout in census files" >&2
+  exit 1
+fi
 
 status=0
 count=0


### PR DESCRIPTION
The knowledge-soundness bridge: turn the Action circuit's extracted witnesses into the ledger's annotated actions, closing the gap that #171's `_idealizedks` capstones name as a gap.

## The Action-to-ledger refinement as data

`actionSpecToLedgerData` replaces the bridge's existential endpoint: classify the combined circuit witness, and either return the refined ledger action as data (`ActionLedgerSuccess` — the instance, the witness, and the proofs that they satisfy the games-facing statement) or the computed discrete-log relation of the first Sinsemilla escape (`ActionDLBreak`). The structure is indexed by the full circuit witness, so no component of the extracted data is projected away. The success construction computes through the ledger's own primitives: the key-binding witness's hash point is the defined value of `Pool.commitIvkHash`, its incoming viewing key is the extraction the opening relation demands (so that equation holds by construction), and the new-note commitment is the defined value of `Pool.noteCommit`. The existential-returning forms (`actionSpec_to_ledger`, `commitIvkSuccess_to_ledger`, `noteCommitNewSuccess_to_ledger`) are deleted rather than kept as corollaries: returning the data already shows the existential form is inhabited. Census and prose pointers move to the data forms.

## The named vocabulary and the constructive success layer

This is a refactoring cleanup — not strictly necessary for the circuit-to-ledger bridge, but this was a good time to do it.

The per-site hash abbreviations (`ivkHash`, `noteOldHash`, `noteNewHash`, `merkleHash`) pin the deployed generator table and each site's domain point once; `extractP` names `Extract_P` (§5.4.9.7), with the representation caveat that makes `.x` a correct implementation; and `sinsemillaCommitBlind`/`sinsemillaCommitBlindShort` name the commitment steps (§5.4.8.4), so statements do not depend on how `SinsemillaCommit` spells them. The `∃`-shaped definedness facts and success predicates become their constructive normal forms: `isSome` fields with the values recovered by `Option.get` and computed accessors (`commitIvkOf`, `merkleRootOf`). `successes_or_break`/`successes_of_noBreak` are deleted —the classifier match was already the mechanism— and the `_get_spec` dependent pairs split into `_get_valid`/`_get_eq`, derived through the Pool lemmas, which also removes the consumers' `Exists.choose` uses. The reduction's site and the extraction-failure arm's datum are likewise computed (`classifierSiteOf`, `extractFailureOf`).

## The Satisfying structure and the bundle lift

`Zcash.Common.Satisfying R x` is a Type-valued structure bundling a witness with its satisfaction proof. It is modelled on zcash-lean's `Satisfying`, with the divergences noted in its module doc. `TopLevelSemanticWitness` becomes an abbreviation of it. Each accepted bundle member's extracted witness is then either a satisfying witness of the circuit-facing `ActionSpec` (`memberSatisfying`) refined to the member's ledger data, or the computed escape relation (`memberLedgerData`), and is traversed across the bundle via `bundleLedgerData`. The census pins all of these as computed data.

## The composed ledger extractor

`actionLedgerOutcome` composes the bundle bridge with the adaptive-statement knowledge outcome: one run yields every member's ledger data, a ledger Sinsemilla escape, or the circuit-side algebraic relation over the run's own basis, and `none` is exactly the runs on which the knowledge outcome is undefined (`actionLedgerOutcome_isSome_iff`). The routing is deliberate: circuit-side relations stay in their own arm —on accepting runs, that arm and `none` together are the knowledge-failure event that the knowledge-error endpoint bounds— and only the bridge's Sinsemilla escapes surface as ledger breaks. `actionLedgerExtractor` is the composed knowledge-soundness map.

## The escape arm and the failure decomposition

`actionLedgerEscapeFinder` returns the computed discrete-log relation data of the extracted bundle's first Sinsemilla escape, and `actionLedgerExtractor_eq_none_iff` decomposes failure of the composed extractor exactly: either the witness projection of the shared knowledge outcome returned nothing (the knowledge-failure event that the knowledge-error endpoint bounds), or a member escaped the bridge. The supporting characterization lives with the knowledge layer, universally quantified so that it applies at any elaboration of the shared outcome.

## Census housekeeping

The endpoint census script now accepts pin entries whose name wraps onto a continuation line, and it fails loudly on an entry that it cannot parse a valid name from — including a herestring fix for a guard that `pipefail` would otherwise skip silently through SIGPIPE when the pin list exceeds the pipe buffer.

A separate commit updates the Sinsemilla relation section's prose in `Zcash/TrustBoundary.lean`. That prose still attributed the relation entries' `+native` budget to the deployed bases' on-curve certificates. After #161 kernel-checked the fixed-base certificates, the only native owner that those entries reach is the Pallas point-count witness.

## Remaining after this PR

Review (thanks @TalDerei) found two soundness holes in the first composed experiment: it required validity at the programmed value bases while the extracted witnesses open the value commitments at the deployed bases, making its violation arm essentially empty, and its per-slot-and-size oracle tables did not model one random oracle. That experiment has been removed from this branch (preserved on the `fv/action-witness-bridge-pre-basis-rework` ref) and will be rebuilt in a follow-up PR: ledger validity and the violation events move to the deployed primitives; the conservation arm becomes a computed nontrivial discrete-log relation among the deployed value bases — symmetric with the Sinsemilla side — with the programmed-basis step (Jaeger–Tessaro) as an isolated terminal lemma on the standalone relation game; and the oracle tables are shared per bundle size. The sequential generalization of the proof-emitting adversary model is tracked with #214 and #155.

Progress on #147: the bridge machinery lands here, and #147 stays open for the games-side composition.

🤖 Claude Fable 5




