### PR TITLE
cleanup: spell out short argument and advantage names

### DIFF
--- a/Zcash/Security/KeyBinding/Basic.lean
+++ b/Zcash/Security/KeyBinding/Basic.lean
@@ -20,8 +20,8 @@ verifying Recovery-Statement witness pins the key components — `ak` up to y-si
 
 The route, each step proven here:
 
-1. `commit_scalar_pm` — two openings of one `Commitivk` value force their Pedersen scalars equal
-   or negated; `CollisionUpToSign.ofOpeningBreak` packages this as computed data.
+1. `commit_scalar_pm` — two openings of one `Commitivk` value force their Pedersen scalars
+   equal or negated; `CollisionUpToSign.ofOpeningBreak` packages this as computed data.
 2. `rivk_eq_finalOracle` — under the derivation constraints, `rivk` is the combined final
    oracle's output at the witness's decoded query.
 3. `CollisionUpToSign.ofBreak` — a full `Break` computes a ±-collision of the shifted combined
@@ -31,9 +31,8 @@ The route, each step proven here:
 
 The probabilistic side — producing the computed collision is hard — is the birthday bound
 `ε_kb ≤ q(q-1)/|RIVK|` (`Birthday.lean`, with `|RIVK| = r_ℙ` at the intended Pallas
-instantiation), ZIP 2005's `ε_kb` as sharpened in zcash/zips#1338.
-nf-pinning, which the Spendability argument consumes, is the games'
-`nfOldEqOrBreak` (`Security/Ledger/Statement.lean`).
+instantiation), ZIP 2005's `ε_kb`. nf-pinning, which the Spendability argument consumes,
+is the games' `nfOldEqOrBreak` (`Security/Ledger/Statement.lean`).
 
 Abstract setting: a prime-order group `G` as an `RIVK`-vector space. The scalar types are
 `RIVK` (rivk values and the rivk-derivation oracle outputs) and `ASK` (`H^ask` outputs, acting
@@ -144,8 +143,8 @@ section Algebra
 variable [AddCommGroup G] [Field IVK] [Field RIVK] [Module RIVK G] [NoZeroSMulDivisors RIVK G]
 
 /-- The `ivk` commitment as a Pedersen lift:
-`Commitivk rivk ak nk = Extract.toIVK ((h ak nk + rivk) • S)`, with `h` abstract-but-non-querying and `S`
-a fixed base. Mirrors the `NoteCommit` repair `(H^rcm + f) • R`. -/
+`Commitivk rivk ak nk = Extract.toIVK ((h ak nk + rivk) • S)`, with `h` abstract-but-non-querying
+and `S` a fixed base. Mirrors the `NoteCommit` repair `(H^rcm + f) • R`. -/
 def Commitivk (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK) (rivk : RIVK)
     (ak : AK) (nk : NK) : IVK :=
   Extract.toIVK ((hfn ak nk + rivk) • S)

--- a/Zcash/Security/KeyBinding/Probability.lean
+++ b/Zcash/Security/KeyBinding/Probability.lean
@@ -15,11 +15,13 @@ Nothing here pins `|RIVK|`: at the intended Pallas instantiation `RIVK` is the s
 so `|RIVK| = r_ℙ`, and an undersized instantiation would make the bounds vacuous.
 
 The model samples the combined final `rivk`-derivation oracle `H^*` as one uniform table
-`O : FinalQuery AK NK RIVK QK SK → RIVK`. A uniform table is the same as independent uniform outputs at
-every query — the product structure of the uniform measure. (In Markov-category terms `PMF` is a
-commutative monad, so samples reorder freely; see Fritz [eprint arXiv:1908.07021] and
-`Mathlib.CategoryTheory.MarkovCategory` for the abstract setting.) The three constituent oracles
-are the table's restrictions along the `FinalQuery` constructors (`FinalQuery.eval_restrict`).
+`table : FinalQuery AK NK RIVK QK SK → RIVK`. A uniform table is the same as independent
+uniform outputs at every query — the product structure of the uniform measure. (In
+Markov-category terms `PMF` is a commutative monad, so samples reorder freely; see Fritz,
+[A synthetic approach to Markov kernels, conditional independence and theorems on sufficient statistics](https://arxiv.org/abs/1908.07021),
+arXiv:1908.07021 and `Mathlib.CategoryTheory.MarkovCategory` for the abstract setting.)
+The three constituent oracles are the table's restrictions along the `FinalQuery` constructors
+(`FinalQuery.eval_restrict`).
 
 The remaining data (the extract maps, the bases, `hfn`, `Hask`, `Hnk`) are fixed parameters. The shift
 `shiftOf` reads only the query and these parameters, never the sampled table — so a shifted read
@@ -36,15 +38,15 @@ Results (static model — the query set is fixed before the table is sampled):
   query set of size at most `q`: probability at most `q·(q−1)/|F|`.
 * `break_measure_le` — the key-binding capstone: an adversary whose witnesses' derivation
   queries land in the static set produces a `Break` with probability at most `q·(q−1)/|RIVK|`.
-  This is ZIP 2005's `ε_kb` as sharpened in zcash/zips#1338. At the intended instantiation,
-  `|RIVK|` is the Pallas group order `r_ℙ`.
+  This is ZIP 2005's `ε_kb`. At the intended instantiation, `|RIVK|` is the Pallas group
+  order `r_ℙ`.
 
 Results (adaptive — a bounded-query machine choosing queries after seeing earlier answers, as
 an `OracleComp` from the Fiat–Shamir layer):
 
 * `CollidesDuring` / `collidesDuring_measure_le` — the history-carrying collision event, and
-  the sum-over-steps bound `(2·m·Q + Q·(Q−1))/|F|` for a cache-avoiding `Q`-query machine with
-  `m` recorded answers: the triangle sum `Σ 2·(j−1)` recovers the non-adaptive constant
+  the sum-over-steps bound `(2·m·Q + Q·(Q−1))/|F|` for a cache-avoiding `Q`-query machine
+  with `m` recorded answers: the triangle sum `Σ 2·(j−1)` recovers the non-adaptive constant
   exactly.
 * `queries_pair_collision_measure_le` — a `Q`-query machine's trace contains a shifted
   ±-colliding pair with probability at most `Q·(Q−1)/|F|`.
@@ -88,9 +90,9 @@ instance [Fintype AK] [Fintype NK] [Fintype RIVK] [Fintype QK] [Fintype SK] :
 
 /-- Assembling the combined final oracle from a table's constructor restrictions gives back the
 table. -/
-theorem eval_restrict (O : FinalQuery AK NK RIVK QK SK → RIVK) :
-    FinalQuery.eval (fun sk => O (.legacy sk)) (fun qk ak nk => O (.ext qk ak nk))
-      (fun rivk_ext ak nk => O (.int rivk_ext ak nk)) = O := by
+theorem eval_restrict (table : FinalQuery AK NK RIVK QK SK → RIVK) :
+    FinalQuery.eval (fun sk => table (.legacy sk)) (fun qk ak nk => table (.ext qk ak nk))
+      (fun rivk_ext ak nk => table (.int rivk_ext ak nk)) = table := by
   funext q; cases q <;> rfl
 
 /-! ## The per-pair and union bounds, over an arbitrary finite query domain -/
@@ -104,34 +106,34 @@ omit [Fintype Q] [DecidableEq Q] [Fintype F] [DecidableEq F] in
 theorem eqUpToSign_symm {x y : F} (h : x =± y) : y =± x :=
   h.elim (fun h => Or.inl h.symm) (fun h => Or.inr (by rw [h, neg_neg]))
 
-/-- **Non-adaptive per-pair bound.** For distinct queries `a ≠ b` and any shift `s` fixed
-independently of the table, a uniform table's shifted outputs at `a` and `b` ±-collide with
-probability at most `2/|F|`: the pair read is uniform on `F × F`
+/-- **Non-adaptive per-pair bound.** For distinct queries `a ≠ b` and any `shift` fixed
+independently of the table, a uniform table's shifted outputs at `a` and `b` ±-collide
+with probability at most `2/|F|`: the pair read is uniform on `F × F`
 (`uniformOfFintype_map_precomp_injective`), and the shifted collision set has at most
 `2·|F|` elements (`card_shifted_pm_collision_le`). -/
-theorem pair_shifted_collision_measure_le (s : Q → F) {a b : Q} (hne : a ≠ b) :
+theorem pair_shifted_collision_measure_le (shift : Q → F) {a b : Q} (hne : a ≠ b) :
     (PMF.uniformOfFintype (Q → F)).toOuterMeasure
-        {O : Q → F | s a + O a =± s b + O b}
+        {table : Q → F | shift a + table a =± shift b + table b}
       ≤ 2 / Fintype.card F := by
   have hφ : Function.Injective (![a, b] : Fin 2 → Q) := by
     intro i j hij
     fin_cases i <;> fin_cases j <;> simp_all
-  have hpre : {O : Q → F | s a + O a =± s b + O b}
-      = (fun O : Q → F => (piFinTwoEquiv fun _ => F) (O ∘ ![a, b])) ⁻¹'
-          {p : F × F | s a + p.1 =± s b + p.2} := rfl
+  have hpre : {table : Q → F | shift a + table a =± shift b + table b}
+      = (fun table : Q → F => (piFinTwoEquiv fun _ => F) (table ∘ ![a, b])) ⁻¹'
+          {p : F × F | shift a + p.1 =± shift b + p.2} := rfl
   rw [hpre, ← PMF.toOuterMeasure_map_apply]
   have hmap : (PMF.uniformOfFintype (Q → F)).map
-        (fun O : Q → F => (piFinTwoEquiv fun _ => F) (O ∘ ![a, b]))
+        (fun table : Q → F => (piFinTwoEquiv fun _ => F) (table ∘ ![a, b]))
       = PMF.uniformOfFintype (F × F) := by
-    rw [show (fun O : Q → F => (piFinTwoEquiv fun _ => F) (O ∘ ![a, b]))
-          = ⇑(piFinTwoEquiv fun _ => F) ∘ (fun O : Q → F => O ∘ ![a, b]) from rfl,
+    rw [show (fun table : Q → F => (piFinTwoEquiv fun _ => F) (table ∘ ![a, b]))
+          = ⇑(piFinTwoEquiv fun _ => F) ∘ (fun table : Q → F => table ∘ ![a, b]) from rfl,
       ← PMF.map_comp, uniformOfFintype_map_precomp_injective _ hφ,
       map_uniformOfFintype_equiv]
   rw [hmap, uniformOfFintype_toOuterMeasure_set]
-  have hcard : Nat.card {p : F × F | s a + p.1 =± s b + p.2} ≤ 2 * Fintype.card F := by
+  have hcard : Nat.card {p : F × F | shift a + p.1 =± shift b + p.2} ≤ 2 * Fintype.card F := by
     rw [Nat.card_coe_set_eq, Set.ncard_eq_toFinset_card', Set.toFinset_setOf]
-    exact card_shifted_pm_collision_le (s a) (s b)
-  calc (Nat.card {p : F × F | s a + p.1 =± s b + p.2} : ℝ≥0∞) / Fintype.card (F × F)
+    exact card_shifted_pm_collision_le (shift a) (shift b)
+  calc (Nat.card {p : F × F | shift a + p.1 =± shift b + p.2} : ℝ≥0∞) / Fintype.card (F × F)
       ≤ (2 * Fintype.card F : ℕ) / Fintype.card (F × F) := by
         gcongr
     _ = 2 / Fintype.card F := by
@@ -143,15 +145,16 @@ theorem pair_shifted_collision_measure_le (s : Q → F) {a b : Q} (hne : a ≠ b
 /-- **Non-adaptive union bound.** A query set of size at most `q`, fixed before the table is
 sampled, contains a shifted ±-colliding pair with probability at most `q·(q−1)/|F|`: sum the
 per-pair bound over the `C(q,2)` unordered pairs (`Finset.powersetCard 2`). -/
-theorem finset_shifted_collision_measure_le (s : Q → F) (Qs : Finset Q) {q : ℕ}
+theorem finset_shifted_collision_measure_le (shift : Q → F) (Qs : Finset Q) {q : ℕ}
     (hq : Qs.card ≤ q) :
     (PMF.uniformOfFintype (Q → F)).toOuterMeasure
-        {O : Q → F | ∃ a ∈ Qs, ∃ b ∈ Qs, a ≠ b ∧ s a + O a =± s b + O b}
+        {table : Q → F | ∃ a ∈ Qs, ∃ b ∈ Qs, a ≠ b ∧ shift a + table a =± shift b + table b}
       ≤ (q * (q - 1) : ℕ) / Fintype.card F := by
-  have hcover : {O : Q → F | ∃ a ∈ Qs, ∃ b ∈ Qs, a ≠ b ∧ s a + O a =± s b + O b}
+  have hcover : {table : Q → F | ∃ a ∈ Qs, ∃ b ∈ Qs, a ≠ b ∧ shift a + table a =± shift b + table b}
       ⊆ ⋃ t : ↥(Qs.powersetCard 2),
-          {O : Q → F | ∃ a ∈ t.1, ∃ b ∈ t.1, a ≠ b ∧ s a + O a =± s b + O b} := by
-    rintro O ⟨a, ha, b, hb, hab, hpm⟩
+          {table : Q → F |
+            ∃ a ∈ t.1, ∃ b ∈ t.1, a ≠ b ∧ shift a + table a =± shift b + table b} := by
+    rintro table ⟨a, ha, b, hb, hab, hpm⟩
     refine Set.mem_iUnion.2 ⟨⟨{a, b}, Finset.mem_powersetCard.2 ⟨?_, Finset.card_pair hab⟩⟩,
       ⟨a, ?_, b, ?_, hab, hpm⟩⟩
     · exact Finset.insert_subset ha (Finset.singleton_subset_iff.2 hb)
@@ -159,13 +162,13 @@ theorem finset_shifted_collision_measure_le (s : Q → F) (Qs : Finset Q) {q : �
     · simp
   have hpair : ∀ t : ↥(Qs.powersetCard 2),
       (PMF.uniformOfFintype (Q → F)).toOuterMeasure
-          {O : Q → F | ∃ a ∈ t.1, ∃ b ∈ t.1, a ≠ b ∧ s a + O a =± s b + O b}
+          {table : Q → F | ∃ a ∈ t.1, ∃ b ∈ t.1, a ≠ b ∧ shift a + table a =± shift b + table b}
         ≤ 2 / Fintype.card F := by
     rintro ⟨t, ht⟩
     obtain ⟨-, hcard⟩ := Finset.mem_powersetCard.1 ht
     obtain ⟨a, b, hab, rfl⟩ := Finset.card_eq_two.1 hcard
-    refine le_trans (MeasureTheory.measure_mono ?_) (pair_shifted_collision_measure_le s hab)
-    rintro O ⟨x, hx, y, hy, hxy, hpm⟩
+    refine le_trans (MeasureTheory.measure_mono ?_) (pair_shifted_collision_measure_le shift hab)
+    rintro table ⟨x, hx, y, hy, hxy, hpm⟩
     simp only [Finset.mem_insert, Finset.mem_singleton] at hx hy
     rcases hx with rfl | rfl <;> rcases hy with rfl | rfl
     · exact absurd rfl hxy
@@ -179,13 +182,14 @@ theorem finset_shifted_collision_measure_le (s : Q → F) (Qs : Finset Q) {q : �
   have h2 : q * (q - 1) = q.choose 2 * 2 := by
     rw [Nat.choose_two_right, Nat.div_mul_cancel hdvd]
   calc (PMF.uniformOfFintype (Q → F)).toOuterMeasure
-        {O : Q → F | ∃ a ∈ Qs, ∃ b ∈ Qs, a ≠ b ∧ s a + O a =± s b + O b}
+        {table : Q → F | ∃ a ∈ Qs, ∃ b ∈ Qs, a ≠ b ∧ shift a + table a =± shift b + table b}
       ≤ (PMF.uniformOfFintype (Q → F)).toOuterMeasure
           (⋃ t : ↥(Qs.powersetCard 2),
-            {O : Q → F | ∃ a ∈ t.1, ∃ b ∈ t.1, a ≠ b ∧ s a + O a =± s b + O b}) :=
+            {table : Q → F |
+              ∃ a ∈ t.1, ∃ b ∈ t.1, a ≠ b ∧ shift a + table a =± shift b + table b}) :=
         MeasureTheory.measure_mono hcover
     _ ≤ ∑' t : ↥(Qs.powersetCard 2), (PMF.uniformOfFintype (Q → F)).toOuterMeasure
-          {O : Q → F | ∃ a ∈ t.1, ∃ b ∈ t.1, a ≠ b ∧ s a + O a =± s b + O b} :=
+          {table : Q → F | ∃ a ∈ t.1, ∃ b ∈ t.1, a ≠ b ∧ shift a + table a =± shift b + table b} :=
         MeasureTheory.measure_iUnion_le _
     _ ≤ ∑' _t : ↥(Qs.powersetCard 2), (2 / Fintype.card F : ℝ≥0∞) :=
         ENNReal.tsum_le_tsum hpair
@@ -225,12 +229,12 @@ candidate values per pair, one per sign. A list representing the step's *bad set
 membership matters, but the list length `2·|σ|` is a convenient bound on the set's
 cardinality; coinciding candidates merely leave the inequality slack, they do not
 invalidate it). -/
-def badList (s : Q → F) (σ : List (Q × F)) (t : Q) : List F :=
-  σ.map (fun p => s p.1 + p.2 - s t) ++ σ.map (fun p => -(s p.1 + p.2) - s t)
+def badList (shift : Q → F) (σ : List (Q × F)) (t : Q) : List F :=
+  σ.map (fun p => shift p.1 + p.2 - shift t) ++ σ.map (fun p => -(shift p.1 + p.2) - shift t)
 
 omit [Fintype Q] [DecidableEq Q] [Fintype F] [DecidableEq F] in
-theorem mem_badList {s : Q → F} {σ : List (Q × F)} {t : Q} {y : F} :
-    y ∈ badList s σ t ↔ ∃ p ∈ σ, s t + y =± s p.1 + p.2 := by
+theorem mem_badList {shift : Q → F} {σ : List (Q × F)} {t : Q} {y : F} :
+    y ∈ badList shift σ t ↔ ∃ p ∈ σ, shift t + y =± shift p.1 + p.2 := by
   simp only [badList, List.mem_append, List.mem_map, EqUpToSign]
   constructor
   · rintro (⟨p, hp, rfl⟩ | ⟨p, hp, rfl⟩)
@@ -242,19 +246,19 @@ theorem mem_badList {s : Q → F} {σ : List (Q × F)} {t : Q} {y : F} :
 
 omit [Fintype Q] [DecidableEq Q] in
 /-- One step's bad set has probability at most `2·m/|F|` for a history of length `m`. -/
-theorem badList_measure_le (s : Q → F) (σ : List (Q × F)) (t : Q) :
-    (PMF.uniformOfFintype F).toOuterMeasure {y : F | y ∈ badList s σ t}
+theorem badList_measure_le (shift : Q → F) (σ : List (Q × F)) (t : Q) :
+    (PMF.uniformOfFintype F).toOuterMeasure {y : F | y ∈ badList shift σ t}
       ≤ (2 * σ.length : ℕ) / Fintype.card F := by
   rw [uniformOfFintype_toOuterMeasure_set]
-  have hcard : Nat.card {y : F | y ∈ badList s σ t} ≤ 2 * σ.length := by
+  have hcard : Nat.card {y : F | y ∈ badList shift σ t} ≤ 2 * σ.length := by
     rw [Nat.card_coe_set_eq, Set.ncard_eq_toFinset_card', Set.toFinset_setOf]
-    calc (univ.filter fun y : F => y ∈ badList s σ t).card
-        ≤ (badList s σ t).toFinset.card := by
+    calc (univ.filter fun y : F => y ∈ badList shift σ t).card
+        ≤ (badList shift σ t).toFinset.card := by
           apply card_le_card
           intro y hy
           rw [mem_filter] at hy
           simpa [List.mem_toFinset] using hy.2
-      _ ≤ (badList s σ t).length := (badList s σ t).toFinset_card_le
+      _ ≤ (badList shift σ t).length := (badList shift σ t).toFinset_card_le
       _ ≤ 2 * σ.length := le_of_eq (by simp [badList, two_mul])
   gcongr
 
@@ -265,7 +269,8 @@ history *data* keeps each step's escape set independent of the sampled table. -/
 def escapesWithHistory {α : Type*} (esc : List (Q × F) → Q → Set F) :
     List (Q × F) → OracleComp Q F α → (Q → F) → Prop
   | _, .pure _, _ => False
-  | σ, .query t k, O => O t ∈ esc σ t ∨ escapesWithHistory esc ((t, O t) :: σ) (k (O t)) O
+  | σ, .query t k, table =>
+      table t ∈ esc σ t ∨ escapesWithHistory esc ((t, table t) :: σ) (k (table t)) table
 
 omit [DecidableEq F] in
 /-- **History-indexed escape bound.** If the escape set at history length `m` has probability
@@ -278,61 +283,61 @@ theorem escapesWithHistory_measure_le {α : Type*} (esc : List (Q × F) → Q �
     {A : OracleComp Q F α} {n : ℕ} (hQ : A.QueryBound n)
     {σ : List (Q × F)} (hσ : OracleComp.AvoidsCache σ A) :
     (PMF.uniformOfFintype (Q → F)).toOuterMeasure
-      {O : Q → F | escapesWithHistory esc σ A (applyUpdates σ O)}
+      {table : Q → F | escapesWithHistory esc σ A (applyUpdates σ table)}
       ≤ ∑ i ∈ Finset.range n, f (σ.length + i) := by
   induction hQ generalizing σ with
   | pure a n =>
-      have hempty : {O : Q → F |
-          escapesWithHistory esc σ (OracleComp.pure a) (applyUpdates σ O)} = ∅ := by
-        ext O; simp [escapesWithHistory]
+      have hempty : {table : Q → F |
+          escapesWithHistory esc σ (OracleComp.pure a) (applyUpdates σ table)} = ∅ := by
+        ext table; simp [escapesWithHistory]
       rw [hempty]; simp
   | @query t k n h ih =>
       cases hσ with
       | query ht hk =>
-      have happ : ∀ O : Q → F, applyUpdates σ O t = O t :=
-        fun O => applyUpdates_apply_not_mem ht O
-      have hsub : {O : Q → F |
-            escapesWithHistory esc σ (OracleComp.query t k) (applyUpdates σ O)}
-          ⊆ {O : Q → F | O t ∈ esc σ t}
-            ∪ ⋃ u : F, {O : Q → F | O t = u ∧
-                O ∈ {O' : Q → F | escapesWithHistory esc ((t, u) :: σ) (k u)
-                  (applyUpdates ((t, u) :: σ) O')}} := by
-        intro O hO
-        simp only [escapesWithHistory, Set.mem_setOf_eq, happ O] at hO
+      have happ : ∀ table : Q → F, applyUpdates σ table t = table t :=
+        fun table => applyUpdates_apply_not_mem ht table
+      have hsub : {table : Q → F |
+            escapesWithHistory esc σ (OracleComp.query t k) (applyUpdates σ table)}
+          ⊆ {table : Q → F | table t ∈ esc σ t}
+            ∪ ⋃ u : F, {table : Q → F | table t = u ∧
+                table ∈ {table' : Q → F | escapesWithHistory esc ((t, u) :: σ) (k u)
+                  (applyUpdates ((t, u) :: σ) table')}} := by
+        intro table hO
+        simp only [escapesWithHistory, Set.mem_setOf_eq, happ table] at hO
         rcases hO with h1 | h2
         · exact Or.inl h1
-        · refine Or.inr (Set.mem_iUnion.mpr ⟨O t, rfl, ?_⟩)
-          have hcons : applyUpdates ((t, O t) :: σ) O = applyUpdates σ O := by
+        · refine Or.inr (Set.mem_iUnion.mpr ⟨table t, rfl, ?_⟩)
+          have hcons : applyUpdates ((t, table t) :: σ) table = applyUpdates σ table := by
             rw [applyUpdates_cons, Function.update_eq_self]
           simp only [Set.mem_setOf_eq, hcons]
           exact h2
       refine le_trans (MeasureTheory.measure_mono hsub) ?_
       refine le_trans (MeasureTheory.measure_union_le _ _) ?_
       have hfirst : (PMF.uniformOfFintype (Q → F)).toOuterMeasure
-          {O : Q → F | O t ∈ esc σ t} ≤ f σ.length :=
+          {table : Q → F | table t ∈ esc σ t} ≤ f σ.length :=
         uniformOfFintype_point_mem_blind_le t (fun _ => esc σ t)
           (fun _ _ => rfl) (fun _ => hesc σ t)
       have hsecond : (PMF.uniformOfFintype (Q → F)).toOuterMeasure
-          (⋃ u : F, {O : Q → F | O t = u ∧
-            O ∈ {O' : Q → F | escapesWithHistory esc ((t, u) :: σ) (k u)
-              (applyUpdates ((t, u) :: σ) O')}})
+          (⋃ u : F, {table : Q → F | table t = u ∧
+            table ∈ {table' : Q → F | escapesWithHistory esc ((t, u) :: σ) (k u)
+              (applyUpdates ((t, u) :: σ) table')}})
           ≤ ∑ i ∈ Finset.range n, f (σ.length + (i + 1)) := by
         refine le_trans (MeasureTheory.measure_iUnion_le _) ?_
         rw [tsum_fintype]
         have hper : ∀ u : F, (PMF.uniformOfFintype (Q → F)).toOuterMeasure
-            {O : Q → F | O t = u ∧
-              O ∈ {O' : Q → F | escapesWithHistory esc ((t, u) :: σ) (k u)
-                (applyUpdates ((t, u) :: σ) O')}}
+            {table : Q → F | table t = u ∧
+              table ∈ {table' : Q → F | escapesWithHistory esc ((t, u) :: σ) (k u)
+                (applyUpdates ((t, u) :: σ) table')}}
             ≤ (∑ i ∈ Finset.range n, f (σ.length + (i + 1))) / Fintype.card F := by
           intro u
-          have hblindE : ∀ (O : Q → F) (v : F),
-              Function.update O t v ∈ {O' : Q → F | escapesWithHistory esc ((t, u) :: σ)
-                (k u) (applyUpdates ((t, u) :: σ) O')}
-              ↔ O ∈ {O' : Q → F | escapesWithHistory esc ((t, u) :: σ) (k u)
-                (applyUpdates ((t, u) :: σ) O')} := by
-            intro O v
-            have hcons : applyUpdates ((t, u) :: σ) (Function.update O t v)
-                = applyUpdates ((t, u) :: σ) O := by
+          have hblindE : ∀ (table : Q → F) (v : F),
+              Function.update table t v ∈ {table' : Q → F | escapesWithHistory esc ((t, u) :: σ)
+                (k u) (applyUpdates ((t, u) :: σ) table')}
+              ↔ table ∈ {table' : Q → F | escapesWithHistory esc ((t, u) :: σ) (k u)
+                (applyUpdates ((t, u) :: σ) table')} := by
+            intro table v
+            have hcons : applyUpdates ((t, u) :: σ) (Function.update table t v)
+                = applyUpdates ((t, u) :: σ) table := by
               rw [applyUpdates_cons, applyUpdates_cons, Function.update_idem]
             simp only [Set.mem_setOf_eq, hcons]
           rw [uniformOfFintype_cond_point t u _ hblindE]
@@ -343,7 +348,7 @@ theorem escapesWithHistory_measure_le {α : Type*} (esc : List (Q × F) → Q �
         rw [Finset.sum_const, Finset.card_univ, nsmul_eq_mul, mul_comm,
           ENNReal.div_mul_cancel (Nat.cast_ne_zero.mpr Fintype.card_ne_zero)
             (ENNReal.natCast_ne_top _)]
-      calc (PMF.uniformOfFintype (Q → F)).toOuterMeasure {O : Q → F | O t ∈ esc σ t}
+      calc (PMF.uniformOfFintype (Q → F)).toOuterMeasure {table : Q → F | table t ∈ esc σ t}
           + (PMF.uniformOfFintype (Q → F)).toOuterMeasure (⋃ u : F, _)
           ≤ f σ.length + ∑ i ∈ Finset.range n, f (σ.length + (i + 1)) :=
             add_le_add hfirst hsecond
@@ -352,20 +357,20 @@ theorem escapesWithHistory_measure_le {α : Type*} (esc : List (Q × F) → Q �
             simp
 
 /-- The run ±-collides during execution: the history-escape event at the `badList` sets. -/
-def CollidesDuring {α : Type*} (s : Q → F) :
+def CollidesDuring {α : Type*} (shift : Q → F) :
     List (Q × F) → OracleComp Q F α → (Q → F) → Prop :=
-  escapesWithHistory (fun σ t => {y : F | y ∈ badList s σ t})
+  escapesWithHistory (fun σ t => {y : F | y ∈ badList shift σ t})
 
 omit [Fintype Q] [DecidableEq Q] [Fintype F] [DecidableEq F] in
 /-- A ±-colliding pair of distinct points, each either queried on the run or recorded in a
 table-consistent history (but not both recorded), forces a collision during the run. -/
-theorem CollidesDuring.of_pair {α : Type*} {s : Q → F} {O : Q → F} {A : OracleComp Q F α}
-    {σ : List (Q × F)} (hσ : ∀ p ∈ σ, O p.1 = p.2) {a b : Q} (hab : a ≠ b)
-    (ha : a ∈ A.queries O ∨ a ∈ σ.map Prod.fst)
-    (hb : b ∈ A.queries O ∨ b ∈ σ.map Prod.fst)
+theorem CollidesDuring.of_pair {α : Type*} {shift : Q → F} {table : Q → F} {A : OracleComp Q F α}
+    {σ : List (Q × F)} (hσ : ∀ p ∈ σ, table p.1 = p.2) {a b : Q} (hab : a ≠ b)
+    (ha : a ∈ A.queries table ∨ a ∈ σ.map Prod.fst)
+    (hb : b ∈ A.queries table ∨ b ∈ σ.map Prod.fst)
     (hnot : a ∉ σ.map Prod.fst ∨ b ∉ σ.map Prod.fst)
-    (hpm : s a + O a =± s b + O b) :
-    CollidesDuring s σ A O := by
+    (hpm : shift a + table a =± shift b + table b) :
+    CollidesDuring shift σ A table := by
   induction A generalizing σ with
   | pure c =>
       simp only [OracleComp.queries, List.not_mem_nil, false_or] at ha hb
@@ -373,14 +378,14 @@ theorem CollidesDuring.of_pair {α : Type*} {s : Q → F} {O : Q → F} {A : Ora
       · exact absurd ha h
       · exact absurd hb h
   | query t k ih =>
-      have hconsist : ∀ p ∈ (t, O t) :: σ, O p.1 = p.2 := by
+      have hconsist : ∀ p ∈ (t, table t) :: σ, table p.1 = p.2 := by
         intro p hp
         rcases List.mem_cons.1 hp with rfl | hp
         · rfl
         · exact hσ p hp
       simp only [OracleComp.queries, List.mem_cons] at ha hb
-      show (O t ∈ {y : F | y ∈ badList s σ t}) ∨
-        CollidesDuring s ((t, O t) :: σ) (k (O t)) O
+      show (table t ∈ {y : F | y ∈ badList shift σ t}) ∨
+        CollidesDuring shift ((t, table t) :: σ) (k (table t)) table
       by_cases hat : a = t
       · subst hat
         by_cases hbh : b ∈ σ.map Prod.fst
@@ -388,13 +393,13 @@ theorem CollidesDuring.of_pair {α : Type*} {s : Q → F} {O : Q → F} {A : Ora
           refine Or.inl (mem_badList.2 ⟨p, hp, ?_⟩)
           rw [← hσ p hp, hpfst]
           exact hpm
-        · have hbtail : b ∈ (k (O a)).queries O := by
+        · have hbtail : b ∈ (k (table a)).queries table := by
             rcases hb with hb | hb
             · rcases hb with rfl | hb
               · exact absurd rfl hab
               · exact hb
             · exact absurd hb hbh
-          refine Or.inr (ih (O a) hconsist ?_ ?_ ?_)
+          refine Or.inr (ih (table a) hconsist ?_ ?_ ?_)
           · exact Or.inr (by simp)
           · exact Or.inl hbtail
           · refine Or.inr ?_
@@ -407,32 +412,32 @@ theorem CollidesDuring.of_pair {α : Type*} {s : Q → F} {O : Q → F} {A : Ora
             refine Or.inl (mem_badList.2 ⟨p, hp, ?_⟩)
             rw [← hσ p hp, hpfst]
             exact eqUpToSign_symm hpm
-          · have hatail : a ∈ (k (O b)).queries O := by
+          · have hatail : a ∈ (k (table b)).queries table := by
               rcases ha with ha | ha
               · rcases ha with rfl | ha
                 · exact absurd rfl hat
                 · exact ha
               · exact absurd ha hah
-            refine Or.inr (ih (O b) hconsist ?_ ?_ ?_)
+            refine Or.inr (ih (table b) hconsist ?_ ?_ ?_)
             · exact Or.inl hatail
             · exact Or.inr (by simp)
             · refine Or.inl ?_
               simp only [List.map_cons, List.mem_cons, not_or]
               exact ⟨hat, hah⟩
-        · have ha' : a ∈ (k (O t)).queries O ∨ a ∈ ((t, O t) :: σ).map Prod.fst := by
+        · have ha' : a ∈ (k (table t)).queries table ∨ a ∈ ((t, table t) :: σ).map Prod.fst := by
             rcases ha with ha | ha
             · rcases ha with rfl | ha
               · exact absurd rfl hat
               · exact Or.inl ha
             · exact Or.inr (by simp [ha])
-          have hb' : b ∈ (k (O t)).queries O ∨ b ∈ ((t, O t) :: σ).map Prod.fst := by
+          have hb' : b ∈ (k (table t)).queries table ∨ b ∈ ((t, table t) :: σ).map Prod.fst := by
             rcases hb with hb | hb
             · rcases hb with rfl | hb
               · exact absurd rfl hbt
               · exact Or.inl hb
             · exact Or.inr (by simp [hb])
-          have hnot' : a ∉ ((t, O t) :: σ).map Prod.fst
-              ∨ b ∉ ((t, O t) :: σ).map Prod.fst := by
+          have hnot' : a ∉ ((t, table t) :: σ).map Prod.fst
+              ∨ b ∉ ((t, table t) :: σ).map Prod.fst := by
             rcases hnot with h | h
             · refine Or.inl ?_
               simp only [List.map_cons, List.mem_cons, not_or]
@@ -440,7 +445,7 @@ theorem CollidesDuring.of_pair {α : Type*} {s : Q → F} {O : Q → F} {A : Ora
             · refine Or.inr ?_
               simp only [List.map_cons, List.mem_cons, not_or]
               exact ⟨hbt, h⟩
-          exact Or.inr (ih (O t) hconsist ha' hb' hnot')
+          exact Or.inr (ih (table t) hconsist ha' hb' hnot')
 
 omit [Fintype Q] [DecidableEq Q] [Fintype F] [DecidableEq F] in
 /-- Gauss closed form for the collision budgets: `Σ_{i<n} 2·(m+i) = 2·m·n + n·(n−1)`. -/
@@ -457,36 +462,37 @@ theorem sum_two_mul_add (m n : ℕ) :
 /-- **Adaptive sum-over-steps bound.** A cache-avoiding `n`-query machine with `m` recorded
 answers collides during its run with probability at most `(2·m·n + n·(n−1))/|F|`: instantiate
 the history-escape bound at the `badList` sets and close the Gauss sum. -/
-theorem collidesDuring_measure_le {α : Type*} (s : Q → F)
+theorem collidesDuring_measure_le {α : Type*} (shift : Q → F)
     {A : OracleComp Q F α} {n : ℕ} (hQ : A.QueryBound n)
     {σ : List (Q × F)} (hσ : OracleComp.AvoidsCache σ A) :
     (PMF.uniformOfFintype (Q → F)).toOuterMeasure
-      {O : Q → F | CollidesDuring s σ A (applyUpdates σ O)}
+      {table : Q → F | CollidesDuring shift σ A (applyUpdates σ table)}
       ≤ (2 * σ.length * n + n * (n - 1) : ℕ) / Fintype.card F := by
   refine le_trans (escapesWithHistory_measure_le _
     (f := fun m => (2 * m : ℕ) / Fintype.card F)
-    (fun σ' t => badList_measure_le s σ' t) hQ hσ) (le_of_eq ?_)
+    (fun σ' t => badList_measure_le shift σ' t) hQ hσ) (le_of_eq ?_)
   simp only [div_eq_mul_inv, ← Finset.sum_mul, ← Nat.cast_sum, sum_two_mul_add]
 
 /-- **Adaptive trace bound.** An `n`-query machine's trace contains a shifted ±-colliding
 distinct pair with probability at most `n·(n−1)/|F|` — the non-adaptive constant, adaptively. -/
-theorem queries_pair_collision_measure_le {α : Type*} (s : Q → F)
+theorem queries_pair_collision_measure_le {α : Type*} (shift : Q → F)
     {A : OracleComp Q F α} {n : ℕ} (hQ : A.QueryBound n) :
     (PMF.uniformOfFintype (Q → F)).toOuterMeasure
-      {O : Q → F | ∃ a ∈ A.queries O, ∃ b ∈ A.queries O, a ≠ b ∧ s a + O a =± s b + O b}
+      {table : Q → F | ∃ a ∈ A.queries table, ∃ b ∈ A.queries table,
+        a ≠ b ∧ shift a + table a =± shift b + table b}
       ≤ (n * (n - 1) : ℕ) / Fintype.card F := by
-  have hsub : {O : Q → F | ∃ a ∈ A.queries O, ∃ b ∈ A.queries O,
-        a ≠ b ∧ s a + O a =± s b + O b}
-      ⊆ {O : Q → F | CollidesDuring s [] (OracleComp.dedup [] A) O} := by
-    rintro O ⟨a, ha, b, hb, hab, hpm⟩
-    have ha' : a ∈ (OracleComp.dedup [] A).queries O :=
+  have hsub : {table : Q → F | ∃ a ∈ A.queries table, ∃ b ∈ A.queries table,
+        a ≠ b ∧ shift a + table a =± shift b + table b}
+      ⊆ {table : Q → F | CollidesDuring shift [] (OracleComp.dedup [] A) table} := by
+    rintro table ⟨a, ha, b, hb, hab, hpm⟩
+    have ha' : a ∈ (OracleComp.dedup [] A).queries table :=
       mem_queries_dedup (by simp) (by simp) ha
-    have hb' : b ∈ (OracleComp.dedup [] A).queries O :=
+    have hb' : b ∈ (OracleComp.dedup [] A).queries table :=
       mem_queries_dedup (by simp) (by simp) hb
     exact CollidesDuring.of_pair (by simp) hab (Or.inl ha') (Or.inl hb')
       (Or.inl (by simp)) hpm
   refine le_trans (MeasureTheory.measure_mono hsub) ?_
-  have hmain := collidesDuring_measure_le s (OracleComp.dedup_queryBound hQ [])
+  have hmain := collidesDuring_measure_le shift (OracleComp.dedup_queryBound hQ [])
     (OracleComp.dedup_avoidsCache [] A)
   simpa using hmain
 
@@ -496,11 +502,11 @@ end Generic
 
 /-- A measure bound that holds for every conditioned slice survives averaging: if each
 component `f a` gives the event measure at most `ε`, so does the mixture `p.bind f`. -/
-theorem toOuterMeasure_bind_le {α β : Type*} (p : PMF α) (f : α → PMF β) (s : Set β)
-    {ε : ℝ≥0∞} (h : ∀ a, (f a).toOuterMeasure s ≤ ε) :
-    (p.bind f).toOuterMeasure s ≤ ε := by
+theorem toOuterMeasure_bind_le {α β : Type*} (p : PMF α) (f : α → PMF β) (shift : Set β)
+    {ε : ℝ≥0∞} (h : ∀ a, (f a).toOuterMeasure shift ≤ ε) :
+    (p.bind f).toOuterMeasure shift ≤ ε := by
   rw [PMF.toOuterMeasure_bind_apply]
-  calc ∑' a, p a * (f a).toOuterMeasure s
+  calc ∑' a, p a * (f a).toOuterMeasure shift
       ≤ ∑' a, p a * ε := ENNReal.tsum_le_tsum fun a => mul_le_mul_right (h a) _
     _ = ε := by rw [ENNReal.tsum_mul_right, PMF.tsum_coe, one_mul]
 
@@ -533,10 +539,10 @@ def evalEquiv :
     ((SK → RIVK) × (QK → AK → NK → RIVK) × (RIVK → AK → NK → RIVK))
       ≃ (FinalQuery AK NK RIVK QK SK → RIVK) where
   toFun H := FinalQuery.eval H.1 H.2.1 H.2.2
-  invFun O := (fun sk => O (.legacy sk), fun qk ak nk => O (.ext qk ak nk),
-    fun rivk_ext ak nk => O (.int rivk_ext ak nk))
+  invFun table := (fun sk => table (.legacy sk), fun qk ak nk => table (.ext qk ak nk),
+    fun rivk_ext ak nk => table (.int rivk_ext ak nk))
   left_inv _H := rfl
-  right_inv O := eval_restrict O
+  right_inv table := eval_restrict table
 
 /-- **Triple↔table uniformity transport**, as a stated PMF equality: drawing the three final
 `rivk`-derivation oracles independently and uniformly and combining them with
@@ -589,29 +595,29 @@ theorem ofBreak_queries {Extract : Extractor G IVK AK} {S : G} {hfn : AK → NK 
 table. An adversary —here, any pair of witness choices depending on the whole table— whose
 witnesses' derivation queries lie in a set `Qs` of at most `q` queries *fixed in advance*,
 produces a key-binding `Break` with probability at most `q·(q−1)/|RIVK|`. This is ZIP 2005's
-`ε_kb` as sharpened in zcash/zips#1338. At the intended instantiation, `|RIVK|` is the
-Pallas group order `r_ℙ`. -/
+`ε_kb`. At the intended instantiation, `|RIVK|` is the Pallas group order `r_ℙ`. -/
 theorem break_measure_le (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK)
     (Ggen : G) (hS : S ≠ 0)
     (Hask : SK → ASK) (Hnk : SK → NK)
     (w₁ w₂ : (FinalQuery AK NK RIVK QK SK → RIVK) → Witness G IVK AK NK RIVK QK SK)
     (Qs : Finset (FinalQuery AK NK RIVK QK SK)) {q : ℕ} (hq : Qs.card ≤ q)
-    (hqueries : ∀ O, finalQueryOf Extract (w₁ O) ∈ Qs ∧ finalQueryOf Extract (w₂ O) ∈ Qs ∧
-      extQueryOf Extract (w₁ O) ∈ Qs ∧ extQueryOf Extract (w₂ O) ∈ Qs) :
+    (hqueries : ∀ table,
+      finalQueryOf Extract (w₁ table) ∈ Qs ∧ finalQueryOf Extract (w₂ table) ∈ Qs ∧
+      extQueryOf Extract (w₁ table) ∈ Qs ∧ extQueryOf Extract (w₂ table) ∈ Qs) :
     (PMF.uniformOfFintype (FinalQuery AK NK RIVK QK SK → RIVK)).toOuterMeasure
-        {O : FinalQuery AK NK RIVK QK SK → RIVK |
+        {table : FinalQuery AK NK RIVK QK SK → RIVK |
           Break Extract S hfn Ggen
-            ⟨Hask, Hnk, fun sk => O (.legacy sk), fun qk ak nk => O (.ext qk ak nk),
-              fun rivk_ext ak nk => O (.int rivk_ext ak nk)⟩ (w₁ O) (w₂ O)}
+            ⟨Hask, Hnk, fun sk => table (.legacy sk), fun qk ak nk => table (.ext qk ak nk),
+              fun rivk_ext ak nk => table (.int rivk_ext ak nk)⟩ (w₁ table) (w₂ table)}
       ≤ (q * (q - 1) : ℕ) / Fintype.card RIVK := by
   refine le_trans (MeasureTheory.measure_mono ?_)
     (finset_shifted_collision_measure_le (shiftOf Extract Ggen hfn Hask Hnk) Qs hq)
-  intro O hO
-  obtain ⟨hf₁, hf₂, he₁, he₂⟩ := hqueries O
+  intro table hO
+  obtain ⟨hf₁, hf₂, he₁, he₂⟩ := hqueries table
   set c := CollisionUpToSign.ofBreak Extract S hfn Ggen hS _ hO with hc
   have hq12 := ofBreak_queries hc
-  have hpm : shiftOf Extract Ggen hfn Hask Hnk c.q₁ + O c.q₁
-      =± shiftOf Extract Ggen hfn Hask Hnk c.q₂ + O c.q₂ := by
+  have hpm : shiftOf Extract Ggen hfn Hask Hnk c.q₁ + table c.q₁
+      =± shiftOf Extract Ggen hfn Hask Hnk c.q₂ + table c.q₂ := by
     have hp := c.pm
     simpa only [shiftedFinalOracle, eval_restrict] using hp
   refine ⟨c.q₁, ?_, c.q₂, ?_, c.ne, hpm⟩
@@ -631,38 +637,37 @@ def derivQueries (Extract : Extractor G IVK AK)
 /-- **Adaptive key-binding bound (ZIP 2005 accounting).** An `n`-query machine that queries its
 output witnesses' derivation inputs produces a key-binding `Break` with probability at most
 `n·(n−1)/|RIVK|`, with the adversary's queries chosen adaptively. This is ZIP 2005's
-`ε_kb` as sharpened in zcash/zips#1338. At the intended instantiation, `|RIVK|` is the
-Pallas group order `r_ℙ`. -/
+`ε_kb`. At the intended instantiation, `|RIVK|` is the Pallas group order `r_ℙ`. -/
 theorem break_measure_le_adaptive (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK)
     (Ggen : G) (hS : S ≠ 0)
     (Hask : SK → ASK) (Hnk : SK → NK)
     {A : OracleComp (FinalQuery AK NK RIVK QK SK) RIVK
       (Witness G IVK AK NK RIVK QK SK × Witness G IVK AK NK RIVK QK SK)}
     {n : ℕ} (hQ : A.QueryBound n)
-    (hqueries : ∀ (O : FinalQuery AK NK RIVK QK SK → RIVK) (i : Fin 4),
-      derivQueries Extract (A.run O) i ∈ A.queries O) :
+    (hqueries : ∀ (table : FinalQuery AK NK RIVK QK SK → RIVK) (i : Fin 4),
+      derivQueries Extract (A.run table) i ∈ A.queries table) :
     (PMF.uniformOfFintype (FinalQuery AK NK RIVK QK SK → RIVK)).toOuterMeasure
-        {O : FinalQuery AK NK RIVK QK SK → RIVK |
+        {table : FinalQuery AK NK RIVK QK SK → RIVK |
           Break Extract S hfn Ggen
-            ⟨Hask, Hnk, fun sk => O (.legacy sk), fun qk ak nk => O (.ext qk ak nk),
-              fun rivk_ext ak nk => O (.int rivk_ext ak nk)⟩ (A.run O).1 (A.run O).2}
+            ⟨Hask, Hnk, fun sk => table (.legacy sk), fun qk ak nk => table (.ext qk ak nk),
+              fun rivk_ext ak nk => table (.int rivk_ext ak nk)⟩ (A.run table).1 (A.run table).2}
       ≤ (n * (n - 1) : ℕ) / Fintype.card RIVK := by
   refine le_trans (MeasureTheory.measure_mono ?_)
     (queries_pair_collision_measure_le (shiftOf Extract Ggen hfn Hask Hnk) hQ)
-  intro O hO
+  intro table hO
   set c := CollisionUpToSign.ofBreak Extract S hfn Ggen hS _ hO with hc
   have hq12 := ofBreak_queries hc
-  have hpm : shiftOf Extract Ggen hfn Hask Hnk c.q₁ + O c.q₁
-      =± shiftOf Extract Ggen hfn Hask Hnk c.q₂ + O c.q₂ := by
+  have hpm : shiftOf Extract Ggen hfn Hask Hnk c.q₁ + table c.q₁
+      =± shiftOf Extract Ggen hfn Hask Hnk c.q₂ + table c.q₂ := by
     have hp := c.pm
     simpa only [shiftedFinalOracle, eval_restrict] using hp
   refine ⟨c.q₁, ?_, c.q₂, ?_, c.ne, hpm⟩
   · rcases hq12 with ⟨h1, -⟩ | ⟨h1, -⟩
-    · simpa [derivQueries, h1] using hqueries O 2
-    · simpa [derivQueries, h1] using hqueries O 0
+    · simpa [derivQueries, h1] using hqueries table 2
+    · simpa [derivQueries, h1] using hqueries table 0
   · rcases hq12 with ⟨-, h2⟩ | ⟨-, h2⟩
-    · simpa [derivQueries, h2] using hqueries O 3
-    · simpa [derivQueries, h2] using hqueries O 1
+    · simpa [derivQueries, h2] using hqueries table 3
+    · simpa [derivQueries, h2] using hqueries table 1
 
 /-- **Adaptive key-binding bound, hypothesis-free.** Any `n`-query machine produces a
 key-binding `Break` with probability at most `(n+4)·(n+3)/|F|`: complete the machine with its
@@ -675,15 +680,15 @@ theorem break_measure_le_of_queryBound (Extract : Extractor G IVK AK) (S : G) (h
       (Witness G IVK AK NK RIVK QK SK × Witness G IVK AK NK RIVK QK SK)}
     {n : ℕ} (hQ : A.QueryBound n) :
     (PMF.uniformOfFintype (FinalQuery AK NK RIVK QK SK → RIVK)).toOuterMeasure
-        {O : FinalQuery AK NK RIVK QK SK → RIVK |
+        {table : FinalQuery AK NK RIVK QK SK → RIVK |
           Break Extract S hfn Ggen
-            ⟨Hask, Hnk, fun sk => O (.legacy sk), fun qk ak nk => O (.ext qk ak nk),
-              fun rivk_ext ak nk => O (.int rivk_ext ak nk)⟩ (A.run O).1 (A.run O).2}
+            ⟨Hask, Hnk, fun sk => table (.legacy sk), fun qk ak nk => table (.ext qk ak nk),
+              fun rivk_ext ak nk => table (.int rivk_ext ak nk)⟩ (A.run table).1 (A.run table).2}
       ≤ ((n + 4) * (n + 3) : ℕ) / Fintype.card RIVK := by
-  have hqueries : ∀ (O : FinalQuery AK NK RIVK QK SK → RIVK) (i : Fin 4),
-      derivQueries Extract ((A.completing (derivQueries Extract)).run O) i
-        ∈ (A.completing (derivQueries Extract)).queries O := by
-    intro O i
+  have hqueries : ∀ (table : FinalQuery AK NK RIVK QK SK → RIVK) (i : Fin 4),
+      derivQueries Extract ((A.completing (derivQueries Extract)).run table) i
+        ∈ (A.completing (derivQueries Extract)).queries table := by
+    intro table i
     rw [OracleComp.run_completing, OracleComp.completing, OracleComp.queries_bind,
       OracleComp.queries_queryList]
     exact List.mem_append.2 (Or.inr (List.mem_ofFn.2 ⟨i, rfl⟩))
@@ -737,11 +742,11 @@ theorem break_measure_le_product {ι : Type*} [Fintype ASK] [Nonempty NK] [Nonem
             (PMF.uniformOfFintype (QK → AK → NK → RIVK)).bind fun Hext =>
               (PMF.uniformOfFintype (RIVK → AK → NK → RIVK)).map fun Hint =>
                 (i, Hask, Hnk, FinalQuery.eval Hleg Hext Hint))).toOuterMeasure
-        (setOf fun (i, Hask, Hnk, O) =>
+        (setOf fun (i, Hask, Hnk, table) =>
           Break Extract S hfn Ggen
-            ⟨Hask, Hnk, fun sk => O (.legacy sk), fun qk ak nk => O (.ext qk ak nk),
-              fun rivk_ext ak nk => O (.int rivk_ext ak nk)⟩
-            ((A i Hask Hnk).run O).1 ((A i Hask Hnk).run O).2)
+            ⟨Hask, Hnk, fun sk => table (.legacy sk), fun qk ak nk => table (.ext qk ak nk),
+              fun rivk_ext ak nk => table (.int rivk_ext ak nk)⟩
+            ((A i Hask Hnk).run table).1 ((A i Hask Hnk).run table).2)
       ≤ ((n + 4) * (n + 3) : ℕ) / Fintype.card RIVK := by
   refine toOuterMeasure_bind_le _ _ _ fun i => ?_
   refine toOuterMeasure_bind_le _ _ _ fun Hask => ?_
@@ -750,8 +755,8 @@ theorem break_measure_le_product {ι : Type*} [Fintype ASK] [Nonempty NK] [Nonem
         (PMF.uniformOfFintype (QK → AK → NK → RIVK)).bind fun Hext =>
           (PMF.uniformOfFintype (RIVK → AK → NK → RIVK)).map fun Hint =>
             (i, Hask, Hnk, FinalQuery.eval Hleg Hext Hint))
-      = (PMF.uniformOfFintype (FinalQuery AK NK RIVK QK SK → RIVK)).map fun O =>
-          (i, Hask, Hnk, O) := by
+      = (PMF.uniformOfFintype (FinalQuery AK NK RIVK QK SK → RIVK)).map fun table =>
+          (i, Hask, Hnk, table) := by
     rw [← uniform_triple_eval]
     simp only [PMF.map_bind, PMF.map_comp]
     rfl

--- a/Zcash/Security/Ledger/Balance.lean
+++ b/Zcash/Security/Ledger/Balance.lean
@@ -58,7 +58,7 @@ def findPair {α β : Type*} [DecidableEq β] (f : α → β) : List α → Opti
   | [] => none
   | a :: t =>
     match t.find? fun b => f b = f a with
-    | some b => some (a, b)
+    | some brk => some (a, brk)
     | none => findPair f t
 
 /-- A successful scan certifies its pair: equal images under `f`, and the two entries
@@ -70,9 +70,9 @@ theorem findPair_spec {α β : Type*} [DecidableEq β] (f : α → β) :
   | a :: t, a₁, a₂, h => by
     rw [findPair] at h
     cases hf : t.find? fun b => f b = f a with
-    | some b =>
+    | some brk =>
         rw [hf] at h
-        obtain ⟨rfl, rfl⟩ : a = a₁ ∧ b = a₂ := by simpa [eq_comm] using h
+        obtain ⟨rfl, rfl⟩ : a = a₁ ∧ brk = a₂ := by simpa [eq_comm] using h
         refine ⟨?_, ?_⟩
         · have := List.find?_some hf
           simpa [eq_comm] using this
@@ -89,16 +89,16 @@ theorem findPair_none {α β : Type*} [DecidableEq β] (f : α → β) :
   | a :: t, h => by
     rw [findPair] at h
     cases hf : t.find? fun b => f b = f a with
-    | some b => rw [hf] at h; exact absurd h (by simp)
+    | some brk => rw [hf] at h; exact absurd h (by simp)
     | none =>
         rw [hf] at h
-        have hnot : ∀ b ∈ t, ¬ f b = f a := by
+        have hnot : ∀ brk ∈ t, ¬ f brk = f a := by
           have := List.find?_eq_none.mp hf
           simpa using this
         simp only [List.map_cons, List.nodup_cons]
         refine ⟨fun hmem => ?_, findPair_none f h⟩
-        obtain ⟨b, hb, hfb⟩ := List.mem_map.mp hmem
-        exact hnot b hb hfb
+        obtain ⟨brk, hb, hfb⟩ := List.mem_map.mp hmem
+        exact hnot brk hb hfb
 
 /-! ## List plumbing: sublists and prefixes through the ledger's flat maps -/
 
@@ -182,7 +182,7 @@ witnesses. -/
 inductive BalanceBreak (P : Primitives F G IVK NK RHO PSI MHASH MENC MSG SIG)
     (kv : KeyBindingInterface KW G IVK NK) where
   | merkle (c : Merkle.Collision P.merkle)
-  | noteCommit (b : NoteCommitBreak P)
+  | noteCommit (brk : NoteCommitBreak P)
   | keyBinding (w₁ w₂ : KW) (h : kv.Break w₁ w₂)
 
 /-- A spend whose commitment `extract`-matches an output's, with a different opening,
@@ -284,10 +284,10 @@ def allPinnedOrBreak [DecidableEq F] [DecidableEq G] [DecidableEq RHO]
   | [], _ => .inl (by simp)
   | a :: t, hL =>
     match spendPinnedOrBreak hval (hL a (by simp)) with
-    | .inr b => .inr b
+    | .inr brk => .inr brk
     | .inl hmem =>
       match allPinnedOrBreak hval t (fun x hx => hL x (by simp [hx])) with
-      | .inr b => .inr b
+      | .inr brk => .inr brk
       | .inl hall => .inl (by
           intro x hx
           rcases List.mem_cons.mp hx with rfl | hx'
@@ -333,7 +333,7 @@ def balanceSubsetOrBreak [DecidableEq F] [DecidableEq G] [DecidableEq RHO]
       have hnodup : ((spendActions ledger (i + 1)).map spendRecord).Nodup :=
         findPair_none spendRecord hfp
       match allPinnedOrBreak hval (spendActions ledger (i + 1)) (fun _ h => h) with
-      | .inr b => .inr b
+      | .inr brk => .inr brk
       | .inl hall =>
           .inl (by
             rw [nonZeroSpends]
@@ -363,11 +363,11 @@ theorem spendPinnedOrBreak_kbPair [DecidableEq F] [DecidableEq G] [DecidableEq R
     [DecidableEq PSI] [DecidableEq MHASH] [DecidableEq MENC]
     (hval : ValidLedger P kv issuance maxActions ledger) {i : ℕ}
     {a : Action KW F G RHO PSI MHASH MENC SIG P.depth}
-    (ha : a ∈ spendActions ledger (i + 1)) {b : BalanceBreak P kv} :
-    spendPinnedOrBreak hval ha = .inr b → b.kbPair = none := by
-  revert b
+    (ha : a ∈ spendActions ledger (i + 1)) {brk : BalanceBreak P kv} :
+    spendPinnedOrBreak hval ha = .inr brk → brk.kbPair = none := by
+  revert brk
   fun_cases spendPinnedOrBreak hval ha <;>
-    intro b hb <;>
+    intro brk hb <;>
     (try simp_all only [reduceCtorEq, PSum.inr.injEq, BalanceBreak.kbPair]) <;>
     (subst hb; rfl)
 
@@ -377,20 +377,20 @@ theorem allPinnedOrBreak_kbPair [DecidableEq F] [DecidableEq G] [DecidableEq RHO
     [DecidableEq PSI] [DecidableEq MHASH] [DecidableEq MENC]
     (hval : ValidLedger P kv issuance maxActions ledger) {i : ℕ} :
     ∀ (L : List (Action KW F G RHO PSI MHASH MENC SIG P.depth))
-      (hL : ∀ a ∈ L, a ∈ spendActions ledger (i + 1)) {b : BalanceBreak P kv},
-      allPinnedOrBreak hval L hL = .inr b → b.kbPair = none := by
+      (hL : ∀ a ∈ L, a ∈ spendActions ledger (i + 1)) {brk : BalanceBreak P kv},
+      allPinnedOrBreak hval L hL = .inr brk → brk.kbPair = none := by
   intro L
   induction L with
-  | nil => intro hL b hb; simp only [allPinnedOrBreak, reduceCtorEq] at hb
+  | nil => intro hL brk hb; simp only [allPinnedOrBreak, reduceCtorEq] at hb
   | cons a t ih =>
-      intro hL b hb
+      intro hL brk hb
       rw [allPinnedOrBreak] at hb
       split at hb
-      · rename_i b' hsp
+      · rename_i brk' hsp
         rw [PSum.inr.injEq] at hb; subst hb
         exact spendPinnedOrBreak_kbPair hval _ hsp
       · split at hb
-        · rename_i b' hall
+        · rename_i brk' hall
           rw [PSum.inr.injEq] at hb; subst hb
           exact ih (fun x hx => hL x (by simp [hx])) hall
         · simp only [reduceCtorEq] at hb
@@ -402,10 +402,10 @@ what lets an oracle machine output the arm's pair without running the reduction.
 theorem balanceSubsetOrBreak_kbPair [DecidableEq F] [DecidableEq G] [DecidableEq RHO]
     [DecidableEq PSI] [DecidableEq MHASH] [DecidableEq MENC] [DecidableEq NK]
     [NoZeroSMulDivisors F G]
-    (hval : ValidLedger P kv issuance maxActions ledger) (i : ℕ) {b : BalanceBreak P kv} :
-    balanceSubsetOrBreak hval i = .inr b → b.kbPair = kbPairOf ledger i := by
-  revert b
-  fun_cases balanceSubsetOrBreak hval i <;> intro b hb <;>
+    (hval : ValidLedger P kv issuance maxActions ledger) (i : ℕ) {brk : BalanceBreak P kv} :
+    balanceSubsetOrBreak hval i = .inr brk → brk.kbPair = kbPairOf ledger i := by
+  revert brk
+  fun_cases balanceSubsetOrBreak hval i <;> intro brk hb <;>
     (try (rw [PSum.inr.injEq] at hb; subst hb)) <;>
     (try simp_all only [reduceCtorEq])
   · -- key-binding break from a `findPair` duplicate: its pair is `kbPairOf`
@@ -566,10 +566,10 @@ def allConservedOrBreak {VB : Type*}
   | [], _ => .inl (by simp)
   | tx :: t, hL =>
     match perTx tx (hL tx (by simp)) with
-    | .inr b => .inr b
+    | .inr brk => .inr brk
     | .inl heq =>
       match allConservedOrBreak perTx t (fun x hx => hL x (by simp [hx])) with
-      | .inr b => .inr b
+      | .inr brk => .inr brk
       | .inl hall => .inl (by
           intro x hx
           rcases List.mem_cons.mp hx with rfl | hx'
@@ -584,7 +584,7 @@ def balanceConservationOrBreak {VB : Type*}
         = issuanceTotal issuance ledger i) ⊕' VB :=
   match allConservedOrBreak perTx (ledger.take i)
       (fun _ h => (List.take_sublist i ledger).subset h) with
-  | .inr b => .inr b
+  | .inr brk => .inr brk
   | .inl hall => .inl (by
       have hsum : ((ledger.take i).map txNetValue).sum
           = ((ledger.take i).map fun tx => tx.vBalance).sum :=
@@ -601,7 +601,7 @@ def shieldedBalanceCapOrBreak {VB : Type*}
       (txNetValue tx = tx.vBalance) ⊕' VB) (i : ℕ) :
     (shieldedPoolBalance ledger i ≤ issuanceTotal issuance ledger i) ⊕' VB :=
   match balanceConservationOrBreak (issuance := issuance) perTx i with
-  | .inr b => .inr b
+  | .inr brk => .inr brk
   | .inl h => .inl (by
       have hnn := hval.transparent_nonneg i
       omega)
@@ -688,7 +688,7 @@ def balanceIntegrityOrBreak [DecidableEq F] [DecidableEq G] [DecidableEq RHO]
       ⊕' (BalanceBreak P kv ⊕' VB) :=
   match balanceSubsetOrBreak hval i,
       balanceConservationOrBreak (issuance := issuance) perTx (i + 1) with
-  | .inr b, _ => .inr (.inl b)
+  | .inr brk, _ => .inr (.inl brk)
   | _, .inr vb => .inr (.inr vb)
   | .inl hsub, .inl hcons =>
       .inl ⟨shieldedPoolBalance_nonneg ledger i hsub, hval.transparent_nonneg (i + 1), hcons⟩

--- a/Zcash/Security/Ledger/Capstone.lean
+++ b/Zcash/Security/Ledger/Capstone.lean
@@ -287,11 +287,11 @@ transactions are not covered by the positioned outputs of the first `i` is at mo
 the sum of the three break-arm probabilities, each bounded by its named ε
 hypothesis. -/
 theorem balanceSubsetPerTx_measure_le (A : PMF (ValidAnnotated P kv issuance maxActions))
-    (i : ℕ) {εm εnc εkb : ℝ≥0∞}
-    (hm : A.toOuterMeasure (balanceSubsetBreakEvent i .merkle) ≤ εm)
-    (hnc : A.toOuterMeasure (balanceSubsetBreakEvent i .noteCommit) ≤ εnc)
-    (hkb : A.toOuterMeasure (balanceSubsetBreakEvent i .keyBinding) ≤ εkb) :
-    A.toOuterMeasure (balanceSubsetViolation i) ≤ εm + εnc + εkb :=
+    (i : ℕ) {ε_merkle ε_nc ε_kb : ℝ≥0∞}
+    (hm : A.toOuterMeasure (balanceSubsetBreakEvent i .merkle) ≤ ε_merkle)
+    (hnc : A.toOuterMeasure (balanceSubsetBreakEvent i .noteCommit) ≤ ε_nc)
+    (hkb : A.toOuterMeasure (balanceSubsetBreakEvent i .keyBinding) ≤ ε_kb) :
+    A.toOuterMeasure (balanceSubsetViolation i) ≤ ε_merkle + ε_nc + ε_kb :=
   le_trans (toOuterMeasure_le_add₃ A (balanceSubsetViolation_subset i))
     (add_le_add (add_le_add hm hnc) hkb)
 
@@ -329,11 +329,11 @@ adversary, the probability that the nonzero spends escape the earlier positioned
 at some step `i < k` is at most the sum of three ε's — one per arm, each hypothesized on
 that arm's shared all-prefixes event. The containment adds no factor of `k`. -/
 theorem balanceSubset_measure_le (A : PMF (ValidAnnotated P kv issuance maxActions))
-    (k : ℕ) {εm εnc εkb : ℝ≥0∞}
-    (hm : A.toOuterMeasure (balanceSubsetBreakEventUpTo k .merkle) ≤ εm)
-    (hnc : A.toOuterMeasure (balanceSubsetBreakEventUpTo k .noteCommit) ≤ εnc)
-    (hkb : A.toOuterMeasure (balanceSubsetBreakEventUpTo k .keyBinding) ≤ εkb) :
-    A.toOuterMeasure (balanceSubsetViolationUpTo k) ≤ εm + εnc + εkb :=
+    (k : ℕ) {ε_merkle ε_nc ε_kb : ℝ≥0∞}
+    (hm : A.toOuterMeasure (balanceSubsetBreakEventUpTo k .merkle) ≤ ε_merkle)
+    (hnc : A.toOuterMeasure (balanceSubsetBreakEventUpTo k .noteCommit) ≤ ε_nc)
+    (hkb : A.toOuterMeasure (balanceSubsetBreakEventUpTo k .keyBinding) ≤ ε_kb) :
+    A.toOuterMeasure (balanceSubsetViolationUpTo k) ≤ ε_merkle + ε_nc + ε_kb :=
   le_trans (toOuterMeasure_le_add₃ A (balanceSubsetViolationUpTo_subset k))
     (add_le_add (add_le_add hm hnc) hkb)
 
@@ -370,11 +370,11 @@ after a transaction: for any adversary, the probability that the shielded pool g
 negative after the first `i + 1` transactions is at most the three step-`i`
 Balance-subset arm ε's. -/
 theorem shieldedBalanceNonNegative_succ_measure_le
-    (A : PMF (ValidAnnotated P kv issuance maxActions)) (i : ℕ) {εm εnc εkb : ℝ≥0∞}
-    (hm : A.toOuterMeasure (balanceSubsetBreakEvent i .merkle) ≤ εm)
-    (hnc : A.toOuterMeasure (balanceSubsetBreakEvent i .noteCommit) ≤ εnc)
-    (hkb : A.toOuterMeasure (balanceSubsetBreakEvent i .keyBinding) ≤ εkb) :
-    A.toOuterMeasure (shieldedBalanceNonNegativeViolation (i + 1)) ≤ εm + εnc + εkb :=
+    (A : PMF (ValidAnnotated P kv issuance maxActions)) (i : ℕ) {ε_merkle ε_nc ε_kb : ℝ≥0∞}
+    (hm : A.toOuterMeasure (balanceSubsetBreakEvent i .merkle) ≤ ε_merkle)
+    (hnc : A.toOuterMeasure (balanceSubsetBreakEvent i .noteCommit) ≤ ε_nc)
+    (hkb : A.toOuterMeasure (balanceSubsetBreakEvent i .keyBinding) ≤ ε_kb) :
+    A.toOuterMeasure (shieldedBalanceNonNegativeViolation (i + 1)) ≤ ε_merkle + ε_nc + ε_kb :=
   le_trans
     (toOuterMeasure_le_add₃ A (shieldedBalanceNonNegativeViolation_succ_subset i))
     (add_le_add (add_le_add hm hnc) hkb)
@@ -497,12 +497,13 @@ theorem balanceIntegrity_measure_le {VB : Type*}
     (A : PMF (ValidAnnotated P kv issuance maxActions))
     (perTx : ∀ ω : ValidAnnotated P kv issuance maxActions,
       (tx : Tx KW F G RHO PSI MHASH MENC MSG SIG P.depth) → tx ∈ ω.1 →
-        (txNetValue tx = tx.vBalance) ⊕' VB) (k : ℕ) {εm εnc εkb ε_conservation : ℝ≥0∞}
-    (hm : A.toOuterMeasure (balanceSubsetBreakEventUpTo k .merkle) ≤ εm)
-    (hnc : A.toOuterMeasure (balanceSubsetBreakEventUpTo k .noteCommit) ≤ εnc)
-    (hkb : A.toOuterMeasure (balanceSubsetBreakEventUpTo k .keyBinding) ≤ εkb)
+        (txNetValue tx = tx.vBalance) ⊕' VB) (k : ℕ) {ε_merkle ε_nc ε_kb ε_conservation : ℝ≥0∞}
+    (hm : A.toOuterMeasure (balanceSubsetBreakEventUpTo k .merkle) ≤ ε_merkle)
+    (hnc : A.toOuterMeasure (balanceSubsetBreakEventUpTo k .noteCommit) ≤ ε_nc)
+    (hkb : A.toOuterMeasure (balanceSubsetBreakEventUpTo k .keyBinding) ≤ ε_kb)
     (hvb : A.toOuterMeasure (txBalanceBreakEventBefore perTx k) ≤ ε_conservation) :
-    A.toOuterMeasure (balanceIntegrityViolationBefore k) ≤ εm + εnc + εkb + ε_conservation :=
+    A.toOuterMeasure (balanceIntegrityViolationBefore k)
+      ≤ ε_merkle + ε_nc + ε_kb + ε_conservation :=
   le_trans (toOuterMeasure_le_add₂ A (balanceIntegrityViolationBefore_subset perTx k))
     (add_le_add
       (le_trans (toOuterMeasure_le_add₃ A subset_rfl)
@@ -560,10 +561,10 @@ theorem spendAuthorityViolation_subset (wV : KW) (hKB : kv.KB wV)
 some Action spends a note addressed to `wV` over an unsigned sighash is at most the
 forgery arm's ε plus the key-binding arm's ε. -/
 theorem spendAuthority_measure_le (A : PMF (ValidAnnotated P kv issuance maxActions))
-    (wV : KW) (hKB : kv.KB wV) (Signed : MSG → Prop) {εf εkb : ℝ≥0∞}
-    (hf : A.toOuterMeasure (spendAuthorityForgeryEvent wV hKB Signed) ≤ εf)
-    (hkb : A.toOuterMeasure (spendAuthorityBreakEvent wV hKB Signed) ≤ εkb) :
-    A.toOuterMeasure (spendAuthorityViolation wV Signed) ≤ εf + εkb :=
+    (wV : KW) (hKB : kv.KB wV) (Signed : MSG → Prop) {ε_forge ε_kb : ℝ≥0∞}
+    (hf : A.toOuterMeasure (spendAuthorityForgeryEvent wV hKB Signed) ≤ ε_forge)
+    (hkb : A.toOuterMeasure (spendAuthorityBreakEvent wV hKB Signed) ≤ ε_kb) :
+    A.toOuterMeasure (spendAuthorityViolation wV Signed) ≤ ε_forge + ε_kb :=
   le_trans (toOuterMeasure_le_add₂ A (spendAuthorityViolation_subset wV hKB Signed))
     (add_le_add hf hkb)
 

--- a/Zcash/Security/Ledger/ConservationExperiment.lean
+++ b/Zcash/Security/Ledger/ConservationExperiment.lean
@@ -4,7 +4,7 @@ import Zcash.Security.Ledger.ValueRelationArm
 /-!
 # The conservation experiment: both arms in one sample space
 
-The capstones bound the conservation and cap violations by `εdlr + κ`, over an abstract
+The capstones bound the conservation and cap violations by `ε_dlr + κ`, over an abstract
 `PMF (ValidAnnotated …)` with the two arms' bounds as named hypotheses. This module
 instantiates that composition in the challenge-oracle model, in one experiment: over the
 adversary's coins, the challenge table, and the logs of the `m` presented bases, the
@@ -105,22 +105,23 @@ bound covers both arms' relation slices. -/
 def conservationRelFinder (hne_idx : v_idx ≠ r_idx) (k : ℕ)
     (LA : (Fin m → G) → LabeledOracleComp Q (ZMod r) (fun _ => QueryRep (ZMod r) m)
       (List (Tx KW (ZMod r) G RHO PSI MHASH MENC MSG SIG P₀.depth × QueryRep (ZMod r) m)))
-    (O : Q → ZMod r) (b : Fin m → G) :
-    Option (AlgebraicRelationWitness (F := ZMod r) b) :=
-  valueRelFinder m v_idx r_idx queryOf P₀ toSig hne_idx k LA O b
-    <|> relFinder m r_idx (kappaComposite m v_idx r_idx queryOf P₀ toSig k LA) O b
+    (table : Q → ZMod r) (basis : Fin m → G) :
+    Option (AlgebraicRelationWitness (F := ZMod r) basis) :=
+  valueRelFinder m v_idx r_idx queryOf P₀ toSig hne_idx k LA table basis
+    <|> relFinder m r_idx (kappaComposite m v_idx r_idx queryOf P₀ toSig k LA) table basis
 
 omit [Fintype Q] in
 /-- The combined finder returns a relation whenever either arm's finder does. -/
 theorem conservationRelFinder_isSome {hne_idx : v_idx ≠ r_idx} {k : ℕ}
     {LA : (Fin m → G) → LabeledOracleComp Q (ZMod r) (fun _ => QueryRep (ZMod r) m)
       (List (Tx KW (ZMod r) G RHO PSI MHASH MENC MSG SIG P₀.depth × QueryRep (ZMod r) m))}
-    {O : Q → ZMod r} {b : Fin m → G}
-    (h : (valueRelFinder m v_idx r_idx queryOf P₀ toSig hne_idx k LA O b).isSome
-      ∨ (relFinder m r_idx (kappaComposite m v_idx r_idx queryOf P₀ toSig k LA) O b).isSome) :
-    (conservationRelFinder m v_idx r_idx queryOf P₀ toSig hne_idx k LA O b).isSome := by
+    {table : Q → ZMod r} {basis : Fin m → G}
+    (h : (valueRelFinder m v_idx r_idx queryOf P₀ toSig hne_idx k LA table basis).isSome
+      ∨ (relFinder m r_idx (kappaComposite m v_idx r_idx queryOf P₀ toSig k LA)
+          table basis).isSome) :
+    (conservationRelFinder m v_idx r_idx queryOf P₀ toSig hne_idx k LA table basis).isSome := by
   unfold conservationRelFinder
-  rcases hv : valueRelFinder m v_idx r_idx queryOf P₀ toSig hne_idx k LA O b with _ | w
+  rcases hv : valueRelFinder m v_idx r_idx queryOf P₀ toSig hne_idx k LA table basis with _ | w
   · rcases h with h | h
     · exact absurd h (by simp [hv])
     · simpa using h
@@ -134,8 +135,8 @@ def conservationRelOrBadChallenge (hne_idx : v_idx ≠ r_idx) (k : ℕ)
     (LA : (Fin m → G) → LabeledOracleComp Q (ZMod r) (fun _ => QueryRep (ZMod r) m)
       (List (Tx KW (ZMod r) G RHO PSI MHASH MENC MSG SIG P₀.depth × QueryRep (ZMod r) m))) :
     Set ((Q → ZMod r) × (Fin m → ZMod r)) :=
-  {ω | (ω.2, ω.1) ∈ ↑(relSetWithCoins gen (fun b O =>
-        conservationRelFinder m v_idx r_idx queryOf P₀ toSig hne_idx k LA O b))}
+  {ω | (ω.2, ω.1) ∈ ↑(relSetWithCoins gen (fun basis table =>
+        conservationRelFinder m v_idx r_idx queryOf P₀ toSig hne_idx k LA table basis))}
     ∪ {ω | ω.1 ∈ badFiber m gen r_idx (kappaComposite m v_idx r_idx queryOf P₀ toSig k LA) ω.2}
 
 /-- **The per-coin discharge: one discrete-log bound covers both arms.** Within query budget
@@ -146,25 +147,25 @@ to the combined finder) and the bad-challenge fibre at `(qH+1)/#F`
 theorem conservationRelOrBadChallenge_measure_le (hne_idx : v_idx ≠ r_idx) (k : ℕ)
     {LA : (Fin m → G) → LabeledOracleComp Q (ZMod r) (fun _ => QueryRep (ZMod r) m)
       (List (Tx KW (ZMod r) G RHO PSI MHASH MENC MSG SIG P₀.depth × QueryRep (ZMod r) m))}
-    {qH : ℕ} (hQ : ∀ b, (LA b).QueryBound qH) {ε_dl : ℝ≥0∞}
-    (hdl : TextbookDLWithCoinsAdvantageLE gen (fun b O =>
-      conservationRelFinder m v_idx r_idx queryOf P₀ toSig hne_idx k LA O b) ε_dl) :
+    {qH : ℕ} (hQ : ∀ basis, (LA basis).QueryBound qH) {ε_dl : ℝ≥0∞}
+    (hdl : TextbookDLWithCoinsAdvantageLE gen (fun basis table =>
+      conservationRelFinder m v_idx r_idx queryOf P₀ toSig hne_idx k LA table basis) ε_dl) :
     (PMF.uniformOfFintype ((Q → ZMod r) × (Fin m → ZMod r))).toOuterMeasure
         (conservationRelOrBadChallenge m gen v_idx r_idx queryOf P₀ toSig hne_idx k LA)
       ≤ ε_dl + ((qH + 2 : ℕ) : ℝ≥0∞) / Fintype.card (ZMod r) := by
   haveI : Nonempty (Fin m) := ⟨r_idx⟩
   have hrel : (PMF.uniformOfFintype ((Q → ZMod r) × (Fin m → ZMod r))).toOuterMeasure
       {ω : (Q → ZMod r) × (Fin m → ZMod r) |
-        (ω.2, ω.1) ∈ ↑(relSetWithCoins gen (fun b O =>
-          conservationRelFinder m v_idx r_idx queryOf P₀ toSig hne_idx k LA O b))}
+        (ω.2, ω.1) ∈ ↑(relSetWithCoins gen (fun basis table =>
+          conservationRelFinder m v_idx r_idx queryOf P₀ toSig hne_idx k LA table basis))}
       ≤ ε_dl + 1 / Fintype.card (ZMod r) := by
     have hswap : (PMF.uniformOfFintype ((Q → ZMod r) × (Fin m → ZMod r))).toOuterMeasure
         {ω : (Q → ZMod r) × (Fin m → ZMod r) |
-          (ω.2, ω.1) ∈ ↑(relSetWithCoins gen (fun b O =>
-            conservationRelFinder m v_idx r_idx queryOf P₀ toSig hne_idx k LA O b))}
+          (ω.2, ω.1) ∈ ↑(relSetWithCoins gen (fun basis table =>
+            conservationRelFinder m v_idx r_idx queryOf P₀ toSig hne_idx k LA table basis))}
         = (PMF.uniformOfFintype ((Fin m → ZMod r) × (Q → ZMod r))).toOuterMeasure
-          ↑(relSetWithCoins gen (fun b O =>
-            conservationRelFinder m v_idx r_idx queryOf P₀ toSig hne_idx k LA O b)) := by
+          ↑(relSetWithCoins gen (fun basis table =>
+            conservationRelFinder m v_idx r_idx queryOf P₀ toSig hne_idx k LA table basis)) := by
       rw [← map_uniformOfFintype_equiv (Equiv.prodComm (Q → ZMod r) (Fin m → ZMod r)),
         PMF.toOuterMeasure_map_apply]
       congr 1
@@ -176,7 +177,7 @@ theorem conservationRelOrBadChallenge_measure_le (hne_idx : v_idx ≠ r_idx) (k 
       ≤ ((qH + 1 : ℕ) : ℝ≥0∞) / Fintype.card (ZMod r) :=
     uniformOfFintype_prod_fiber_bound
       (badFiber m gen r_idx (kappaComposite m v_idx r_idx queryOf P₀ toSig k LA))
-      (fun s => badFiber_measure_le m gen r_idx _
+      (fun logs => badFiber_measure_le m gen r_idx _
         (kappaComposite_queryBound m v_idx r_idx queryOf P₀ toSig (hQ _)))
   unfold conservationRelOrBadChallenge
   refine le_trans (MeasureTheory.measure_union_le _ _)
@@ -195,11 +196,11 @@ theorem balanceConservationBefore_measure_le_experiment {ι : Type u} (p : PMF �
     {LA : ι → (Fin m → G) → LabeledOracleComp Q (ZMod r) (fun _ => QueryRep (ZMod r) m)
       (List (Tx KW (ZMod r) G RHO PSI MHASH MENC MSG SIG P₀.depth × QueryRep (ZMod r) m))}
     (hne_idx : v_idx ≠ r_idx)
-    {qH : ℕ} (hQ : ∀ j b, (LA j b).QueryBound qH)
+    {qH : ℕ} (hQ : ∀ j basis, (LA j basis).QueryBound qH)
     (halg : ∀ j : ι, AlgebraicAtBindingPoints m gen v_idx r_idx queryOf P₀ toSig (LA j))
     (hr : maxActions * (P₀.valueBound - 1) + P₀.vBalanceBound < r) (k : ℕ) {ε_dl : ℝ≥0∞}
-    (hdl : ∀ j : ι, TextbookDLWithCoinsAdvantageLE gen (fun b O =>
-      conservationRelFinder m v_idx r_idx queryOf P₀ toSig hne_idx k (LA j) O b) ε_dl) :
+    (hdl : ∀ j : ι, TextbookDLWithCoinsAdvantageLE gen (fun basis table =>
+      conservationRelFinder m v_idx r_idx queryOf P₀ toSig hne_idx k (LA j) table basis) ε_dl) :
     (challengeExperiment m p).toOuterMeasure
         (sampledLedgerEvent m gen v_idx r_idx queryOf P₀ toSig LA
           (fun P => balanceConservationViolationBefore (P := P) (kv := kv) (issuance := issuance)
@@ -210,20 +211,20 @@ theorem balanceConservationBefore_measure_le_experiment {ι : Type u} (p : PMF �
   refine le_trans (MeasureTheory.measure_mono ?_)
     (conservationRelOrBadChallenge_measure_le m gen v_idx r_idx queryOf P₀ toSig hne_idx k
       (hQ j) (hdl j))
-  rintro ⟨O, s⟩ ⟨hval, hviol⟩
+  rintro ⟨table, logs⟩ ⟨hval, hviol⟩
   dsimp only at hval hviol
   rcases balanceConservationViolationBefore_subset_fallible
-      (kappaShapeAt m gen v_idx r_idx queryOf P₀ toSig O s)
-      (kappaBindingAt m gen v_idx r_idx queryOf P₀ toSig O s) hr
-      (kappaExtractor m gen r_idx queryOf P₀ k (LA j) O s) k hviol
-    with ⟨i, hik, w, hw⟩ | ⟨i, hik, e, he⟩
+      (kappaShapeAt m gen v_idx r_idx queryOf P₀ toSig table logs)
+      (kappaBindingAt m gen v_idx r_idx queryOf P₀ toSig table logs) hr
+      (kappaExtractor m gen r_idx queryOf P₀ k (LA j) table logs) k hviol
+    with ⟨i, hik, w, hw⟩ | ⟨i, hik, failure, hfailure⟩
   · exact Or.inl (Finset.mem_coe.mpr (Finset.mem_filter.mpr ⟨Finset.mem_univ _,
       conservationRelFinder_isSome m v_idx r_idx queryOf P₀ toSig
         (Or.inl (valueRelation_finder_isSome m gen v_idx r_idx queryOf P₀ toSig hne_idx hr
           (le_of_lt hik) hval hw))⟩))
   · rcases kappaEvent_subset m gen r_idx (kappaComposite m v_idx r_idx queryOf P₀ toSig k (LA j))
         (extractFail_mem_kappaEvent m gen v_idx r_idx queryOf P₀ toSig
-          ((halg j).atLabel) ((halg j).atOutput) hr (le_of_lt hik) hval he)
+          ((halg j).atLabel) ((halg j).atOutput) hr (le_of_lt hik) hval hfailure)
       with hbad | hrel
     · exact Or.inr hbad
     · exact Or.inl (Finset.mem_coe.mpr (Finset.mem_filter.mpr ⟨Finset.mem_univ _,
@@ -235,11 +236,11 @@ theorem shieldedBalanceCapBefore_measure_le_experiment {ι : Type u} (p : PMF ι
     {LA : ι → (Fin m → G) → LabeledOracleComp Q (ZMod r) (fun _ => QueryRep (ZMod r) m)
       (List (Tx KW (ZMod r) G RHO PSI MHASH MENC MSG SIG P₀.depth × QueryRep (ZMod r) m))}
     (hne_idx : v_idx ≠ r_idx)
-    {qH : ℕ} (hQ : ∀ j b, (LA j b).QueryBound qH)
+    {qH : ℕ} (hQ : ∀ j basis, (LA j basis).QueryBound qH)
     (halg : ∀ j : ι, AlgebraicAtBindingPoints m gen v_idx r_idx queryOf P₀ toSig (LA j))
     (hr : maxActions * (P₀.valueBound - 1) + P₀.vBalanceBound < r) (k : ℕ) {ε_dl : ℝ≥0∞}
-    (hdl : ∀ j : ι, TextbookDLWithCoinsAdvantageLE gen (fun b O =>
-      conservationRelFinder m v_idx r_idx queryOf P₀ toSig hne_idx k (LA j) O b) ε_dl) :
+    (hdl : ∀ j : ι, TextbookDLWithCoinsAdvantageLE gen (fun basis table =>
+      conservationRelFinder m v_idx r_idx queryOf P₀ toSig hne_idx k (LA j) table basis) ε_dl) :
     (challengeExperiment m p).toOuterMeasure
         (sampledLedgerEvent m gen v_idx r_idx queryOf P₀ toSig LA
           (fun P => shieldedBalanceCapViolationBefore (P := P) (kv := kv) (issuance := issuance)
@@ -250,20 +251,20 @@ theorem shieldedBalanceCapBefore_measure_le_experiment {ι : Type u} (p : PMF ι
   refine le_trans (MeasureTheory.measure_mono ?_)
     (conservationRelOrBadChallenge_measure_le m gen v_idx r_idx queryOf P₀ toSig hne_idx k
       (hQ j) (hdl j))
-  rintro ⟨O, s⟩ ⟨hval, hviol⟩
+  rintro ⟨table, logs⟩ ⟨hval, hviol⟩
   dsimp only at hval hviol
   rcases shieldedBalanceCapViolationBefore_subset_fallible
-      (kappaShapeAt m gen v_idx r_idx queryOf P₀ toSig O s)
-      (kappaBindingAt m gen v_idx r_idx queryOf P₀ toSig O s) hr
-      (kappaExtractor m gen r_idx queryOf P₀ k (LA j) O s) k hviol
-    with ⟨i, hik, w, hw⟩ | ⟨i, hik, e, he⟩
+      (kappaShapeAt m gen v_idx r_idx queryOf P₀ toSig table logs)
+      (kappaBindingAt m gen v_idx r_idx queryOf P₀ toSig table logs) hr
+      (kappaExtractor m gen r_idx queryOf P₀ k (LA j) table logs) k hviol
+    with ⟨i, hik, w, hw⟩ | ⟨i, hik, failure, hfailure⟩
   · exact Or.inl (Finset.mem_coe.mpr (Finset.mem_filter.mpr ⟨Finset.mem_univ _,
       conservationRelFinder_isSome m v_idx r_idx queryOf P₀ toSig
         (Or.inl (valueRelation_finder_isSome m gen v_idx r_idx queryOf P₀ toSig hne_idx hr
           (le_of_lt hik) hval hw))⟩))
   · rcases kappaEvent_subset m gen r_idx (kappaComposite m v_idx r_idx queryOf P₀ toSig k (LA j))
         (extractFail_mem_kappaEvent m gen v_idx r_idx queryOf P₀ toSig
-          ((halg j).atLabel) ((halg j).atOutput) hr (le_of_lt hik) hval he)
+          ((halg j).atLabel) ((halg j).atOutput) hr (le_of_lt hik) hval hfailure)
       with hbad | hrel
     · exact Or.inr hbad
     · exact Or.inl (Finset.mem_coe.mpr (Finset.mem_filter.mpr ⟨Finset.mem_univ _,

--- a/Zcash/Security/Ledger/ExtractionArm.lean
+++ b/Zcash/Security/Ledger/ExtractionArm.lean
@@ -12,7 +12,7 @@ import Zcash.Security.RedDSA.Extraction
 
 The transaction-balance premiss discharge, in extractor-plus-knowledge-error form:
 the extractor is an arbitrary *function*, its failures are *exhibited*, and the
-capstones bound the violation probability by `εdlr + κ` — equivalently, a violation
+capstones bound the violation probability by `ε_dlr + κ` — equivalently, a violation
 yields a computed `(Vbase, Rbase)` relation with probability at least `Pr[violation] − κ`.
 A total extraction hypothesis would be classically satisfiable and carry no
 computational content (see the module doc of `Zcash.Security.Ledger.Value`).
@@ -29,7 +29,7 @@ computational content (see the module doc of `Zcash.Security.Ledger.Value`).
   event, as data.
 * `balanceConservation_measure_le_kerr` / `shieldedBalanceCap_measure_le_kerr`
   compose the three-way premiss into the probabilistic capstones:
-  violation ≤ `εdlr + κ`, with `εdlr` bounding the relation arm (discharged onward
+  violation ≤ `ε_dlr + κ`, with `ε_dlr` bounding the relation arm (discharged onward
   against DL hardness via the AGM layer) and `κ` bounding the extraction-failure
   arm.
 
@@ -60,10 +60,10 @@ the value-commitment randomness base `Rbase` whose verification equation is what
 `bindingVerify` computes, with `toSig` decoding the model's opaque signature type.
 The signature-side counterpart of the same shape's `ValueShape` commitment side. -/
 structure BindingSigShape (P : Primitives (ZMod r) G IVK NK RHO PSI MHASH MENC MSG SIG)
-    (S : ValueShape P) where
+    (shape : ValueShape P) where
   sch : RedDSA.Scheme (ZMod r) G MSG
   toSig : SIG → RedDSA.Sig (ZMod r) G
-  base_eq : sch.base = S.Rbase
+  base_eq : sch.base = shape.Rbase
   verify_iff : ∀ (bvk : G) (m : MSG) (σ : SIG),
     P.bindingVerify bvk m σ ↔ sch.Verify bvk m (toSig σ)
 
@@ -87,38 +87,40 @@ theorem ValidLedger.imbalance_natAbs_lt
           (hval.vbalance_bound tx htx)
     _ < r := hr
 
-/-- **The transaction-balance premiss discharge, with a fallible extractor.** Decide
-the per-transaction net-value equation. On failure, run the extractor `E` on the
-transaction's verifying binding signature. If `E` pins `bvk = [bsk] Rbase`, the witnessed
-bundle computes the nontrivial `(Vbase, Rbase)` relation, with the no-overflow bound `hr`.
-Otherwise the failure is exhibited as a `RedDSA.ExtractionFailure`: a verifying
-signature whose key the extractor misses — the event that the knowledge error `κ`
-bounds. Nothing is assumed of `E`. -/
+/-- **The transaction-balance premiss discharge, with a fallible extractor.** Decide the
+per-transaction net-value equation. On failure, run `extractor` on the transaction's
+verifying binding signature. If `extractor` pins `bvk = [bsk] Rbase`, the witnessed bundle
+computes the nontrivial `(Vbase, Rbase)` relation, with the no-overflow bound `hr`.
+Otherwise the failure is exhibited as a `RedDSA.ExtractionFailure`: a verifying signature
+whose key the extractor misses — the event that the knowledge error `κ` bounds. Nothing is
+assumed of `extractor`. -/
 def ValueShape.premissOrBreakFallible [DecidableEq G]
     {ledger : Ledger KW (ZMod r) G RHO PSI MHASH MENC MSG SIG P.depth}
-    (S : ValueShape P) (B : BindingSigShape P S)
+    (shape : ValueShape P) (binding : BindingSigShape P shape)
     (hval : ValidLedger P kv issuance maxActions ledger)
     (hr : maxActions * (P.valueBound - 1) + P.vBalanceBound < r)
-    (E : RedDSA.Extractor (ZMod r) G MSG)
+    (extractor : RedDSA.Extractor (ZMod r) G MSG)
     (tx : Tx KW (ZMod r) G RHO PSI MHASH MENC MSG SIG P.depth) (htx : tx ∈ ledger) :
     (txNetValue tx = tx.vBalance)
-      ⊕' (BindingSignature.NontrivialRelation (F := ZMod r) S.Vbase S.Rbase
-          ⊕' RedDSA.ExtractionFailure B.sch E) :=
+      ⊕' (BindingSignature.NontrivialRelation (F := ZMod r) shape.Vbase shape.Rbase
+          ⊕' RedDSA.ExtractionFailure binding.sch extractor) :=
   if heq : txNetValue tx = tx.vBalance then .inl heq
-  else if hex : tx.bvk P = E (tx.bvk P) tx.sighash (B.toSig tx.bindingSig) • S.Rbase then
-    .inr (.inl (NontrivialRelation.ofBundleIntImbalance S.Vbase S.Rbase (txBundle tx) [] tx.vBalance
-      (E (tx.bvk P) tx.sighash (B.toSig tx.bindingSig))
+  else if hex : tx.bvk P
+      = extractor (tx.bvk P) tx.sighash (binding.toSig tx.bindingSig) • shape.Rbase then
+    .inr (.inl (NontrivialRelation.ofBundleIntImbalance shape.Vbase shape.Rbase (txBundle tx) []
+      tx.vBalance
+      (extractor (tx.bvk P) tx.sighash (binding.toSig tx.bindingSig))
       (by
         simp only [List.map_nil, List.sum_nil, sub_zero, txBundle_fst_sum]
         exact sub_ne_zero.mpr heq)
       (by
         simp only [List.map_nil, List.sum_nil, sub_zero, txBundle_fst_sum]
         exact hval.imbalance_natAbs_lt hr htx)
-      ((bvk_eq S (hval.satisfied tx htx)).symm.trans hex)))
+      ((bvk_eq shape (hval.satisfied tx htx)).symm.trans hex)))
   else
-    .inr (.inr ⟨tx.bvk P, tx.sighash, B.toSig tx.bindingSig,
-      (B.verify_iff _ _ _).mp (hval.binding_verified tx htx),
-      by rw [B.base_eq]; exact hex⟩)
+    .inr (.inr ⟨tx.bvk P, tx.sighash, binding.toSig tx.bindingSig,
+      (binding.verify_iff _ _ _).mp (hval.binding_verified tx htx),
+      by rw [binding.base_eq]; exact hex⟩)
 
 section Capstone
 
@@ -127,94 +129,99 @@ variable [DecidableEq G]
 variable (kv) in
 /-- `premissOrBreakFallible` as the per-sample premiss the probabilistic capstones
 consume, at the break type `NontrivialRelation ⊕' ExtractionFailure`. -/
-def txBalancePremissFallible (S : ValueShape P) (B : BindingSigShape P S)
+def txBalancePremissFallible (shape : ValueShape P) (binding : BindingSigShape P shape)
     (hr : maxActions * (P.valueBound - 1) + P.vBalanceBound < r)
-    (E : RedDSA.Extractor (ZMod r) G MSG)
+    (extractor : RedDSA.Extractor (ZMod r) G MSG)
     (ω : ValidAnnotated P kv issuance maxActions)
     (tx : Tx KW (ZMod r) G RHO PSI MHASH MENC MSG SIG P.depth) (htx : tx ∈ ω.1) :
     (txNetValue tx = tx.vBalance)
-      ⊕' (BindingSignature.NontrivialRelation (F := ZMod r) S.Vbase S.Rbase
-          ⊕' RedDSA.ExtractionFailure B.sch E) :=
-  S.premissOrBreakFallible B ω.2 hr E tx htx
+      ⊕' (BindingSignature.NontrivialRelation (F := ZMod r) shape.Vbase shape.Rbase
+          ⊕' RedDSA.ExtractionFailure binding.sch extractor) :=
+  shape.premissOrBreakFallible binding ω.2 hr extractor tx htx
 
 variable (kv) in
 /-- The relation arm: the samples on which the conservation reduction computes a
 nontrivial `(Vbase, Rbase)` relation. Bounded onward by DL hardness (via the AGM layer's
-relation-to-DL handoff); its named bound is the `εdlr` slot. -/
-def valueRelationEvent (S : ValueShape P) (B : BindingSigShape P S)
+relation-to-DL handoff); its named bound is the `ε_dlr` slot. -/
+def valueRelationEvent (shape : ValueShape P) (binding : BindingSigShape P shape)
     (hr : maxActions * (P.valueBound - 1) + P.vBalanceBound < r)
-    (E : RedDSA.Extractor (ZMod r) G MSG) (i : ℕ) :
+    (extractor : RedDSA.Extractor (ZMod r) G MSG) (i : ℕ) :
     Set (ValidAnnotated P kv issuance maxActions) :=
   {ω | ∃ b, balanceConservationOrBreak (issuance := issuance)
-    (txBalancePremissFallible kv S B hr E ω) i = .inr (.inl b)}
+    (txBalancePremissFallible kv shape binding hr extractor ω) i = .inr (.inl b)}
 
 variable (kv) in
 /-- The extraction-failure arm: the samples on which the reduction exhibits a
 verifying binding signature whose key the extractor misses
 (`RedDSA.ExtractionFailure`, carried as data in the branch). Its named bound is the
 knowledge error `κ`. -/
-def extractFailEvent (S : ValueShape P) (B : BindingSigShape P S)
+def extractFailEvent (shape : ValueShape P) (binding : BindingSigShape P shape)
     (hr : maxActions * (P.valueBound - 1) + P.vBalanceBound < r)
-    (E : RedDSA.Extractor (ZMod r) G MSG) (i : ℕ) :
+    (extractor : RedDSA.Extractor (ZMod r) G MSG) (i : ℕ) :
     Set (ValidAnnotated P kv issuance maxActions) :=
-  {ω | ∃ e, balanceConservationOrBreak (issuance := issuance)
-    (txBalancePremissFallible kv S B hr E ω) i = .inr (.inr e)}
+  {ω | ∃ failure, balanceConservationOrBreak (issuance := issuance)
+    (txBalancePremissFallible kv shape binding hr extractor ω) i = .inr (.inr failure)}
 
 variable (kv) in
 /-- The extraction failure computed on a sample: the branch value of the conservation
 reduction, when it lands in the extraction-failure arm. -/
-def extractFailureOf (S : ValueShape P) (B : BindingSigShape P S)
+def extractFailureOf (shape : ValueShape P) (binding : BindingSigShape P shape)
     (hr : maxActions * (P.valueBound - 1) + P.vBalanceBound < r)
-    (E : RedDSA.Extractor (ZMod r) G MSG)
+    (extractor : RedDSA.Extractor (ZMod r) G MSG)
     (ω : ValidAnnotated P kv issuance maxActions) (i : ℕ) :
-    Option (RedDSA.ExtractionFailure B.sch E) :=
+    Option (RedDSA.ExtractionFailure binding.sch extractor) :=
   match balanceConservationOrBreak (issuance := issuance)
-    (txBalancePremissFallible kv S B hr E ω) i with
-  | .inr (.inr e) => some e
+    (txBalancePremissFallible kv shape binding hr extractor ω) i with
+  | .inr (.inr failure) => some failure
   | _ => none
 
 /-- On the extraction-failure arm the computed failure is defined: the arm's named
 `κ` is a bound on the adversary's probability of beating the extractor, and nothing
 else. -/
-theorem extractFailureOf_isSome (S : ValueShape P) (B : BindingSigShape P S)
+theorem extractFailureOf_isSome (shape : ValueShape P) (binding : BindingSigShape P shape)
     (hr : maxActions * (P.valueBound - 1) + P.vBalanceBound < r)
-    (E : RedDSA.Extractor (ZMod r) G MSG) (i : ℕ)
+    (extractor : RedDSA.Extractor (ZMod r) G MSG) (i : ℕ)
     {ω : ValidAnnotated P kv issuance maxActions}
-    (hω : ω ∈ extractFailEvent kv S B hr E i) :
-    (extractFailureOf kv S B hr E ω i).isSome := by
-  obtain ⟨e, he⟩ := hω
-  simp only [extractFailureOf, he, Option.isSome_some]
+    (hω : ω ∈ extractFailEvent kv shape binding hr extractor i) :
+    (extractFailureOf kv shape binding hr extractor ω i).isSome := by
+  obtain ⟨failure, hfailure⟩ := hω
+  simp only [extractFailureOf, hfailure, Option.isSome_some]
 
 /-- The transaction-balance premiss arm splits into the relation arm and the
 extraction-failure arm. -/
-theorem txBalanceBreakEvent_fallible_subset (S : ValueShape P) (B : BindingSigShape P S)
+theorem txBalanceBreakEvent_fallible_subset (shape : ValueShape P)
+    (binding : BindingSigShape P shape)
     (hr : maxActions * (P.valueBound - 1) + P.vBalanceBound < r)
-    (E : RedDSA.Extractor (ZMod r) G MSG) (i : ℕ) :
-    txBalanceBreakEvent (txBalancePremissFallible (issuance := issuance) kv S B hr E) i
-      ⊆ valueRelationEvent kv S B hr E i ∪ extractFailEvent kv S B hr E i := by
+    (extractor : RedDSA.Extractor (ZMod r) G MSG) (i : ℕ) :
+    txBalanceBreakEvent
+        (txBalancePremissFallible (issuance := issuance) kv shape binding hr extractor) i
+      ⊆ valueRelationEvent kv shape binding hr extractor i
+        ∪ extractFailEvent kv shape binding hr extractor i := by
   rintro ω ⟨b, hb⟩
   cases b with
   | inl rel => exact Or.inl ⟨rel, hb⟩
-  | inr e => exact Or.inr ⟨e, hb⟩
+  | inr failure => exact Or.inr ⟨failure, hb⟩
 
 /-- **Value conservation in extractor-plus-knowledge-error form.** For any adversary
-and any extractor `E`, the probability that the value ledger fails to balance is at
-most `εdlr + κ`: the relation arm's bound plus the knowledge error. Read
+and any `extractor`, the probability that the value ledger fails to balance
+is at most `ε_dlr + κ`: the relation arm's bound plus the knowledge error. Read
 contrapositively, a violation computes a nontrivial `(Vbase, Rbase)` relation with
 probability at least `Pr[violation] − κ` — the extraction succeeds up to the
 knowledge error, which is the form a forking discharge of `κ` composes with. -/
 theorem balanceConservation_measure_le_kerr
     (A : PMF (ValidAnnotated P kv issuance maxActions))
-    (S : ValueShape P) (B : BindingSigShape P S)
+    (shape : ValueShape P) (binding : BindingSigShape P shape)
     (hr : maxActions * (P.valueBound - 1) + P.vBalanceBound < r)
-    (E : RedDSA.Extractor (ZMod r) G MSG) (i : ℕ) {εdlr κ : ℝ≥0∞}
-    (hdlr : A.toOuterMeasure (valueRelationEvent kv S B hr E i) ≤ εdlr)
-    (hκ : A.toOuterMeasure (extractFailEvent kv S B hr E i) ≤ κ) :
-    A.toOuterMeasure (balanceConservationViolation i) ≤ εdlr + κ :=
+    (extractor : RedDSA.Extractor (ZMod r) G MSG) (i : ℕ) {ε_dlr κ : ℝ≥0∞}
+    (hdlr : A.toOuterMeasure (valueRelationEvent kv shape binding hr extractor i) ≤ ε_dlr)
+    (hκ : A.toOuterMeasure (extractFailEvent kv shape binding hr extractor i) ≤ κ) :
+    A.toOuterMeasure (balanceConservationViolation i) ≤ ε_dlr + κ :=
   le_trans
     (toOuterMeasure_le_add₂ A
-      (le_trans (balanceConservationViolation_subset (txBalancePremissFallible kv S B hr E) i)
-        (txBalanceBreakEvent_fallible_subset S B hr E i)))
+      (le_trans
+        (balanceConservationViolation_subset
+          (txBalancePremissFallible kv shape binding hr extractor) i)
+        (txBalanceBreakEvent_fallible_subset shape binding hr extractor i)))
     (add_le_add hdlr hκ)
 
 /-- **Balance-value in extractor-plus-knowledge-error form.** As
@@ -222,16 +229,18 @@ theorem balanceConservation_measure_le_kerr
 issuance. -/
 theorem shieldedBalanceCap_measure_le_kerr
     (A : PMF (ValidAnnotated P kv issuance maxActions))
-    (S : ValueShape P) (B : BindingSigShape P S)
+    (shape : ValueShape P) (binding : BindingSigShape P shape)
     (hr : maxActions * (P.valueBound - 1) + P.vBalanceBound < r)
-    (E : RedDSA.Extractor (ZMod r) G MSG) (i : ℕ) {εdlr κ : ℝ≥0∞}
-    (hdlr : A.toOuterMeasure (valueRelationEvent kv S B hr E i) ≤ εdlr)
-    (hκ : A.toOuterMeasure (extractFailEvent kv S B hr E i) ≤ κ) :
-    A.toOuterMeasure (shieldedBalanceCapViolation i) ≤ εdlr + κ :=
+    (extractor : RedDSA.Extractor (ZMod r) G MSG) (i : ℕ) {ε_dlr κ : ℝ≥0∞}
+    (hdlr : A.toOuterMeasure (valueRelationEvent kv shape binding hr extractor i) ≤ ε_dlr)
+    (hκ : A.toOuterMeasure (extractFailEvent kv shape binding hr extractor i) ≤ κ) :
+    A.toOuterMeasure (shieldedBalanceCapViolation i) ≤ ε_dlr + κ :=
   le_trans
     (toOuterMeasure_le_add₂ A
-      (le_trans (shieldedBalanceCapViolation_subset (txBalancePremissFallible kv S B hr E) i)
-        (txBalanceBreakEvent_fallible_subset S B hr E i)))
+      (le_trans
+        (shieldedBalanceCapViolation_subset
+          (txBalancePremissFallible kv shape binding hr extractor) i)
+        (txBalanceBreakEvent_fallible_subset shape binding hr extractor i)))
     (add_le_add hdlr hκ)
 
 /-! ### All prefixes -/
@@ -239,68 +248,70 @@ theorem shieldedBalanceCap_measure_le_kerr
 variable (kv) in
 /-- The all-prefixes relation arm: at some prefix `i < k`, the conservation reduction
 computes a nontrivial `(Vbase, Rbase)` relation. -/
-def valueRelationEventBefore (S : ValueShape P) (B : BindingSigShape P S)
+def valueRelationEventBefore (shape : ValueShape P) (binding : BindingSigShape P shape)
     (hr : maxActions * (P.valueBound - 1) + P.vBalanceBound < r)
-    (E : RedDSA.Extractor (ZMod r) G MSG) (k : ℕ) :
+    (extractor : RedDSA.Extractor (ZMod r) G MSG) (k : ℕ) :
     Set (ValidAnnotated P kv issuance maxActions) :=
-  {ω | ∃ i, i < k ∧ ω ∈ valueRelationEvent kv S B hr E i}
+  {ω | ∃ i, i < k ∧ ω ∈ valueRelationEvent kv shape binding hr extractor i}
 
 variable (kv) in
 /-- The all-prefixes extraction-failure arm: at some prefix `i < k`, the reduction
 exhibits a verifying binding signature whose key the extractor misses. -/
-def extractFailEventBefore (S : ValueShape P) (B : BindingSigShape P S)
+def extractFailEventBefore (shape : ValueShape P) (binding : BindingSigShape P shape)
     (hr : maxActions * (P.valueBound - 1) + P.vBalanceBound < r)
-    (E : RedDSA.Extractor (ZMod r) G MSG) (k : ℕ) :
+    (extractor : RedDSA.Extractor (ZMod r) G MSG) (k : ℕ) :
     Set (ValidAnnotated P kv issuance maxActions) :=
-  {ω | ∃ i, i < k ∧ ω ∈ extractFailEvent kv S B hr E i}
+  {ω | ∃ i, i < k ∧ ω ∈ extractFailEvent kv shape binding hr extractor i}
 
 /-- A conservation violation at some prefix lands in the all-prefixes relation arm or
 the all-prefixes extraction-failure arm, at that same prefix. -/
-theorem balanceConservationViolationBefore_subset_fallible (S : ValueShape P)
-    (B : BindingSigShape P S) (hr : maxActions * (P.valueBound - 1) + P.vBalanceBound < r)
-    (E : RedDSA.Extractor (ZMod r) G MSG) (k : ℕ) :
+theorem balanceConservationViolationBefore_subset_fallible (shape : ValueShape P)
+    (binding : BindingSigShape P shape) (hr : maxActions * (P.valueBound - 1) + P.vBalanceBound < r)
+    (extractor : RedDSA.Extractor (ZMod r) G MSG) (k : ℕ) :
     balanceConservationViolationBefore (P := P) (kv := kv) (issuance := issuance)
         (maxActions := maxActions) k
-      ⊆ valueRelationEventBefore kv S B hr E k
-        ∪ extractFailEventBefore kv S B hr E k := by
+      ⊆ valueRelationEventBefore kv shape binding hr extractor k
+        ∪ extractFailEventBefore kv shape binding hr extractor k := by
   rintro ω ⟨i, hik, hω⟩
-  rcases txBalanceBreakEvent_fallible_subset S B hr E i
-      (balanceConservationViolation_subset (txBalancePremissFallible kv S B hr E) i hω)
+  rcases txBalanceBreakEvent_fallible_subset shape binding hr extractor i
+      (balanceConservationViolation_subset
+        (txBalancePremissFallible kv shape binding hr extractor) i hω)
     with h | h
   · exact Or.inl ⟨i, hik, h⟩
   · exact Or.inr ⟨i, hik, h⟩
 
 /-- A cap violation at some prefix lands in the same two all-prefixes arms. -/
-theorem shieldedBalanceCapViolationBefore_subset_fallible (S : ValueShape P)
-    (B : BindingSigShape P S) (hr : maxActions * (P.valueBound - 1) + P.vBalanceBound < r)
-    (E : RedDSA.Extractor (ZMod r) G MSG) (k : ℕ) :
+theorem shieldedBalanceCapViolationBefore_subset_fallible (shape : ValueShape P)
+    (binding : BindingSigShape P shape) (hr : maxActions * (P.valueBound - 1) + P.vBalanceBound < r)
+    (extractor : RedDSA.Extractor (ZMod r) G MSG) (k : ℕ) :
     shieldedBalanceCapViolationBefore (P := P) (kv := kv) (issuance := issuance)
         (maxActions := maxActions) k
-      ⊆ valueRelationEventBefore kv S B hr E k
-        ∪ extractFailEventBefore kv S B hr E k := by
+      ⊆ valueRelationEventBefore kv shape binding hr extractor k
+        ∪ extractFailEventBefore kv shape binding hr extractor k := by
   rintro ω ⟨i, hik, hω⟩
-  rcases txBalanceBreakEvent_fallible_subset S B hr E i
-      (shieldedBalanceCapViolation_subset (txBalancePremissFallible kv S B hr E) i hω)
+  rcases txBalanceBreakEvent_fallible_subset shape binding hr extractor i
+      (shieldedBalanceCapViolation_subset
+        (txBalancePremissFallible kv shape binding hr extractor) i hω)
     with h | h
   · exact Or.inl ⟨i, hik, h⟩
   · exact Or.inr ⟨i, hik, h⟩
 
 /-- **All-prefixes value conservation in extractor-plus-knowledge-error form.** The
 probability that the ledger fails to balance at some prefix `i < k` is at most
-`εdlr + κ`, with no factor of `k`: every prefix's violation lands in the one
+`ε_dlr + κ`, with no factor of `k`: every prefix's violation lands in the one
 all-prefixes relation arm or the one all-prefixes extraction-failure arm. -/
 theorem balanceConservationBefore_measure_le_kerr
     (A : PMF (ValidAnnotated P kv issuance maxActions))
-    (S : ValueShape P) (B : BindingSigShape P S)
+    (shape : ValueShape P) (binding : BindingSigShape P shape)
     (hr : maxActions * (P.valueBound - 1) + P.vBalanceBound < r)
-    (E : RedDSA.Extractor (ZMod r) G MSG) (k : ℕ) {εdlr κ : ℝ≥0∞}
-    (hdlr : A.toOuterMeasure (valueRelationEventBefore kv S B hr E k) ≤ εdlr)
-    (hκ : A.toOuterMeasure (extractFailEventBefore kv S B hr E k) ≤ κ) :
+    (extractor : RedDSA.Extractor (ZMod r) G MSG) (k : ℕ) {ε_dlr κ : ℝ≥0∞}
+    (hdlr : A.toOuterMeasure (valueRelationEventBefore kv shape binding hr extractor k) ≤ ε_dlr)
+    (hκ : A.toOuterMeasure (extractFailEventBefore kv shape binding hr extractor k) ≤ κ) :
     A.toOuterMeasure (balanceConservationViolationBefore (P := P) (kv := kv)
-        (issuance := issuance) (maxActions := maxActions) k) ≤ εdlr + κ :=
+        (issuance := issuance) (maxActions := maxActions) k) ≤ ε_dlr + κ :=
   le_trans
     (toOuterMeasure_le_add₂ A
-      (balanceConservationViolationBefore_subset_fallible S B hr E k))
+      (balanceConservationViolationBefore_subset_fallible shape binding hr extractor k))
     (add_le_add hdlr hκ)
 
 /-- **All-prefixes shielded-balance cap in extractor-plus-knowledge-error form.** As
@@ -308,16 +319,16 @@ theorem balanceConservationBefore_measure_le_kerr
 minted issuance at some prefix. -/
 theorem shieldedBalanceCapBefore_measure_le_kerr
     (A : PMF (ValidAnnotated P kv issuance maxActions))
-    (S : ValueShape P) (B : BindingSigShape P S)
+    (shape : ValueShape P) (binding : BindingSigShape P shape)
     (hr : maxActions * (P.valueBound - 1) + P.vBalanceBound < r)
-    (E : RedDSA.Extractor (ZMod r) G MSG) (k : ℕ) {εdlr κ : ℝ≥0∞}
-    (hdlr : A.toOuterMeasure (valueRelationEventBefore kv S B hr E k) ≤ εdlr)
-    (hκ : A.toOuterMeasure (extractFailEventBefore kv S B hr E k) ≤ κ) :
+    (extractor : RedDSA.Extractor (ZMod r) G MSG) (k : ℕ) {ε_dlr κ : ℝ≥0∞}
+    (hdlr : A.toOuterMeasure (valueRelationEventBefore kv shape binding hr extractor k) ≤ ε_dlr)
+    (hκ : A.toOuterMeasure (extractFailEventBefore kv shape binding hr extractor k) ≤ κ) :
     A.toOuterMeasure (shieldedBalanceCapViolationBefore (P := P) (kv := kv)
-        (issuance := issuance) (maxActions := maxActions) k) ≤ εdlr + κ :=
+        (issuance := issuance) (maxActions := maxActions) k) ≤ ε_dlr + κ :=
   le_trans
     (toOuterMeasure_le_add₂ A
-      (shieldedBalanceCapViolationBefore_subset_fallible S B hr E k))
+      (shieldedBalanceCapViolationBefore_subset_fallible shape binding hr extractor k))
     (add_le_add hdlr hκ)
 
 end Capstone

--- a/Zcash/Security/Ledger/ExtractionKnowledgeError.lean
+++ b/Zcash/Security/Ledger/ExtractionKnowledgeError.lean
@@ -20,13 +20,14 @@ with the key-binding arm, everything is joint with validity. The capstones' name
 over an abstract `PMF (ValidAnnotated …)`; the conservation experiment is the
 joint-experiment composition, and bounds the challenge-oracle measure directly.
 
-The sample is a challenge table `O` and the logs `s` of the `m` presented bases. The value
-commitment and the binding verification are instantiated at sampled slots, as a record
-update of the fixed primitives (`kappaPrimitivesAt`), so the ledger type does not depend on
-the sample; the other primitives deliberately stay fixed, and the value and signature fields
-are not separated out of `Primitives`. The challenge hash reads the table at
-`queryOf R bvk m`, intended to be an injective encoding — collisions only constrain the
-algebraic hypotheses, shrinking the covered adversary class.
+The sample is a challenge table `table` and the discrete logarithms `logs`, relative to
+the generator `gen`, of the `m` presented bases. The value commitment and the binding
+verification are instantiated at sampled slots, as a record update of the fixed primitives
+(`kappaPrimitivesAt`), so the ledger type does not depend on the sample; the other
+primitives deliberately stay fixed, and the value and signature fields are not separated
+out of `Primitives`. The challenge hash reads the table at `queryOf R bvk m`, intended to
+be an injective encoding — collisions only constrain the algebraic hypotheses, shrinking
+the covered adversary class.
 
 The adversary outputs an annotated ledger: each transaction paired with the announced
 representation of its commitment and binding key. Being algebraic is the
@@ -63,47 +64,48 @@ variable (gen : G) (v_idx r_idx : Fin m) (queryOf : G → G → MSG → Q)
   (P₀ : Primitives (ZMod r) G IVK NK RHO PSI MHASH MENC MSG SIG)
   (toSig : SIG → RedDSA.Sig (ZMod r) G)
 
-/-- The primitives at a sampled challenge table `O` and basis logs `s`. The value commitment
-is the Pedersen commitment at the sampled slots `𝒱 = (s v_idx) • gen`, `ℛ = (s r_idx) • gen`.
-Binding verification is the Schnorr equation at base ℛ, with the challenge read off the table
-at the query point `queryOf R vk m`. A record update of `P₀`, so the tree depth — and with it
-the ledger type — does not depend on the sample. -/
-def kappaPrimitivesAt (O : Q → ZMod r) (s : Fin m → ZMod r) :
+/-- The primitives at a sampled challenge table `table` and the basis discrete logarithms
+`logs`. The value commitment is the Pedersen commitment at the sampled slots
+`𝒱 = (logs v_idx) • gen`, `ℛ = (logs r_idx) • gen`. Binding verification is the Schnorr
+equation at base ℛ, with the challenge read off the table at the query point
+`queryOf R vk m`. A record update of `P₀`, so the tree depth — and with it the ledger
+type — does not depend on the sample. -/
+def kappaPrimitivesAt (table : Q → ZMod r) (logs : Fin m → ZMod r) :
     Primitives (ZMod r) G IVK NK RHO PSI MHASH MENC MSG SIG :=
   { P₀ with
-    valueCommit := fun v rcv => (v : ZMod r) • (s v_idx • gen) + rcv • (s r_idx • gen)
+    valueCommit := fun v rcv => (v : ZMod r) • (logs v_idx • gen) + rcv • (logs r_idx • gen)
     bindingVerify := fun vk m σ =>
-      (toSig σ).S • (s r_idx • gen)
-        = (toSig σ).R + O (queryOf (toSig σ).R vk m) • vk }
+      (toSig σ).S • (logs r_idx • gen)
+        = (toSig σ).R + table (queryOf (toSig σ).R vk m) • vk }
 
 /-- The value-commitment shape at the sampled bases. -/
-def kappaShapeAt (O : Q → ZMod r) (s : Fin m → ZMod r) :
-    ValueShape (kappaPrimitivesAt m gen v_idx r_idx queryOf P₀ toSig O s) :=
-  ⟨s v_idx • gen, s r_idx • gen, fun _ _ => rfl⟩
+def kappaShapeAt (table : Q → ZMod r) (logs : Fin m → ZMod r) :
+    ValueShape (kappaPrimitivesAt m gen v_idx r_idx queryOf P₀ toSig table logs) :=
+  ⟨logs v_idx • gen, logs r_idx • gen, fun _ _ => rfl⟩
 
 /-- The RedDSA shape at the sampled table and bases: the scheme based at ℛ whose challenge
 hash reads the table at the query point. Its verification equation is definitionally what
 `kappaPrimitivesAt`'s `bindingVerify` states. -/
-def kappaBindingAt (O : Q → ZMod r) (s : Fin m → ZMod r) :
-    BindingSigShape (kappaPrimitivesAt m gen v_idx r_idx queryOf P₀ toSig O s)
-      (kappaShapeAt m gen v_idx r_idx queryOf P₀ toSig O s) :=
-  { sch := ⟨s r_idx • gen, fun R vk m => O (queryOf R vk m)⟩
+def kappaBindingAt (table : Q → ZMod r) (logs : Fin m → ZMod r) :
+    BindingSigShape (kappaPrimitivesAt m gen v_idx r_idx queryOf P₀ toSig table logs)
+      (kappaShapeAt m gen v_idx r_idx queryOf P₀ toSig table logs) :=
+  { sch := ⟨logs r_idx • gen, fun R vk m => table (queryOf R vk m)⟩
     toSig := toSig
     base_eq := rfl
     verify_iff := fun _ _ _ => Iff.rfl }
 
 /-- A transaction's binding verification key, computed from the presented bases: the machine
 receives the bases, not their logs, so this is an oracle-free function of its inputs. At
-`b = scalarBasis gen s` it is `Tx.bvk` of the sampled primitives. -/
-def bvkAt (b : Fin m → G) (tx : Tx KW (ZMod r) G RHO PSI MHASH MENC MSG SIG P₀.depth) : G :=
+`basis = scalarBasis gen logs` it is `Tx.bvk` of the sampled primitives. -/
+def bvkAt (basis : Fin m → G) (tx : Tx KW (ZMod r) G RHO PSI MHASH MENC MSG SIG P₀.depth) : G :=
   (tx.actions.map fun a => a.inst.cv_net).sum
-    - ((tx.vBalance : ZMod r) • b v_idx + (0 : ZMod r) • b r_idx)
+    - ((tx.vBalance : ZMod r) • basis v_idx + (0 : ZMod r) • basis r_idx)
 
 omit [DecidableEq G] [Fintype Q] [DecidableEq Q] [Inhabited Q] in
-theorem bvkAt_eq (O : Q → ZMod r) (s : Fin m → ZMod r)
+theorem bvkAt_eq (table : Q → ZMod r) (logs : Fin m → ZMod r)
     (tx : Tx KW (ZMod r) G RHO PSI MHASH MENC MSG SIG P₀.depth) :
-    bvkAt m v_idx r_idx P₀ (scalarBasis gen s) tx
-      = tx.bvk (kappaPrimitivesAt m gen v_idx r_idx queryOf P₀ toSig O s) :=
+    bvkAt m v_idx r_idx P₀ (scalarBasis gen logs) tx
+      = tx.bvk (kappaPrimitivesAt m gen v_idx r_idx queryOf P₀ toSig table logs) :=
   rfl
 
 /-- **The adversary is algebraic at the binding-signature points.** For each transaction it
@@ -124,21 +126,21 @@ structure AlgebraicAtBindingPoints
   /-- At query time: the label recorded at a challenge query represents the querying
   transaction's nonce and binding key. The half that pins the query's one bad challenge before
   the oracle answers. -/
-  atLabel : ∀ (O : Q → ZMod r) (s : Fin m → ZMod r) (q : Q) (ℓ : QueryRep (ZMod r) m),
-    (LA (scalarBasis gen s)).findLabel O q = some ℓ →
-    ∀ p ∈ (LA (scalarBasis gen s)).run O,
-      queryOf (toSig p.1.bindingSig).R (bvkAt m v_idx r_idx P₀ (scalarBasis gen s) p.1)
-          p.1.sighash = q →
-        (toSig p.1.bindingSig).R = representationEval (scalarBasis gen s) ℓ.commitment
-        ∧ bvkAt m v_idx r_idx P₀ (scalarBasis gen s) p.1
-          = representationEval (scalarBasis gen s) ℓ.key
+  atLabel : ∀ (table : Q → ZMod r) (logs : Fin m → ZMod r) (query : Q) (ℓ : QueryRep (ZMod r) m),
+    (LA (scalarBasis gen logs)).findLabel table query = some ℓ →
+    ∀ tx_rep ∈ (LA (scalarBasis gen logs)).run table,
+      queryOf (toSig tx_rep.1.bindingSig).R (bvkAt m v_idx r_idx P₀ (scalarBasis gen logs) tx_rep.1)
+          tx_rep.1.sighash = query →
+        (toSig tx_rep.1.bindingSig).R = representationEval (scalarBasis gen logs) ℓ.commitment
+        ∧ bvkAt m v_idx r_idx P₀ (scalarBasis gen logs) tx_rep.1
+          = representationEval (scalarBasis gen logs) ℓ.key
   /-- At output time: each transaction's announced representation represents its own nonce and
   binding key. The half the extractor falls back on when the run never queried that point. -/
-  atOutput : ∀ (O : Q → ZMod r) (s : Fin m → ZMod r),
-    ∀ p ∈ (LA (scalarBasis gen s)).run O,
-      (toSig p.1.bindingSig).R = representationEval (scalarBasis gen s) p.2.commitment
-      ∧ bvkAt m v_idx r_idx P₀ (scalarBasis gen s) p.1
-        = representationEval (scalarBasis gen s) p.2.key
+  atOutput : ∀ (table : Q → ZMod r) (logs : Fin m → ZMod r),
+    ∀ tx_rep ∈ (LA (scalarBasis gen logs)).run table,
+      (toSig tx_rep.1.bindingSig).R = representationEval (scalarBasis gen logs) tx_rep.2.commitment
+      ∧ bvkAt m v_idx r_idx P₀ (scalarBasis gen logs) tx_rep.1
+        = representationEval (scalarBasis gen logs) tx_rep.2.key
 
 /-- The first transaction of the length-`i` prefix failing the net-value equation, paired
 with its announced representation: the transaction at which the conservation reduction's
@@ -147,7 +149,7 @@ def failTxOfAnn
     (L : List (Tx KW (ZMod r) G RHO PSI MHASH MENC MSG SIG P₀.depth × QueryRep (ZMod r) m))
     (i : ℕ) :
     Option (Tx KW (ZMod r) G RHO PSI MHASH MENC MSG SIG P₀.depth × QueryRep (ZMod r) m) :=
-  (L.take i).find? fun p => decide (txNetValue p.1 ≠ p.1.vBalance)
+  (L.take i).find? fun tx_rep => decide (txNetValue tx_rep.1 ≠ tx_rep.1.vBalance)
 
 end OracleModel
 
@@ -161,28 +163,30 @@ variable {ledger : Ledger KW (ZMod r) G RHO PSI MHASH MENC MSG SIG P.depth}
 /-- The extraction-failure arm's exhibited data, identified with the searched list's first
 imbalanced transaction: `find?` selects `tx`, and the failure's components are that
 transaction's signature data. Computed data, in the breaks-as-computed-data style. -/
-structure ExtractFailSelection {S : ValueShape P} (B : BindingSigShape P S)
-    {E : RedDSA.Extractor (ZMod r) G MSG} (e : RedDSA.ExtractionFailure B.sch E)
+structure ExtractFailSelection {shape : ValueShape P} (binding : BindingSigShape P shape)
+    {extractor : RedDSA.Extractor (ZMod r) G MSG}
+    (failure : RedDSA.ExtractionFailure binding.sch extractor)
     (L : List (Tx KW (ZMod r) G RHO PSI MHASH MENC MSG SIG P.depth)) where
   tx : Tx KW (ZMod r) G RHO PSI MHASH MENC MSG SIG P.depth
   find : L.find? (fun tx => decide (txNetValue tx ≠ tx.vBalance)) = some tx
-  vk_eq : e.vk = tx.bvk P
-  m_eq : e.m = tx.sighash
-  σ_eq : e.σ = B.toSig tx.bindingSig
+  vk_eq : failure.vk = tx.bvk P
+  m_eq : failure.m = tx.sighash
+  σ_eq : failure.σ = binding.toSig tx.bindingSig
 
 /-- The premiss fold's extraction-failure arm breaks at the first transaction of the list
 failing the net-value equation; the selection is computed from the fold hypothesis. -/
 def allConservedOrBreak_extractFail
     (hval : ValidLedger P kv issuance maxActions ledger)
-    (S : ValueShape P) (B : BindingSigShape P S)
+    (shape : ValueShape P) (binding : BindingSigShape P shape)
     (hr : maxActions * (P.valueBound - 1) + P.vBalanceBound < r)
-    (E : RedDSA.Extractor (ZMod r) G MSG)
+    (extractor : RedDSA.Extractor (ZMod r) G MSG)
     (L : List (Tx KW (ZMod r) G RHO PSI MHASH MENC MSG SIG P.depth))
     (hL : ∀ tx ∈ L, tx ∈ ledger)
-    {e : RedDSA.ExtractionFailure B.sch E}
-    (h : allConservedOrBreak (fun tx htx => S.premissOrBreakFallible B hval hr E tx htx) L hL
-        = .inr (.inr e)) :
-    ExtractFailSelection B e L := by
+    {failure : RedDSA.ExtractionFailure binding.sch extractor}
+    (h : allConservedOrBreak
+        (fun tx htx => shape.premissOrBreakFallible binding hval hr extractor tx htx) L hL
+        = .inr (.inr failure)) :
+    ExtractFailSelection binding failure L := by
   induction L with
   | nil => simp [allConservedOrBreak] at h
   | cons tx t ih =>
@@ -192,7 +196,7 @@ def allConservedOrBreak_extractFail
         rw [dif_pos heq] at h
         simp only at h
         split at h
-        next b hb =>
+        next brk hb =>
           simp only [PSum.inr.injEq] at h
           subst h
           obtain ⟨tx', hfind, hvk, hm, hσ⟩ := ih _ hb
@@ -202,7 +206,7 @@ def allConservedOrBreak_extractFail
       · rw [ValueShape.premissOrBreakFallible] at h
         rw [dif_neg heq] at h
         by_cases hex : tx.bvk P
-            = E (tx.bvk P) tx.sighash (B.toSig tx.bindingSig) • S.Rbase
+            = extractor (tx.bvk P) tx.sighash (binding.toSig tx.bindingSig) • shape.Rbase
         · rw [dif_pos hex] at h
           exact absurd h (by simp)
         · rw [dif_neg hex] at h
@@ -214,19 +218,20 @@ def allConservedOrBreak_extractFail
 first imbalanced transaction; the selection is computed from the reduction hypothesis. -/
 def balanceConservationOrBreak_extractFail
     (hval : ValidLedger P kv issuance maxActions ledger)
-    (S : ValueShape P) (B : BindingSigShape P S)
+    (shape : ValueShape P) (binding : BindingSigShape P shape)
     (hr : maxActions * (P.valueBound - 1) + P.vBalanceBound < r)
-    (E : RedDSA.Extractor (ZMod r) G MSG) (i : ℕ)
-    {e : RedDSA.ExtractionFailure B.sch E}
+    (extractor : RedDSA.Extractor (ZMod r) G MSG) (i : ℕ)
+    {failure : RedDSA.ExtractionFailure binding.sch extractor}
     (h : balanceConservationOrBreak (issuance := issuance)
-        (fun tx htx => S.premissOrBreakFallible B hval hr E tx htx) i = .inr (.inr e)) :
-    ExtractFailSelection B e (ledger.take i) := by
+        (fun tx htx => shape.premissOrBreakFallible binding hval hr extractor tx htx) i
+      = .inr (.inr failure)) :
+    ExtractFailSelection binding failure (ledger.take i) := by
   rw [balanceConservationOrBreak] at h
   split at h
-  next b hb =>
+  next brk hb =>
     simp only [PSum.inr.injEq] at h
     subst h
-    exact allConservedOrBreak_extractFail hval S B hr E _ _ hb
+    exact allConservedOrBreak_extractFail hval shape binding hr extractor _ _ hb
   next hall => exact absurd h (by simp)
 
 end Identification
@@ -242,14 +247,15 @@ variable {issuance : ℕ → ℕ} {maxActions : ℕ}
 /-- The composite machine's output: the response, challenge-query point, and announced
 representation of the failing transaction's binding signature — an oracle-free function of
 the presented bases and the adversary's annotated output. -/
-def kappaOut (i : ℕ) (b : Fin m → G)
+def kappaOut (i : ℕ) (basis : Fin m → G)
     (L : List (Tx KW (ZMod r) G RHO PSI MHASH MENC MSG SIG P₀.depth × QueryRep (ZMod r) m)) :
     KappaOutput (ZMod r) Q m :=
   match failTxOfAnn m P₀ L i with
-  | some p =>
-      ⟨(toSig p.1.bindingSig).S,
-        queryOf (toSig p.1.bindingSig).R (bvkAt m v_idx r_idx P₀ b p.1) p.1.sighash,
-        p.2⟩
+  | some tx_rep =>
+      ⟨(toSig tx_rep.1.bindingSig).S,
+        queryOf (toSig tx_rep.1.bindingSig).R (bvkAt m v_idx r_idx P₀ basis tx_rep.1)
+          tx_rep.1.sighash,
+        tx_rep.2⟩
   | none => default
 
 /-- The composite knowledge-error adversary: run the labeled ledger adversary and return the
@@ -259,17 +265,17 @@ def kappaComposite (i : ℕ)
       (List (Tx KW (ZMod r) G RHO PSI MHASH MENC MSG SIG P₀.depth × QueryRep (ZMod r) m))) :
     (Fin m → G) → LabeledOracleComp Q (ZMod r) (fun _ => QueryRep (ZMod r) m)
       (KappaOutput (ZMod r) Q m) :=
-  fun b => (LA b).bind fun L => .pure (kappaOut m v_idx r_idx queryOf P₀ toSig i b L)
+  fun basis => (LA basis).bind fun L => .pure (kappaOut m v_idx r_idx queryOf P₀ toSig i basis L)
 
 omit [Fintype Q] [DecidableEq Q] [DecidableEq G] in
 /-- Post-processing the annotated ledger costs no queries. -/
 theorem kappaComposite_queryBound {i : ℕ}
     {LA : (Fin m → G) → LabeledOracleComp Q (ZMod r) (fun _ => QueryRep (ZMod r) m)
       (List (Tx KW (ZMod r) G RHO PSI MHASH MENC MSG SIG P₀.depth × QueryRep (ZMod r) m))}
-    {qH : ℕ} {b : Fin m → G} (h : (LA b).QueryBound qH) :
-    (kappaComposite m v_idx r_idx queryOf P₀ toSig i LA b).QueryBound qH := by
+    {qH : ℕ} {basis : Fin m → G} (h : (LA basis).QueryBound qH) :
+    (kappaComposite m v_idx r_idx queryOf P₀ toSig i LA basis).QueryBound qH := by
   have h' := OracleComp.queryBound_bind h
-    (fun L => OracleComp.QueryBound.pure (kappaOut m v_idx r_idx queryOf P₀ toSig i b L) 0)
+    (fun L => OracleComp.QueryBound.pure (kappaOut m v_idx r_idx queryOf P₀ toSig i basis L) 0)
   simpa [LabeledOracleComp.QueryBound, kappaComposite] using h'
 
 /-- The extractor at one sample: read the `key` coefficient at the ℛ slot off the
@@ -280,19 +286,19 @@ extractor). -/
 def kappaExtractor (i : ℕ)
     (LA : (Fin m → G) → LabeledOracleComp Q (ZMod r) (fun _ => QueryRep (ZMod r) m)
       (List (Tx KW (ZMod r) G RHO PSI MHASH MENC MSG SIG P₀.depth × QueryRep (ZMod r) m)))
-    (O : Q → ZMod r) (s : Fin m → ZMod r) : RedDSA.Extractor (ZMod r) G MSG :=
+    (table : Q → ZMod r) (logs : Fin m → ZMod r) : RedDSA.Extractor (ZMod r) G MSG :=
   fun vk msg σ =>
-    match (LA (scalarBasis gen s)).findLabel O (queryOf σ.R vk msg) with
+    match (LA (scalarBasis gen logs)).findLabel table (queryOf σ.R vk msg) with
     | some ℓ => ℓ.key r_idx
     | none =>
-        ((failTxOfAnn m P₀ ((LA (scalarBasis gen s)).run O) i).map
-          fun p => p.2.key r_idx).getD 0
+        ((failTxOfAnn m P₀ ((LA (scalarBasis gen logs)).run table) i).map
+          fun tx_rep => tx_rep.2.key r_idx).getD 0
 
 /-- `List.find?` over a prefix is stable under extending the prefix: the first match in
 `l.take i` is the first match in `l.take k` for any `k ≥ i`. -/
-theorem find?_take_eq_some_of_le {α : Type*} {p : α → Bool} {l : List α} {i k : ℕ}
-    (hik : i ≤ k) {x : α} (h : (l.take i).find? p = some x) :
-    (l.take k).find? p = some x := by
+theorem find?_take_eq_some_of_le {α : Type*} {tx_rep : α → Bool} {l : List α} {i k : ℕ}
+    (hik : i ≤ k) {x : α} (h : (l.take i).find? tx_rep = some x) :
+    (l.take k).find? tx_rep = some x := by
   have hsplit : l.take k = l.take i ++ (l.take k).drop i := by
     conv_lhs => rw [← List.take_append_drop i (l.take k)]
     rw [List.take_take, Nat.min_eq_left hik]
@@ -307,81 +313,89 @@ transaction of its prefix, which is the same transaction for every prefix contai
 theorem extractFail_mem_kappaEvent
     {LA : (Fin m → G) → LabeledOracleComp Q (ZMod r) (fun _ => QueryRep (ZMod r) m)
       (List (Tx KW (ZMod r) G RHO PSI MHASH MENC MSG SIG P₀.depth × QueryRep (ZMod r) m))}
-    (halgLabel : ∀ (O : Q → ZMod r) (s : Fin m → ZMod r) (q : Q) (ℓ : QueryRep (ZMod r) m),
-      (LA (scalarBasis gen s)).findLabel O q = some ℓ →
-      ∀ p ∈ (LA (scalarBasis gen s)).run O,
-        queryOf (toSig p.1.bindingSig).R (bvkAt m v_idx r_idx P₀ (scalarBasis gen s) p.1)
-            p.1.sighash = q →
-          (toSig p.1.bindingSig).R = representationEval (scalarBasis gen s) ℓ.commitment
-          ∧ bvkAt m v_idx r_idx P₀ (scalarBasis gen s) p.1
-            = representationEval (scalarBasis gen s) ℓ.key)
-    (halgOut : ∀ (O : Q → ZMod r) (s : Fin m → ZMod r),
-      ∀ p ∈ (LA (scalarBasis gen s)).run O,
-        (toSig p.1.bindingSig).R = representationEval (scalarBasis gen s) p.2.commitment
-        ∧ bvkAt m v_idx r_idx P₀ (scalarBasis gen s) p.1
-          = representationEval (scalarBasis gen s) p.2.key)
+    (halgLabel : ∀ (table : Q → ZMod r) (logs : Fin m → ZMod r) (query : Q)
+        (ℓ : QueryRep (ZMod r) m),
+      (LA (scalarBasis gen logs)).findLabel table query = some ℓ →
+      ∀ tx_rep ∈ (LA (scalarBasis gen logs)).run table,
+        queryOf (toSig tx_rep.1.bindingSig).R
+            (bvkAt m v_idx r_idx P₀ (scalarBasis gen logs) tx_rep.1)
+            tx_rep.1.sighash = query →
+          (toSig tx_rep.1.bindingSig).R = representationEval (scalarBasis gen logs) ℓ.commitment
+          ∧ bvkAt m v_idx r_idx P₀ (scalarBasis gen logs) tx_rep.1
+            = representationEval (scalarBasis gen logs) ℓ.key)
+    (halgOut : ∀ (table : Q → ZMod r) (logs : Fin m → ZMod r),
+      ∀ tx_rep ∈ (LA (scalarBasis gen logs)).run table,
+        (toSig tx_rep.1.bindingSig).R
+          = representationEval (scalarBasis gen logs) tx_rep.2.commitment
+        ∧ bvkAt m v_idx r_idx P₀ (scalarBasis gen logs) tx_rep.1
+          = representationEval (scalarBasis gen logs) tx_rep.2.key)
     (hr : maxActions * (P₀.valueBound - 1) + P₀.vBalanceBound < r) {i k : ℕ} (hik : i ≤ k)
-    {O : Q → ZMod r} {s : Fin m → ZMod r}
-    (hval : ValidLedger (kappaPrimitivesAt m gen v_idx r_idx queryOf P₀ toSig O s) kv issuance
-      maxActions (((LA (scalarBasis gen s)).run O).map Prod.fst))
-    {e : RedDSA.ExtractionFailure (kappaBindingAt m gen v_idx r_idx queryOf P₀ toSig O s).sch
-      (kappaExtractor m gen r_idx queryOf P₀ k LA O s)}
+    {table : Q → ZMod r} {logs : Fin m → ZMod r}
+    (hval : ValidLedger (kappaPrimitivesAt m gen v_idx r_idx queryOf P₀ toSig table logs)
+        kv issuance
+      maxActions (((LA (scalarBasis gen logs)).run table).map Prod.fst))
+    {failure : RedDSA.ExtractionFailure
+      (kappaBindingAt m gen v_idx r_idx queryOf P₀ toSig table logs).sch
+      (kappaExtractor m gen r_idx queryOf P₀ k LA table logs)}
     (heq : balanceConservationOrBreak (issuance := issuance)
-        (fun tx htx => (kappaShapeAt m gen v_idx r_idx queryOf P₀ toSig O s)
-          |>.premissOrBreakFallible (kappaBindingAt m gen v_idx r_idx queryOf P₀ toSig O s)
-            hval hr (kappaExtractor m gen r_idx queryOf P₀ k LA O s) tx htx) i
-      = .inr (.inr e)) :
-    (O, s) ∈ kappaEvent m gen r_idx (kappaComposite m v_idx r_idx queryOf P₀ toSig k LA) := by
+        (fun tx htx => (kappaShapeAt m gen v_idx r_idx queryOf P₀ toSig table logs)
+          |>.premissOrBreakFallible (kappaBindingAt m gen v_idx r_idx queryOf P₀ toSig table logs)
+            hval hr (kappaExtractor m gen r_idx queryOf P₀ k LA table logs) tx htx) i
+      = .inr (.inr failure)) :
+    (table, logs)
+      ∈ kappaEvent m gen r_idx (kappaComposite m v_idx r_idx queryOf P₀ toSig k LA) := by
   obtain ⟨tx, hfind, hvk, hm, hσ⟩ :=
     balanceConservationOrBreak_extractFail hval _ _ hr
-      (kappaExtractor m gen r_idx queryOf P₀ k LA O s) i heq
-  have hvk' : e.vk = bvkAt m v_idx r_idx P₀ (scalarBasis gen s) tx := hvk
-  have hσ' : e.σ = toSig tx.bindingSig := hσ
+      (kappaExtractor m gen r_idx queryOf P₀ k LA table logs) i heq
+  have hvk' : failure.vk = bvkAt m v_idx r_idx P₀ (scalarBasis gen logs) tx := hvk
+  have hσ' : failure.σ = toSig tx.bindingSig := hσ
   -- lift the first-failure selection to the annotated ledger
-  obtain ⟨pr, hpr, hfst⟩ : ∃ pr,
-      failTxOfAnn m P₀ ((LA (scalarBasis gen s)).run O) i = some pr ∧ pr.1 = tx := by
+  obtain ⟨tx_rep, hpr, hfst⟩ : ∃ tx_rep,
+      failTxOfAnn m P₀ ((LA (scalarBasis gen logs)).run table) i = some tx_rep ∧ tx_rep.1 = tx := by
     rw [← List.map_take, List.find?_map] at hfind
-    obtain ⟨pr, hpr, hfst⟩ := Option.map_eq_some_iff.mp hfind
-    exact ⟨pr, hpr, hfst⟩
-  obtain ⟨rep, rfl⟩ : ∃ rep, pr = (tx, rep) := ⟨pr.2, by rw [← hfst, Prod.mk.eta]⟩
-  have hfindAnnK : failTxOfAnn m P₀ ((LA (scalarBasis gen s)).run O) k = some (tx, rep) :=
+    obtain ⟨tx_rep, hpr, hfst⟩ := Option.map_eq_some_iff.mp hfind
+    exact ⟨tx_rep, hpr, hfst⟩
+  obtain ⟨rep, rfl⟩ : ∃ rep, tx_rep = (tx, rep) := ⟨tx_rep.2, by rw [← hfst, Prod.mk.eta]⟩
+  have hfindAnnK : failTxOfAnn m P₀ ((LA (scalarBasis gen logs)).run table) k = some (tx, rep) :=
     find?_take_eq_some_of_le hik hpr
-  have hmem : (tx, rep) ∈ (LA (scalarBasis gen s)).run O :=
+  have hmem : (tx, rep) ∈ (LA (scalarBasis gen logs)).run table :=
     (List.take_sublist k _).subset (List.mem_of_find?_eq_some hfindAnnK)
-  have hout : dischargeOut m gen (kappaComposite m v_idx r_idx queryOf P₀ toSig k LA) O s
+  have hout : dischargeOut m gen (kappaComposite m v_idx r_idx queryOf P₀ toSig k LA) table logs
       = ⟨(toSig tx.bindingSig).S,
-          queryOf (toSig tx.bindingSig).R (bvkAt m v_idx r_idx P₀ (scalarBasis gen s) tx)
+          queryOf (toSig tx.bindingSig).R (bvkAt m v_idx r_idx P₀ (scalarBasis gen logs) tx)
             tx.sighash,
           rep⟩ := by
     simp only [dischargeOut, kappaComposite, LabeledOracleComp.run_bind,
       LabeledOracleComp.run_pure, kappaOut]
     rw [hfindAnnK]
-  have heff : effectiveRep m gen (kappaComposite m v_idx r_idx queryOf P₀ toSig k LA) O s
-      = ((LA (scalarBasis gen s)).findLabel O
-          (queryOf (toSig tx.bindingSig).R (bvkAt m v_idx r_idx P₀ (scalarBasis gen s) tx)
+  have heff : effectiveRep m gen (kappaComposite m v_idx r_idx queryOf P₀ toSig k LA) table logs
+      = ((LA (scalarBasis gen logs)).findLabel table
+          (queryOf (toSig tx.bindingSig).R (bvkAt m v_idx r_idx P₀ (scalarBasis gen logs) tx)
             tx.sighash)).getD rep := by
     unfold effectiveRep
     rw [hout]
     simp only [kappaComposite, LabeledOracleComp.findLabel_bind_pure]
   have hRB : (toSig tx.bindingSig).R
-        = representationEval (scalarBasis gen s)
-            (effectiveRep m gen (kappaComposite m v_idx r_idx queryOf P₀ toSig k LA) O s).commitment
-      ∧ bvkAt m v_idx r_idx P₀ (scalarBasis gen s) tx
-        = representationEval (scalarBasis gen s)
-            (effectiveRep m gen (kappaComposite m v_idx r_idx queryOf P₀ toSig k LA) O s).key := by
+        = representationEval (scalarBasis gen logs)
+            (effectiveRep m gen (kappaComposite m v_idx r_idx queryOf P₀ toSig k LA)
+              table logs).commitment
+      ∧ bvkAt m v_idx r_idx P₀ (scalarBasis gen logs) tx
+        = representationEval (scalarBasis gen logs)
+            (effectiveRep m gen (kappaComposite m v_idx r_idx queryOf P₀ toSig k LA)
+              table logs).key := by
     rw [heff]
-    cases hfound : (LA (scalarBasis gen s)).findLabel O
-        (queryOf (toSig tx.bindingSig).R (bvkAt m v_idx r_idx P₀ (scalarBasis gen s) tx)
+    cases hfound : (LA (scalarBasis gen logs)).findLabel table
+        (queryOf (toSig tx.bindingSig).R (bvkAt m v_idx r_idx P₀ (scalarBasis gen logs) tx)
           tx.sighash) with
-    | some ℓ => simpa using halgLabel O s _ ℓ hfound (tx, rep) hmem rfl
-    | none => simpa using halgOut O s (tx, rep) hmem
-  have hEval : kappaExtractor m gen r_idx queryOf P₀ k LA O s e.vk e.m e.σ
-      = (effectiveRep m gen (kappaComposite m v_idx r_idx queryOf P₀ toSig k LA) O s).key
+    | some ℓ => simpa using halgLabel table logs _ ℓ hfound (tx, rep) hmem rfl
+    | none => simpa using halgOut table logs (tx, rep) hmem
+  have hEval : kappaExtractor m gen r_idx queryOf P₀ k LA table logs failure.vk failure.m failure.σ
+      = (effectiveRep m gen (kappaComposite m v_idx r_idx queryOf P₀ toSig k LA) table logs).key
           r_idx := by
     rw [hvk', hm, hσ', heff]
     unfold kappaExtractor
-    cases (LA (scalarBasis gen s)).findLabel O
-        (queryOf (toSig tx.bindingSig).R (bvkAt m v_idx r_idx P₀ (scalarBasis gen s) tx)
+    cases (LA (scalarBasis gen logs)).findLabel table
+        (queryOf (toSig tx.bindingSig).R (bvkAt m v_idx r_idx P₀ (scalarBasis gen logs) tx)
           tx.sighash) <;>
       simp [hfindAnnK]
     rfl
@@ -391,17 +405,17 @@ theorem extractFail_mem_kappaEvent
     rw [hout]
     dsimp only
     rw [← hRB.1, ← hRB.2]
-    have hver := e.verifies
+    have hver := failure.verifies
     rw [hvk, hm, hσ] at hver
     exact hver
   · -- a pivot-free effective key would make the extractor succeed
     rcases hpiv : (effectiveRep m gen
-        (kappaComposite m v_idx r_idx queryOf P₀ toSig k LA) O s).pivot r_idx with _ | j
+        (kappaComposite m v_idx r_idx queryOf P₀ toSig k LA) table logs).pivot r_idx with _ | j
     · exfalso
       have hkey := QueryRep.representationEval_key_of_pivot_eq_none
-        (effectiveRep m gen (kappaComposite m v_idx r_idx queryOf P₀ toSig k LA) O s) r_idx
-        (scalarBasis gen s) hpiv
-      apply e.ne
+        (effectiveRep m gen (kappaComposite m v_idx r_idx queryOf P₀ toSig k LA) table logs) r_idx
+        (scalarBasis gen logs) hpiv
+      apply failure.ne
       rw [hEval, hvk', hRB.2, hkey]
       rfl
     · rfl

--- a/Zcash/Security/Ledger/IntegrityExperiment.lean
+++ b/Zcash/Security/Ledger/IntegrityExperiment.lean
@@ -6,12 +6,12 @@ import Zcash.Security.Ledger.Capstone
 # The integrity experiment: the non-negativity and conservation arms in one sample space
 
 The `BalanceIntegrity` capstone bounds an integrity violation by
-`εm + εnc + εkb + ε_conservation`, over an abstract `PMF (ValidAnnotated …)`, with each arm's
-bound a named hypothesis (`balanceIntegrity_measure_le`). A violation is the shielded pool
-going negative, or the pools failing to sum to the minted issuance, at some prefix `i < k`.
-This module places that composition in the challenge-oracle model, over the *same* sample
-space as the conservation experiment: the adversary's coins, the challenge table, and the
-logs of the `m` presented bases.
+`ε_merkle + ε_nc + ε_kb + ε_conservation`, over an abstract `PMF (ValidAnnotated …)`, with
+each arm's bound a named hypothesis (`balanceIntegrity_measure_le`). A violation is the
+shielded pool going negative, or the pools failing to sum to the minted issuance, at some
+prefix `i < k`. This module places that composition in the challenge-oracle model, over the
+*same* sample space as the conservation experiment: the adversary's coins, the challenge
+table, and the logs of the `m` presented bases.
 
 The reduction layer is what lets the two sides share one sample space. The conservation side
 runs on the sampled value and binding bases (`kappaPrimitivesAt`) and is discharged wholesale by
@@ -99,7 +99,7 @@ theorem balanceIntegrityBefore_measure_le_experiment {ι : Type u} (p : PMF ι)
     {LA : ι → (Fin m → G) → LabeledOracleComp Q (ZMod r) (fun _ => QueryRep (ZMod r) m)
       (List (Tx KW (ZMod r) G RHO PSI MHASH MENC MSG SIG P₀.depth × QueryRep (ZMod r) m))}
     (hne_idx : v_idx ≠ r_idx)
-    {qH : ℕ} (hQ : ∀ j b, (LA j b).QueryBound qH)
+    {qH : ℕ} (hQ : ∀ j basis, (LA j basis).QueryBound qH)
     (halg : ∀ j : ι, AlgebraicAtBindingPoints m gen v_idx r_idx queryOf P₀ toSig (LA j))
     (hr : maxActions * (P₀.valueBound - 1) + P₀.vBalanceBound < r) (k : ℕ) {ε_nonneg ε_dl : ℝ≥0∞}
     (hnn : (challengeExperiment m p).toOuterMeasure
@@ -110,8 +110,8 @@ theorem balanceIntegrityBefore_measure_le_experiment {ι : Type u} (p : PMF ι)
               (maxActions := maxActions) k .noteCommit
             ∪ balanceSubsetBreakEventUpTo (P := P) (kv := kv) (issuance := issuance)
               (maxActions := maxActions) k .keyBinding)) ≤ ε_nonneg)
-    (hdl : ∀ j : ι, TextbookDLWithCoinsAdvantageLE gen (fun b O =>
-      conservationRelFinder m v_idx r_idx queryOf P₀ toSig hne_idx k (LA j) O b) ε_dl) :
+    (hdl : ∀ j : ι, TextbookDLWithCoinsAdvantageLE gen (fun basis table =>
+      conservationRelFinder m v_idx r_idx queryOf P₀ toSig hne_idx k (LA j) table basis) ε_dl) :
     (challengeExperiment m p).toOuterMeasure
         (sampledLedgerEvent m gen v_idx r_idx queryOf P₀ toSig LA
           (fun P => balanceIntegrityViolationBefore (P := P) (kv := kv) (issuance := issuance)

--- a/Zcash/Security/Ledger/KeyBindingArm.lean
+++ b/Zcash/Security/Ledger/KeyBindingArm.lean
@@ -63,12 +63,12 @@ variable [AddCommGroup G] [Field IVK] [Field RIVK] [Module RIVK G]
 /-- The games-facing key-binding interface at a sampled oracle assignment: the two
 sampled key tables plus the three components of the combined `rivk` oracle. -/
 abbrev kvAt (Extract : Extractor G IVK AK) (S : G) (hfn : AK → NK → RIVK) (Ggen : G)
-    (Hask : SK → ASK) (Hnk : SK → NK) (O : FinalQuery AK NK RIVK QK SK → RIVK) :
+    (Hask : SK → ASK) (Hnk : SK → NK) (table : FinalQuery AK NK RIVK QK SK → RIVK) :
     KeyBindingInterface (KeyBinding.Witness G IVK AK NK RIVK QK SK) G IVK NK :=
   KeyBinding.toInterface Extract S hfn Ggen
-    ⟨Hask, Hnk, fun sk => O (.legacy sk),
-      fun qk ak nk => O (.ext qk ak nk),
-      fun rivk_ext ak nk => O (.int rivk_ext ak nk)⟩
+    ⟨Hask, Hnk, fun sk => table (.legacy sk),
+      fun qk ak nk => table (.ext qk ak nk),
+      fun rivk_ext ak nk => table (.int rivk_ext ak nk)⟩
 
 /-- **The key-binding arm's ε, discharged.** For any `n`-query-bounded ledger adversary
 in the key-binding oracle model, the probability that its output ledger is valid and the
@@ -93,9 +93,9 @@ theorem balanceSubset_keyBindingArm_measure_le {ι : Type u}
             MSG SIG P.depth)}
     {n : ℕ} (hQ : ∀ j Hask Hnk, (LA j Hask Hnk).QueryBound n) :
     ((kbExperiment p)).toOuterMeasure
-        (setOf fun (j, Hask, Hnk, O) =>
-          ∃ hval : ValidLedger P (kvAt Extract S hfn Ggen Hask Hnk O)
-              issuance maxActions ((LA j Hask Hnk).run O),
+        (setOf fun (j, Hask, Hnk, table) =>
+          ∃ hval : ValidLedger P (kvAt Extract S hfn Ggen Hask Hnk table)
+              issuance maxActions ((LA j Hask Hnk).run table),
             ∃ w₁ w₂ h, balanceSubsetOrBreak hval i
               = PSum.inr (BalanceBreak.keyBinding w₁ w₂ h))
       ≤ ((n + 4) * (n + 3) : ℕ) / Fintype.card RIVK := by
@@ -103,9 +103,9 @@ theorem balanceSubset_keyBindingArm_measure_le {ι : Type u}
     (toInterface_break_measure_le Extract S hfn Ggen hS p
       (A := fun j Hask Hnk => (LA j Hask Hnk).bind fun L => .pure ((kbPairOf L i).getD default))
       (n := n) (fun j Hask Hnk => ?_))
-  · rintro ⟨j, Hask, Hnk, O⟩ ⟨hval, w₁, w₂, h, heq⟩
+  · rintro ⟨j, Hask, Hnk, table⟩ ⟨hval, w₁, w₂, h, heq⟩
     simp only [Set.mem_setOf_eq, OracleComp.run_bind, OracleComp.run_pure]
-    have hkp : kbPairOf ((LA j Hask Hnk).run O) i = some (w₁, w₂) := by
+    have hkp : kbPairOf ((LA j Hask Hnk).run table) i = some (w₁, w₂) := by
       have := balanceSubsetOrBreak_kbPair hval i heq
       simpa [BalanceBreak.kbPair] using this.symm
     rw [hkp]
@@ -138,25 +138,25 @@ theorem spendAuthority_keyBindingArm_measure_le {ι : Type u}
           × ℕ × ℕ)}
     {n : ℕ} (hQ : ∀ j Hask Hnk, (LA j Hask Hnk).QueryBound n) :
     ((kbExperiment p)).toOuterMeasure
-        (setOf fun (j, Hask, Hnk, O) =>
-          Nonempty (SpendAuthorityKBArm P (kvAt Extract S hfn Ggen Hask Hnk O)
-            issuance maxActions ((LA j Hask Hnk).run O).1
-            ((LA j Hask Hnk).run O).2.1 ((LA j Hask Hnk).run O).2.2 wV Signed))
+        (setOf fun (j, Hask, Hnk, table) =>
+          Nonempty (SpendAuthorityKBArm P (kvAt Extract S hfn Ggen Hask Hnk table)
+            issuance maxActions ((LA j Hask Hnk).run table).1
+            ((LA j Hask Hnk).run table).2.1 ((LA j Hask Hnk).run table).2.2 wV Signed))
       ≤ ((n + 4) * (n + 3) : ℕ) / Fintype.card RIVK := by
   refine le_trans (MeasureTheory.measure_mono ?_)
     (toInterface_break_measure_le Extract S hfn Ggen hS p
       (A := fun j Hask Hnk => (LA j Hask Hnk).bind fun out =>
         .pure ((kwAt out.1 out.2.1 out.2.2).getD default, wV))
       (n := n) (fun j Hask Hnk => ?_))
-  · rintro ⟨j, Hask, Hnk, O⟩ ⟨hf⟩
+  · rintro ⟨j, Hask, Hnk, table⟩ ⟨hf⟩
     simp only [Set.mem_setOf_eq, OracleComp.run_bind, OracleComp.run_pure]
     obtain ⟨hw₁, hw₂⟩ :=
       spendAuthorityOrBreak_pair hf.hval _ _ hf.hKB hf.hrecv hf.hfresh hf.hb
-    have hkw : kwAt ((LA j Hask Hnk).run O).1 ((LA j Hask Hnk).run O).2.1
-        ((LA j Hask Hnk).run O).2.2 = some hf.a.w.kw := by
+    have hkw : kwAt ((LA j Hask Hnk).run table).1 ((LA j Hask Hnk).run table).2.1
+        ((LA j Hask Hnk).run table).2.2 = some hf.a.w.kw := by
       simp [kwAt, hf.htx, hf.ha]
     rw [hkw]
-    simpa [hw₁, hw₂] using hf.b.h
+    simpa [hw₁, hw₂] using hf.brk.h
   · exact OracleComp.queryBound_bind (hQ j Hask Hnk)
       fun out => OracleComp.QueryBound.pure _ 0
 

--- a/Zcash/Security/Ledger/KeyBindingDLR.lean
+++ b/Zcash/Security/Ledger/KeyBindingDLR.lean
@@ -71,30 +71,30 @@ base. The reduction is hypothesis-free: the chunk-coefficient injectivity is
 chunk-encoding injectivity is `commitIvkChunks_inj`. -/
 def relationOfKeyBindingBreak
     {w₁ w₂ : KeyBinding.Pool.Witness Fq PallasGroup Fp}
-    (b : KeyBinding.Pool.CommitIvkCollision extract commitIvkHash commitIvkRpt w₁ w₂)
+    (brk : KeyBinding.Pool.CommitIvkCollision extract commitIvkHash commitIvkRpt w₁ w₂)
  :
     NontrivialRelation (F := Fq) pallasS ivkQpt commitIvkRpt :=
-  let hs₁ := commitIvkHash_isSome b.kb₁.hash_eq
-  let hs₂ := commitIvkHash_isSome b.kb₂.hash_eq
+  let hs₁ := commitIvkHash_isSome brk.kb₁.hash_eq
+  let hs₂ := commitIvkHash_isSome brk.kb₂.hash_eq
   relationOfChainPmEq (Q := ivkQ) (Or.inl ivkQ_onCurve) (W := commitIvkRpt)
     (fun _ hm => chunksOf_mem_lt hm) (fun _ hm => chunksOf_mem_lt hm)
     (by simp)
-    (Option.some_get hs₁).symm (commitIvkHash_get_valid b.kb₁.hash_eq)
-    (Option.some_get hs₂).symm (commitIvkHash_get_valid b.kb₂.hash_eq)
+    (Option.some_get hs₁).symm (commitIvkHash_get_valid brk.kb₁.hash_eq)
+    (Option.some_get hs₂).symm (commitIvkHash_get_valid brk.kb₂.hash_eq)
     (by
       have hx : extract (w₁.hashPoint + w₁.rivk • commitIvkRpt)
           = extract (w₂.hashPoint + w₂.rivk • commitIvkRpt) := by
-        rw [← b.kb₁.ivk_eq, ← b.kb₂.ivk_eq]
-        exact b.ivk_eq
+        rw [← brk.kb₁.ivk_eq, ← brk.kb₂.ivk_eq]
+        exact brk.ivk_eq
       have hpm := (PallasGroup.toPoint_x_eq_iff _ _).mp hx
-      rwa [commitIvkHash_get_eq b.kb₁.hash_eq,
-        commitIvkHash_get_eq b.kb₂.hash_eq] at hpm)
+      rwa [commitIvkHash_get_eq brk.kb₁.hash_eq,
+        commitIvkHash_get_eq brk.kb₂.hash_eq] at hpm)
     (by simp)
     (by
       rintro ⟨hl, hr⟩
       obtain ⟨hak, hnk⟩ := commitIvkChunks_inj
         (fp_val_lt _) (fp_val_lt _) (fp_val_lt _) (fp_val_lt _) hl
-      refine b.projection_ne ?_
+      refine brk.projection_ne ?_
       unfold KeyBinding.Pool.Witness.breakProjection
       rw [ZMod.val_injective _ hak, ZMod.val_injective _ hnk, hr])
 

--- a/Zcash/Security/Ledger/NoteCommitDLR.lean
+++ b/Zcash/Security/Ledger/NoteCommitDLR.lean
@@ -86,18 +86,18 @@ scalars and applies the chain-collision reducer at the `NoteCommit` domain point
 randomness base. -/
 def relationOfNoteCommitBreak {MSG SIG : Type*}
     (spendAuthVerify bindingVerify : PallasGroup → MSG → SIG → Prop)
-    (b : NoteCommitBreak (primitives (MSG := MSG) (SIG := SIG) spendAuthVerify bindingVerify)) :
+    (brk : NoteCommitBreak (primitives (MSG := MSG) (SIG := SIG) spendAuthVerify bindingVerify)) :
     NontrivialRelation (F := Fq) pallasS noteQpt noteCommitRpt :=
   relationOfChainPmEq (Q := noteQ) (Or.inl noteQ_onCurve) (W := noteCommitRpt)
     (fun _ hm => chunksOf_mem_lt hm) (fun _ hm => chunksOf_mem_lt hm)
     (by simp [Pool.noteScalars])
-    (Option.some_get (noteCommit_hash_isSome b.open₁)).symm
-    (noteCommit_get_valid b.open₁)
-    (Option.some_get (noteCommit_hash_isSome b.open₂)).symm
-    (noteCommit_get_valid b.open₂)
+    (Option.some_get (noteCommit_hash_isSome brk.open₁)).symm
+    (noteCommit_get_valid brk.open₁)
+    (Option.some_get (noteCommit_hash_isSome brk.open₂)).symm
+    (noteCommit_get_valid brk.open₂)
     (by
-      have hx : extract b.cm₁ = extract b.cm₂ := b.extract_eq
-      rw [noteCommit_get_eq b.open₁, noteCommit_get_eq b.open₂] at hx
+      have hx : extract brk.cm₁ = extract brk.cm₂ := brk.extract_eq
+      rw [noteCommit_get_eq brk.open₁, noteCommit_get_eq brk.open₂] at hx
       exact (PallasGroup.toPoint_x_eq_iff _ _).mp hx)
     (by simp [Pool.noteScalars])
     (by
@@ -107,27 +107,27 @@ def relationOfNoteCommitBreak {MSG SIG : Type*}
         (fp_val_lt _) (Nat.mod_lt _ (by norm_num)) (fp_val_lt _)
         (Nat.mod_lt _ (by norm_num))
         (by
-          rw [ZMod.val_natCast_of_lt (valueBound_lt_card b.v₁_lt)]
-          exact b.v₁_lt)
+          rw [ZMod.val_natCast_of_lt (valueBound_lt_card brk.v₁_lt)]
+          exact brk.v₁_lt)
         (fp_val_lt _) (fp_val_lt _)
         (fp_val_lt _) (Nat.mod_lt _ (by norm_num)) (fp_val_lt _)
         (Nat.mod_lt _ (by norm_num))
         (by
-          rw [ZMod.val_natCast_of_lt (valueBound_lt_card b.v₂_lt)]
-          exact b.v₂_lt)
+          rw [ZMod.val_natCast_of_lt (valueBound_lt_card brk.v₂_lt)]
+          exact brk.v₂_lt)
         (fp_val_lt _) (fp_val_lt _) hl
-      have hgd : b.n₁.gd = b.n₂.gd :=
+      have hgd : brk.n₁.gd = brk.n₂.gd :=
         PallasGroup.eq_of_toPoint_x_eq_of_y_parity_eq (ZMod.val_injective _ hgx) hgy
-      have hpkd : b.n₁.pkd = b.n₂.pkd :=
+      have hpkd : brk.n₁.pkd = brk.n₂.pkd :=
         PallasGroup.eq_of_toPoint_x_eq_of_y_parity_eq (ZMod.val_injective _ hpx) hpy
-      have hvv : b.n₁.v = b.n₂.v := by
-        rwa [ZMod.val_natCast_of_lt (valueBound_lt_card b.v₁_lt),
-          ZMod.val_natCast_of_lt (valueBound_lt_card b.v₂_lt)] at hv
-      have hrho' : b.n₁.ρ = b.n₂.ρ := ZMod.val_injective _ hrho
-      have hpsi' : b.n₁.ψ = b.n₂.ψ := ZMod.val_injective _ hpsi
-      refine b.ne ?_
-      have hn : b.n₁ = b.n₂ := by
-        rw [show b.n₁ = ⟨b.n₁.gd, b.n₁.pkd, b.n₁.v, b.n₁.ρ, b.n₁.ψ⟩ from rfl,
+      have hvv : brk.n₁.v = brk.n₂.v := by
+        rwa [ZMod.val_natCast_of_lt (valueBound_lt_card brk.v₁_lt),
+          ZMod.val_natCast_of_lt (valueBound_lt_card brk.v₂_lt)] at hv
+      have hrho' : brk.n₁.ρ = brk.n₂.ρ := ZMod.val_injective _ hrho
+      have hpsi' : brk.n₁.ψ = brk.n₂.ψ := ZMod.val_injective _ hpsi
+      refine brk.ne ?_
+      have hn : brk.n₁ = brk.n₂ := by
+        rw [show brk.n₁ = ⟨brk.n₁.gd, brk.n₁.pkd, brk.n₁.v, brk.n₁.ρ, brk.n₁.ψ⟩ from rfl,
           hgd, hpkd, hvv, hrho', hpsi']
       rw [hn, hr])
 

--- a/Zcash/Security/Ledger/OrchardCapstone.lean
+++ b/Zcash/Security/Ledger/OrchardCapstone.lean
@@ -38,7 +38,7 @@ binding signature. `ε_bindsig` is a named hypothesis on the conservation events
 extractor-plus-knowledge-error form replaces it with named bounds further down the
 reduction: with the binding-signature primitives pinned to a RedDSA shape,
 `orchardBalanceConservationBefore_measure_le_kerr` and
-`orchardBalanceIntegrity_measure_le_kerr` bound the same events by `εdlr + κ`, a
+`orchardBalanceIntegrity_measure_le_kerr` bound the same events by `ε_dlr + κ`, a
 `(Vbase, Rbase)` discrete-log-relation advantage plus the extractor's knowledge error;
 the conservation experiment discharges both in the challenge-oracle model, through one
 combined finder.
@@ -277,9 +277,9 @@ the `CommitIvkCollision` that `relationOfKeyBindingBreak` consumes, so the Spend
 Authority key-binding arm reaches the same discrete-log terminal as the Balance
 key-binding arm. The break is computed from the exhibited witness pair, and the
 reduction needs no oracle model. -/
-def relationOfSpendAuthorityKBBreak (b : KeyBindingBreakData keyBinding) :
+def relationOfSpendAuthorityKBBreak (brk : KeyBindingBreakData keyBinding) :
     NontrivialRelation (F := Fq) pallasS ivkQpt commitIvkRpt :=
-  relationOfKeyBindingBreak b.h
+  relationOfKeyBindingBreak brk.h
 
 /-- The Orchard Spend Authority reduction with its key-binding arm routed to the
 discrete-log terminal: as `spendAuthorityOrBreak`, with a key-binding break converted
@@ -340,15 +340,16 @@ hypothesis is named on the relation event — every break-arm sample computes a 
 theorem orchardSpendAuthority_measure_le
     (A : PMF (OrchardAnnotated spendAuthVerify bindingVerify issuance maxActions))
     (wV : KeyBinding.Pool.Witness Fq PallasGroup Fp) (hKB : keyBinding.KB wV)
-    (Signed : MSG → Prop) {εf ε_sinsemilladlr : ℝ≥0∞}
+    (Signed : MSG → Prop) {ε_forge ε_sinsemilladlr : ℝ≥0∞}
     (hf : A.toOuterMeasure
-      (spendAuthorityForgeryEvent (P := primitives spendAuthVerify bindingVerify) wV hKB Signed) ≤ εf)
+      (spendAuthorityForgeryEvent (P := primitives spendAuthVerify bindingVerify) wV hKB Signed)
+        ≤ ε_forge)
     (hsin : A.toOuterMeasure
       (orchardSpendAuthorityRelationEvent spendAuthVerify bindingVerify issuance maxActions wV hKB
         Signed) ≤ ε_sinsemilladlr) :
     A.toOuterMeasure
       (spendAuthorityViolation (P := primitives spendAuthVerify bindingVerify) wV Signed)
-      ≤ εf + ε_sinsemilladlr :=
+      ≤ ε_forge + ε_sinsemilladlr :=
   spendAuthority_measure_le A wV hKB Signed hf
     (le_trans (MeasureTheory.measure_mono
       (spendAuthorityBreakEvent_subset_relation spendAuthVerify bindingVerify issuance maxActions wV
@@ -357,57 +358,60 @@ theorem orchardSpendAuthority_measure_le
 /-! ## The Orchard conservation arm in extractor-plus-knowledge-error form -/
 
 /-- **Orchard value conservation with a fallible extractor.** For any adversary, any
-Pedersen shape `S` and RedDSA shape `B` of the binding-signature primitives, and any
-candidate extractor `E`, the probability that the ledger fails to balance at some
-prefix `i < k` is at most `εdlr + κ`: the `(Vbase, Rbase)` discrete-log-relation advantage
+Pedersen `shape` and RedDSA shape `binding` of the binding-signature primitives, and any
+candidate `extractor`, the probability that the ledger fails to balance at some
+prefix `i < k` is at most `ε_dlr + κ`: the `(Vbase, Rbase)` discrete-log-relation advantage
 plus the knowledge error, with no factor of `k`. The no-overflow premiss bounds the
 net value against the Pallas scalar order `r_ℙ`. Nothing is assumed of the extractor:
 its failures are exhibited on the extraction-failure arm. -/
 theorem orchardBalanceConservationBefore_measure_le_kerr
     (A : PMF (OrchardAnnotated spendAuthVerify bindingVerify issuance maxActions))
-    (S : ValueShape (primitives (MSG := MSG) (SIG := SIG) spendAuthVerify bindingVerify))
-    (B : BindingSigShape (primitives spendAuthVerify bindingVerify) S)
+    (shape : ValueShape (primitives (MSG := MSG) (SIG := SIG) spendAuthVerify bindingVerify))
+    (binding : BindingSigShape (primitives spendAuthVerify bindingVerify) shape)
     (hr : maxActions
           * ((primitives (MSG := MSG) (SIG := SIG) spendAuthVerify bindingVerify).valueBound - 1)
         + (primitives spendAuthVerify bindingVerify).vBalanceBound
       < CompElliptic.Fields.Pasta.PALLAS_SCALAR_CARD)
-    (E : RedDSA.Extractor Fq PallasGroup MSG) (k : ℕ) {εdlr κ : ℝ≥0∞}
-    (hdlr : A.toOuterMeasure (valueRelationEventBefore keyBinding S B hr E k) ≤ εdlr)
-    (hκ : A.toOuterMeasure (extractFailEventBefore keyBinding S B hr E k) ≤ κ) :
+    (extractor : RedDSA.Extractor Fq PallasGroup MSG) (k : ℕ) {ε_dlr κ : ℝ≥0∞}
+    (hdlr :
+      A.toOuterMeasure (valueRelationEventBefore keyBinding shape binding hr extractor k) ≤ ε_dlr)
+    (hκ : A.toOuterMeasure (extractFailEventBefore keyBinding shape binding hr extractor k) ≤ κ) :
     A.toOuterMeasure (balanceConservationViolationBefore
         (P := primitives spendAuthVerify bindingVerify) (kv := keyBinding) (issuance := issuance)
         (maxActions := maxActions) k)
-      ≤ εdlr + κ :=
-  balanceConservationBefore_measure_le_kerr A S B hr E k hdlr hκ
+      ≤ ε_dlr + κ :=
+  balanceConservationBefore_measure_le_kerr A shape binding hr extractor k hdlr hκ
 
 /-- **Orchard Balance integrity in extractor-plus-knowledge-error form.** Balance
 integrity holds at every prefix `i < k`, except with probability at most
-`ε_sinsemilladlr + εdlr + κ`: the Sinsemilla discrete-log-relation advantage covers
+`ε_sinsemilladlr + ε_dlr + κ`: the Sinsemilla discrete-log-relation advantage covers
 the non-negativity side, and the conservation side is covered by the `(Vbase, Rbase)`
 discrete-log-relation advantage plus the extractor's knowledge error, in place of
 `orchardBalanceIntegrity_measure_le`'s named `ε_bindsig`. -/
 theorem orchardBalanceIntegrity_measure_le_kerr
     (A : PMF (OrchardAnnotated spendAuthVerify bindingVerify issuance maxActions))
-    (S : ValueShape (primitives (MSG := MSG) (SIG := SIG) spendAuthVerify bindingVerify))
-    (B : BindingSigShape (primitives spendAuthVerify bindingVerify) S)
+    (shape : ValueShape (primitives (MSG := MSG) (SIG := SIG) spendAuthVerify bindingVerify))
+    (binding : BindingSigShape (primitives spendAuthVerify bindingVerify) shape)
     (hr : maxActions
           * ((primitives (MSG := MSG) (SIG := SIG) spendAuthVerify bindingVerify).valueBound - 1)
         + (primitives spendAuthVerify bindingVerify).vBalanceBound
       < CompElliptic.Fields.Pasta.PALLAS_SCALAR_CARD)
-    (E : RedDSA.Extractor Fq PallasGroup MSG) (k : ℕ)
-    {ε_sinsemilladlr εdlr κ : ℝ≥0∞}
+    (extractor : RedDSA.Extractor Fq PallasGroup MSG) (k : ℕ)
+    {ε_sinsemilladlr ε_dlr κ : ℝ≥0∞}
     (hsin : A.toOuterMeasure
       (orchardRelationEventUpTo spendAuthVerify bindingVerify issuance maxActions k) ≤ ε_sinsemilladlr)
-    (hdlr : A.toOuterMeasure (valueRelationEventBefore keyBinding S B hr E k) ≤ εdlr)
-    (hκ : A.toOuterMeasure (extractFailEventBefore keyBinding S B hr E k) ≤ κ) :
+    (hdlr :
+      A.toOuterMeasure (valueRelationEventBefore keyBinding shape binding hr extractor k) ≤ ε_dlr)
+    (hκ : A.toOuterMeasure (extractFailEventBefore keyBinding shape binding hr extractor k) ≤ κ) :
     A.toOuterMeasure (balanceIntegrityViolationBefore (P := primitives spendAuthVerify bindingVerify)
         (kv := keyBinding) (issuance := issuance) (maxActions := maxActions) k)
-      ≤ ε_sinsemilladlr + εdlr + κ := by
+      ≤ ε_sinsemilladlr + ε_dlr + κ := by
   rw [add_assoc]
   exact le_trans
     (toOuterMeasure_le_add₂ A
       (balanceIntegrityViolationBefore_subset_relation spendAuthVerify bindingVerify issuance
         maxActions k))
-    (add_le_add hsin (balanceConservationBefore_measure_le_kerr A S B hr E k hdlr hκ))
+    (add_le_add hsin
+      (balanceConservationBefore_measure_le_kerr A shape binding hr extractor k hdlr hκ))
 
 end Zcash.Security.Ledger.Bridge

--- a/Zcash/Security/Ledger/OrchardIntegrityExperiment.lean
+++ b/Zcash/Security/Ledger/OrchardIntegrityExperiment.lean
@@ -57,9 +57,9 @@ touching only `valueCommit` and `bindingVerify` — leaves those three fields eq
 ones, so every field transports by definitional equality. (`NoteCommitBreak` is indexed by the whole
 primitives record, which the sampling does change, so the two break types are not definitionally
 equal; rebuilding field-by-field is what carries the break across.) -/
-def noteCommitBreakOfKappa (O : Q → Fq) (s : Fin m → Fq)
+def noteCommitBreakOfKappa (table : Q → Fq) (logs : Fin m → Fq)
     (nb : NoteCommitBreak (kappaPrimitivesAt m gen v_idx r_idx queryOf
-      (primitives spendAuthVerify bindingVerify) toSig O s)) :
+      (primitives spendAuthVerify bindingVerify) toSig table logs)) :
     NoteCommitBreak (primitives spendAuthVerify bindingVerify) :=
   ⟨nb.rcm₁, nb.n₁, nb.rcm₂, nb.n₂, nb.cm₁, nb.cm₂, nb.ne, nb.open₁, nb.open₂, nb.extract_eq,
     nb.v₁_lt, nb.v₂_lt⟩
@@ -69,33 +69,36 @@ def noteCommitBreakOfKappa (O : Q → Fq) (s : Fin m → Fq)
 primitives with the value and binding fields replaced by the sampled slots. Those replaced fields
 are not read by any Balance-subset arm, so the reduction routes each break through the same Orchard
 reducer and lands in the same `OrchardBalanceRelation`. -/
-def kappaOrchardBalanceSubsetOrRelation (O : Q → Fq) (s : Fin m → Fq)
+def kappaOrchardBalanceSubsetOrRelation (table : Q → Fq) (logs : Fin m → Fq)
     {ledger : Ledger _ Fq PallasGroup Fp Fp Fp Encoding MSG SIG _}
     (hval : ValidLedger (kappaPrimitivesAt m gen v_idx r_idx queryOf
-        (primitives spendAuthVerify bindingVerify) toSig O s) keyBinding issuance maxActions ledger) (i : ℕ) :
+        (primitives spendAuthVerify bindingVerify) toSig table logs) keyBinding issuance maxActions
+        ledger) (i : ℕ) :
     (nonZeroSpends ledger (i + 1) ≤ ↑(positionedOutputs ledger i)) ⊕' OrchardBalanceRelation :=
   match balanceSubsetOrBreak hval i with
   | .inl hsub => .inl hsub
   | .inr (.keyBinding _ _ h) => .inr (.keyBinding (relationOfKeyBindingBreak h))
   | .inr (.noteCommit nb) => .inr (.noteCommit (relationOfNoteCommitBreak spendAuthVerify bindingVerify
-      (noteCommitBreakOfKappa spendAuthVerify bindingVerify m gen v_idx r_idx queryOf toSig O s nb)))
+      (noteCommitBreakOfKappa spendAuthVerify bindingVerify m gen v_idx r_idx queryOf toSig
+        table logs nb)))
   | .inr (.merkle c) => .inr (.merkle (relationOfMerkleCollision c.2))
 
 omit [Fintype Q] [DecidableEq Q] [Inhabited Q] in
 /-- A Balance-subset break at the sampled primitives computes an Orchard Sinsemilla relation: the
 total reduction cannot return the containment when handed a break, so it returns a relation. -/
-theorem kappaOrchardBalanceSubsetOrRelation_inr_of_break (O : Q → Fq) (s : Fin m → Fq)
+theorem kappaOrchardBalanceSubsetOrRelation_inr_of_break (table : Q → Fq) (logs : Fin m → Fq)
     {ledger : Ledger _ Fq PallasGroup Fp Fp Fp Encoding MSG SIG _}
     (hval : ValidLedger (kappaPrimitivesAt m gen v_idx r_idx queryOf
-        (primitives spendAuthVerify bindingVerify) toSig O s) keyBinding issuance maxActions ledger) (i : ℕ)
-    {b : BalanceBreak (kappaPrimitivesAt m gen v_idx r_idx queryOf
-        (primitives spendAuthVerify bindingVerify) toSig O s) keyBinding}
-    (hb : balanceSubsetOrBreak hval i = .inr b) :
+        (primitives spendAuthVerify bindingVerify) toSig table logs) keyBinding issuance maxActions
+        ledger) (i : ℕ)
+    {brk : BalanceBreak (kappaPrimitivesAt m gen v_idx r_idx queryOf
+        (primitives spendAuthVerify bindingVerify) toSig table logs) keyBinding}
+    (hb : balanceSubsetOrBreak hval i = .inr brk) :
     ∃ rel, kappaOrchardBalanceSubsetOrRelation spendAuthVerify bindingVerify issuance maxActions m gen v_idx r_idx
-      queryOf toSig O s hval i = .inr rel := by
+      queryOf toSig table logs hval i = .inr rel := by
   unfold kappaOrchardBalanceSubsetOrRelation
   rw [hb]
-  cases b <;> exact ⟨_, rfl⟩
+  cases brk <;> exact ⟨_, rfl⟩
 
 variable {ι : Type u}
   (LA : ι → (Fin m → PallasGroup) → LabeledOracleComp Q Fq (fun _ => QueryRep Fq m)
@@ -154,7 +157,7 @@ discrete-log advantage per side: `ε_sinsemilladlr` among the fixed Sinsemilla b
 sampled value-commitment bases. -/
 theorem orchardBalanceIntegrityBefore_measure_le_experiment_idealizedks (p : PMF ι)
     (hne_idx : v_idx ≠ r_idx)
-    {qH : ℕ} (hQ : ∀ j b, (LA j b).QueryBound qH)
+    {qH : ℕ} (hQ : ∀ j basis, (LA j basis).QueryBound qH)
     (halg : ∀ j : ι, AlgebraicAtBindingPoints m gen v_idx r_idx queryOf
       (primitives spendAuthVerify bindingVerify) toSig (LA j))
     (hr : maxActions * ((primitives spendAuthVerify bindingVerify).valueBound - 1)
@@ -164,9 +167,9 @@ theorem orchardBalanceIntegrityBefore_measure_le_experiment_idealizedks (p : PMF
     (hsin : (challengeExperiment m p).toOuterMeasure
       (sampledOrchardRelationEventUpTo spendAuthVerify bindingVerify issuance maxActions m gen v_idx r_idx queryOf
         toSig LA k) ≤ ε_sinsemilladlr)
-    (hdl : ∀ j : ι, TextbookDLWithCoinsAdvantageLE gen (fun b O =>
+    (hdl : ∀ j : ι, TextbookDLWithCoinsAdvantageLE gen (fun basis table =>
       conservationRelFinder m v_idx r_idx queryOf (primitives spendAuthVerify bindingVerify) toSig hne_idx k
-        (LA j) O b) ε_dl) :
+        (LA j) table basis) ε_dl) :
     (challengeExperiment m p).toOuterMeasure
         (sampledLedgerEvent m gen v_idx r_idx queryOf (primitives spendAuthVerify bindingVerify) toSig LA
           (fun P => balanceIntegrityViolationBefore (P := P) (kv := keyBinding) (issuance := issuance)
@@ -312,10 +315,11 @@ def sinsemillaRelationEvent (A : IdealizedKSBalanceAdversary MSG spendAuthVerify
 /-- The combined conservation finder the discrete-log advantage is stated for: replay coin
 `j`'s machine once and return whichever arm's relation the sample yields. -/
 def conservationFinder (A : IdealizedKSBalanceAdversary MSG spendAuthVerify H_bind) (k : ℕ)
-    (j : A.ι) (b : Fin 2 → PallasGroup) (O : OrchardQuery MSG → Fq) :
-    Option (AlgebraicRelationWitness (F := Fq) b) :=
+    (j : A.ι) (basis : Fin 2 → PallasGroup) (table : OrchardQuery MSG → Fq) :
+    Option (AlgebraicRelationWitness (F := Fq) basis) :=
   conservationRelFinder 2 0 1 orchardQueryOf
-    (primitives spendAuthVerify (redPallasBindingVerify H_bind)) id (by decide) k (A.LA j) O b
+    (primitives spendAuthVerify (redPallasBindingVerify H_bind)) id (by decide) k (A.LA j)
+      table basis
 
 end IdealizedKSBalanceAdversary
 

--- a/Zcash/Security/Ledger/SpendAuthority.lean
+++ b/Zcash/Security/Ledger/SpendAuthority.lean
@@ -138,9 +138,9 @@ theorem spendAuthorityOrBreak_pair [DecidableEq G] [NoZeroSMulDivisors F G]
     {wV : KW} (hKB : kv.KB wV)
     (hrecv : a.w.note_old.pkd = P.emb (kv.ivk wV) • a.w.note_old.gd)
     {Signed : MSG → Prop} (hfresh : ¬ Signed tx.sighash)
-    {b : KeyBindingBreakData kv}
-    (hb : spendAuthorityOrBreak hval htx ha hKB hrecv hfresh = .inr b) :
-    b.w₁ = a.w.kw ∧ b.w₂ = wV := by
+    {brk : KeyBindingBreakData kv}
+    (hb : spendAuthorityOrBreak hval htx ha hKB hrecv hfresh = .inr brk) :
+    brk.w₁ = a.w.kw ∧ brk.w₂ = wV := by
   rw [spendAuthorityOrBreak, spendAuthForgeryOrBreak] at hb
   split_ifs at hb
   simp_all only [PSum.inr.injEq]
@@ -166,9 +166,9 @@ structure SpendAuthorityKBArm [DecidableEq G] [NoZeroSMulDivisors F G]
   hKB : kv.KB wV
   hrecv : a.w.note_old.pkd = P.emb (kv.ivk wV) • a.w.note_old.gd
   hfresh : ¬ Signed tx.sighash
-  b : KeyBindingBreakData kv
+  brk : KeyBindingBreakData kv
   hb : spendAuthorityOrBreak hval (List.mem_of_getElem? htx)
-    (List.mem_of_getElem? ha) hKB hrecv hfresh = .inr b
+    (List.mem_of_getElem? ha) hKB hrecv hfresh = .inr brk
 
 end Validity
 

--- a/Zcash/Security/Ledger/Value.lean
+++ b/Zcash/Security/Ledger/Value.lean
@@ -70,19 +70,20 @@ theorem txBundle_fst_sum (tx : Tx KW (ZMod r) G RHO PSI MHASH MENC MSG SIG d) :
 
 /-- On a statement-satisfying transaction, the model's binding verification key is the
 binding-signature layer's `bindingVK` of the witnessed bundle. -/
-theorem bvk_eq (S : ValueShape P)
+theorem bvk_eq (shape : ValueShape P)
     {tx : Tx KW (ZMod r) G RHO PSI MHASH MENC MSG SIG P.depth}
     (hsat : ∀ a ∈ tx.actions, ActionSatisfied P kv a.inst a.w) :
     tx.bvk P
-      = bindingVK S.Vbase S.Rbase (castBundle (txBundle tx)) [] (tx.vBalance : ZMod r) := by
+      = bindingVK shape.Vbase shape.Rbase (castBundle (txBundle tx)) [] (tx.vBalance : ZMod r) := by
   have hsum : (tx.actions.map fun a => a.inst.cv_net).sum
-      = ((castBundle (txBundle tx)).map fun p => valueCommit S.Vbase S.Rbase p.1 p.2).sum := by
+      = ((castBundle (txBundle tx)).map
+          fun p => valueCommit shape.Vbase shape.Rbase p.1 p.2).sum := by
     simp only [castBundle, txBundle, List.map_map]
     refine congrArg List.sum (List.map_congr_left fun a ha => ?_)
-    rw [Function.comp_apply, Function.comp_apply, (hsat a ha).cv_net_eq, S.commit_eq]
+    rw [Function.comp_apply, Function.comp_apply, (hsat a ha).cv_net_eq, shape.commit_eq]
     rfl
-  have hvb : P.valueCommit tx.vBalance 0 = (tx.vBalance : ZMod r) • S.Vbase := by
-    rw [S.commit_eq]
+  have hvb : P.valueCommit tx.vBalance 0 = (tx.vBalance : ZMod r) • shape.Vbase := by
+    rw [shape.commit_eq]
     simp
   rw [Tx.bvk, bindingVK, hsum, hvb]
   simp

--- a/Zcash/Security/Ledger/ValueRelationArm.lean
+++ b/Zcash/Security/Ledger/ValueRelationArm.lean
@@ -7,7 +7,7 @@ import Zcash.Common.RelationProbabilityCoins
 /-!
 # The conservation relation arm in the oracle model
 
-The capstone layer bounds the conservation reduction's relation arm by the named `εdlr`. This
+The capstone layer bounds the conservation reduction's relation arm by the named `ε_dlr`. This
 module places that arm in the challenge-oracle model, at the reduction's own events: the
 computable finder `valueRelFinder` replays the adversary and rebuilds the arm's nontrivial
 `(𝒱, ℛ)` relation, and on every relation-arm sample it returns one
@@ -53,27 +53,29 @@ variable {ledger : Ledger KW (ZMod r) G RHO PSI MHASH MENC MSG SIG P.depth}
 /-- The relation arm's selection, identified with the searched list's first imbalanced
 transaction: `find?` selects `tx`, and the extractor pins its binding key. Computed data, in
 the breaks-as-computed-data style. -/
-structure ValueRelationSelection {S : ValueShape P} (B : BindingSigShape P S)
-    (E : RedDSA.Extractor (ZMod r) G MSG)
+structure ValueRelationSelection {shape : ValueShape P} (binding : BindingSigShape P shape)
+    (extractor : RedDSA.Extractor (ZMod r) G MSG)
     (L : List (Tx KW (ZMod r) G RHO PSI MHASH MENC MSG SIG P.depth)) where
   tx : Tx KW (ZMod r) G RHO PSI MHASH MENC MSG SIG P.depth
   find : L.find? (fun tx => decide (txNetValue tx ≠ tx.vBalance)) = some tx
-  extract_eq : tx.bvk P = E (tx.bvk P) tx.sighash (B.toSig tx.bindingSig) • S.Rbase
+  extract_eq :
+    tx.bvk P = extractor (tx.bvk P) tx.sighash (binding.toSig tx.bindingSig) • shape.Rbase
 
 /-- The premiss fold's relation arm breaks at the first transaction of the list failing the
 net-value equation, with the extractor pinning its key; the selection is computed from the
 fold hypothesis. -/
 def allConservedOrBreak_valueRelation
     (hval : ValidLedger P kv issuance maxActions ledger)
-    (S : ValueShape P) (B : BindingSigShape P S)
+    (shape : ValueShape P) (binding : BindingSigShape P shape)
     (hr : maxActions * (P.valueBound - 1) + P.vBalanceBound < r)
-    (E : RedDSA.Extractor (ZMod r) G MSG)
+    (extractor : RedDSA.Extractor (ZMod r) G MSG)
     (L : List (Tx KW (ZMod r) G RHO PSI MHASH MENC MSG SIG P.depth))
     (hL : ∀ tx ∈ L, tx ∈ ledger)
-    {w : BindingSignature.NontrivialRelation (F := ZMod r) S.Vbase S.Rbase}
-    (h : allConservedOrBreak (fun tx htx => S.premissOrBreakFallible B hval hr E tx htx) L hL
+    {w : BindingSignature.NontrivialRelation (F := ZMod r) shape.Vbase shape.Rbase}
+    (h : allConservedOrBreak
+        (fun tx htx => shape.premissOrBreakFallible binding hval hr extractor tx htx) L hL
         = .inr (.inl w)) :
-    ValueRelationSelection B E L := by
+    ValueRelationSelection binding extractor L := by
   induction L with
   | nil => simp [allConservedOrBreak] at h
   | cons tx t ih =>
@@ -83,7 +85,7 @@ def allConservedOrBreak_valueRelation
         rw [dif_pos heq] at h
         simp only at h
         split at h
-        next b hb =>
+        next brk hb =>
           simp only [PSum.inr.injEq] at h
           subst h
           obtain ⟨tx', hfind, hex⟩ := ih _ hb
@@ -93,7 +95,7 @@ def allConservedOrBreak_valueRelation
       · rw [ValueShape.premissOrBreakFallible] at h
         rw [dif_neg heq] at h
         by_cases hex : tx.bvk P
-            = E (tx.bvk P) tx.sighash (B.toSig tx.bindingSig) • S.Rbase
+            = extractor (tx.bvk P) tx.sighash (binding.toSig tx.bindingSig) • shape.Rbase
         · exact ⟨tx, List.find?_cons_of_pos (by simp [heq]), hex⟩
         · rw [dif_neg hex] at h
           exact absurd h (by simp)
@@ -103,19 +105,20 @@ imbalanced transaction, with the extractor pinning its key; the selection is com
 the reduction hypothesis. -/
 def balanceConservationOrBreak_valueRelation
     (hval : ValidLedger P kv issuance maxActions ledger)
-    (S : ValueShape P) (B : BindingSigShape P S)
+    (shape : ValueShape P) (binding : BindingSigShape P shape)
     (hr : maxActions * (P.valueBound - 1) + P.vBalanceBound < r)
-    (E : RedDSA.Extractor (ZMod r) G MSG) (i : ℕ)
-    {w : BindingSignature.NontrivialRelation (F := ZMod r) S.Vbase S.Rbase}
+    (extractor : RedDSA.Extractor (ZMod r) G MSG) (i : ℕ)
+    {w : BindingSignature.NontrivialRelation (F := ZMod r) shape.Vbase shape.Rbase}
     (h : balanceConservationOrBreak (issuance := issuance)
-        (fun tx htx => S.premissOrBreakFallible B hval hr E tx htx) i = .inr (.inl w)) :
-    ValueRelationSelection B E (ledger.take i) := by
+        (fun tx htx => shape.premissOrBreakFallible binding hval hr extractor tx htx) i
+      = .inr (.inl w)) :
+    ValueRelationSelection binding extractor (ledger.take i) := by
   rw [balanceConservationOrBreak] at h
   split at h
-  next b hb =>
+  next brk hb =>
     simp only [PSum.inr.injEq] at h
     subst h
-    exact allConservedOrBreak_valueRelation hval S B hr E _ _ hb
+    exact allConservedOrBreak_valueRelation hval shape binding hr extractor _ _ hb
   next hall => exact absurd h (by simp)
 
 end Identification
@@ -137,25 +140,25 @@ pass because validity supplies the same facts the reduction derived. -/
 def valueRelFinder (hne_idx : v_idx ≠ r_idx) (i : ℕ)
     (LA : (Fin m → G) → LabeledOracleComp Q (ZMod r) (fun _ => QueryRep (ZMod r) m)
       (List (Tx KW (ZMod r) G RHO PSI MHASH MENC MSG SIG P₀.depth × QueryRep (ZMod r) m)))
-    (O : Q → ZMod r) (b : Fin m → G) :
-    Option (AlgebraicRelationWitness (F := ZMod r) b) :=
-  match failTxOfAnn m P₀ ((LA b).run O) i with
+    (table : Q → ZMod r) (basis : Fin m → G) :
+    Option (AlgebraicRelationWitness (F := ZMod r) basis) :=
+  match failTxOfAnn m P₀ ((LA basis).run table) i with
   | none => none
-  | some p =>
-      letI tx := p.1
+  | some tx_rep =>
+      letI tx := tx_rep.1
       letI bsk :=
-        match (LA b).findLabel O
-            (queryOf (toSig tx.bindingSig).R (bvkAt m v_idx r_idx P₀ b tx) tx.sighash) with
+        match (LA basis).findLabel table
+            (queryOf (toSig tx.bindingSig).R (bvkAt m v_idx r_idx P₀ basis tx) tx.sighash) with
         | some ℓ => ℓ.key r_idx
-        | none => p.2.key r_idx
+        | none => tx_rep.2.key r_idx
       if h : (((txBundle tx).map Prod.fst).sum
             - (([] : List (ℤ × ZMod r)).map Prod.fst).sum - tx.vBalance ≠ 0)
           ∧ ((((txBundle tx).map Prod.fst).sum
             - (([] : List (ℤ × ZMod r)).map Prod.fst).sum - tx.vBalance).natAbs < r)
-          ∧ bindingVK (b v_idx) (b r_idx) (castBundle (txBundle tx)) (castBundle [])
-              (tx.vBalance : ZMod r) = bsk • b r_idx then
-        some ((NontrivialRelation.ofBundleIntImbalance (b v_idx) (b r_idx) (txBundle tx) []
-            tx.vBalance bsk h.1 h.2.1 h.2.2).toAlgebraicRelationWitnessAt b v_idx r_idx
+          ∧ bindingVK (basis v_idx) (basis r_idx) (castBundle (txBundle tx)) (castBundle [])
+              (tx.vBalance : ZMod r) = bsk • basis r_idx then
+        some ((NontrivialRelation.ofBundleIntImbalance (basis v_idx) (basis r_idx) (txBundle tx) []
+            tx.vBalance bsk h.1 h.2.1 h.2.2).toAlgebraicRelationWitnessAt basis v_idx r_idx
           hne_idx rfl rfl)
       else none
 
@@ -168,49 +171,50 @@ theorem valueRelation_finder_isSome [DecidableEq (ZMod r)]
       (List (Tx KW (ZMod r) G RHO PSI MHASH MENC MSG SIG P₀.depth × QueryRep (ZMod r) m))}
     (hne_idx : v_idx ≠ r_idx)
     (hr : maxActions * (P₀.valueBound - 1) + P₀.vBalanceBound < r) {i k : ℕ} (hik : i ≤ k)
-    {O : Q → ZMod r} {s : Fin m → ZMod r}
-    (hval : ValidLedger (kappaPrimitivesAt m gen v_idx r_idx queryOf P₀ toSig O s) kv issuance
-      maxActions (((LA (scalarBasis gen s)).run O).map Prod.fst))
+    {table : Q → ZMod r} {logs : Fin m → ZMod r}
+    (hval : ValidLedger (kappaPrimitivesAt m gen v_idx r_idx queryOf P₀ toSig table logs)
+        kv issuance
+      maxActions (((LA (scalarBasis gen logs)).run table).map Prod.fst))
     {w : BindingSignature.NontrivialRelation (F := ZMod r)
-      (kappaShapeAt m gen v_idx r_idx queryOf P₀ toSig O s).Vbase
-      (kappaShapeAt m gen v_idx r_idx queryOf P₀ toSig O s).Rbase}
+      (kappaShapeAt m gen v_idx r_idx queryOf P₀ toSig table logs).Vbase
+      (kappaShapeAt m gen v_idx r_idx queryOf P₀ toSig table logs).Rbase}
     (heq : balanceConservationOrBreak (issuance := issuance)
-        (fun tx htx => (kappaShapeAt m gen v_idx r_idx queryOf P₀ toSig O s)
-          |>.premissOrBreakFallible (kappaBindingAt m gen v_idx r_idx queryOf P₀ toSig O s)
-            hval hr (kappaExtractor m gen r_idx queryOf P₀ k LA O s) tx htx) i
+        (fun tx htx => (kappaShapeAt m gen v_idx r_idx queryOf P₀ toSig table logs)
+          |>.premissOrBreakFallible (kappaBindingAt m gen v_idx r_idx queryOf P₀ toSig table logs)
+            hval hr (kappaExtractor m gen r_idx queryOf P₀ k LA table logs) tx htx) i
       = .inr (.inl w)) :
-    (valueRelFinder m v_idx r_idx queryOf P₀ toSig hne_idx k LA O (scalarBasis gen s)).isSome
+    (valueRelFinder m v_idx r_idx queryOf P₀ toSig hne_idx k LA table (scalarBasis gen logs)).isSome
       := by
   obtain ⟨tx, hfind, hex⟩ :=
     balanceConservationOrBreak_valueRelation hval _ _ hr
-      (kappaExtractor m gen r_idx queryOf P₀ k LA O s) i heq
-  have hex' : bvkAt m v_idx r_idx P₀ (scalarBasis gen s) tx
-      = kappaExtractor m gen r_idx queryOf P₀ k LA O s
-          (bvkAt m v_idx r_idx P₀ (scalarBasis gen s) tx) tx.sighash
-          (toSig tx.bindingSig) • (s r_idx • gen) := hex
-  obtain ⟨pr, hpr, hfst⟩ : ∃ pr,
-      failTxOfAnn m P₀ ((LA (scalarBasis gen s)).run O) i = some pr ∧ pr.1 = tx := by
+      (kappaExtractor m gen r_idx queryOf P₀ k LA table logs) i heq
+  have hex' : bvkAt m v_idx r_idx P₀ (scalarBasis gen logs) tx
+      = kappaExtractor m gen r_idx queryOf P₀ k LA table logs
+          (bvkAt m v_idx r_idx P₀ (scalarBasis gen logs) tx) tx.sighash
+          (toSig tx.bindingSig) • (logs r_idx • gen) := hex
+  obtain ⟨tx_rep, hpr, hfst⟩ : ∃ tx_rep,
+      failTxOfAnn m P₀ ((LA (scalarBasis gen logs)).run table) i = some tx_rep ∧ tx_rep.1 = tx := by
     rw [← List.map_take, List.find?_map] at hfind
-    obtain ⟨pr, hpr, hfst⟩ := Option.map_eq_some_iff.mp hfind
-    exact ⟨pr, hpr, hfst⟩
-  obtain ⟨rep, rfl⟩ : ∃ rep, pr = (tx, rep) := ⟨pr.2, by rw [← hfst, Prod.mk.eta]⟩
-  have hfindAnnK : failTxOfAnn m P₀ ((LA (scalarBasis gen s)).run O) k = some (tx, rep) :=
+    obtain ⟨tx_rep, hpr, hfst⟩ := Option.map_eq_some_iff.mp hfind
+    exact ⟨tx_rep, hpr, hfst⟩
+  obtain ⟨rep, rfl⟩ : ∃ rep, tx_rep = (tx, rep) := ⟨tx_rep.2, by rw [← hfst, Prod.mk.eta]⟩
+  have hfindAnnK : failTxOfAnn m P₀ ((LA (scalarBasis gen logs)).run table) k = some (tx, rep) :=
     find?_take_eq_some_of_le hik hpr
-  have hmem : (tx, rep) ∈ (LA (scalarBasis gen s)).run O :=
+  have hmem : (tx, rep) ∈ (LA (scalarBasis gen logs)).run table :=
     (List.take_sublist k _).subset (List.mem_of_find?_eq_some hfindAnnK)
-  have htx : tx ∈ ((LA (scalarBasis gen s)).run O).map Prod.fst :=
+  have htx : tx ∈ ((LA (scalarBasis gen logs)).run table).map Prod.fst :=
     List.mem_map_of_mem hmem
   -- the finder's recomputed extractor value is the extractor's
-  have hbsk : kappaExtractor m gen r_idx queryOf P₀ k LA O s
-        (bvkAt m v_idx r_idx P₀ (scalarBasis gen s) tx) tx.sighash (toSig tx.bindingSig)
-      = (match (LA (scalarBasis gen s)).findLabel O
+  have hbsk : kappaExtractor m gen r_idx queryOf P₀ k LA table logs
+        (bvkAt m v_idx r_idx P₀ (scalarBasis gen logs) tx) tx.sighash (toSig tx.bindingSig)
+      = (match (LA (scalarBasis gen logs)).findLabel table
             (queryOf (toSig tx.bindingSig).R
-              (bvkAt m v_idx r_idx P₀ (scalarBasis gen s) tx) tx.sighash) with
+              (bvkAt m v_idx r_idx P₀ (scalarBasis gen logs) tx) tx.sighash) with
         | some ℓ => ℓ.key r_idx
         | none => rep.key r_idx) := by
     unfold kappaExtractor
-    cases (LA (scalarBasis gen s)).findLabel O
-        (queryOf (toSig tx.bindingSig).R (bvkAt m v_idx r_idx P₀ (scalarBasis gen s) tx)
+    cases (LA (scalarBasis gen logs)).findLabel table
+        (queryOf (toSig tx.bindingSig).R (bvkAt m v_idx r_idx P₀ (scalarBasis gen logs) tx)
           tx.sighash) <;>
       simp [hfindAnnK]
     rfl
@@ -226,14 +230,14 @@ theorem valueRelation_finder_isSome [DecidableEq (ZMod r)]
       - (([] : List (ℤ × ZMod r)).map Prod.fst).sum - tx.vBalance).natAbs < r := by
     simp only [List.map_nil, List.sum_nil, sub_zero, txBundle_fst_sum]
     exact hval.imbalance_natAbs_lt hr htx
-  have hc3 : bindingVK (scalarBasis gen s v_idx) (scalarBasis gen s r_idx)
+  have hc3 : bindingVK (scalarBasis gen logs v_idx) (scalarBasis gen logs r_idx)
       (castBundle (txBundle tx)) (castBundle []) (tx.vBalance : ZMod r)
-      = (match (LA (scalarBasis gen s)).findLabel O
+      = (match (LA (scalarBasis gen logs)).findLabel table
             (queryOf (toSig tx.bindingSig).R
-              (bvkAt m v_idx r_idx P₀ (scalarBasis gen s) tx) tx.sighash) with
+              (bvkAt m v_idx r_idx P₀ (scalarBasis gen logs) tx) tx.sighash) with
         | some ℓ => ℓ.key r_idx
-        | none => rep.key r_idx) • scalarBasis gen s r_idx := by
-    have hb := bvk_eq (kappaShapeAt m gen v_idx r_idx queryOf P₀ toSig O s)
+        | none => rep.key r_idx) • scalarBasis gen logs r_idx := by
+    have hb := bvk_eq (kappaShapeAt m gen v_idx r_idx queryOf P₀ toSig table logs)
       (hval.satisfied tx htx)
     rw [← hbsk]
     exact hb.symm.trans hex'

--- a/Zcash/Security/RedDSA/Extraction.lean
+++ b/Zcash/Security/RedDSA/Extraction.lean
@@ -78,12 +78,13 @@ signature must prove knowledge of the discrete logarithm of the validating key w
 respect to the base ℛ" (spec §5.4.7.2) — is the named bound κ on the probability
 that an adversary exhibits this event; the known discharge routes are in the module
 doc of `Zcash.Security.RedDSA.Basic`. -/
-structure ExtractionFailure {MSG : Type*} (sch : Scheme F M MSG) (E : Extractor F M MSG) where
+structure ExtractionFailure {MSG : Type*} (sch : Scheme F M MSG)
+    (extractor : Extractor F M MSG) where
   vk : M
   m : MSG
   σ : Sig F M
   verifies : sch.Verify vk m σ
-  ne : vk ≠ E vk m σ • sch.base
+  ne : vk ≠ extractor vk m σ • sch.base
 
 /-! ### Signature representations over the public basis -/
 

--- a/Zcash/Security/RedDSA/KnowledgeError.lean
+++ b/Zcash/Security/RedDSA/KnowledgeError.lean
@@ -23,7 +23,7 @@ so presenting a different one later changes nothing — which closes the trivial
 trap (`R = S • ℛ − c · bvk`) structurally.
 
 The sample space is the challenge oracle's whole table (`Q → F`) times the basis logs
-(`Fin m → F`; the bases are presented as `scalarBasis gen s`, and the reference-string
+(`Fin m → F`; the bases are presented as `scalarBasis gen logs`, and the reference-string
 heuristic carries the bound to the deployed fixed bases — see the Security Definitions book
 page). The knowledge-error event splits along the replayed relation finder:
 
@@ -60,16 +60,17 @@ variable {Q F ι : Type*} [Fintype Q] [DecidableEq Q] [Fintype F] [Nonempty F]
   [Fintype ι] [DecidableEq ι]
 
 /-- **The κ bound: the two extraction arms combined.** The extraction-failure event sits in the
-bad-challenge event (`badFiber s`, on the challenge-table factor `Q → F`, per basis-log
-vector `s`) union the relation event (`relFiber O`, on the basis-log factor `ι → F`, per
-challenge table `O` — the extracted relation's coefficients read the challenge). Each arm is
+bad-challenge event (`badFiber logs`, on the challenge-table factor `Q → F`, per basis-log
+vector `logs`) union the relation event (`relFiber table`, on the basis-log factor `ι → F`, per
+challenge table `table` — the extracted relation's coefficients read the challenge). Each arm is
 bounded on its own factor, so a union bound gives `κ ≤ qH/|F| + (ε + 1/|F|)`. -/
 theorem kappa_le_of_arms
     {κEvent : Set ((Q → F) × (ι → F))}
     (badFiber : (ι → F) → Set (Q → F)) (relFiber : (Q → F) → Set (ι → F)) {qH ε : ℝ≥0∞}
     (hcontain : κEvent ⊆ {ω | ω.1 ∈ badFiber ω.2} ∪ {ω | ω.2 ∈ relFiber ω.1})
-    (hbad : ∀ s, (PMF.uniformOfFintype (Q → F)).toOuterMeasure (badFiber s) ≤ qH / Fintype.card F)
-    (hrel : ∀ O, (PMF.uniformOfFintype (ι → F)).toOuterMeasure (relFiber O)
+    (hbad : ∀ logs,
+      (PMF.uniformOfFintype (Q → F)).toOuterMeasure (badFiber logs) ≤ qH / Fintype.card F)
+    (hrel : ∀ table, (PMF.uniformOfFintype (ι → F)).toOuterMeasure (relFiber table)
       ≤ ε + 1 / Fintype.card F) :
     (PMF.uniformOfFintype ((Q → F) × (ι → F))).toOuterMeasure κEvent
       ≤ qH / Fintype.card F + (ε + 1 / Fintype.card F) := by
@@ -98,30 +99,30 @@ variable {Q F M : Type*} [Fintype Q] [DecidableEq Q] [Field F] [Fintype F] [None
 variable (gen : M) (r_idx : Fin m)
   (adv : (Fin m → M) → LabeledOracleComp Q F (fun _ => QueryRep F m) (KappaOutput F Q m))
 
-/-- The adversary's output at challenge table `O` and basis logs `s`. -/
-def dischargeOut (O : Q → F) (s : Fin m → F) : KappaOutput F Q m :=
-  (adv (scalarBasis gen s)).run O
+/-- The adversary's output at challenge table `table` and the basis discrete logarithms `logs`. -/
+def dischargeOut (table : Q → F) (logs : Fin m → F) : KappaOutput F Q m :=
+  (adv (scalarBasis gen logs)).run table
 
 /-- The run's challenge: the oracle's answer at the output's query point. -/
-def dischargeChallenge (O : Q → F) (s : Fin m → F) : F :=
-  O (dischargeOut m gen adv O s).queryPoint
+def dischargeChallenge (table : Q → F) (logs : Fin m → F) : F :=
+  table (dischargeOut m gen adv table logs).queryPoint
 
 /-- The representation in effect at the output's query point: the first query-time annotation
 when the run queried that point, and the announced output representation otherwise. The
 fallback plays the game's own final challenge query — the Fuchsbauer–Plouviez–Seurin
 `q_H + 1` accounting. -/
-def effectiveRep (O : Q → F) (s : Fin m → F) : QueryRep F m :=
-  ((adv (scalarBasis gen s)).findLabel O (dischargeOut m gen adv O s).queryPoint).getD
-    (dischargeOut m gen adv O s).announced
+def effectiveRep (table : Q → F) (logs : Fin m → F) : QueryRep F m :=
+  ((adv (scalarBasis gen logs)).findLabel table (dischargeOut m gen adv table logs).queryPoint).getD
+    (dischargeOut m gen adv table logs).announced
 
 /-- The Schnorr verification equation `S • ℛ = R + c • bvk`, with `R` and `bvk` read off the
 effective representation at the presented basis. -/
-def Verifies (O : Q → F) (s : Fin m → F) : Prop :=
-  letI b := scalarBasis gen s
-  letI t := effectiveRep m gen adv O s
-  (dischargeOut m gen adv O s).response • b r_idx
-    = representationEval b t.commitment
-      + (dischargeChallenge m gen adv O s) • representationEval b t.key
+def Verifies (table : Q → F) (logs : Fin m → F) : Prop :=
+  letI basis := scalarBasis gen logs
+  letI t := effectiveRep m gen adv table logs
+  (dischargeOut m gen adv table logs).response • basis r_idx
+    = representationEval basis t.commitment
+      + (dischargeChallenge m gen adv table logs) • representationEval basis t.key
 
 variable [DecidableEq F]
 
@@ -137,27 +138,28 @@ variable [DecidableEq M]
 /-- The relation finder the discrete-log reduction runs: replay the adversary at the presented
 basis, and when its output verifies with nonzero assembled coefficients, return the assembled
 relation. Computable — the branch conditions are equalities in `M` and in `Fin m → F`. -/
-def relFinder (O : Q → F) (b : Fin m → M) : Option (AlgebraicRelationWitness (F := F) b) :=
-  letI out := (adv b).run O
-  letI t := ((adv b).findLabel O out.queryPoint).getD out.announced
-  letI c := O out.queryPoint
-  if h : (out.response • b r_idx
-        = representationEval b t.commitment + c • representationEval b t.key)
+def relFinder (table : Q → F) (basis : Fin m → M) :
+    Option (AlgebraicRelationWitness (F := F) basis) :=
+  letI out := (adv basis).run table
+  letI t := ((adv basis).findLabel table out.queryPoint).getD out.announced
+  letI c := table out.queryPoint
+  if h : (out.response • basis r_idx
+        = representationEval basis t.commitment + c • representationEval basis t.key)
       ∧ t.assembled r_idx c out.response ≠ 0 then
-    some (bindingSig_relation_of_nontrivial b r_idx t c out.response h.1 h.2)
+    some (bindingSig_relation_of_nontrivial basis r_idx t c out.response h.1 h.2)
   else none
 
-/-- Bad-challenge arm (fibre over the basis logs `s`): the knowledge-error conditions hold and
-the replayed finder returns no relation. -/
-def badFiber (s : Fin m → F) : Set (Q → F) :=
-  {O | Verifies m gen r_idx adv O s
-    ∧ ((effectiveRep m gen adv O s).pivot r_idx).isSome
-    ∧ relFinder m r_idx adv O (scalarBasis gen s) = none}
+/-- Bad-challenge arm (fibre over the basis discrete logarithms `logs`): the knowledge-error
+conditions hold and the replayed finder returns no relation. -/
+def badFiber (logs : Fin m → F) : Set (Q → F) :=
+  {table | Verifies m gen r_idx adv table logs
+    ∧ ((effectiveRep m gen adv table logs).pivot r_idx).isSome
+    ∧ relFinder m r_idx adv table (scalarBasis gen logs) = none}
 
-/-- Relation arm (fibre over the challenge table `O`): the replayed finder returns a
+/-- Relation arm (fibre over the challenge table `table`): the replayed finder returns a
 relation. -/
-def relFiber (O : Q → F) : Set (Fin m → F) :=
-  {s | (relFinder m r_idx adv O (scalarBasis gen s)).isSome}
+def relFiber (table : Q → F) : Set (Fin m → F) :=
+  {logs | (relFinder m r_idx adv table (scalarBasis gen logs)).isSome}
 
 omit [Fintype Q] [Fintype F] [Nonempty F] in
 /-- **Deterministic containment.** On the knowledge-error event, either the replayed finder
@@ -165,36 +167,37 @@ found a relation (the relation arm) or it found none (the bad-challenge arm). -/
 theorem kappaEvent_subset :
     kappaEvent m gen r_idx adv
       ⊆ {ω | ω.1 ∈ badFiber m gen r_idx adv ω.2} ∪ {ω | ω.2 ∈ relFiber m gen r_idx adv ω.1} := by
-  rintro ⟨O, s⟩ ⟨hver, hpiv⟩
-  rcases hfind : relFinder m r_idx adv O (scalarBasis gen s) with _ | w
+  rintro ⟨table, logs⟩ ⟨hver, hpiv⟩
+  rcases hfind : relFinder m r_idx adv table (scalarBasis gen logs) with _ | w
   · exact Or.inl ⟨hver, hpiv, hfind⟩
   · exact Or.inr (by simp only [relFiber, Set.mem_setOf_eq, hfind, Option.isSome_some])
 
 /-- The knowledge-error conditions as a set of answers at the output's query point — the
 `finalBad` handed to the labeled squeeze: challenges satisfying the verification equation on
 the effective representation, when that representation has a pivot. -/
-def finalBadSet (b : Fin m → M) (out : KappaOutput F Q m) (O : Q → F) : Set F :=
-  letI eff := ((adv b).findLabel O out.queryPoint).getD out.announced
-  {x | out.response • b r_idx
-      = representationEval b eff.commitment + x • representationEval b eff.key
+def finalBadSet (basis : Fin m → M) (out : KappaOutput F Q m) (table : Q → F) : Set F :=
+  letI eff := ((adv basis).findLabel table out.queryPoint).getD out.announced
+  {x | out.response • basis r_idx
+      = representationEval basis eff.commitment + x • representationEval basis eff.key
     ∧ (eff.pivot r_idx).isSome}
 
-/-- **The bad-challenge arm discharged by the labeled squeeze.** At basis logs `s`, within
-query budget `qH`, the bad-challenge fibre has measure at most `(qH+1)/|F|`. On that fibre the
-oracle's answer at the output's query point equals the effective representation's one bad
-challenge: on the annotation branch a singleton fixed before the answer was drawn, and on the
-fallback branch a singleton computed from an output that reprogramming the point cannot
-change. The `+1` is the Fuchsbauer–Plouviez–Seurin `q_H + 1` accounting, with the game's own
-final challenge query played by the fallback branch. -/
-theorem badFiber_measure_le {s : Fin m → F} {qH : ℕ}
-    (hQ : (adv (scalarBasis gen s)).QueryBound qH) :
-    (PMF.uniformOfFintype (Q → F)).toOuterMeasure (badFiber m gen r_idx adv s)
+/-- **The bad-challenge arm discharged by the labeled squeeze.** At the basis discrete
+logarithms `logs`, within query budget `qH`, the bad-challenge fibre has measure at most
+`(qH+1)/|F|`. On that fibre the oracle's answer at the output's query point equals the
+effective representation's one bad challenge: on the annotation branch a singleton fixed
+before the answer was drawn, and on the fallback branch a singleton computed from an output
+that reprogramming the point cannot change. The `+1` is the Fuchsbauer–Plouviez–Seurin
+`q_H + 1` accounting, with the game's own final challenge query played by the fallback
+branch. -/
+theorem badFiber_measure_le {logs : Fin m → F} {qH : ℕ}
+    (hQ : (adv (scalarBasis gen logs)).QueryBound qH) :
+    (PMF.uniformOfFintype (Q → F)).toOuterMeasure (badFiber m gen r_idx adv logs)
       ≤ ((qH + 1 : ℕ) : ℝ≥0∞) / Fintype.card F := by
   refine le_trans (MeasureTheory.measure_mono ?_)
-    (le_trans (finalBadWithoutRelation_measure_le (adv (scalarBasis gen s))
+    (le_trans (finalBadWithoutRelation_measure_le (adv (scalarBasis gen logs))
       (fun out => out.queryPoint)
-      (fun out _ O => finalBadSet m r_idx adv (scalarBasis gen s) out O)
-      (fun O => relFinder m r_idx adv O (scalarBasis gen s))
+      (fun out _ table => finalBadSet m r_idx adv (scalarBasis gen logs) out table)
+      (fun table => relFinder m r_idx adv table (scalarBasis gen logs))
       (fun _ label _ => {label.badChallenge r_idx})
       (fun out _ _ => {out.announced.badChallenge r_idx})
       ?_ (fun _ _ _ _ => rfl) (fun _ _ _ _ => rfl)
@@ -203,47 +206,47 @@ theorem badFiber_measure_le {s : Fin m → F} {qH : ℕ}
       hQ)
     (le_of_eq (mul_one_div _ _)))
   · -- the bad-challenge fibre is the squeeze's event
-    rintro O ⟨hver, hpiv, hnone⟩
+    rintro table ⟨hver, hpiv, hnone⟩
     exact ⟨⟨hver, hpiv⟩, hnone⟩
   · -- hcover: with no relation found, the challenge is the effective bad challenge
-    intro O hfinal hnone
+    intro table hfinal hnone
     obtain ⟨hver, hpiv⟩ := hfinal
     obtain ⟨j, hj⟩ := Option.isSome_iff_exists.mp hpiv
-    have hc : O (((adv (scalarBasis gen s)).run O).queryPoint)
-        = (((adv (scalarBasis gen s)).findLabel O
-              ((adv (scalarBasis gen s)).run O).queryPoint).getD
-            ((adv (scalarBasis gen s)).run O).announced).badChallenge r_idx := by
+    have hc : table (((adv (scalarBasis gen logs)).run table).queryPoint)
+        = (((adv (scalarBasis gen logs)).findLabel table
+              ((adv (scalarBasis gen logs)).run table).queryPoint).getD
+            ((adv (scalarBasis gen logs)).run table).announced).badChallenge r_idx := by
       by_contra hne
       have hcond := And.intro hver
         (QueryRep.assembled_ne_zero_of_ne_badChallenge
-          (S := ((adv (scalarBasis gen s)).run O).response) hj hne)
-      have hnone' : relFinder m r_idx adv O (scalarBasis gen s) = none := hnone
+          (S := ((adv (scalarBasis gen logs)).run table).response) hj hne)
+      have hnone' : relFinder m r_idx adv table (scalarBasis gen logs) = none := hnone
       rw [relFinder, dif_pos hcond] at hnone'
       exact Option.some_ne_none _ hnone'
     unfold firstLabelOrFallbackBad
     rw [hc]
-    cases (adv (scalarBasis gen s)).findLabel O
-        (((adv (scalarBasis gen s)).run O).queryPoint) <;>
+    cases (adv (scalarBasis gen logs)).findLabel table
+        (((adv (scalarBasis gen logs)).run table).queryPoint) <;>
       rfl
 
 omit [Fintype Q] [Nonempty F] in
 /-- The relation arm is the relation-finding event of the replayed finder. -/
-theorem relFiber_subset_relSet (O : Q → F) :
-    relFiber m gen r_idx adv O ⊆ ↑(relSet gen (relFinder m r_idx adv O)) := by
-  intro s hs
+theorem relFiber_subset_relSet (table : Q → F) :
+    relFiber m gen r_idx adv table ⊆ ↑(relSet gen (relFinder m r_idx adv table)) := by
+  intro logs hs
   simpa only [relSet, Finset.coe_filter, Set.mem_setOf_eq, Finset.mem_univ, true_and] using hs
 
 omit [Fintype Q] in
 /-- **The relation arm discharged against textbook discrete log.** If the finder's textbook-DL
 advantage is at most `ε`, the relation fibre has measure at most `ε + 1/|F|` — the tight
 Jaeger–Tessaro accounting, with no multiplicative loss. -/
-theorem relFiber_measure_le {O : Q → F} {ε : ℝ≥0∞}
-    (hdl : TextbookDLAdvantageLE gen (relFinder m r_idx adv O) ε) :
-    (PMF.uniformOfFintype (Fin m → F)).toOuterMeasure (relFiber m gen r_idx adv O)
+theorem relFiber_measure_le {table : Q → F} {ε : ℝ≥0∞}
+    (hdl : TextbookDLAdvantageLE gen (relFinder m r_idx adv table) ε) :
+    (PMF.uniformOfFintype (Fin m → F)).toOuterMeasure (relFiber m gen r_idx adv table)
       ≤ ε + 1 / Fintype.card F :=
   haveI : Nonempty (Fin m) := ⟨r_idx⟩
-  le_trans (MeasureTheory.measure_mono (relFiber_subset_relSet m gen r_idx adv O))
-    (relation_prob_le_of_textbookDL gen (relFinder m r_idx adv O) hdl)
+  le_trans (MeasureTheory.measure_mono (relFiber_subset_relSet m gen r_idx adv table))
+    (relation_prob_le_of_textbookDL gen (relFinder m r_idx adv table) hdl)
 
 /-- **The knowledge error bounded: κ ≤ (qH+1)/|F| + (ε_DL + 1/|F|).** For a labeled algebraic
 adversary within query budget `qH`, if every replayed relation finder has textbook-DL
@@ -253,18 +256,18 @@ representation has a pivot is at most `(qH+1)/|F| + (ε + 1/|F|)`. The `qH + 1` 
 hypothesis that the adversary queries its output's point.
 
 The DL hypothesis is per challenge table — one `ε` bounding the finder's advantage for every
-`O`, a supremum over unbounded advice and so stronger than the advantage of any single
+`table`, a supremum over unbounded advice and so stronger than the advantage of any single
 reduction. That is an artefact of the fibre-wise composition; a joint experiment in which the
 reduction samples the table itself needs only the one composite reduction's advantage. -/
 theorem kappaEvent_measure_le {qH : ℕ} {ε : ℝ≥0∞}
-    (hQ : ∀ s : Fin m → F, (adv (scalarBasis gen s)).QueryBound qH)
-    (hdl : ∀ O : Q → F, TextbookDLAdvantageLE gen (relFinder m r_idx adv O) ε) :
+    (hQ : ∀ logs : Fin m → F, (adv (scalarBasis gen logs)).QueryBound qH)
+    (hdl : ∀ table : Q → F, TextbookDLAdvantageLE gen (relFinder m r_idx adv table) ε) :
     (PMF.uniformOfFintype ((Q → F) × (Fin m → F))).toOuterMeasure (kappaEvent m gen r_idx adv)
       ≤ ((qH + 1 : ℕ) : ℝ≥0∞) / Fintype.card F + (ε + 1 / Fintype.card F) :=
   kappa_le_of_arms (badFiber m gen r_idx adv) (relFiber m gen r_idx adv)
     (kappaEvent_subset m gen r_idx adv)
-    (fun s => badFiber_measure_le m gen r_idx adv (hQ s))
-    (fun O => relFiber_measure_le m gen r_idx adv (hdl O))
+    (fun logs => badFiber_measure_le m gen r_idx adv (hQ logs))
+    (fun table => relFiber_measure_le m gen r_idx adv (hdl table))
 
 /-- **The knowledge error bounded, with a single randomized reduction:
 κ ≤ (qH+1)/#F + (ε_DL + 1/#F).** As `kappaEvent_measure_le`, with the per-table DL
@@ -272,15 +275,17 @@ hypothesis replaced by one bound for the coin-consuming finder — the reduction
 challenge table as its own coins (`TextbookDLWithCoinsAdvantageLE` at `ρ := Q → F`), so the
 supremum over tables disappears. -/
 theorem kappaEvent_measure_le_of_coins {qH : ℕ} {ε : ℝ≥0∞}
-    (hQ : ∀ s : Fin m → F, (adv (scalarBasis gen s)).QueryBound qH)
-    (hdl : TextbookDLWithCoinsAdvantageLE gen (fun b O => relFinder m r_idx adv O b) ε) :
+    (hQ : ∀ logs : Fin m → F, (adv (scalarBasis gen logs)).QueryBound qH)
+    (hdl : TextbookDLWithCoinsAdvantageLE gen
+        (fun basis table => relFinder m r_idx adv table basis) ε) :
     (PMF.uniformOfFintype ((Q → F) × (Fin m → F))).toOuterMeasure (kappaEvent m gen r_idx adv)
       ≤ ((qH + 1 : ℕ) : ℝ≥0∞) / Fintype.card F + (ε + 1 / Fintype.card F) := by
   haveI : Nonempty (Fin m) := ⟨r_idx⟩
   have hsub : kappaEvent m gen r_idx adv
       ⊆ {ω | ω.1 ∈ badFiber m gen r_idx adv ω.2}
         ∪ {ω : (Q → F) × (Fin m → F) |
-            (ω.2, ω.1) ∈ ↑(relSetWithCoins gen (fun b O => relFinder m r_idx adv O b))} := by
+            (ω.2, ω.1)
+              ∈ ↑(relSetWithCoins gen (fun basis table => relFinder m r_idx adv table basis))} := by
     intro ω hω
     rcases kappaEvent_subset m gen r_idx adv hω with h | h
     · exact Or.inl h
@@ -289,12 +294,13 @@ theorem kappaEvent_measure_le_of_coins {qH : ℕ} {ε : ℝ≥0∞}
   refine le_trans (MeasureTheory.measure_mono hsub) ?_
   refine le_trans (MeasureTheory.measure_union_le _ _) (add_le_add ?_ ?_)
   · exact uniformOfFintype_prod_fiber_bound (badFiber m gen r_idx adv)
-      (fun s => badFiber_measure_le m gen r_idx adv (hQ s))
+      (fun logs => badFiber_measure_le m gen r_idx adv (hQ logs))
   · have hswap : (PMF.uniformOfFintype ((Q → F) × (Fin m → F))).toOuterMeasure
         {ω : (Q → F) × (Fin m → F) |
-          (ω.2, ω.1) ∈ ↑(relSetWithCoins gen (fun b O => relFinder m r_idx adv O b))}
+          (ω.2, ω.1)
+            ∈ ↑(relSetWithCoins gen (fun basis table => relFinder m r_idx adv table basis))}
         = (PMF.uniformOfFintype ((Fin m → F) × (Q → F))).toOuterMeasure
-          ↑(relSetWithCoins gen (fun b O => relFinder m r_idx adv O b)) := by
+          ↑(relSetWithCoins gen (fun basis table => relFinder m r_idx adv table basis)) := by
       rw [← map_uniformOfFintype_equiv (Equiv.prodComm (Q → F) (Fin m → F)),
         PMF.toOuterMeasure_map_apply]
       congr 1
@@ -311,9 +317,9 @@ variable {F M ι : Type*} [Field F] [Fintype F] [Nonempty F] [DecidableEq F]
 
 /-- The relation finder for an all-zero basis: every coefficient vector is a relation there,
 so return the all-ones one. Returns nothing on any other basis. -/
-def zeroBasisRelationFinder : (b : ι → M) → Option (AlgebraicRelationWitness (F := F) b) :=
-  fun b =>
-    if h : ∀ i, b i = 0 then
+def zeroBasisRelationFinder : (basis : ι → M) → Option (AlgebraicRelationWitness (F := F) basis) :=
+  fun basis =>
+    if h : ∀ i, basis i = 0 then
       some { coeffs := fun _ => 1
              nontrivial := fun h1 => one_ne_zero (congrFun h1 (Classical.arbitrary ι))
              relation := by simp [representationEval, h] }
@@ -329,7 +335,7 @@ theorem textbookDLAdvantageLE_base_zero {ε : ℝ≥0∞}
     1 ≤ ε + 1 / Fintype.card F := by
   have hrel := relation_prob_le_of_textbookDL (0 : M) _ h
   have huniv : relSet (0 : M) (zeroBasisRelationFinder (F := F) (ι := ι)) = Finset.univ := by
-    ext s
+    ext logs
     simp [relSet, zeroBasisRelationFinder, scalarBasis]
   rw [huniv] at hrel
   calc (1 : ℝ≥0∞)

--- a/Zcash/Snark/Capstones/Action.lean
+++ b/Zcash/Snark/Capstones/Action.lean
@@ -275,7 +275,7 @@ and the shared relation finder fit a `2^126` random-oracle/group-work envelope a
 statistical remainder; the finder and the extractor consult the table only inside the certified
 read set.  Complete adversary and reduction group work are explicit profile premises; the
 separately costed assembly/basis component fits its derived formula at every table.  The final
-conjunct also records a generic whole-distribution `εBias` transport.  The deployed endpoint
+conjunct also records a generic whole-distribution `ε_bias` transport.  The deployed endpoint
 instead consumes the first conjunct and proves its dedicated joint Challenge255 observer hybrid
 below. -/
 theorem adaptiveStatementKnowledgeFailure_le_at_2pow123
@@ -312,15 +312,15 @@ theorem adaptiveStatementKnowledgeFailure_le_at_2pow123
           (family.adaptiveStatementKnowledgeExtractor
             (adaptiveStatement_pairCount_lt numProofs family) basis O).isSome) ∧
       ∀ (actual : PMF ((↥(Set.range query) → VestaG) × family.Coins))
-        (εBias : ENNReal),
+        (ε_bias : ENNReal),
         PMFEventBiasLE actual
           (independentProductPMF (orchardGeneratorROSetup query)
             (PMF.uniformOfFintype family.Coins))
-          εBias →
+          ε_bias →
         actual.toOuterMeasure
             ((fun p => (orchardGeneratorROBasis query p.1, p.2)) ⁻¹'
               family.adaptiveStatementKnowledgeFailureEvent (adaptiveStatement_pairCount_lt numProofs family)) ≤
-          (profile.advantage (2 ^ 126) (2 ^ 126) + 1 / (2 ^ 83 : ENNReal)) + εBias := by
+          (profile.advantage (2 ^ 126) (2 ^ 126) + 1 / (2 ^ 83 : ENNReal)) + ε_bias := by
   have hcost := profile.knowledgeExtractorCost_le
   have hqueries : adaptiveStatementKnowledgeExtractorRandomOracleQueries family ≤
       2 ^ 126 := by
@@ -385,7 +385,7 @@ theorem adaptiveStatementKnowledgeFailure_le_at_2pow123
       ⟨family.relationFinder_eq_of_agree (adaptiveStatement_pairCount_lt numProofs family) h,
         family.adaptiveStatementKnowledgeExtractor_isSome_eq_of_agree
           (adaptiveStatement_pairCount_lt numProofs family) h⟩, ?_⟩
-  intro actual εBias hbias
+  intro actual ε_bias hbias
   exact event_measure_le_of_bias hbias _ hprob
 
 /-- The deployed knowledge-failure bound with the joint Challenge255 charge left symbolic.  A

--- a/Zcash/Snark/Soundness/Pricing/DegreeWalk.lean
+++ b/Zcash/Snark/Soundness/Pricing/DegreeWalk.lean
@@ -3,9 +3,9 @@ import Zcash.Snark.Soundness.Constraint.Constraints
 /-!
 # Degree accounting for the combined constraint polynomial
 
-The good-challenge term prices the squeeze bad set at `εx`, the Schwartz–Zippel measure of the
+The good-challenge term prices the squeeze bad set at `ε_bad`, the Schwartz–Zippel measure of the
 combined constraint difference. This module walks the constraint builders and bounds that
-difference's `natDegree` by an explicit `D`, giving `εx = D / |𝔽|`.
+difference's `natDegree` by an explicit `D`, giving `ε_bad = D / |𝔽|`.
 
 The walk covers a syntactic degree per gate expression (`Expr.degreeBound`), per-member bounds for
 the permutation and lookup values, the `acc·y + v` fold, and the pre-`x` quotient tail. Throughout,

--- a/Zcash/TrustBoundary.lean
+++ b/Zcash/TrustBoundary.lean
@@ -631,13 +631,13 @@ assert_axioms Zcash.Security.RedDSA.textbookDLAdvantageLE_base_zero
 
 The transaction-balance premiss discharge with a fallible extractor: the extractor is an
 arbitrary function, its failures are exhibited `RedDSA.ExtractionFailure` data, and the Balance
-capstones bound the violation by `εdlr + κ`, per prefix and at all prefixes with no factor of
+capstones bound the violation by `ε_dlr + κ`, per prefix and at all prefixes with no factor of
 `k`. The premiss lands in the binding-signature layer's nontrivial `(Vbase, Rbase)` relation
 via `ofBundleIntImbalance`, with the no-overflow bound discharged from the statement's value
 ranges, validity's action-count and `vBalance` range rules, and the named numeric hypothesis in
 the `vSum` shape, `maxActions * (valueBound - 1) + vBalanceBound < r`. The Orchard
 instantiation names the same bounds at the Orchard-protocol primitives; the integrity bound
-takes `εdlr + κ` in place of the opaque `ε_bindsig`. `+choice` is the erased-positions tier. -/
+takes `ε_dlr + κ` in place of the opaque `ε_bindsig`. `+choice` is the erased-positions tier. -/
 
 assert_computable Zcash.Security.Ledger.Model.ValueShape.premissOrBreakFallible +choice
 assert_computable Zcash.Security.Ledger.Model.txBalancePremissFallible +choice


### PR DESCRIPTION
Spell out the short argument names in the security layer, where the letter named a domain object: the presented basis `b` becomes `basis`, the sampled basis logs `s` become `logs`, extractors `E` become `extractor`, extraction failures `e` become `failure`, and the value-commitment and binding-signature shapes `S` and `B` become `shape` and `binding`. Break values named `b` become `brk` (`break` is a reserved keyword), including the `SpendAuthorityKBArm` field and its projection. The challenge tables `O` become `table`, the shift functions `s : Q → F` of the key-binding escape argument become `shift`, the annotated transaction-representation pairs `p` and `pr` become `tx_rep`, and the query point `q` becomes `query`. The advantage names gain the underscore the rest of the ε family already uses: `εdlr`, `εm`, `εnc`, `εkb`, `εf`, `εBias`, and `εx` become `ε_dlr`, `ε_merkle`, `ε_nc`, `ε_kb`, `ε_forge`, `ε_bias`, and `ε_bad`.

Letters naming types, events, list elements, and literature notation are unchanged: Merkle's `E`/`B` are type variables, the capstone measure lemmas' `E` is an event, `Balance`'s `find?` binders are list elements, and `σ`, `vk`, `R`, `ℓ`, and `qH` are standard notation. The witnesses named `w` also stay: the letter is unambiguous, and the bridge layer already uses `wit` for the circuit witness. The extraction module's sample paragraph now states what the logs are logs of — each presented basis element's discrete logarithm relative to the generator — and a Markov-category citation moves to the standard format.

In several references to ZIP 2005's `ε_kb`, the fact that its bound was sharpened in zcash/zips#1338 is dropped.

The κ-layer basis-generalization work (#219) stacks on this branch.

🤖 Claude Fable 5
