### PR TITLE
Remove the circuit layer's references to the phase-1 donor development

### DIFF
--- a/Zcash/Circuits/Action/AddressIntegrity.lean
+++ b/Zcash/Circuits/Action/AddressIntegrity.lean
@@ -22,11 +22,7 @@ separate building block; its output cell feeds in here as `ivk`):
    region (`ecc/chip.rs:474-488`), two copy constraints.
 
 The block returns the witnessed `pk_d_old`. `Spec` is knowledge-sound with no
-existential: `pk_d_old = ivk • g_d_old` at the input `ivk` cell (the phase-1 donor
-carried the whole `CommitIvk` call inside and an `∃ ivk` — here `ivk` is an input, so
-the statement is direct).
-
-Phase-1 donor: `Clean/Orchard/Action/AddressIntegrity.lean` (post-`CommitIvk` part).
+existential: `pk_d_old = ivk • g_d_old` at the input `ivk` cell.
 -/
 
 namespace Zcash.Circuits.Action.AddressIntegrity

--- a/Zcash/Circuits/Action/DeriveNullifier.lean
+++ b/Zcash/Circuits/Action/DeriveNullifier.lean
@@ -21,8 +21,6 @@ in source order:
    `Ecc.MulFixed.BaseFieldElem` bundle);
 4. `cm.add(product)` (region `"complete point addition"`, `ecc/chip.rs:582-595`); the
    returned nullifier is `.extract_p()` — the x-coordinate.
-
-Phase-1 donor: `Clean/Orchard/Action/DeriveNullifier.lean`.
 -/
 
 namespace Zcash.Circuits.Action.DeriveNullifier
@@ -42,7 +40,7 @@ structure Input (F : Type) where
 deriving ProvableStruct
 
 /-- The `ConstantLength<2>` hash value is the one-padded-block hash at capacity
-`2·2^{64}`: the message is exactly one rate-2 block, so the donor scheduler's fold
+`2·2^{64}`: the message is exactly one rate-2 block, so the `ConstantLength` scheduler's fold
 is a single absorb/permute step — the value-level bridge onto the Orchard-protocol
 `Poseidon.hash` bundle's `HashPaddedBlock` contract. -/
 theorem constantLength_value_two (a b : Fp) :
@@ -162,7 +160,7 @@ def synthesize (K : FixedBase)
 
 /-- Rust `gadget.rs::derive_nullifier`: the Poseidon hash of `(nk, rho)`, the add-chip
 sum with `psi`, the `scalar • NullifierK` base-field-element fixed-base mul, and the
-complete addition with `cm`. `Spec` is the donor contract: the nullifier is
+complete addition with `cm`. `Spec` is the contract: the nullifier is
 `extract_p(cm + (poseidon_hash(nk, rho) + psi) • NullifierK)` — the x-coordinate of the
 complete sum. -/
 def circuit (K : FixedBase) : FormalCircuit Fp

--- a/Zcash/Circuits/Action/SpendAuthority.lean
+++ b/Zcash/Circuits/Action/SpendAuthority.lean
@@ -18,12 +18,11 @@ synthesis.
 
 ## Knowledge soundness
 
-The phase-1 donor (`Clean/Orchard/Action/SpendAuthority.lean`) could only state
-`∃ alpha, rk = α • SpendAuthG + ak_P` — vacuous, since `SpendAuthG` generates the group.
-Here `α` is the `FullWidth` child's extraction data (the scalar its witnessed window
-cells encode), so the `Spec` is the real knowledge-soundness statement: the extractor
-reads `α` off any satisfying assignment and `rk = α • SpendAuthG + ak_P` holds at that
-`α`, with no existential.
+An existential `∃ α, rk = α • SpendAuthG + ak_P` would be vacuous, since `SpendAuthG`
+generates the group. Instead `α` is the `FullWidth` child's extraction data (the scalar
+encoded by the child's witnessed window cells), so the `Spec` is a real knowledge-soundness
+statement. The extractor reads `α` off any satisfying assignment, and
+`rk = α • SpendAuthG + ak_P` holds at that `α`, with no existential.
 -/
 
 namespace Zcash.Circuits.Action.SpendAuthority

--- a/Zcash/Circuits/Action/ValueCommit.lean
+++ b/Zcash/Circuits/Action/ValueCommit.lean
@@ -19,8 +19,6 @@ Reference (ported from actual Rust, not memory):
    bundle; the full-width scalar lives on the child's witness boundary — the caller's
    85 window witness programs encode it, and the scalar is the extraction data);
 3. `commitment.add(blind)` (region `"complete point addition"`, `ecc/chip.rs:582-595`).
-
-Phase-1 donor: `Clean/Orchard/Action/ValueCommit.lean`.
 -/
 
 namespace Zcash.Circuits.Action.ValueCommit
@@ -194,7 +192,7 @@ theorem synthesize_copyCellsAssignedFrom
 
 /-- Rust `gadget.rs::value_commit_orchard`: `v • ValueCommitV` (short signed),
 `rcv • ValueCommitR` (full-width; the scalar is the child's extraction data), and
-the final complete addition. `Spec` is the donor contract: the commitment is
+the final complete addition. `Spec` is the contract: the commitment is
 `(±m) • V + rcv • R` at the sign-resolved magnitude with `m < 2^{64}` and the
 extracted full-width scalar. -/
 def circuit (V : Ecc.MulFixed.Short.FixedBase) (R : FixedBase) :

--- a/Zcash/Circuits/CommitIvk/Bundle.lean
+++ b/Zcash/Circuits/CommitIvk/Bundle.lean
@@ -8,9 +8,8 @@ Reference (ported from actual Rust, not memory):
 `ak/a/b/b_0/b_2/z13_a/a_prime/z13_a_prime` and witnesses `b_1`; row 1 copies
 `nk/c/d/d_0/z13_c/b2_c_prime/z14_b2_c_prime` and witnesses `d_1`.
 
-The semantic contract is the phase-1 `CommitIvk.Gate` spec verbatim; the canonicity
-value arguments are the donor row-level lemmas (`soundness_ak`/`soundness_nk` and the
-extracted `eqs_of_spec`).
+The semantic contract is the `CommitIvk.Gate` spec; the canonicity value arguments are
+the row-level lemmas (`soundness_ak`/`soundness_nk` and the extracted `eqs_of_spec`).
 -/
 
 namespace Zcash.Circuits.CommitIvk
@@ -46,7 +45,7 @@ structure Inputs (F : Type) where
   z14B2CPrime : F
 deriving ProvableStruct
 
-/-- The donor-side row at the witnessed `(b1, d1)` pair. -/
+/-- The gate row at the witnessed `(b1, d1)` pair. -/
 def toDonor (row : Inputs Fp) (b1 d1 : Fp) : DRow Fp :=
   ⟨row.ak, row.nk, row.a, row.bWhole, row.c, row.dWhole, row.b0, b1, row.b2,
     row.d0, d1, row.z13A, row.z13C, row.aPrime, row.b2CPrime, row.z13APrime,
@@ -148,8 +147,8 @@ def bundleElaborated (wb1 wd1 : WitgenIR Fp 1) :
 
 /-- Rust `CommitIvkChip` canonicity `assign` (`commit_ivk.rs:519-660`), parameterized by
 the `b_1`/`d_1` witness programs. The `(b1, d1)` readings are the extraction data;
-`Spec` is the donor `CommitIvk.Gate.Spec` at them, `Assumptions` the input-only donor
-rely-conditions (the two witnessed-bit implications move to `ProverAssumptions`). -/
+`Spec` is `CommitIvk.Gate.Spec` at them, `Assumptions` the input-only rely-conditions
+(the two witnessed-bit implications move to `ProverAssumptions`). -/
 def bundle (wb1 wd1 : WitgenIR Fp 1) :
     FormalRegionCircuit Fp Config Config Inputs unit where
   configure := pure
@@ -161,7 +160,7 @@ def bundle (wb1 wd1 : WitgenIR Fp 1) :
     (eval env (AssignedCell.of self offset (cfg.advices 4) : Var field Fp),
      eval env (AssignedCell.of self (offset + 1) (cfg.advices 4) : Var field Fp))
 
-  -- the input-only rely-conditions (donor `Assumptions` minus the witnessed-bit
+  -- the input-only rely-conditions (`Assumptions` minus the witnessed-bit
   -- implications)
   -- input-only rely-conditions: the gate itself enforces both shifts (constraints 9/13)
   Assumptions input :=

--- a/Zcash/Circuits/CommitIvk/Bundle.lean
+++ b/Zcash/Circuits/CommitIvk/Bundle.lean
@@ -16,9 +16,9 @@ namespace Zcash.Circuits.CommitIvk
 
 open Halo2
 
-private abbrev DRow := Gate.Input
-private abbrev DSpec := Gate.Spec
-private abbrev DAssumptions := Gate.Assumptions
+private abbrev GateRow := Gate.Input
+private abbrev GateSpec := Gate.Spec
+private abbrev GateAssumptions := Gate.Assumptions
 
 /-- `v·(1−v) = 0` pins a boolean. -/
 private theorem isBool_of_boolCheck {v : Fp} (h : v * (1 - v) = 0) : IsBool v := by
@@ -46,7 +46,7 @@ structure Inputs (F : Type) where
 deriving ProvableStruct
 
 /-- The gate row at the witnessed `(b1, d1)` pair. -/
-def toDonor (row : Inputs Fp) (b1 d1 : Fp) : DRow Fp :=
+def toGateRow (row : Inputs Fp) (b1 d1 : Fp) : GateRow Fp :=
   ⟨row.ak, row.nk, row.a, row.bWhole, row.c, row.dWhole, row.b0, b1, row.b2,
     row.d0, d1, row.z13A, row.z13C, row.aPrime, row.b2CPrime, row.z13APrime,
     row.z14B2CPrime⟩
@@ -173,14 +173,14 @@ def bundle (wb1 wd1 : WitgenIR Fp 1) :
     (∃ lo : ℕ, lo < 2 ^ 140 ∧
       input.b2CPrime = ((lo : ℕ) : Fp) + ((2 ^ 140 : ℕ) : Fp) * input.z14B2CPrime)
 
-  Spec := fun input _ (wit : Fp × Fp) => DSpec (toDonor input wit.1 wit.2)
+  Spec := fun input _ (wit : Fp × Fp) => GateSpec (toGateRow input wit.1 wit.2)
 
   ProverAssumptions := fun input (wit : Fp × Fp) _ =>
     (wit.1 = 1 → input.z13APrime = 0) ∧ (wit.2 = 1 → input.z14B2CPrime = 0) ∧
     input.aPrime = input.a + ((2 ^ 130 : ℕ) : Fp) - tP ∧
     input.b2CPrime = input.b2 + input.c * ((2 ^ 5 : ℕ) : Fp)
       + ((2 ^ 140 : ℕ) : Fp) - tP ∧
-    DSpec (toDonor input wit.1 wit.2)
+    GateSpec (toGateRow input wit.1 wit.2)
 
   soundness := by
     circuit_proof_start [gate, boolCheck]
@@ -229,8 +229,8 @@ def bundle (wb1 wd1 : WitgenIR Fp 1) :
         (isBool_of_boolCheck hd1c) hb2cS
         hA.2.2.2.2.2.2.2.2 hnkEq hd1d0 hd1z14
     exact ⟨hakE1, hakE2, hakE3, hnkE1, hnkE2, hnkE3, hnkE4,
-      by simp only [toDonor]; push_cast at hbW ⊢; linear_combination hbW,
-      by simp only [toDonor]; push_cast at hdW ⊢
+      by simp only [toGateRow]; push_cast at hbW ⊢; linear_combination hbW,
+      by simp only [toGateRow]; push_cast at hdW ⊢
          rw [hidx1] at hdW
          ring_nf at hdW ⊢
          linear_combination hdW⟩
@@ -278,7 +278,7 @@ def bundle (wb1 wd1 : WitgenIR Fp 1) :
     have hib2CPrime : AssignedCell.eval env.place env.env.toEnvironment input_var.b2CPrime = input.b2CPrime := congrArg Inputs.b2CPrime h_input
     have hiz14B2CPrime : AssignedCell.eval env.place env.env.toEnvironment input_var.z14B2CPrime = input.z14B2CPrime := congrArg Inputs.z14B2CPrime h_input
     have heqs := Gate.eqs_of_spec
-      (toDonor input
+      (toGateRow input
         (env.env.advice (cfg.advices 4) ((env.place self + offset : ℕ) : ℤ))
         (env.env.advice (cfg.advices 4) ((env.place self + (offset + 1) : ℕ) : ℤ)))
       ⟨hA.1, hA.2.1, hA.2.2.1, hA.2.2.2.1, hA.2.2.2.2.1, hPA.2.2.1,
@@ -287,7 +287,7 @@ def bundle (wb1 wd1 : WitgenIR Fp 1) :
       hPA.2.2.2.2
     obtain ⟨hbb1, hbd1, he3, he4, he5, he6, he7, he8, he9, he10, he11, he12,
       he13, he14⟩ := heqs
-    simp only [toDonor] at hbb1 hbd1 he3 he4 he5 he6 he7 he8 he9 he10 he11 he12 he13 he14
+    simp only [toGateRow] at hbb1 hbd1 he3 he4 he5 he6 he7 he8 he9 he10 he11 he12 he13 he14
     rw [← hibWhole, ← hib0, ← hib2, ← hwb, ← hwb0, ← hwb2] at he3
     rw [← hidWhole, ← hid0, ← hwd, ← hwd0] at he4
     rw [← hia, ← hib0, ← hiak, ← hwa, ← hwb0, ← hwak] at he5

--- a/Zcash/Circuits/CommitIvk/Composite.lean
+++ b/Zcash/Circuits/CommitIvk/Composite.lean
@@ -7,13 +7,12 @@ Reference (ported from actual Rust, not memory):
 `canon_bitshift_130` for `a' = a + 2^130 - t_P` (13-word `witness_check`), the `b2_c'`
 shift `b_2 + 2^5·c + 2^140 - t_P` (14-word `witness_check`), then the
 `"Assign cells used in canonicity gate"` region (`CommitIvkChip::assign`,
-`commit_ivk.rs:519-660`). Phase-1 donor: `CommitIvk.Canonicity`
-(`Clean/Orchard/Action/CommitIvk.lean`).
+`commit_ivk.rs:519-660`).
 
 The composite is a three-child layouter `FormalCircuit` parameterized (like the gate
-bundle) by the `b_1`/`d_1` witness programs. `Spec` is the donor composite payoff — the
-canonical bit slices of `ak`/`nk` and the `b`/`d` decompositions — at the witnessed
-`(b_1, d_1)` readings, which are the extraction data.
+bundle) by the `b_1`/`d_1` witness programs. `Spec`, the composite's guarantee, gives the
+canonical bit slices of `ak`/`nk` and the `b`/`d` decompositions at the witnessed
+`(b_1, d_1)` readings, and those readings are the extraction data.
 -/
 
 namespace Zcash.Circuits.CommitIvk
@@ -149,8 +148,8 @@ theorem circuitSynthesisSummary_lookupActivationCount
   simp only [circuitSynthesisSummary, synthesis_summary_norm]
 
 /-- Rust `CommitIvkChip` canonicity flow: the two shift `witness_check`s, then the
-`"Assign cells used in canonicity gate"` region. `Spec` is the donor composite payoff
-(`CommitIvk.Canonicity.Spec`): the canonical bit slices of `ak`/`nk` and
+`"Assign cells used in canonicity gate"` region. `Spec`, the composite's guarantee
+(`CommitIvk.Canonicity.Spec`), gives the canonical bit slices of `ak`/`nk` and
 the `b`/`d` sub-piece decompositions, at the witnessed `(b_1, d_1)` readings. -/
 def circuit (wb1 wd1 : WitgenIR Fp 1) :
     FormalCircuit Fp (Config × LookupRangeCheck.Config 10)
@@ -323,7 +322,7 @@ def circuit (wb1 wd1 : WitgenIR Fp 1) :
     rw [LookupRangeCheck.rangeCheckAt_spec_eq, rangeCheckAt_output] at hWSb
     simp only [circuit_norm, show (10 * 14 : ℕ) = 140 from by norm_num] at hWSb
     obtain ⟨hz0b, loB, hloB, htelB⟩ := hWSb
-    -- the gate child: discharge its rely-conditions, harvest the donor gate `Spec`
+    -- the gate child: discharge its rely-conditions, harvest the gate `Spec`
     rw [rangeCheckAt_output, rangeCheckAt_output] at hGate
     simp only [gateChild_assumptions_eq, gateChild_spec_eq, gateChild_extract_cells,
       circuit_norm] at hGate
@@ -388,7 +387,7 @@ def circuit (wb1 wd1 : WitgenIR Fp 1) :
       exact ⟨hA.1, hA.2.1, hA.2.2.1, hA.2.2.2.1, hA.2.2.2.2.1, hA.2.2.2.2.2.1,
         ⟨loA, hloA, by rw [hz0a]; exact htelA⟩, hA.2.2.2.2.2.2,
         ⟨loB, hloB, by rw [hz0b]; exact htelB⟩⟩
-    · -- the gate child's honest-prover precondition: tails + shifts + the donor `Spec`
+    · -- the gate child's honest-prover precondition: tails + shifts + the gate `Spec`
       rw [rangeCheckAt_output, rangeCheckAt_output]
       simp only [gateChild_proverAssumptions_eq, gateChild_extract_cells, circuit_norm]
       rw [hiak, hia, hib, hib0, hib2, hiz13a, hInputNk, hic, hid, hid0, hiz13c]
@@ -409,7 +408,7 @@ def circuit (wb1 wd1 : WitgenIR Fp 1) :
           (bit_one_of_val_eq hpa7 h1) (by norm_num)
         rw [shifted_high_zero (by norm_num) (by norm_num) hbase_lt]
         simp
-      · -- the donor gate `Spec` at the witnessed `(b_1, d_1)` readings
+      · -- the gate `Spec` at the witnessed `(b_1, d_1)` readings
         simp only [CommitIvk.toDonor, CommitIvk.Gate.Spec]
         exact ⟨hpa1, hpa2, hpa3, hpa4, hpa5, hpa6, hpa7, hpa8, hpa9⟩
 

--- a/Zcash/Circuits/CommitIvk/Composite.lean
+++ b/Zcash/Circuits/CommitIvk/Composite.lean
@@ -333,7 +333,7 @@ def circuit (wb1 wd1 : WitgenIR Fp 1) :
     have hGSpec := hGate trivial
       ⟨hA.1, hA.2.1, hA.2.2.1, hA.2.2.2.1, hA.2.2.2.2.1, hA.2.2.2.2.2.1,
        ⟨loA, hloA, htelA⟩, hA.2.2.2.2.2.2, ⟨loB, hloB, htelB⟩⟩
-    simp only [CommitIvk.toDonor,
+    simp only [CommitIvk.toGateRow,
       CommitIvk.Gate.Spec] at hGSpec
     exact hGSpec
 
@@ -409,7 +409,7 @@ def circuit (wb1 wd1 : WitgenIR Fp 1) :
         rw [shifted_high_zero (by norm_num) (by norm_num) hbase_lt]
         simp
       · -- the gate `Spec` at the witnessed `(b_1, d_1)` readings
-        simp only [CommitIvk.toDonor, CommitIvk.Gate.Spec]
+        simp only [CommitIvk.toGateRow, CommitIvk.Gate.Spec]
         exact ⟨hpa1, hpa2, hpa3, hpa4, hpa5, hpa6, hpa7, hpa8, hpa9⟩
 
 @[keygen_norm]

--- a/Zcash/Circuits/CommitIvk/MainBundle.lean
+++ b/Zcash/Circuits/CommitIvk/MainBundle.lean
@@ -31,43 +31,6 @@ private theorem short_output (b : ℕ) (cfg : LookupRangeCheck.Config 10)
 
 /-! ## Value-level infrastructure -/
 
-/-- The ironwood `Chain.PieceChunks` is the donor's, verbatim. -/
-private theorem pieceChunks_donor_iff :
-    ∀ (ms : List ℕ) (pieces : Vector Fp ms.length) (chunks : List ℕ),
-      Sinsemilla.Chain.PieceChunks ms pieces chunks ↔
-      Sinsemilla.Chain.PieceChunks ms pieces chunks := by
-  intro ms
-  induction ms with
-  | nil =>
-    intro pieces chunks
-    simp only [Sinsemilla.Chain.PieceChunks, Sinsemilla.Chain.PieceChunks]
-  | cons n rest ih =>
-    intro pieces chunks
-    constructor
-    · rintro ⟨msf, h1, h2, tailChunks, h3, h4⟩
-      exact ⟨msf, h1, h2, tailChunks, h3, (ih _ _).mp h4⟩
-    · rintro ⟨msf, h1, h2, tailChunks, h3, h4⟩
-      exact ⟨msf, h1, h2, tailChunks, h3, (ih _ _).mpr h4⟩
-
-/-- The ironwood `Chain.ZsFacts` is the donor's, verbatim. -/
-private theorem zsFacts_donor_iff :
-    ∀ (ms : List ℕ) (chunks : List ℕ)
-      (zs : Sinsemilla.HVec (Sinsemilla.Chain.zLengths ms) Fp),
-      Sinsemilla.Chain.ZsFacts ms chunks zs ↔
-      Sinsemilla.Chain.ZsFacts ms chunks zs := by
-  intro ms
-  induction ms with
-  | nil =>
-    intro chunks zs
-    simp only [Sinsemilla.Chain.ZsFacts, Sinsemilla.Chain.ZsFacts]
-  | cons n rest ih =>
-    intro chunks zs
-    constructor
-    · rintro ⟨h1, h2⟩
-      exact ⟨h1, (ih _ _).mp h2⟩
-    · rintro ⟨h1, h2⟩
-      exact ⟨h1, (ih _ _).mpr h2⟩
-
 /-- The hash child's extracted running sums are the `bits`-column reads. -/
 private theorem hashExtract_zs (G : Generators) (Q : Point Fp) (hQ : Q.OnCurve)
     (cfg : Sinsemilla.HashPiece.Config)
@@ -160,21 +123,19 @@ theorem soundness (G : Generators) (R : FixedBase) (Q : Point Fp)
   simp only [circuit_norm] at hCmS
   obtain ⟨chunks, hPC, hZs, hContract⟩ := hCmS
   rw [hashExtract_zs] at hZs
-  have hPC' := (pieceChunks_donor_iff _ _ _).mp hPC
-  have hZs' := (zsFacts_donor_iff _ _ _).mp hZs
   -- the two hash running-sum value facts
   have hz13a := NoteCommit.zsFacts_cell ns _ chunks _
-    ⟨0, by decide⟩ hPC' hZs' (by decide) (r := 13) (by decide)
+    ⟨0, by decide⟩ hPC hZs (by decide) (r := 13) (by decide)
   rw [zs_get_z13a] at hz13a
   have hz13c := NoteCommit.zsFacts_cell ns _ chunks _
-    ⟨2, by decide⟩ hPC' hZs' (by decide) (r := 13) (by decide)
+    ⟨2, by decide⟩ hPC hZs (by decide) (r := 13) (by decide)
   rw [zs_get_z13c] at hz13c
   simp only [Nat.add_assoc, Nat.reduceAdd] at hz13a hz13c
   -- the piece value bounds
   have hpieceA := NoteCommit.pieceChunks_val_lt ns _ chunks
-    ⟨0, by decide⟩ hPC' (by decide)
+    ⟨0, by decide⟩ hPC (by decide)
   have hpieceC := NoteCommit.pieceChunks_val_lt ns _ chunks
-    ⟨2, by decide⟩ hPC' (by decide)
+    ⟨2, by decide⟩ hPC (by decide)
   -- ── the canonicity composite ──
   subcircuit_rw at hCan
   have hCanS := hCan (by rw [Canonicity.circuit_envAssumptions_eq]; exact ⟨hTableL, hDistinct⟩)
@@ -259,7 +220,7 @@ theorem soundness (G : Generators) (R : FixedBase) (Q : Point Fp)
     push_cast
     ring
   have hchunks := CommitIvk.pieceChunks_eq_commitIvkChunks_of_indexed_piece_values
-    hPC'
+    hPC
     (by with_unfolding_all exact hAv)
     (by with_unfolding_all exact hBv)
     (by with_unfolding_all exact hCv)
@@ -294,30 +255,6 @@ theorem soundness (G : Generators) (R : FixedBase) (Q : Point Fp)
   rfl
 
 /-! ## Completeness infrastructure -/
-
-private theorem pieceBounds_donor_iff :
-    ∀ (ms : List ℕ) (pieces : Vector Fp ms.length),
-      Sinsemilla.Chain.PieceBounds ms pieces ↔
-      Sinsemilla.Chain.PieceBounds ms pieces := by
-  intro ms
-  induction ms with
-  | nil =>
-    intro pieces
-    simp only [Sinsemilla.Chain.PieceBounds, Sinsemilla.Chain.PieceBounds]
-  | cons n rest ih =>
-    intro pieces
-    constructor
-    · rintro ⟨h1, h2⟩
-      exact ⟨h1, (ih _).mp h2⟩
-    · rintro ⟨h1, h2⟩
-      exact ⟨h1, (ih _).mpr h2⟩
-
-private theorem honestChunks_donor_eq :
-    ∀ (ms : List ℕ) (pieces : Vector Fp ms.length),
-      Sinsemilla.Chain.honestChunks ms pieces
-        = Sinsemilla.Chain.honestChunks ms pieces := by
-  intro ms pieces
-  rfl
 
 private theorem short_extract_eq' (b : ℕ) (cfg : LookupRangeCheck.Config 10)
     (i : RegionIndex) (env : Placed Environment Fp) :
@@ -493,22 +430,21 @@ theorem completeness (G : Generators) (R : FixedBase) (Q : Point Fp)
     (env.advice cfg.hashConfig.witnessPieces ((place (i₀ + 4) : ℕ) : ℤ))
     (env.advice cfg.hashConfig.witnessPieces ((place (i₀ + 6) : ℕ) : ℤ))
     hwa (by rw [hwb]) hwc (by rw [hwd])
-  obtain ⟨hPBdonor, hHonestDonor⟩ := hHF
+  obtain ⟨hPB₀, hHonest₀⟩ := hHF
   have hPB : Sinsemilla.Chain.PieceBounds ns
       #v[env.advice cfg.hashConfig.witnessPieces ((place i₀ : ℕ) : ℤ),
         env.advice cfg.hashConfig.witnessPieces ((place (i₀ + 3) : ℕ) : ℤ),
         env.advice cfg.hashConfig.witnessPieces ((place (i₀ + 4) : ℕ) : ℤ),
         env.advice cfg.hashConfig.witnessPieces ((place (i₀ + 6) : ℕ) : ℤ)] :=
-    (pieceBounds_donor_iff _ _).mpr hPBdonor
+    hPB₀
   have hHonest : Sinsemilla.Chain.honestChunks ns
       #v[env.advice cfg.hashConfig.witnessPieces ((place i₀ : ℕ) : ℤ),
         env.advice cfg.hashConfig.witnessPieces ((place (i₀ + 3) : ℕ) : ℤ),
         env.advice cfg.hashConfig.witnessPieces ((place (i₀ + 4) : ℕ) : ℤ),
         env.advice cfg.hashConfig.witnessPieces ((place (i₀ + 6) : ℕ) : ℤ)]
       = commitIvkChunks (show Fp from input_ak).val (show Fp from input_nk).val := by
-    rw [honestChunks_donor_eq]
-    rw [hiak, hInputNk] at hHonestDonor
-    exact hHonestDonor
+    rw [hiak, hInputNk] at hHonest₀
+    exact hHonest₀
   -- ── derived commit contract (the composite's rely-conditions) ──
   have hPB2 : Sinsemilla.Chain.PieceBounds ns
       (eval (⟨place, env⟩ : Placed ProverEnvironment Fp)
@@ -544,19 +480,17 @@ theorem completeness (G : Generators) (R : FixedBase) (Q : Point Fp)
   rw [hashExtract_zs] at hZs
   rw [pieces_eval_eq_env] at hPC
   try simp only [circuit_norm, Nat.add_zero] at hPC
-  have hPC' := (pieceChunks_donor_iff _ _ _).mp hPC
-  have hZs' := (zsFacts_donor_iff _ _ _).mp hZs
   have hz13a := NoteCommit.zsFacts_cell ns _ chunks _
-    ⟨0, by decide⟩ hPC' hZs' (by decide) (r := 13) (by decide)
+    ⟨0, by decide⟩ hPC hZs (by decide) (r := 13) (by decide)
   rw [zs_get_z13a] at hz13a
   have hz13c := NoteCommit.zsFacts_cell ns _ chunks _
-    ⟨2, by decide⟩ hPC' hZs' (by decide) (r := 13) (by decide)
+    ⟨2, by decide⟩ hPC hZs (by decide) (r := 13) (by decide)
   rw [zs_get_z13c] at hz13c
   simp only [Nat.add_assoc, Nat.reduceAdd] at hz13a hz13c
   have hpieceA := NoteCommit.pieceChunks_val_lt ns _ chunks
-    ⟨0, by decide⟩ hPC' (by decide)
+    ⟨0, by decide⟩ hPC (by decide)
   have hpieceC := NoteCommit.pieceChunks_val_lt ns _ chunks
-    ⟨2, by decide⟩ hPC' (by decide)
+    ⟨2, by decide⟩ hPC (by decide)
   -- the b1/d1 gate-internal witnesses
   have hbits := canon_bit_witness (brWit input_var_ak 254 1) (brWit input_var_nk 254 1)
     (cfg.gate, cfg.lookupConfig) _ (i₀ + 11) place env hWCan

--- a/Zcash/Circuits/NoteCommit/Canonicity.lean
+++ b/Zcash/Circuits/NoteCommit/Canonicity.lean
@@ -25,9 +25,9 @@ private theorem isBool_of_boolCheck' {v : Fp} (h : v * (1 - v) = 0) : IsBool v :
 
 namespace ValueCanonicity
 
-private abbrev DRow := NoteCommit.ValueCanonicity.Gate.Row
-private abbrev DSpec := NoteCommit.ValueCanonicity.Gate.Spec
-private abbrev DAssumptions := NoteCommit.ValueCanonicity.Gate.Assumptions
+private abbrev GateRow := NoteCommit.ValueCanonicity.Gate.Row
+private abbrev GateSpec := NoteCommit.ValueCanonicity.Gate.Spec
+private abbrev GateAssumptions := NoteCommit.ValueCanonicity.Gate.Assumptions
 
 structure Row (F : Type) where
   value : F
@@ -37,7 +37,7 @@ structure Row (F : Type) where
 deriving ProvableStruct
 
 /-- The gate row record. -/
-def toDonor (row : Row Fp) : DRow Fp :=
+def toGateRow (row : Row Fp) : GateRow Fp :=
   { value := row.value, d2 := row.d2, d3 := row.d3, e0 := row.e0 }
 
 def synthesisSummary (cfg : Config) (offset : ℕ) :
@@ -94,9 +94,9 @@ def bundle : FormalRegionCircuit Fp Config Config Row unit where
             synthesis_summary_norm]
         · simp only [ValueCanonicity.synthesisSummary, bundleSynthesize, circuit_norm,
             synthesis_summary_norm] }
-  Assumptions input := DAssumptions (toDonor input)
+  Assumptions input := GateAssumptions (toGateRow input)
 
-  Spec input _ _ := DSpec (toDonor input)
+  Spec input _ _ := GateSpec (toGateRow input)
 
   ProverAssumptions input _ _ :=
     input.value = input.d2 + input.d3 * (2 ^ 8 : Fp) + input.e0 * (2 ^ 58 : Fp)
@@ -125,9 +125,9 @@ end ValueCanonicity
 
 namespace GdCanonicity
 
-private abbrev DRow := NoteCommit.GdCanonicity.Gate.Row
-private abbrev DSpec := NoteCommit.GdCanonicity.Gate.Spec
-private abbrev DAssumptions := NoteCommit.GdCanonicity.Gate.Assumptions
+private abbrev GateRow := NoteCommit.GdCanonicity.Gate.Row
+private abbrev GateSpec := NoteCommit.GdCanonicity.Gate.Spec
+private abbrev GateAssumptions := NoteCommit.GdCanonicity.Gate.Assumptions
 
 structure Row (F : Type) where
   gdX : F
@@ -140,7 +140,7 @@ structure Row (F : Type) where
 deriving ProvableStruct
 
 /-- The gate row record. -/
-def toDonor (row : Row Fp) : DRow Fp :=
+def toGateRow (row : Row Fp) : GateRow Fp :=
   ⟨row.gdX, row.b0, row.b1, row.a, row.aPrime, row.z13A, row.z13APrime⟩
 
 def synthesisSummary (cfg : Config) (offset : ℕ) :
@@ -217,9 +217,9 @@ def bundle : FormalRegionCircuit Fp Config Config Row unit where
     ∃ lo : ℕ, lo < 2 ^ 130 ∧
       input.aPrime = ((lo : ℕ) : Fp) + ((2 ^ 130 : ℕ) : Fp) * input.z13APrime
 
-  Spec input _ _ := DSpec (toDonor input)
+  Spec input _ _ := GateSpec (toGateRow input)
 
-  ProverAssumptions input _ _ := DSpec (toDonor input) ∧
+  ProverAssumptions input _ _ := GateSpec (toGateRow input) ∧
     input.aPrime = input.a + ((2 ^ 130 : ℕ) : Fp) - tP
 
   soundness := by
@@ -241,11 +241,11 @@ def bundle : FormalRegionCircuit Fp Config Config Row unit where
   completeness := by
     circuit_proof_start [gate]
     have heqs := NoteCommit.GdCanonicity.Gate.eqs_of_spec
-      (toDonor { gdX := input_gdX, b0 := input_b0, b1 := input_b1, a := input_a,
-                 aPrime := input_aPrime, z13A := input_z13A, z13APrime := input_z13APrime })
+      (toGateRow { gdX := input_gdX, b0 := input_b0, b1 := input_b1, a := input_a,
+                   aPrime := input_aPrime, z13A := input_z13A, z13APrime := input_z13APrime })
       ⟨hA.1, hA.2.1, hA.2.2.1, hPA.2, hA.2.2.2.1, hA.2.2.2.2⟩ hPA.1
     obtain ⟨he1, he2, he3, he4, he5⟩ := heqs
-    simp only [toDonor] at he1 he2 he3 he4 he5
+    simp only [toGateRow] at he1 he2 he3 he4 he5
     refine ⟨?_, ?_, ?_, ?_, ?_⟩
     · push_cast at he1 ⊢
       linear_combination he1
@@ -267,9 +267,9 @@ end GdCanonicity
 
 namespace PkdCanonicity
 
-private abbrev DRow := NoteCommit.PkdCanonicity.Gate.Row
-private abbrev DSpec := NoteCommit.PkdCanonicity.Gate.Spec
-private abbrev DAssumptions := NoteCommit.PkdCanonicity.Gate.Assumptions
+private abbrev GateRow := NoteCommit.PkdCanonicity.Gate.Row
+private abbrev GateSpec := NoteCommit.PkdCanonicity.Gate.Spec
+private abbrev GateAssumptions := NoteCommit.PkdCanonicity.Gate.Assumptions
 
 structure Row (F : Type) where
   pkdX : F
@@ -282,7 +282,7 @@ structure Row (F : Type) where
 deriving ProvableStruct
 
 /-- The gate row record. -/
-def toDonor (row : Row Fp) : DRow Fp :=
+def toGateRow (row : Row Fp) : GateRow Fp :=
   ⟨row.pkdX, row.b3, row.d0, row.c, row.b3CPrime, row.z13C, row.z14B3CPrime⟩
 
 def synthesisSummary (cfg : Config) (offset : ℕ) :
@@ -359,9 +359,9 @@ def bundle : FormalRegionCircuit Fp Config Config Row unit where
     ∃ lo : ℕ, lo < 2 ^ 140 ∧
       input.b3CPrime = ((lo : ℕ) : Fp) + ((2 ^ 140 : ℕ) : Fp) * input.z14B3CPrime
 
-  Spec input _ _ := DSpec (toDonor input)
+  Spec input _ _ := GateSpec (toGateRow input)
 
-  ProverAssumptions input _ _ := DSpec (toDonor input) ∧
+  ProverAssumptions input _ _ := GateSpec (toGateRow input) ∧
     input.b3CPrime = input.b3 + input.c * ((2 ^ 4 : ℕ) : Fp) + ((2 ^ 140 : ℕ) : Fp) - tP
 
   soundness := by
@@ -383,12 +383,12 @@ def bundle : FormalRegionCircuit Fp Config Config Row unit where
   completeness := by
     circuit_proof_start [gate]
     have heqs := NoteCommit.PkdCanonicity.Gate.eqs_of_spec
-      (toDonor { pkdX := input_pkdX, b3 := input_b3, d0 := input_d0, c := input_c,
-                 b3CPrime := input_b3CPrime, z13C := input_z13C,
-                 z14B3CPrime := input_z14B3CPrime })
+      (toGateRow { pkdX := input_pkdX, b3 := input_b3, d0 := input_d0, c := input_c,
+                   b3CPrime := input_b3CPrime, z13C := input_z13C,
+                   z14B3CPrime := input_z14B3CPrime })
       ⟨hA.1, hA.2.1, hA.2.2.1, hPA.2, hA.2.2.2.1, hA.2.2.2.2⟩ hPA.1
     obtain ⟨he1, he2, he3, he4⟩ := heqs
-    simp only [toDonor] at he1 he2 he3 he4
+    simp only [toGateRow] at he1 he2 he3 he4
     refine ⟨?_, ?_, ?_, ?_⟩
     · push_cast at he1 ⊢
       linear_combination he1
@@ -409,9 +409,9 @@ end PkdCanonicity
 
 namespace RhoCanonicity
 
-private abbrev DRow := NoteCommit.RhoCanonicity.Gate.Row
-private abbrev DSpec := NoteCommit.RhoCanonicity.Gate.Spec
-private abbrev DAssumptions := NoteCommit.RhoCanonicity.Gate.Assumptions
+private abbrev GateRow := NoteCommit.RhoCanonicity.Gate.Row
+private abbrev GateSpec := NoteCommit.RhoCanonicity.Gate.Spec
+private abbrev GateAssumptions := NoteCommit.RhoCanonicity.Gate.Assumptions
 
 structure Row (F : Type) where
   rho : F
@@ -424,7 +424,7 @@ structure Row (F : Type) where
 deriving ProvableStruct
 
 /-- The gate row record. -/
-def toDonor (row : Row Fp) : DRow Fp :=
+def toGateRow (row : Row Fp) : GateRow Fp :=
   ⟨row.rho, row.e1, row.g0, row.f, row.e1FPrime, row.z13F, row.z14E1FPrime⟩
 
 def synthesisSummary (cfg : Config) (offset : ℕ) :
@@ -501,9 +501,9 @@ def bundle : FormalRegionCircuit Fp Config Config Row unit where
     ∃ lo : ℕ, lo < 2 ^ 140 ∧
       input.e1FPrime = ((lo : ℕ) : Fp) + ((2 ^ 140 : ℕ) : Fp) * input.z14E1FPrime
 
-  Spec input _ _ := DSpec (toDonor input)
+  Spec input _ _ := GateSpec (toGateRow input)
 
-  ProverAssumptions input _ _ := DSpec (toDonor input) ∧
+  ProverAssumptions input _ _ := GateSpec (toGateRow input) ∧
     input.e1FPrime = input.e1 + input.f * ((2 ^ 4 : ℕ) : Fp) + ((2 ^ 140 : ℕ) : Fp) - tP
 
   soundness := by
@@ -525,12 +525,12 @@ def bundle : FormalRegionCircuit Fp Config Config Row unit where
   completeness := by
     circuit_proof_start [gate]
     have heqs := NoteCommit.RhoCanonicity.Gate.eqs_of_spec
-      (toDonor { rho := input_rho, e1 := input_e1, g0 := input_g0, f := input_f,
-                 e1FPrime := input_e1FPrime, z13F := input_z13F,
-                 z14E1FPrime := input_z14E1FPrime })
+      (toGateRow { rho := input_rho, e1 := input_e1, g0 := input_g0, f := input_f,
+                   e1FPrime := input_e1FPrime, z13F := input_z13F,
+                   z14E1FPrime := input_z14E1FPrime })
       ⟨hA.1, hA.2.1, hA.2.2.1, hPA.2, hA.2.2.2.1, hA.2.2.2.2⟩ hPA.1
     obtain ⟨he1, he2, he3, he4⟩ := heqs
-    simp only [toDonor] at he1 he2 he3 he4
+    simp only [toGateRow] at he1 he2 he3 he4
     refine ⟨?_, ?_, ?_, ?_⟩
     · push_cast at he1 ⊢
       linear_combination he1
@@ -551,9 +551,9 @@ end RhoCanonicity
 
 namespace PsiCanonicity
 
-private abbrev DRow := NoteCommit.PsiCanonicity.Gate.Row
-private abbrev DSpec := NoteCommit.PsiCanonicity.Gate.Spec
-private abbrev DAssumptions := NoteCommit.PsiCanonicity.Gate.Assumptions
+private abbrev GateRow := NoteCommit.PsiCanonicity.Gate.Row
+private abbrev GateSpec := NoteCommit.PsiCanonicity.Gate.Spec
+private abbrev GateAssumptions := NoteCommit.PsiCanonicity.Gate.Assumptions
 
 structure Row (F : Type) where
   psi : F
@@ -567,7 +567,7 @@ structure Row (F : Type) where
 deriving ProvableStruct
 
 /-- The gate row record. -/
-def toDonor (row : Row Fp) : DRow Fp :=
+def toGateRow (row : Row Fp) : GateRow Fp :=
   ⟨row.psi, row.h0, row.g1, row.h1, row.g2, row.g1G2Prime, row.z13G, row.z13G1G2Prime⟩
 
 def synthesisSummary (cfg : Config) (offset : ℕ) :
@@ -647,9 +647,9 @@ def bundle : FormalRegionCircuit Fp Config Config Row unit where
     ∃ lo : ℕ, lo < 2 ^ 130 ∧
       input.g1G2Prime = ((lo : ℕ) : Fp) + ((2 ^ 130 : ℕ) : Fp) * input.z13G1G2Prime
 
-  Spec input _ _ := DSpec (toDonor input)
+  Spec input _ _ := GateSpec (toGateRow input)
 
-  ProverAssumptions input _ _ := DSpec (toDonor input) ∧
+  ProverAssumptions input _ _ := GateSpec (toGateRow input) ∧
     input.g1G2Prime = input.g1 + input.g2 * ((2 ^ 9 : ℕ) : Fp)
       + ((2 ^ 130 : ℕ) : Fp) - tP
 
@@ -673,12 +673,12 @@ def bundle : FormalRegionCircuit Fp Config Config Row unit where
   completeness := by
     circuit_proof_start [gate]
     have heqs := NoteCommit.PsiCanonicity.Gate.eqs_of_spec
-      (toDonor { psi := input_psi, h0 := input_h0, g1 := input_g1, h1 := input_h1,
-                 g2 := input_g2, g1G2Prime := input_g1G2Prime, z13G := input_z13G,
-                 z13G1G2Prime := input_z13G1G2Prime })
+      (toGateRow { psi := input_psi, h0 := input_h0, g1 := input_g1, h1 := input_h1,
+                   g2 := input_g2, g1G2Prime := input_g1G2Prime, z13G := input_z13G,
+                   z13G1G2Prime := input_z13G1G2Prime })
       ⟨hA.1, hA.2.1, hA.2.2.1, hA.2.2.2.1, hPA.2, hA.2.2.2.2.1, hA.2.2.2.2.2⟩ hPA.1
     obtain ⟨he1, he2, he3, he4, he5⟩ := heqs
-    simp only [toDonor] at he1 he2 he3 he4 he5
+    simp only [toGateRow] at he1 he2 he3 he4 he5
     refine ⟨?_, ?_, ?_, ?_, ?_⟩
     · push_cast at he1 ⊢
       linear_combination he1
@@ -700,9 +700,9 @@ end PsiCanonicity
 
 namespace YCanonicity
 
-private abbrev DRow := NoteCommit.YCanonicity.Gate.Row
-private abbrev DSpec := NoteCommit.YCanonicity.Gate.Spec
-private abbrev DAssumptions := NoteCommit.YCanonicity.Gate.Assumptions
+private abbrev GateRow := NoteCommit.YCanonicity.Gate.Row
+private abbrev GateSpec := NoteCommit.YCanonicity.Gate.Spec
+private abbrev GateAssumptions := NoteCommit.YCanonicity.Gate.Assumptions
 
 /-- The copied-in cells (the `lsb`/`k_3` sign bits are witnessed in-region). -/
 structure Row (F : Type) where
@@ -717,7 +717,7 @@ structure Row (F : Type) where
 deriving ProvableStruct
 
 /-- The gate row at the witnessed `(lsb, k3)` pair. -/
-def toDonor (row : Row Fp) (lsb k3 : Fp) : DRow Fp :=
+def toGateRow (row : Row Fp) (lsb k3 : Fp) : GateRow Fp :=
   ⟨row.y, lsb, row.k0, row.k2, k3, row.j, row.z1J, row.z13J, row.jPrime,
     row.z13JPrime⟩
 
@@ -823,10 +823,10 @@ def bundle (wlsb wk3 : WitgenIR Fp 1) :
       input.jPrime = ((lo : ℕ) : Fp) + ((2 ^ 130 : ℕ) : Fp) * input.z13JPrime
 
   Spec := fun input (out : Fp) (wit : Fp × Fp) =>
-    out = wit.1 ∧ (IsBool out → DSpec (toDonor input out wit.2))
+    out = wit.1 ∧ (IsBool out → GateSpec (toGateRow input out wit.2))
 
   ProverAssumptions := fun input (wit : Fp × Fp) _ =>
-    IsBool wit.1 ∧ DSpec (toDonor input wit.1 wit.2) ∧
+    IsBool wit.1 ∧ GateSpec (toGateRow input wit.1 wit.2) ∧
     input.jPrime = input.j + ((2 ^ 130 : ℕ) : Fp) - tP
 
   ProverSpec := fun _ (out : Fp) (wit : Fp × Fp) _ => out = wit.1
@@ -847,28 +847,28 @@ def bundle (wlsb wk3 : WitgenIR Fp 1) :
     rw [hidx] at hk3c hyc hg1 hg3
     exact ⟨trivial, fun hbool =>
       NoteCommit.YCanonicity.Gate.spec_of_eqs
-        (toDonor ⟨input_y, input_k0, input_k2, input_j, input_z1J, input_z13J,
+        (toGateRow ⟨input_y, input_k0, input_k2, input_j, input_z1J, input_z13J,
           input_jPrime, input_z13JPrime⟩ _ _)
         ⟨hbool, hA.1, hA.2.1, hA.2.2.1, hjP, hA.2.2.2.1,
           hA.2.2.2.2.1, hA.2.2.2.2.2⟩
         (isBool_of_boolCheck' hk3c)
-        (by simp only [toDonor]; linear_combination hjdec)
-        (by simp only [toDonor]; push_cast at hyc ⊢; linear_combination hyc)
-        (by simp only [toDonor]; push_cast at hg1 ⊢; linear_combination hg1)
-        (by simp only [toDonor]; push_cast at hg3 ⊢; linear_combination hg3)⟩
+        (by simp only [toGateRow]; linear_combination hjdec)
+        (by simp only [toGateRow]; push_cast at hyc ⊢; linear_combination hyc)
+        (by simp only [toGateRow]; push_cast at hg1 ⊢; linear_combination hg1)
+        (by simp only [toGateRow]; push_cast at hg3 ⊢; linear_combination hg3)⟩
 
   completeness := by
     circuit_proof_start [gate, boolCheck]
     have heqs := NoteCommit.YCanonicity.Gate.eqs_of_spec
-      (toDonor { y := input_y, k0 := input_k0, k2 := input_k2, j := input_j,
-                 z1J := input_z1J, z13J := input_z13J, jPrime := input_jPrime,
-                 z13JPrime := input_z13JPrime }
+      (toGateRow { y := input_y, k0 := input_k0, k2 := input_k2, j := input_j,
+                   z1J := input_z1J, z13J := input_z13J, jPrime := input_jPrime,
+                   z13JPrime := input_z13JPrime }
         (Witgen.WitgenIROver.eval wlsb ⟨place, env⟩)[0]
         (Witgen.WitgenIROver.eval wk3 ⟨place, env⟩)[0])
       ⟨hPA.1, hA.1, hA.2.1, hA.2.2.1, hPA.2.2, hA.2.2.2.1,
         hA.2.2.2.2.1, hA.2.2.2.2.2⟩ hPA.2.1
     obtain ⟨hb, he2, he3, he4, he5, he6, he7⟩ := heqs
-    simp only [toDonor] at hb he2 he3 he4 he5 he6 he7
+    simp only [toGateRow] at hb he2 he3 he4 he5 he6 he7
     refine ⟨⟨?_, ?_, ?_, ?_, ?_, ?_, ?_⟩, h_output.symm⟩
     · rcases hb with h | h <;> rw [h] <;> ring
     · linear_combination he2

--- a/Zcash/Circuits/NoteCommit/Canonicity.lean
+++ b/Zcash/Circuits/NoteCommit/Canonicity.lean
@@ -6,11 +6,11 @@ Reference (ported from Rust):
 `orchard@0.14.0/src/circuit/note_commit.rs` — the input-canonicity `assign` regions
 (`"NoteCommit input value"` 994-1035: pure copies of `value`/`d_2`/`d_3 = z1_d`/`e_0`).
 
-The semantic contracts are the phase-1 gate specs (`Clean/Orchard/Action/Canonicity.lean`)
-verbatim; the heavyweight canonicity value arguments are REUSED wholesale via the
-donor-replay bridge: the donor `Gate.circuit` is a main-Clean `FormalAssertion` over the
-same field equations, so applying its `soundness` at offset 0, a trivial environment and
-const-lifted inputs turns the ironwood-landed equations into the donor `Spec`.
+The semantic contracts are the gate specs. The heavyweight canonicity value arguments come
+from the gate circuits by replay: each `Gate.circuit` is a main-Clean `FormalAssertion` over
+the same field equations, so applying the gate circuit's `soundness` at offset 0, with a
+trivial environment and const-lifted inputs, turns the region's equations into the gate
+`Spec`.
 -/
 
 namespace Zcash.Circuits.NoteCommit
@@ -36,7 +36,7 @@ structure Row (F : Type) where
   e0 : F
 deriving ProvableStruct
 
-/-- The donor-side row record. -/
+/-- The gate row record. -/
 def toDonor (row : Row Fp) : DRow Fp :=
   { value := row.value, d2 := row.d2, d3 := row.d3, e0 := row.e0 }
 
@@ -67,8 +67,8 @@ def bundleSynthesize (cfg : Config) (offset : ℕ)
   pure ()
 
 /-- Rust `ValueCanonicity::assign` (`note_commit.rs:994-1035`): pure copies. `Spec` is
-the donor `ValueCanonicity.Gate.Spec` (canonical 64-bit value with its slices);
-`Assumptions` the donor rely-conditions (the slices are range-checked). -/
+`ValueCanonicity.Gate.Spec` (canonical 64-bit value with its slices);
+`Assumptions` the rely-conditions (the slices are range-checked). -/
 def bundle : FormalRegionCircuit Fp Config Config Row unit where
   configure := pure
   synthesize := bundleSynthesize
@@ -139,7 +139,7 @@ structure Row (F : Type) where
   z13APrime : F
 deriving ProvableStruct
 
-/-- The donor-side row record. -/
+/-- The gate row record. -/
 def toDonor (row : Row Fp) : DRow Fp :=
   ⟨row.gdX, row.b0, row.b1, row.a, row.aPrime, row.z13A, row.z13APrime⟩
 
@@ -203,8 +203,8 @@ def bundleElaborated :
           synthesis_summary_norm] }
 
 /-- Rust `GdCanonicity::assign` (`note_commit.rs:789-841`): pure copies (rows 0/1 of
-`col_l/m/r/z`), gate enabled at row 0. `Spec`/`Assumptions` are the donor
-`GdCanonicity.Gate` contract; the canonicity value argument is the donor `spec_of_eqs`. -/
+`col_l/m/r/z`), gate enabled at row 0. `Spec`/`Assumptions` are the
+`GdCanonicity.Gate` contract; the canonicity value argument is `spec_of_eqs`. -/
 def bundle : FormalRegionCircuit Fp Config Config Row unit where
   configure := pure
   synthesize := bundleSynthesize
@@ -281,7 +281,7 @@ structure Row (F : Type) where
   z14B3CPrime : F
 deriving ProvableStruct
 
-/-- The donor-side row record. -/
+/-- The gate row record. -/
 def toDonor (row : Row Fp) : DRow Fp :=
   ⟨row.pkdX, row.b3, row.d0, row.c, row.b3CPrime, row.z13C, row.z14B3CPrime⟩
 
@@ -336,8 +336,8 @@ theorem bundleSynthesisSummary_eq (cfg : Config) (offset : ℕ)
       synthesis_summary_norm]
 
 /-- Rust `PkdCanonicity::assign` (`note_commit.rs:789-841`): pure copies (rows 0/1 of
-`col_l/m/r/z`), gate enabled at row 0. `Spec`/`Assumptions` are the donor
-`PkdCanonicity.Gate` contract; the canonicity value argument is the donor `spec_of_eqs`. -/
+`col_l/m/r/z`), gate enabled at row 0. `Spec`/`Assumptions` are the
+`PkdCanonicity.Gate` contract; the canonicity value argument is `spec_of_eqs`. -/
 def bundle : FormalRegionCircuit Fp Config Config Row unit where
   configure := pure
   synthesize := bundleSynthesize
@@ -423,7 +423,7 @@ structure Row (F : Type) where
   z14E1FPrime : F
 deriving ProvableStruct
 
-/-- The donor-side row record. -/
+/-- The gate row record. -/
 def toDonor (row : Row Fp) : DRow Fp :=
   ⟨row.rho, row.e1, row.g0, row.f, row.e1FPrime, row.z13F, row.z14E1FPrime⟩
 
@@ -478,8 +478,8 @@ theorem bundleSynthesisSummary_eq (cfg : Config) (offset : ℕ)
       synthesis_summary_norm]
 
 /-- Rust `RhoCanonicity::assign` (`note_commit.rs:789-841`): pure copies (rows 0/1 of
-`col_l/m/r/z`), gate enabled at row 0. `Spec`/`Assumptions` are the donor
-`RhoCanonicity.Gate` contract; the canonicity value argument is the donor `spec_of_eqs`. -/
+`col_l/m/r/z`), gate enabled at row 0. `Spec`/`Assumptions` are the
+`RhoCanonicity.Gate` contract; the canonicity value argument is `spec_of_eqs`. -/
 def bundle : FormalRegionCircuit Fp Config Config Row unit where
   configure := pure
   synthesize := bundleSynthesize
@@ -566,7 +566,7 @@ structure Row (F : Type) where
   z13G1G2Prime : F
 deriving ProvableStruct
 
-/-- The donor-side row record. -/
+/-- The gate row record. -/
 def toDonor (row : Row Fp) : DRow Fp :=
   ⟨row.psi, row.h0, row.g1, row.h1, row.g2, row.g1G2Prime, row.z13G, row.z13G1G2Prime⟩
 
@@ -623,7 +623,7 @@ theorem bundleSynthesisSummary_eq (cfg : Config) (offset : ℕ)
       synthesis_summary_norm]
 
 /-- Rust `PsiCanonicity::assign` (`note_commit.rs:1240-1274`): pure copies (rows 0/1 of
-`col_l/m/r/z`), gate enabled at row 0. `Spec`/`Assumptions` are the donor
+`col_l/m/r/z`), gate enabled at row 0. `Spec`/`Assumptions` are the
 `PsiCanonicity.Gate` contract. -/
 def bundle : FormalRegionCircuit Fp Config Config Row unit where
   configure := pure
@@ -716,7 +716,7 @@ structure Row (F : Type) where
   z13JPrime : F
 deriving ProvableStruct
 
-/-- The donor-side row at the witnessed `(lsb, k3)` pair. -/
+/-- The gate row at the witnessed `(lsb, k3)` pair. -/
 def toDonor (row : Row Fp) (lsb k3 : Fp) : DRow Fp :=
   ⟨row.y, lsb, row.k0, row.k2, k3, row.j, row.z1J, row.z13J, row.jPrime,
     row.z13JPrime⟩
@@ -787,7 +787,7 @@ theorem bundleSynthesisSummary_eq (wlsb wk3 : WitgenIR Fp 1)
 /-- Rust `YCanonicity::assign` (`note_commit.rs:1345-1409`): `q_y_canon` at row 0; row 0
 copies `y`/`k_0`/`k_2` and witnesses `LSB`/`k_3` (the `wlsb`/`wk3` programs); row 1 copies
 `j`/`z1_j`/`z13_j`/`j_prime`/`z13_j_prime`. Output is the witnessed `lsb` cell; the
-`(lsb, k3)` readings are the extraction data. `Spec` is the donor `YCanonicity.Gate.Spec`
+`(lsb, k3)` readings are the extraction data. `Spec` is `YCanonicity.Gate.Spec`
 CONDITIONED on the output's booleanity — as in Rust, the lsb cell is boolean-constrained
 *outside* this gate (the decompose gates' `bool_check` on the copied cell), so the
 composite threads it back as a rely. -/
@@ -813,7 +813,7 @@ def bundle (wlsb wk3 : WitgenIR Fp 1) :
     (eval env (AssignedCell.of self offset (cfg.advices 6) : Var field Fp),
      eval env (AssignedCell.of self offset (cfg.advices 9) : Var field Fp))
 
-  -- the input-only rely-conditions (donor `Assumptions` minus `IsBool lsb`)
+  -- the input-only rely-conditions (`Assumptions` minus `IsBool lsb`)
   -- input-only rely-conditions: the gate itself enforces the `j'` shift (constraint 4)
   Assumptions input :=
     input.j.val < 2 ^ 250 ∧ input.k0.val < 2 ^ 9 ∧ input.k2.val < 2 ^ 4 ∧

--- a/Zcash/Circuits/NoteCommit/Composites.lean
+++ b/Zcash/Circuits/NoteCommit/Composites.lean
@@ -213,7 +213,7 @@ def circuit :
     simp only [gateChild_assumptions_eq, gateChild_spec_eq, circuit_norm] at hGate
     have hGSpec := hGate trivial
       ⟨hA.1, hA.2.1, hA.2.2.1, hA.2.2.2, lo, hlo, by rw [hz0eq]; exact htel⟩
-    simp only [GdCanonicity.toDonor, NoteCommit.GdCanonicity.Gate.Spec] at hGSpec
+    simp only [GdCanonicity.toGateRow, NoteCommit.GdCanonicity.Gate.Spec] at hGSpec
     exact ⟨hGSpec.1, hGSpec.2.1, hGSpec.2.2.1⟩
 
   completeness := by
@@ -251,7 +251,7 @@ def circuit :
       simp only [gateChild_proverAssumptions_eq, circuit_norm]
       rw [h_input.2.2.2.1] at hWaP
       rw [h_input.1, h_input.2.1, h_input.2.2.1, h_input.2.2.2.1, h_input.2.2.2.2]
-      simp only [GdCanonicity.toDonor, NoteCommit.GdCanonicity.Gate.Spec]
+      simp only [GdCanonicity.toGateRow, NoteCommit.GdCanonicity.Gate.Spec]
       refine ⟨⟨hPA.1, hPA.2.1, hPA.2.2, ?_⟩, hWaP⟩
       -- honest tail of `a' = a + 2^130 - t_P`: with the top bit set, `a < t_P`, so the
       -- 130-bit shift stays below `2^130` and the running-sum tail vanishes
@@ -430,7 +430,7 @@ def circuit :
     simp only [gateChild_assumptions_eq, gateChild_spec_eq, circuit_norm] at hGate
     have hGSpec := hGate trivial
       ⟨hA.1, hA.2.1, hA.2.2.1, hA.2.2.2, lo, hlo, by rw [hz0eq]; exact htel⟩
-    simp only [PkdCanonicity.toDonor, NoteCommit.PkdCanonicity.Gate.Spec] at hGSpec
+    simp only [PkdCanonicity.toGateRow, NoteCommit.PkdCanonicity.Gate.Spec] at hGSpec
     exact ⟨hGSpec.1, hGSpec.2.1, hGSpec.2.2.1⟩
 
   completeness := by
@@ -465,7 +465,7 @@ def circuit :
       simp only [gateChild_proverAssumptions_eq, circuit_norm]
       rw [h_input.2.1, h_input.2.2.1] at hWaP
       rw [h_input.1, h_input.2.1, h_input.2.2.1, h_input.2.2.2.1, h_input.2.2.2.2]
-      simp only [PkdCanonicity.toDonor, NoteCommit.PkdCanonicity.Gate.Spec]
+      simp only [PkdCanonicity.toGateRow, NoteCommit.PkdCanonicity.Gate.Spec]
       refine ⟨⟨hPA.1, hPA.2.1, hPA.2.2, ?_⟩, by rw [hWaP]; ring⟩
       intro h1
       rw [hzLast, ← hz0eqP, hWaP]
@@ -639,7 +639,7 @@ def circuit :
     simp only [gateChild_assumptions_eq, gateChild_spec_eq, circuit_norm] at hGate
     have hGSpec := hGate trivial
       ⟨hA.1, hA.2.1, hA.2.2.1, hA.2.2.2, lo, hlo, by rw [hz0eq]; exact htel⟩
-    simp only [RhoCanonicity.toDonor, NoteCommit.RhoCanonicity.Gate.Spec] at hGSpec
+    simp only [RhoCanonicity.toGateRow, NoteCommit.RhoCanonicity.Gate.Spec] at hGSpec
     exact ⟨hGSpec.1, hGSpec.2.1, hGSpec.2.2.1⟩
 
   completeness := by
@@ -674,7 +674,7 @@ def circuit :
       simp only [gateChild_proverAssumptions_eq, circuit_norm]
       rw [h_input.2.1, h_input.2.2.1] at hWaP
       rw [h_input.1, h_input.2.1, h_input.2.2.1, h_input.2.2.2.1, h_input.2.2.2.2]
-      simp only [RhoCanonicity.toDonor, NoteCommit.RhoCanonicity.Gate.Spec]
+      simp only [RhoCanonicity.toGateRow, NoteCommit.RhoCanonicity.Gate.Spec]
       refine ⟨⟨hPA.1, hPA.2.1, hPA.2.2, ?_⟩, by rw [hWaP]; ring⟩
       intro h1
       rw [hzLast, ← hz0eqP, hWaP]
@@ -853,7 +853,7 @@ def circuit :
     simp only [gateChild_assumptions_eq, gateChild_spec_eq, circuit_norm] at hGate
     have hGSpec := hGate trivial
       ⟨hA.1, hA.2.1, hA.2.2.1, hA.2.2.2.1, hA.2.2.2.2, lo, hlo, by rw [hz0eq]; exact htel⟩
-    simp only [PsiCanonicity.toDonor, NoteCommit.PsiCanonicity.Gate.Spec] at hGSpec
+    simp only [PsiCanonicity.toGateRow, NoteCommit.PsiCanonicity.Gate.Spec] at hGSpec
     exact ⟨hGSpec.1, hGSpec.2.1, hGSpec.2.2.1, hGSpec.2.2.2.1⟩
 
   completeness := by
@@ -889,7 +889,7 @@ def circuit :
       rw [h_input.2.2.1, h_input.2.2.2.2.1] at hWaP
       rw [h_input.1, h_input.2.1, h_input.2.2.1, h_input.2.2.2.1, h_input.2.2.2.2.1,
         h_input.2.2.2.2.2]
-      simp only [PsiCanonicity.toDonor, NoteCommit.PsiCanonicity.Gate.Spec]
+      simp only [PsiCanonicity.toGateRow, NoteCommit.PsiCanonicity.Gate.Spec]
       refine ⟨⟨hPA.1, hPA.2.1, hPA.2.2.1, hPA.2.2.2, ?_⟩, by rw [hWaP]; ring⟩
       intro h1
       rw [hzLast, ← hz0eqP, hWaP]

--- a/Zcash/Circuits/NoteCommit/Composites.lean
+++ b/Zcash/Circuits/NoteCommit/Composites.lean
@@ -8,14 +8,12 @@ Reference (ported from actual Rust, not memory):
   its own `"Witness element"` region, witnessing `a' = a + 2^130 - t_P`.
 - the gate regions (`"NoteCommit input g_d"` etc.): the per-input canonicity gates, one
   region each.
-Phase-1 donors: `Clean/Orchard/Action/NoteCommit.lean`
-(`NoteCommit.{Gd,Pkd,Rho,Psi}Canonicity` — Telescoped copy-check + gate).
 
 Each composite is a two-child layouter `FormalCircuit`: the `witnessCheck` child pins the
 shifted value's telescoped decomposition (the gate bundle's `∃ lo` rely-condition), the
 gate bundle carries the semantic canonicity contract, and the shift equation itself is
 the gate's own constraint (derived inside the gate bundle's soundness). `Spec` is the
-donor composite's bit-slice payoff.
+composite's bit-slice guarantee.
 -/
 
 namespace Zcash.Circuits.NoteCommit
@@ -115,7 +113,7 @@ theorem synth_regionCount (gcfg : GdCanonicity.Config) (lcfg : LookupRangeCheck.
     operations_assignRegion, Operations.regionCount]
 
 /-- Rust `gd_x_canonicity` (`note_commit.rs`): `witness_check(a', 13)` then the
-`"NoteCommit input g_d"` gate region. `Spec` is the donor composite payoff:
+`"NoteCommit input g_d"` gate region. `Spec` is the composite's guarantee:
 `a`/`b0`/`b1` are the canonical bit slices of `x(g_d)`. -/
 def circuit :
     FormalCircuit Fp (GdCanonicity.Config × LookupRangeCheck.Config 10)
@@ -210,7 +208,7 @@ def circuit :
     rw [LookupRangeCheck.rangeCheckAt_spec_eq, rangeCheckAt_output] at hWSpec
     simp only [circuit_norm, show (10 * 13 : ℕ) = 130 from by norm_num] at hWSpec
     obtain ⟨hz0eq, lo, hlo, htel⟩ := hWSpec
-    -- the gate child: discharge its rely-conditions, harvest the donor gate `Spec`
+    -- the gate child: discharge its rely-conditions, harvest the gate `Spec`
     rw [rangeCheckAt_output] at hGate
     simp only [gateChild_assumptions_eq, gateChild_spec_eq, circuit_norm] at hGate
     have hGSpec := hGate trivial
@@ -248,7 +246,7 @@ def circuit :
       rw [rangeCheckAt_output]
       simp only [gateChild_assumptions_eq, circuit_norm, h_input]
       exact ⟨hA.1, hA.2.1, hA.2.2.1, hA.2.2.2, lo, hlo, by rw [hz0eq]; exact htel⟩
-    · -- the gate child's honest-prover precondition: the donor gate `Spec` + the shift
+    · -- the gate child's honest-prover precondition: the gate `Spec` + the shift
       rw [rangeCheckAt_output]
       simp only [gateChild_proverAssumptions_eq, circuit_norm]
       rw [h_input.2.2.2.1] at hWaP

--- a/Zcash/Circuits/NoteCommit/Decompose.lean
+++ b/Zcash/Circuits/NoteCommit/Decompose.lean
@@ -8,11 +8,10 @@ Reference (ported from actual Rust, not memory):
 `h` 660-694): enable the gate at row 0, copy the piece and the externally-constrained
 subpieces in, assign the in-gate boolean subpiece (returned; `e` assigns nothing).
 
-The semantic contracts are the phase-1 gate specs
-(`Clean/Orchard/Action/Decompose.lean`, `Decompose{B,D,E,G,H}.Gate.Spec`) verbatim: the
+The semantic contracts are the gate specs (`Decompose{B,D,E,G,H}.Gate.Spec`): the
 booleanity of the in-gate bits plus the piece decomposition identity. Externally-provided
 range facts stay OUT of these bundles (they are the callers' rely-conditions, threaded at
-the composite level exactly as in phase 1).
+the composite level).
 -/
 
 namespace Zcash.Circuits.NoteCommit
@@ -55,7 +54,7 @@ theorem synthesisSummary_hasNoFixedColumns (config : Config) (offset : ℕ) :
 
 /-- Rust `DecomposeB::assign` (`note_commit.rs:179-215`), parameterized by the `b_1`
 witness program (Rust: `RangeConstrained::bitrange_of(gd_x, 254..255)`). Output is the
-witnessed `b_1` cell; `Spec` is the donor `DecomposeB.Gate.Spec`. -/
+witnessed `b_1` cell; `Spec` is `DecomposeB.Gate.Spec`. -/
 def bundle (wb1 : WitgenIR Fp 1) : FormalRegionCircuit Fp Config Config Inputs field where
   configure := pure
   elaborated :=
@@ -174,7 +173,7 @@ theorem synthesisSummary_hasNoFixedColumns (config : Config) (offset : ℕ) :
 
 /-- Rust `DecomposeD::assign` (`note_commit.rs:297-340`), parameterized by the `d_0`
 witness program (bit 254 of `x(pk_d)`). Output is the witnessed `d_0` cell; `Spec` is
-the donor `DecomposeD.Gate.Spec`. -/
+`DecomposeD.Gate.Spec`. -/
 def bundle (wd0 : WitgenIR Fp 1) : FormalRegionCircuit Fp Config Config Inputs field where
   configure := pure
   elaborated :=
@@ -289,7 +288,7 @@ theorem synthesisSummary_hasNoFixedColumns (config : Config) (offset : ℕ) :
   simp
 
 /-- Rust `DecomposeE::assign` (`note_commit.rs:418-448`): pure copies, no in-gate
-witness. `Spec` is the donor `DecomposeE.Gate.Spec`. -/
+witness. `Spec` is `DecomposeE.Gate.Spec`. -/
 def bundle : FormalRegionCircuit Fp Config Config Inputs unit where
   configure := pure
   elaborated :=
@@ -372,8 +371,8 @@ theorem synthesisSummary_hasNoFixedColumns (config : Config) (offset : ℕ) :
   simp
 
 /-- Rust `DecomposeG::assign` (`note_commit.rs:540-575`), parameterized by the `g_0`
-witness program (bit 254 of `rho`). Output is the witnessed `g_0` cell; `Spec` is the
-donor `DecomposeG.Gate.Spec`. -/
+witness program (bit 254 of `rho`). Output is the witnessed `g_0` cell; `Spec` is
+`DecomposeG.Gate.Spec`. -/
 def bundle (wg0 : WitgenIR Fp 1) : FormalRegionCircuit Fp Config Config Inputs field where
   configure := pure
   elaborated :=
@@ -482,8 +481,8 @@ theorem synthesisSummary_hasNoFixedColumns (config : Config) (offset : ℕ) :
   simp
 
 /-- Rust `DecomposeH::assign` (`note_commit.rs:660-694`), parameterized by the `h_1`
-witness program (bit 254 of `psi`). Output is the witnessed `h_1` cell; `Spec` is the
-donor `DecomposeH.Gate.Spec`. -/
+witness program (bit 254 of `psi`). Output is the witnessed `h_1` cell; `Spec` is
+`DecomposeH.Gate.Spec`. -/
 def bundle (wh1 : WitgenIR Fp 1) : FormalRegionCircuit Fp Config Config Inputs field where
   configure := pure
   elaborated :=

--- a/Zcash/Circuits/NoteCommit/MainBundle.lean
+++ b/Zcash/Circuits/NoteCommit/MainBundle.lean
@@ -927,7 +927,7 @@ theorem soundness (G : Generators) (R : FixedBase)
     Nat.add_assoc, Nat.reduceAdd, Nat.add_zero] at hGrhoS
   simp only [prefixRows_ns_3,
     prefixRows_ns_6, Nat.reduceAdd] at hGbS hGdS hGeS hGgS hGhS
-  -- Psi: the z13G tail via the donor bridge over the DecomposeG facts
+  -- Psi: the z13G tail over the DecomposeG facts
   have hz13G_tail := NoteCommit.z13G_tail_of_decompose_g
     hGgS.1 hg1 (by rw [hzg1]; exact hzg1val) hGgS.2 hzg13
   have hGpsiS := hGpsi (by rw [toFormal_envAssumptions_eq]; trivial)

--- a/Zcash/Circuits/NoteCommit/MainBundle.lean
+++ b/Zcash/Circuits/NoteCommit/MainBundle.lean
@@ -90,25 +90,6 @@ private theorem prefixRows_ns_3 : Sinsemilla.Chain.prefixRows ns 3 = 51 := rfl
 private theorem prefixRows_ns_5 : Sinsemilla.Chain.prefixRows ns 5 = 58 := rfl
 private theorem prefixRows_ns_6 : Sinsemilla.Chain.prefixRows ns 6 = 83 := rfl
 
-/-- The ironwood `Chain.PieceChunks` is the donor's, verbatim — the bridge unlocks the
-donor's piece-value/chunk-equality connectors. -/
-private theorem pieceChunks_donor_iff :
-    ∀ (ms : List ℕ) (pieces : Vector Fp ms.length) (chunks : List ℕ),
-      Sinsemilla.Chain.PieceChunks ms pieces chunks ↔
-      Sinsemilla.Chain.PieceChunks ms pieces chunks := by
-  intro ms
-  induction ms with
-  | nil =>
-    intro pieces chunks
-    simp only [Sinsemilla.Chain.PieceChunks, Sinsemilla.Chain.PieceChunks]
-  | cons n rest ih =>
-    intro pieces chunks
-    constructor
-    · rintro ⟨msf, h1, h2, tailChunks, h3, h4⟩
-      exact ⟨msf, h1, h2, tailChunks, h3, (ih _ _).mp h4⟩
-    · rintro ⟨msf, h1, h2, tailChunks, h3, h4⟩
-      exact ⟨msf, h1, h2, tailChunks, h3, (ih _ _).mpr h4⟩
-
 /-- Stage-3 peel, standalone (kernel-checked alone): the ten folded gate-call chunks at
 clean relative indices. -/
 private theorem peelGates (cfg : Config) (input : Var Inputs Fp)
@@ -170,25 +151,6 @@ private theorem peelGates (cfg : Config) (input : Var Inputs Fp)
     circuit_norm, decomposeB_output,
     decomposeD_output, decomposeG_output, decomposeH_output] at h
   exact h
-
-/-- The ironwood `Chain.ZsFacts` is the donor's, verbatim. -/
-private theorem zsFacts_donor_iff :
-    ∀ (ms : List ℕ) (chunks : List ℕ)
-      (zs : Sinsemilla.HVec (Sinsemilla.Chain.zLengths ms) Fp),
-      Sinsemilla.Chain.ZsFacts ms chunks zs ↔
-      Sinsemilla.Chain.ZsFacts ms chunks zs := by
-  intro ms
-  induction ms with
-  | nil =>
-    intro chunks zs
-    simp only [Sinsemilla.Chain.ZsFacts, Sinsemilla.Chain.ZsFacts]
-  | cons n rest ih =>
-    intro chunks zs
-    constructor
-    · rintro ⟨h1, h2⟩
-      exact ⟨h1, (ih _ _).mp h2⟩
-    · rintro ⟨h1, h2⟩
-      exact ⟨h1, (ih _ _).mpr h2⟩
 
 /-- The hash child's extracted running sums are the `bits`-column reads. -/
 private theorem hashExtract_zs (G : Generators) (Q : Point Fp) (hQ : Q.OnCurve)
@@ -531,31 +493,6 @@ private theorem yc_lsb_witness (w : WitgenIR Fp 1)
   simp only [Nat.add_assoc, Nat.reduceAdd] at hlsb ⊢
   exact hlsb
 
-/-- The ironwood `Chain.PieceBounds`/`honestChunks` are the donor's, verbatim. -/
-private theorem pieceBounds_donor_iff :
-    ∀ (ms : List ℕ) (pieces : Vector Fp ms.length),
-      Sinsemilla.Chain.PieceBounds ms pieces ↔
-      Sinsemilla.Chain.PieceBounds ms pieces := by
-  intro ms
-  induction ms with
-  | nil =>
-    intro pieces
-    simp only [Sinsemilla.Chain.PieceBounds, Sinsemilla.Chain.PieceBounds]
-  | cons n rest ih =>
-    intro pieces
-    constructor
-    · rintro ⟨h1, h2⟩
-      exact ⟨h1, (ih _).mp h2⟩
-    · rintro ⟨h1, h2⟩
-      exact ⟨h1, (ih _).mpr h2⟩
-
-private theorem honestChunks_donor_eq :
-    ∀ (ms : List ℕ) (pieces : Vector Fp ms.length),
-      Sinsemilla.Chain.honestChunks ms pieces
-        = Sinsemilla.Chain.honestChunks ms pieces := by
-  intro ms pieces
-  rfl
-
 private theorem decomposeB_extract_eq (w : WitgenIR Fp 1) (name : String)
     (cfg : DecomposeB.Config) (inp : Var DecomposeB.Inputs Fp) (i : RegionIndex)
     (env : Placed Environment Fp) :
@@ -849,25 +786,23 @@ theorem soundness (G : Generators) (R : FixedBase)
   -- ── the six hash running-sum value facts ──
   obtain ⟨chunks, hPC, hZs, hContract⟩ := hCmS
   rw [hashExtract_zs] at hZs
-  have hPC' := (pieceChunks_donor_iff _ _ _).mp hPC
-  have hZs' := (zsFacts_donor_iff _ _ _).mp hZs
   have hz13a := NoteCommit.zsFacts_cell ns _ chunks _
-    ⟨0, by decide⟩ hPC' hZs' (by decide) (r := 13) (by decide)
+    ⟨0, by decide⟩ hPC hZs (by decide) (r := 13) (by decide)
   rw [zs_get_z13a] at hz13a
   have hz13c := NoteCommit.zsFacts_cell ns _ chunks _
-    ⟨2, by decide⟩ hPC' hZs' (by decide) (r := 13) (by decide)
+    ⟨2, by decide⟩ hPC hZs (by decide) (r := 13) (by decide)
   rw [zs_get_z13c] at hz13c
   have hz1d := NoteCommit.zsFacts_cell ns _ chunks _
-    ⟨3, by decide⟩ hPC' hZs' (by decide) (r := 1) (by decide)
+    ⟨3, by decide⟩ hPC hZs (by decide) (r := 1) (by decide)
   rw [zs_get_z1d] at hz1d
   have hz13f := NoteCommit.zsFacts_cell ns _ chunks _
-    ⟨5, by decide⟩ hPC' hZs' (by decide) (r := 13) (by decide)
+    ⟨5, by decide⟩ hPC hZs (by decide) (r := 13) (by decide)
   rw [zs_get_z13f] at hz13f
   have hz1g := NoteCommit.zsFacts_cell ns _ chunks _
-    ⟨6, by decide⟩ hPC' hZs' (by decide) (r := 1) (by decide)
+    ⟨6, by decide⟩ hPC hZs (by decide) (r := 1) (by decide)
   rw [zs_get_z1g] at hz1g
   have hz13g := NoteCommit.zsFacts_cell ns _ chunks _
-    ⟨6, by decide⟩ hPC' hZs' (by decide) (r := 13) (by decide)
+    ⟨6, by decide⟩ hPC hZs (by decide) (r := 13) (by decide)
   rw [zs_get_z13g] at hz13g
   -- ── normalize region-index spellings ──
   simp only [Nat.add_assoc, Nat.reduceAdd] at hGbS hGdS hGeS hGgS hGhS hY1S hY2S
@@ -876,15 +811,15 @@ theorem soundness (G : Generators) (R : FixedBase)
   simp only [Nat.add_assoc, Nat.reduceAdd] at hb0 hb3 hd2 he0 he1 hg1 hh0
   -- ── the piece-value bounds (from the chunk decompositions) ──
   have hpieceA := NoteCommit.pieceChunks_val_lt ns _ chunks
-    ⟨0, by decide⟩ hPC' (by decide)
+    ⟨0, by decide⟩ hPC (by decide)
   have hpieceC := NoteCommit.pieceChunks_val_lt ns _ chunks
-    ⟨2, by decide⟩ hPC' (by decide)
+    ⟨2, by decide⟩ hPC (by decide)
   have hpieceD := NoteCommit.pieceChunks_val_lt ns _ chunks
-    ⟨3, by decide⟩ hPC' (by decide)
+    ⟨3, by decide⟩ hPC (by decide)
   have hpieceF := NoteCommit.pieceChunks_val_lt ns _ chunks
-    ⟨5, by decide⟩ hPC' (by decide)
+    ⟨5, by decide⟩ hPC (by decide)
   have hpieceG := NoteCommit.pieceChunks_val_lt ns _ chunks
-    ⟨6, by decide⟩ hPC' (by decide)
+    ⟨6, by decide⟩ hPC (by decide)
   simp only [Nat.add_assoc, Nat.reduceAdd] at hpieceA hpieceC hpieceD hpieceF hpieceG
   -- restate the vector-element facts on the piece reads (defeq transport)
   have haval : (env.advice cfg.hashConfig.witnessPieces ((place i₀ : ℕ) : ℤ)).val
@@ -1044,7 +979,7 @@ theorem soundness (G : Generators) (R : FixedBase)
         g1 := env.advice cfg.lookupConfig.runningSum ((place (i₀ + 11) : ℕ) : ℤ),
         h0 := env.advice cfg.lookupConfig.runningSum ((place (i₀ + 13) : ℕ) : ℤ),
         h1 := env.advice cfg.gates.h.colR ((place (i₀ + 37) : ℕ) : ℤ) })
-    (by with_unfolding_all exact hPC')
+    (by with_unfolding_all exact hPC)
     ⟨hGgdS.1, hGgdS.2.1, hGgdS.2.2.1, hLow1, hGpkdS.1, hGpkdS.2.1, hGpkdS.2.2.1, hLow2,
      hGvalS.2.1, hGvalS.2.2.2, hGrhoS.1, hGrhoS.2.1, hGrhoS.2.2.1, hGpsiS.1,
      hGpsiS.2.2.1, hGpsiS.2.2.2.1,
@@ -1211,8 +1146,7 @@ theorem completeness (G : Generators) (R : FixedBase)
         env.advice cfg.hashConfig.witnessPieces ((place (i₀ + 10) : ℕ) : ℤ),
         env.advice cfg.hashConfig.witnessPieces ((place (i₀ + 12) : ℕ) : ℤ),
         env.advice cfg.hashConfig.witnessPieces ((place (i₀ + 14) : ℕ) : ℤ)] :=
-    (pieceBounds_donor_iff _ _).mpr
-      (NoteCommit.pieceBounds_of_cellFacts hMCF)
+    NoteCommit.pieceBounds_of_cellFacts hMCF
   have hHonest : Sinsemilla.Chain.honestChunks ns
       #v[env.advice cfg.hashConfig.witnessPieces ((place i₀ : ℕ) : ℤ),
         env.advice cfg.hashConfig.witnessPieces ((place (i₀ + 3) : ℕ) : ℤ),
@@ -1225,7 +1159,6 @@ theorem completeness (G : Generators) (R : FixedBase)
       = Specs.Sinsemilla.noteCommitChunks input_gdX.val (input_gdY.val % 2)
         input_pkdX.val (input_pkdY.val % 2) input_value.val input_rho.val
         input_psi.val := by
-    rw [honestChunks_donor_eq]
     have := NoteCommit.honestChunks_eq_noteCommitChunks_of_cellFacts
       hMCF hVal64'
     rw [higdX, higdY, hipkdX, hipkdY, hival, hirho, hipsi] at this
@@ -1279,25 +1212,23 @@ theorem completeness (G : Generators) (R : FixedBase)
   simp only [AssignedCell.of_cell, Cell.of_regionIndex, Cell.of_rowOffset,
     Cell.of_column, Environment.get_advice, Nat.add_zero, Nat.add_assoc,
     Nat.reduceAdd] at hPC
-  have hPC' := (pieceChunks_donor_iff _ _ _).mp hPC
-  have hZs' := (zsFacts_donor_iff _ _ _).mp hZs
   have hz13a := NoteCommit.zsFacts_cell ns _ chunks _
-    ⟨0, by decide⟩ hPC' hZs' (by decide) (r := 13) (by decide)
+    ⟨0, by decide⟩ hPC hZs (by decide) (r := 13) (by decide)
   rw [zs_get_z13a] at hz13a
   have hz13c := NoteCommit.zsFacts_cell ns _ chunks _
-    ⟨2, by decide⟩ hPC' hZs' (by decide) (r := 13) (by decide)
+    ⟨2, by decide⟩ hPC hZs (by decide) (r := 13) (by decide)
   rw [zs_get_z13c] at hz13c
   have hz1d := NoteCommit.zsFacts_cell ns _ chunks _
-    ⟨3, by decide⟩ hPC' hZs' (by decide) (r := 1) (by decide)
+    ⟨3, by decide⟩ hPC hZs (by decide) (r := 1) (by decide)
   rw [zs_get_z1d] at hz1d
   have hz13f := NoteCommit.zsFacts_cell ns _ chunks _
-    ⟨5, by decide⟩ hPC' hZs' (by decide) (r := 13) (by decide)
+    ⟨5, by decide⟩ hPC hZs (by decide) (r := 13) (by decide)
   rw [zs_get_z13f] at hz13f
   have hz1g := NoteCommit.zsFacts_cell ns _ chunks _
-    ⟨6, by decide⟩ hPC' hZs' (by decide) (r := 1) (by decide)
+    ⟨6, by decide⟩ hPC hZs (by decide) (r := 1) (by decide)
   rw [zs_get_z1g] at hz1g
   have hz13g := NoteCommit.zsFacts_cell ns _ chunks _
-    ⟨6, by decide⟩ hPC' hZs' (by decide) (r := 13) (by decide)
+    ⟨6, by decide⟩ hPC hZs (by decide) (r := 13) (by decide)
   rw [zs_get_z13g] at hz13g
   have hWaSfull := Halo2.SubcircuitRw.region_completeness_derived
     (LookupRangeCheck.rangeCheckAt 10 13 false
@@ -1365,15 +1296,15 @@ theorem completeness (G : Generators) (R : FixedBase)
   obtain ⟨hgz0, loG, hloG, htelG⟩ := hWgS
   simp only [Nat.add_assoc, Nat.reduceAdd] at hz13a hz13c hz1d hz13f hz1g hz13g
   have hpieceA := NoteCommit.pieceChunks_val_lt ns _ chunks
-    ⟨0, by decide⟩ hPC' (by decide)
+    ⟨0, by decide⟩ hPC (by decide)
   have hpieceC := NoteCommit.pieceChunks_val_lt ns _ chunks
-    ⟨2, by decide⟩ hPC' (by decide)
+    ⟨2, by decide⟩ hPC (by decide)
   have hpieceD := NoteCommit.pieceChunks_val_lt ns _ chunks
-    ⟨3, by decide⟩ hPC' (by decide)
+    ⟨3, by decide⟩ hPC (by decide)
   have hpieceF := NoteCommit.pieceChunks_val_lt ns _ chunks
-    ⟨5, by decide⟩ hPC' (by decide)
+    ⟨5, by decide⟩ hPC (by decide)
   have hpieceG := NoteCommit.pieceChunks_val_lt ns _ chunks
-    ⟨6, by decide⟩ hPC' (by decide)
+    ⟨6, by decide⟩ hPC (by decide)
   have haval : (env.advice cfg.hashConfig.witnessPieces ((place i₀ : ℕ) : ℤ)).val
       < 2 ^ 250 := by with_unfolding_all exact hpieceA
   have hcval : (env.advice cfg.hashConfig.witnessPieces ((place (i₀ + 4) : ℕ) : ℤ)).val

--- a/Zcash/Circuits/NoteCommit/MainBundle.lean
+++ b/Zcash/Circuits/NoteCommit/MainBundle.lean
@@ -882,7 +882,7 @@ theorem soundness (G : Generators) (R : FixedBase)
           Nat.add_zero]
         exact ⟨hGbS.1, haval, hb0, hza, loA, hloA, by rw [← haz0] at htelA; exact htelA⟩)
   rw [toFormal_spec_eq, GdCanonicity.bundle_spec_eq] at hGgdS
-  simp only [GdCanonicity.toDonor, NoteCommit.GdCanonicity.Gate.Spec,
+  simp only [GdCanonicity.toGateRow, NoteCommit.GdCanonicity.Gate.Spec,
     synthPieces_output, synthChecks_output, zCell, prefixRows_ns_0,
     circuit_norm,
     Nat.add_assoc, Nat.reduceAdd, Nat.add_zero] at hGgdS
@@ -895,7 +895,7 @@ theorem soundness (G : Generators) (R : FixedBase)
           Nat.add_zero]
         exact ⟨hGdS.1, hcval, hb3, hzc, loB, hloB, by rw [← hbz0] at htelB; exact htelB⟩)
   rw [toFormal_spec_eq, PkdCanonicity.bundle_spec_eq] at hGpkdS
-  simp only [PkdCanonicity.toDonor, NoteCommit.PkdCanonicity.Gate.Spec,
+  simp only [PkdCanonicity.toGateRow, NoteCommit.PkdCanonicity.Gate.Spec,
     synthPieces_output, synthChecks_output, zCell, prefixRows_ns_2,
     circuit_norm,
     Nat.add_assoc, Nat.reduceAdd, Nat.add_zero] at hGpkdS
@@ -908,7 +908,7 @@ theorem soundness (G : Generators) (R : FixedBase)
           Nat.add_zero]
         exact ⟨hd2, by rw [hzd]; exact hzdval, he0⟩)
   rw [toFormal_spec_eq, ValueCanonicity.bundle_spec_eq] at hGvalS
-  simp only [ValueCanonicity.toDonor, NoteCommit.ValueCanonicity.Gate.Spec,
+  simp only [ValueCanonicity.toGateRow, NoteCommit.ValueCanonicity.Gate.Spec,
     synthPieces_output, zCell,
     prefixRows_ns_3, circuit_norm,
     Nat.reduceAdd, Nat.add_zero] at hGvalS
@@ -921,7 +921,7 @@ theorem soundness (G : Generators) (R : FixedBase)
           Nat.add_zero]
         exact ⟨hGgS.1, hfval, he1, hzf, loE, hloE, by rw [← hez0] at htelE; exact htelE⟩)
   rw [toFormal_spec_eq, RhoCanonicity.bundle_spec_eq] at hGrhoS
-  simp only [RhoCanonicity.toDonor, NoteCommit.RhoCanonicity.Gate.Spec,
+  simp only [RhoCanonicity.toGateRow, NoteCommit.RhoCanonicity.Gate.Spec,
     synthPieces_output, synthChecks_output, zCell,
     prefixRows_ns_5, circuit_norm,
     Nat.add_assoc, Nat.reduceAdd, Nat.add_zero] at hGrhoS
@@ -940,7 +940,7 @@ theorem soundness (G : Generators) (R : FixedBase)
         exact ⟨hGhS.1, hg1, by rw [hzg1]; exact hzg1val, hh0, hz13G_tail,
           loG, hloG, by rw [← hgz0] at htelG; exact htelG⟩)
   rw [toFormal_spec_eq, PsiCanonicity.bundle_spec_eq] at hGpsiS
-  simp only [PsiCanonicity.toDonor, NoteCommit.PsiCanonicity.Gate.Spec,
+  simp only [PsiCanonicity.toGateRow, NoteCommit.PsiCanonicity.Gate.Spec,
     synthPieces_output, synthChecks_output, zCell,
     prefixRows_ns_6, circuit_norm,
     Nat.add_assoc, Nat.reduceAdd, Nat.add_zero] at hGpsiS
@@ -1734,7 +1734,7 @@ theorem completeness (G : Generators) (R : FixedBase)
                           circuit_norm,
              Nat.add_assoc, Nat.reduceAdd,
              Nat.add_zero]
-           simp only [GdCanonicity.toDonor,
+           simp only [GdCanonicity.toGateRow,
              NoteCommit.GdCanonicity.Gate.Spec]
            refine ⟨⟨hMa, hMb0, hMb1, fun h1 => ?_⟩, hWaP⟩
            obtain ⟨-, hatp, -⟩ := NoteCommit.high_bit_canonical
@@ -1764,7 +1764,7 @@ theorem completeness (G : Generators) (R : FixedBase)
              circuit_norm,
              Nat.add_assoc, Nat.reduceAdd,
              Nat.add_zero]
-           simp only [PkdCanonicity.toDonor,
+           simp only [PkdCanonicity.toGateRow,
              NoteCommit.PkdCanonicity.Gate.Spec]
            refine ⟨⟨hMb3, hMc, hMd0, fun h1 => ?_⟩, by rw [hWbP]; try ring⟩
            have hbase := NoteCommit.base_val_lt_tP_val hMb3 hMc
@@ -1820,7 +1820,7 @@ theorem completeness (G : Generators) (R : FixedBase)
              circuit_norm,
              Nat.add_assoc, Nat.reduceAdd,
              Nat.add_zero]
-           simp only [RhoCanonicity.toDonor,
+           simp only [RhoCanonicity.toGateRow,
              NoteCommit.RhoCanonicity.Gate.Spec]
            refine ⟨⟨hMe1, hMf, hMg0, fun h1 => ?_⟩, by rw [hWeP]; try ring⟩
            have hbase := NoteCommit.base_val_lt_tP_val hMe1 hMf
@@ -1849,7 +1849,7 @@ theorem completeness (G : Generators) (R : FixedBase)
              circuit_norm,
              Nat.add_assoc, Nat.reduceAdd,
              Nat.add_zero]
-           simp only [PsiCanonicity.toDonor,
+           simp only [PsiCanonicity.toGateRow,
              NoteCommit.PsiCanonicity.Gate.Spec]
            have hg2val : (env.advice cfg.hashConfig.bits
                ((place (i₀ + 27) + 84 : ℕ) : ℤ)).val

--- a/Zcash/Circuits/NoteCommit/YComposite.lean
+++ b/Zcash/Circuits/NoteCommit/YComposite.lean
@@ -442,7 +442,7 @@ def circuit (wlsb : WitgenIR Fp 1) :
     have hb' : IsBool (env.advice (cfg.1.advices 6) ((place (i₀ + 4) : ℕ) : ℤ)) := by
       rw [← h_output] at hb; exact hb
     have hD := hGSpec hb'
-    simp only [YCanonicity.toDonor, NoteCommit.YCanonicity.Gate.Spec]
+    simp only [YCanonicity.toGateRow, NoteCommit.YCanonicity.Gate.Spec]
       at hD
     rw [h_input] at hD
     rw [← h_output]
@@ -604,7 +604,7 @@ def circuit (wlsb : WitgenIR Fp 1) :
         rw [hgk3]
         exact cast_bitrange_val (by norm_num) _
       · -- `k_3 = 1 → z13_j' = 0`
-        simp only [YCanonicity.toDonor]
+        simp only [YCanonicity.toGateRow]
         intro h1
         rw [show (i₀ + 2 + 2 : ℕ) = i₀ + 4 from rfl, hgk3] at h1
         rw [hzLastP, ← hpz0P, hWjp, hjeq]

--- a/Zcash/Circuits/NoteCommit/YComposite.lean
+++ b/Zcash/Circuits/NoteCommit/YComposite.lean
@@ -7,13 +7,12 @@ Reference (ported from actual Rust, not memory):
 `witness_short(y[1..10])` (`k_0`), `witness_short(y[250..254])` (`k_2`),
 `witness_check(j, 25, true)` handing out `zs[1]`/`zs[13]`, `canon_bitshift_130(j)`
 (`witness_check(j', 13, false)`), then the `"y canonicity"` gate region
-(`YCanonicity::assign`, lines 1345-1409). Phase-1 donor:
-`NoteCommit.YCanonicity` (`Clean/Orchard/Action/NoteCommit.lean:525-646`).
+(`YCanonicity::assign`, lines 1345-1409).
 
 Only the `lsb` witness program is a parameter (the caller computes it from its Sinsemilla
 sign bit); `k_0`/`k_2`/`k_3` and `j` are witnessed by the canonical bit-slice programs, so
-their honest values fall out of the parent's witness hypotheses. `Spec` is the donor
-composite payoff (`lsb` is the low bit of `y`), conditioned on the lsb cell's booleanity
+their honest values fall out of the parent's witness hypotheses. `Spec`, the composite's
+guarantee, is that `lsb` is the low bit of `y`, conditioned on the lsb cell's booleanity
 (constrained outside this flow, exactly as in the gate bundle).
 -/
 
@@ -253,8 +252,7 @@ theorem synth_regionCount (wlsb : WitgenIR Fp 1) (gcfg : YCanonicity.Config)
 
 /-- Rust `y_canonicity` (`note_commit.rs:1962-2032`). Output is the witnessed `lsb` cell;
 its reading is the extraction data. `Spec`: given the lsb cell's booleanity (constrained
-outside, by the decompose gates on the copied cell), `lsb` is the low bit of `y` — the
-donor composite payoff. -/
+outside, by the decompose gates on the copied cell), `lsb` is the low bit of `y`. -/
 def circuit (wlsb : WitgenIR Fp 1) :
     FormalCircuit Fp (YCanonicity.Config × LookupRangeCheck.Config 10)
       (YCanonicity.Config × LookupRangeCheck.Config 10) Inputs field where

--- a/Zcash/Circuits/Poseidon/Hash.lean
+++ b/Zcash/Circuits/Poseidon/Hash.lean
@@ -16,8 +16,8 @@ Reference (ported from actual Rust, not memory):
   `state[0]` with no further region. Region sequence: `"initial state for domain
   ConstantLength<2>"`, `"add input for domain ConstantLength<2>"`, `"permute state"`.
 
-The value-level contract is the donor `Hash.HashPaddedBlock.value`
-(`Clean/Orchard/Poseidon/Hash.lean`) at capacity `ConstantLength.capacity 2 = 2·2⁶⁴`.
+The value-level contract is `Hash.HashPaddedBlock.value` at capacity
+`ConstantLength.capacity 2 = 2·2⁶⁴`.
 -/
 
 namespace Zcash.Circuits.Poseidon
@@ -211,7 +211,7 @@ def addInputRegionElaborated : ElaboratedRegionCircuit Fp Config Config
 /-- Rust `Pow5Chip::add_input`'s region body (`pow5.rs:310-396`), `ConstantLength<2>`
 shape (both rate words are `Message` cells): `s_pad_and_add` at row 1, the initial state
 copied at row 0, the input words copied at row 1, the summed output at row 2. `Spec` is
-the donor `Sponge.AddInput.value`. -/
+`Sponge.AddInput.value`. -/
 def addInputRegion : FormalRegionCircuit Fp Config Config Sponge.AddInputInput State where
   configure := pure
   elaborated := addInputRegionElaborated
@@ -350,7 +350,7 @@ theorem hashSynthesisSummary_tableRowExtent_eq (cfg : Config) :
 
 /-- Rust `Hash::<ConstantLength<2>>::hash` (`poseidon.rs:269-286`) on the Pow5 chip:
 initial state, pad-and-add, one permutation; the digest is `state[0]`. `Spec` is the
-donor one-block hash value `HashPaddedBlock.value`. -/
+one-block hash value `HashPaddedBlock.value`. -/
 def hash (capacity : Fp) :
     FormalCircuit Fp Config Config Sponge.Rate2 field where
   name := "poseidon hash ConstantLength<2>"

--- a/Zcash/Circuits/Poseidon/Permute.lean
+++ b/Zcash/Circuits/Poseidon/Permute.lean
@@ -9,8 +9,8 @@ Reference (ported from actual Rust, not memory):
   `round = 4 + 2r`), then 4 more full-round rows (`round = 60 + r`). 37 rows total; the
   final state is read at row 36.
 
-`Spec` is the donor's `Permute.value` (the 4+28+4 `Fin.foldl` schedule,
-`Clean/Orchard/Poseidon/Pow5.lean`), at the ported P128Pow5T3 round constants.
+`Spec` is `Permute.value` (the 4+28+4 `Fin.foldl` schedule) at the P128Pow5T3 round
+constants.
 -/
 
 open ProvableStruct.Halo2 (eval_cells_eq_eval)
@@ -262,7 +262,7 @@ def permuteElaborated :
            simp only [circuit_norm, RegionOperation.copiedCells, List.Forall] <;> done)
         | keygen_registration }
 
-/-- Chain a per-row step family into a `Fin.foldl` (the donor `Permute.value` shape). -/
+/-- Chain a per-row step family into a `Fin.foldl` (the `Permute.value` shape). -/
 private theorem foldl_of_steps (f : ℕ → State Fp → State Fp) (st : ℕ → State Fp)
     (base : ℕ) : ∀ n : ℕ,
     (∀ i : ℕ, i < n → st (base + i + 1) = f i (st (base + i))) →
@@ -276,7 +276,7 @@ private theorem foldl_of_steps (f : ℕ → State Fp → State Fp) (st : ℕ →
     exact h n (by omega)
 
 /-- Rust `Pow5Chip::permute`'s region body (`pow5.rs:235-265`): load the state, 4 full
-rounds, 28 double partial rounds, 4 full rounds. `Spec`: the outgoing state is the donor
+rounds, 28 double partial rounds, 4 full rounds. `Spec`: the outgoing state is the
 `Permute.value` of the incoming one. -/
 def permuteRegion : FormalRegionCircuit Fp Config Config State State where
   configure := pure

--- a/Zcash/Circuits/Poseidon/Pow5.lean
+++ b/Zcash/Circuits/Poseidon/Pow5.lean
@@ -17,10 +17,9 @@ the MDS matrix and its inverse are baked into the gate polynomials as constants 
 Rust, where `m_reg`/`m_inv` come from `S::constants()`), while the round constants live
 in the `rc_a`/`rc_b` fixed columns and are queried by the gates.
 
-The proof-content donor is `Clean/Orchard/Poseidon/` (`Pow5.lean`, `Sponge.lean`,
-`Hash.lean`): `pow5`, `FullRound.value`, `PartialRounds.value` (+ the `mds`/`mdsInv`
-inverse algebra), the `Permute.value` 4+28+4 schedule, and the sponge/hash value
-composition are consumed directly from there.
+The value-level definitions are `pow5`, `FullRound.value`, and `PartialRounds.value` (with
+the `mds`/`mdsInv` inverse algebra), the `Permute.value` 4+28+4 schedule, and the sponge/hash
+value composition.
 -/
 
 namespace Zcash.Circuits.Poseidon

--- a/Zcash/Circuits/Poseidon/Rounds.lean
+++ b/Zcash/Circuits/Poseidon/Rounds.lean
@@ -11,8 +11,7 @@ Reference (ported from actual Rust, not memory):
 The rounds are positional (`MulIncompleteRound` pattern): the entering state row is the
 `Witness`/`extract` neighborhood, the outgoing state row is the output. Round `r` at
 region offset `o` writes row `o + 1`, which is round `r + 1`'s entering row — the loop
-chains by `rfl`. Value-level contracts are the donor's `FullRound.value` /
-`PartialRounds.value` (`Clean/Orchard/Poseidon/Pow5.lean`).
+chains by `rfl`. Value-level contracts are `FullRound.value` and `PartialRounds.value`.
 -/
 
 namespace Zcash.Circuits.Poseidon
@@ -230,7 +229,7 @@ def partialRoundSynthesize (r : ℕ) (cfg : Config) (offset : ℕ)
 /-- Rust `Pow5State::full_round` at source round `r` (`pow5.rs:434-459` + `round`,
 552-592): enable `s_full` at `offset`, load the `rc_a` round constants at `offset`,
 assign the next state at `offset + 1`. Positional: `Witness` is the entering state row,
-`Spec` is the donor `FullRound.value`. -/
+`Spec` is `FullRound.value`. -/
 def fullRound (r : ℕ) : FormalRegionCircuit Fp Config Config unit State where
   configure := pure
   synthesize := fullRoundSynthesize r
@@ -296,7 +295,7 @@ private theorem nextInv_cancel (j : Fin 3) (r0 r1 r2 : Fp) :
 /-- Rust `Pow5State::partial_round` at source round `r` (`pow5.rs:461-534`): one row
 checking two source rounds. Enable `s_partial` at `offset`, load `rc_a` (round `r`) and
 `rc_b` (round `r + 1`) at `offset`, witness the first-round S-box into `partial_sbox` at
-`offset`, assign the next state at `offset + 1`. `Spec` is the donor
+`offset`, assign the next state at `offset + 1`. `Spec` is
 `PartialRounds.value` at `paramsP128 r`. -/
 def partialRound (r : ℕ) : FormalRegionCircuit Fp Config Config unit State where
   configure := pure

--- a/Zcash/Circuits/Sinsemilla/Basic.lean
+++ b/Zcash/Circuits/Sinsemilla/Basic.lean
@@ -284,16 +284,14 @@ theorem chain_eq_sum {n : ℕ} (z : ℕ → Fp) (ms : ℕ → ℕ)
   rw [hzn, zero_mul, _root_.add_zero] at hn
   exact hn
 
-/-- A piece that fits in `K·m` bits is the base-`2^K` recombination of its `K`-bit words.
-Donor `HashPiece.piece_recombine`. -/
+/-- A piece that fits in `K·m` bits is the base-`2^K` recombination of its `K`-bit words. -/
 theorem piece_recombine (p : Fp) (m : ℕ) (hp : p.val < 2 ^ (K * m)) :
     p = ((∑ r ∈ Finset.range m, pieceWord p r * 2 ^ (K * r) : ℕ) : Fp) := by
   have hzn : pieceZ p m = 0 := by simp only [pieceZ, Nat.div_eq_of_lt hp, Nat.cast_zero]
   have h := chain_eq_sum (n := m) (pieceZ p) (pieceWord p) (fun r _ => pieceZ_succ p r) hzn
   rwa [pieceZ_zero] at h
 
-/-- Each running sum `z_r` is the recombination of the words from position `r` onward.
-Donor `HashPiece.chain_eq_suffix_sum`. -/
+/-- Each running sum `z_r` is the recombination of the words from position `r` onward. -/
 theorem chain_eq_suffix_sum {w : ℕ} (zV : ℕ → Fp) (ms : ℕ → ℕ)
     (hword : ∀ s, s < w → zV s = (ms s : Fp) + 2 ^ K * zV (s + 1))
     (hlast : zV w = (ms w : Fp)) (d r : ℕ) (hrw : r + d = w) :
@@ -322,8 +320,7 @@ constraints → output coordinates), `step_honest` the completeness bridge (hone
 assignments → gate invariants and chain point), and `accAfter_eq_chain` lifts a whole honest
 piece to the spec-level `hashToPoint` chain. -/
 
-/-- For one Sinsemilla step, the row equations determine the output coordinates.
-Donor `HashPiece.step_coordinates_of_constraints`. -/
+/-- For one Sinsemilla step, the row equations determine the output coordinates. -/
 theorem step_coordinates_of_constraints (S : ℕ → Point Fp) {A B : Point Fp} {m : ℕ}
     (hstep : step S m A = some B)
     {xp lambda1 lambda2 xa' YA' : Fp}
@@ -338,7 +335,7 @@ theorem step_coordinates_of_constraints (S : ℕ → Point Fp) {A B : Point Fp} 
 
 /-- The honest-prover counterpart of `step_coordinates_of_constraints`: the honest cell
 values (the `rowValue` assignment formulas, given as hypotheses) satisfy the row's lookup-`y`
-derivation and `Y_A` invariant, and the next accumulator is `B`. Donor `HashPiece.step_honest`. -/
+derivation and `Y_A` invariant, and the next accumulator is `B`. -/
 theorem step_honest (S : ℕ → Point Fp) {A B : Point Fp} {m : ℕ}
     (hstep : step S m A = some B)
     {l1 l2 xa' ya' : Fp}
@@ -437,7 +434,7 @@ theorem step_honest (S : ℕ → Point Fp) {A B : Point Fp} {m : ℕ}
   exact ⟨hyp, hYA, hBx', hBy'⟩
 
 /-- The honest accumulator chain follows the spec-level chain points, whenever the
-spec-level chain is defined. Donor `HashPiece.accAfter_eq_chain`. -/
+spec-level chain is defined. -/
 theorem accAfter_eq_chain (G : Generators) {A : Point Fp} (p : Fp)
     {r : ℕ} {Ar : Point Fp}
     (hchain : hashToPoint G.S A ((List.range r).map (pieceWord p)) = some Ar) :

--- a/Zcash/Circuits/Sinsemilla/HashPieceRound.lean
+++ b/Zcash/Circuits/Sinsemilla/HashPieceRound.lean
@@ -782,7 +782,7 @@ theorem honest_yA (G : Generators) {s : State Fp} {p : Fp} {A : Point Fp} {r : �
   rw [hxA, hxP, hl1, hl2, hAr]
   exact hh.2.1.symm
 
-/-- A defined chain restricts to every prefix. Donor `HashPiece.range_prefix_some`. -/
+/-- A defined chain restricts to every prefix. -/
 theorem range_prefix_some (S : ℕ → Point Fp) (Q : Point Fp) (f : ℕ → ℕ) {n : ℕ} {B : Point Fp}
     (hn : hashToPoint S Q ((List.range n).map f) = some B)
     {r : ℕ} (hr : r ≤ n) :

--- a/Zcash/Circuits/Sinsemilla/Merkle.lean
+++ b/Zcash/Circuits/Sinsemilla/Merkle.lean
@@ -556,7 +556,7 @@ def configureCertificate (scfg : HashPiece.Config) (counts : ConfigureCounts) :
 `K`-bit little-endian digit sums: extraction, recombination, bounds. Framework-agnostic `ℕ`
 arithmetic. -/
 
-/-- Factor the lowest digit out of a digit sum. Donor `Merkle.sum_head_shift`. -/
+/-- Factor the lowest digit out of a digit sum. -/
 private theorem sum_head_shift (Kb m : ℕ) (d : ℕ → ℕ) :
     ∑ j ∈ Finset.range (m + 1), d j * 2 ^ (Kb * j)
       = d 0 + 2 ^ Kb * ∑ j ∈ Finset.range m, d (j + 1) * 2 ^ (Kb * j) := by
@@ -569,7 +569,7 @@ private theorem sum_head_shift (Kb m : ℕ) (d : ℕ → ℕ) :
   simp only [hstep, Nat.mul_zero, pow_zero, Nat.mul_one]
   ring
 
-/-- A digit sum of `n` digits fits in `Kb · n` bits. Donor `Merkle.sum_digits_lt`. -/
+/-- A digit sum of `n` digits fits in `Kb · n` bits. -/
 private theorem sum_digits_lt {Kb : ℕ} {d : ℕ → ℕ} (hd : ∀ j, d j < 2 ^ Kb) (n : ℕ) :
     ∑ j ∈ Finset.range n, d j * 2 ^ (Kb * j) < 2 ^ (Kb * n) := by
   induction n with
@@ -583,7 +583,7 @@ private theorem sum_digits_lt {Kb : ℕ} {d : ℕ → ℕ} (hd : ∀ j, d j < 2 
         _ = 2 ^ (Kb * m) * 2 ^ Kb := by ring
     omega
 
-/-- Concatenating a `Kb·m`-bit value with high bits stays within bounds. Donor `Merkle.append_lt`. -/
+/-- Concatenating a `Kb·m`-bit value with high bits stays within bounds. -/
 private theorem append_lt {m n x y : ℕ} (hx : x < 2 ^ m) (hy : y < 2 ^ n) :
     x + 2 ^ m * y < 2 ^ (m + n) := by
   have h1 : x + 2 ^ m * y < 2 ^ m * (1 + y) := by
@@ -593,7 +593,7 @@ private theorem append_lt {m n x y : ℕ} (hx : x < 2 ^ m) (hy : y < 2 ^ n) :
   rw [pow_add]
   omega
 
-/-- Each digit of a bounded-digit sum is recovered by shift-and-mask. Donor `Merkle.digit_of_sum`. -/
+/-- Each digit of a bounded-digit sum is recovered by shift-and-mask. -/
 private theorem digit_of_sum (Kb : ℕ) :
     ∀ (i n : ℕ) (d : ℕ → ℕ), (∀ j, d j < 2 ^ Kb) → i < n →
       (∑ j ∈ Finset.range n, d j * 2 ^ (Kb * j)) / 2 ^ (Kb * i) % 2 ^ Kb = d i := by
@@ -614,7 +614,7 @@ private theorem digit_of_sum (Kb : ℕ) :
       Nat.div_eq_of_lt (hd 0), Nat.zero_add]
     exact ih m (fun j => d (j + 1)) (fun j => hd (j + 1)) (by omega)
 
-/-- A `Kb·n`-bit value is the sum of its shift-and-mask digits. Donor `Merkle.sum_words`. -/
+/-- A `Kb·n`-bit value is the sum of its shift-and-mask digits. -/
 private theorem sum_words (Kb : ℕ) :
     ∀ (n x : ℕ), x < 2 ^ (Kb * n) →
       ∑ j ∈ Finset.range n, (x / 2 ^ (Kb * j) % 2 ^ Kb) * 2 ^ (Kb * j) = x := by
@@ -641,8 +641,7 @@ private theorem sum_words (Kb : ℕ) :
     rw [Nat.mul_zero, pow_zero, Nat.div_one, Nat.mod_add_div]
 
 set_option exponentiation.threshold 600 in
-/-- Split a 52-digit sum into the `a`/`b`/`c` segments of the `MerkleCRH` message. Donor
-`Merkle.merkle_sum_split`. -/
+/-- Split a 52-digit sum into the `a`/`b`/`c` segments of the `MerkleCRH` message. -/
 private theorem merkle_sum_split (D : ℕ → ℕ) :
     ∑ j ∈ Finset.range 52, D j * 2 ^ (K * j)
       = ∑ j ∈ Finset.range 25, D j * 2 ^ (K * j)
@@ -673,7 +672,7 @@ private theorem merkle_sum_split (D : ℕ → ℕ) :
 
 set_option exponentiation.threshold 600 in
 /-- The `MerkleCRH` chunk list is the concatenation of the three pieces' chunk lists, given that
-the packed message value decomposes into the pieces' digits. Donor `Merkle.merkleChunks_eq`. -/
+the packed message value decomposes into the pieces' digits. -/
 private theorem merkleChunks_eq {dA dB dC : ℕ → ℕ}
     (hA : ∀ j, dA j < 2 ^ K) (hB : ∀ j, dB j < 2 ^ K) (hC : ∀ j, dC j < 2 ^ K)
     {l lv rv : ℕ}
@@ -754,7 +753,7 @@ private theorem natCast_inj_lt {a b : ℕ} (ha : a < 2 ^ 10) (hb : b < 2 ^ 10)
 
 From the decomposition-gate equations, the pieces' chunk sums, and the range-checked sub-pieces,
 the 255-bit encodings of `left`/`right` are recovered, and the `MerkleCRH` chunks are exactly the
-pieces' chunks. Donor `Merkle.assemble`. -/
+pieces' chunks. -/
 
 private theorem two_pow_250_lt_p : (2 : ℕ) ^ 250 < PALLAS_BASE_CARD := by
   norm_num [PALLAS_BASE_CARD]
@@ -874,8 +873,7 @@ private theorem assemble {msA msB msC : ℕ → ℕ}
 /-! ### The honest decomposition (lifted verbatim) -/
 
 set_option exponentiation.threshold 600 in
-/-- Decomposing the packed message value into the three honest piece values. Donor
-`Merkle.merkle_honest_sum`. -/
+/-- Decomposing the packed message value into the three honest piece values. -/
 private theorem merkle_honest_sum (l lv rv : ℕ) :
     l + 2 ^ 10 * lv + 2 ^ 265 * rv
       = (l + 2 ^ 10 * (lv % 2 ^ 240))
@@ -885,8 +883,7 @@ private theorem merkle_honest_sum (l lv rv : ℕ) :
   omega
 
 set_option exponentiation.threshold 600 in
-/-- The `MerkleCRH` chunks of the canonical encodings are the honest pieces' chunks. Donor
-`Merkle.honest_chunks`. -/
+/-- The `MerkleCRH` chunks of the canonical encodings are the honest pieces' chunks. -/
 private theorem honest_chunks {l lv rv : ℕ} (hl : l < 2 ^ 10) (hlv : lv < 2 ^ 255)
     (hrv : rv < 2 ^ 255) :
     merkleChunks l lv rv
@@ -934,8 +931,7 @@ private theorem p_lt_two_pow_255 : PALLAS_BASE_CARD < 2 ^ 255 := by
   norm_num [PALLAS_BASE_CARD]
 
 set_option exponentiation.threshold 600 in
-/-- The honest piece values are in range and their chunk words make up the `MerkleCRH` message.
-Donor `Merkle.honest_pieces`. -/
+/-- The honest piece values are in range and their chunk words make up the `MerkleCRH` message. -/
 private theorem honest_pieces {l lv rv : ℕ} (hl : l < 2 ^ 10)
     (hlv : lv < 2 ^ 255) (hrv : rv < 2 ^ 255)
     {aCell bCell cCell : Fp}
@@ -989,7 +985,7 @@ private theorem honest_pieces {l lv rv : ℕ} (hl : l < 2 ^ 10)
         rw [hvalC]
 
 set_option exponentiation.threshold 600 in
-/-- The decomposition-gate equations hold on the honest witness values. Donor `Merkle.honest_gate`. -/
+/-- The decomposition-gate equations hold on the honest witness values. -/
 private theorem honest_gate {l lv rv : ℕ} (hl : l < 2 ^ 10)
     (hlv : lv < 2 ^ 255) (hrv : rv < 2 ^ 255)
     {aCell bCell b1Cell b2Cell cCell z1A z1B left right : Fp}
@@ -2327,14 +2323,13 @@ theorem HashLayer.circuit_lookupSelectorAnchorRequirements
 
 def depth : ℕ := 32
 
-/-- One Merkle step: the parent node from a child + its sibling (position bit unspecified). Donor
-`Merkle.MerkleStep`. -/
+/-- One Merkle step: the parent node from a child + its sibling (position bit unspecified). -/
 def MerkleStep (G : Generators) (Q : Point Fp) (l : ℕ) (node node' : Fp) : Prop :=
   ∃ lv rv : ℕ, lv < 2 ^ 255 ∧ rv < 2 ^ 255 ∧
     ((lv : Fp) = node ∨ (rv : Fp) = node) ∧
     ∀ B, hashToPoint G.S Q (merkleChunks l lv rv) = some B → node' = B.x
 
-/-- The Merkle root after `k` layers. Donor `Merkle.MerkleRoot`. -/
+/-- The Merkle root after `k` layers. -/
 def MerkleRoot (G : Generators) (Q : Point Fp) : ℕ → Fp → ℕ → Fp → Prop
   | _, node, 0, root => root = node
   | l, node, k + 1, root =>
@@ -2458,8 +2453,7 @@ theorem MerkleRoot.trans (G : Generators) (Q : Point Fp) {l a m r : _} {k k' : �
     exact ⟨mid, hstep,
       ih hrest (by rwa [show l + 1 + n = l + (n + 1) from by omega])⟩
 
-/-- Forward induction: a chain of `MerkleStep`s assembles into a `MerkleRoot`. Donor
-`Merkle.merkleRoot_of_steps`. -/
+/-- Forward induction: a chain of `MerkleStep`s assembles into a `MerkleRoot`. -/
 theorem merkleRoot_of_steps (G : Generators) (Q : Point Fp) (f : ℕ → Fp) (l : ℕ) :
     ∀ k, (∀ i, i < k → MerkleStep G Q (l + i) (f i) (f (i + 1))) →
       MerkleRoot G Q l (f 0) k (f k) := by
@@ -2607,8 +2601,7 @@ One Merkle path layer (`MerklePath::calculate_root`'s loop body): conditionally 
 (Rust `Value`s) — then hash the swapped pair. Both children are proven
 (`CondSwap.swap`, `HashLayer.circuit`). -/
 
-/-- The swapped `(left, right)` pair a layer hashes, selected by the position bit. Donor
-`Merkle.Layer.proverChunks` (value-level). -/
+/-- The swapped `(left, right)` pair a layer hashes, selected by the position bit. -/
 def proverChunks (l : ℕ) (node sibling : Fp) (posBit : Bool) : List ℕ :=
   merkleChunks l
     (ZMod.val (if posBit then sibling else node))
@@ -3409,7 +3402,7 @@ def Layer.configurationCertificate (G : Generators) (Q : Point Fp)
 namespace CalculateRoot
 
 /-- The honest running node after `k` layers (`none` if any layer hash is undefined). Index-based
-to mirror the circuit's fold. Donor `CalculateRoot.honestNode`. -/
+to mirror the circuit's fold. -/
 def honestNode (G : Generators) (Q : Point Fp)
     (leaf : Fp) (path : Vector Fp 32) (pos : ℕ) : ℕ → Option Fp
   | 0 => some leaf
@@ -3420,7 +3413,7 @@ def honestNode (G : Generators) (Q : Point Fp)
           (proverChunks k node (path[k]'(by omega)) (decide (pos >>> k % 2 = 1)))).map (·.x)
     else none
 
-/-- `honestNode` is downward-monotone in success. Donor `CalculateRoot.honestNode_isSome_of_succ`. -/
+/-- `honestNode` is downward-monotone in success. -/
 theorem honestNode_isSome_of_succ (G : Generators) (Q : Point Fp)
     (leaf : Fp) (path : Vector Fp 32) (pos : ℕ) (k : ℕ)
     (h : (honestNode G Q leaf path pos (k + 1)).isSome) :

--- a/Zcash/Circuits/Utilities/AddChip.lean
+++ b/Zcash/Circuits/Utilities/AddChip.lean
@@ -11,8 +11,6 @@ Reference (ported from actual Rust, not memory):
   equality on all advices.
 - `AddInstruction::add` (lines 71-91): one region `"c = a + b"`; `q_add` at row 0, copy
   `a` and `b` in, assign `c = a + b`.
-
-The phase-one donor is `Clean/Orchard/Utilities.lean` (`Utilities.AddChip`).
 -/
 
 namespace Zcash.Circuits.AddChip

--- a/Zcash/Circuits/Utilities/CondSwap.lean
+++ b/Zcash/Circuits/Utilities/CondSwap.lean
@@ -16,8 +16,7 @@ Rust `ternary`/`bool_check` helpers, `utilities.rs:133-143`).
 
 This file carries the VK-facing surface (`Config`, the gate, `configure` — Rust-exact in
 registration order, used by `MerkleChip::configure`); the `swap` gadget bundle follows the
-`MulOverflow`-style leaf pattern. Phase-one donor: `Clean/Orchard/Utilities.lean`,
-namespace `CondSwap`.
+`MulOverflow`-style leaf pattern.
 -/
 
 namespace Zcash.Circuits.CondSwap

--- a/Zcash/Circuits/Utilities/DecomposeRunningSum.lean
+++ b/Zcash/Circuits/Utilities/DecomposeRunningSum.lean
@@ -65,13 +65,13 @@ private theorem eval_foldl_rangeCheck (l : List ℕ) (acc word : Expression Fp Q
     rw [List.foldl_cons, List.foldl_cons, ih]
     simp [circuit_norm]
 
-/-- The donor's `rangeCheckValues` in plain `List.map` form. -/
+/-- `rangeCheckValues` in plain `List.map` form. -/
 private theorem rangeCheckValues_eq (range : ℕ) :
     rangeCheckValues (F := Fp) range
       = ((List.range range).drop 1).map (fun i : ℕ => (i : Fp)) := by
   simp [rangeCheckValues, List.map_eq_flatMap]
 
-/-- `rangeCheckExpr` evaluates to the donor's `rangeCheckPoly` of the evaluated word —
+/-- `rangeCheckExpr` evaluates to `rangeCheckPoly` of the evaluated word —
 the bridge to the `InRange` machinery (`Utilities.RunningSum`). -/
 theorem eval_rangeCheckExpr (range : ℕ) (word : Expression Fp Query) (f : Query → Fp) :
     (rangeCheckExpr range word).eval f = rangeCheckPoly range (word.eval f) := by

--- a/Zcash/Circuits/Utilities/LookupRangeCheck.lean
+++ b/Zcash/Circuits/Utilities/LookupRangeCheck.lean
@@ -24,9 +24,8 @@ and `short_range_check` generic over `K : ℕ`. The value-level range arithmetic
 bound as an explicit hypothesis, so the whole port stays `K`-generic (the Orchard `K = 10`
 discharges the bound by `norm_num`). See `lookup-design.md` §4.
 
-The pure field-arithmetic core (the `2^(K−num_bits)` shift argument) is lifted from the
-phase-one donor `Clean/Orchard/Utilities.lean`, namespace `LookupRangeCheck` — restated
-`K`-generically here.
+The pure field-arithmetic core (the `2^(K−num_bits)` shift argument) is stated
+`K`-generically.
 -/
 
 namespace Zcash.Circuits.LookupRangeCheck
@@ -488,12 +487,11 @@ theorem load_tableLoaded (K : ℕ) (cfg : Config K) (place : RegionIndex → ℕ
 
 /-! ## The pure value-math core of `short_range_check` soundness
 
-Lifted from the phase-one donor `Clean/Orchard/Utilities.lean`,
-`LookupRangeCheck.shortRange_soundness_aux`, restated `K`-generically with the field-card
-bound as an explicit hypothesis. Zero framework vocabulary — pure `Fp`/`ℕ` arithmetic:
+This core is stated `K`-generically, with the field-card bound as an explicit hypothesis,
+and with no framework vocabulary — pure `Fp`/`ℕ` arithmetic:
 `element·2^(K−num_bits) < 2^K ∧ element < 2^K ⇒ element < 2^num_bits`. -/
 
-/-- The shift argument (donor `shortRange_soundness_aux`). If the word and its shift by
+/-- The shift argument. If the word and its shift by
 `2^(K−num_bits)` are both `< 2^K`, then the word is `< 2^num_bits`. The card bound
 `2^K · 2^K < |Fp|` licenses reading the product `word.val · 2^(K−num_bits)` off the field
 element `shifted`. -/
@@ -525,8 +523,8 @@ theorem shortRange_soundness_aux (K numBits : ℕ) (hNumBits : numBits ≤ K)
   rw [hShiftedVal] at hShifted
   exact Nat.not_lt_of_ge hle hShifted
 
-/-- Completeness shift-bound (donor `shortRange_completeness_shifted`): if `word < 2^num_bits`
-then its shift by `2^(K−num_bits)` is `< 2^K`. -/
+/-- Completeness shift-bound: if `word < 2^num_bits` then its shift by `2^(K−num_bits)` is
+`< 2^K`. -/
 theorem shortRange_completeness_shifted (K numBits : ℕ) (hNumBits : numBits ≤ K)
     (hCard : 2 ^ K < PALLAS_BASE_CARD)
     (word : Fp) (hWord : word.val < 2 ^ numBits) :
@@ -888,13 +886,11 @@ theorem shortRangeCheck_configured_permutationColumns_eq
 
 /-! ## The pure telescoping algebra for `range_check`
 
-Lifted `K`-generically from the phase-one donor `Clean/Orchard/Utilities.lean`,
-`LookupRangeCheck.CopyCheck.{chain_telescope, element_lt}` (there `K` is fixed at `10`; here
-it is a parameter). Zero framework vocabulary — a running-sum chain `f : ℕ → Fp` with each
-step a `K`-bit word telescopes to `f 0 = lo + 2^{K·k}·f k` with `lo < 2^{K·k}`. -/
+No framework vocabulary, and `K` is a parameter: a running-sum chain `f : ℕ → Fp` whose
+steps are `K`-bit words telescopes to `f 0 = lo + 2^{K·k}·f k` with `lo < 2^{K·k}`. -/
 
-/-- Telescoping a `K`-bit running-sum chain (donor `CopyCheck.chain_telescope`, `K`-generic):
-`f 0` splits into `K·k` low bits and `2^{K·k}·f k`. -/
+/-- Telescoping a `K`-bit running-sum chain: `f 0` splits into `K·k` low bits and
+`2^{K·k}·f k`. -/
 theorem chain_telescope (K : ℕ) (f : ℕ → Fp) :
     ∀ k : ℕ,
     (∀ i, i < k → ∃ w : ℕ, w < 2 ^ K ∧ f i = 2 ^ K * f (i + 1) + (w : Fp)) →
@@ -916,9 +912,8 @@ theorem chain_telescope (K : ℕ) (f : ℕ → Fp) :
       rw [show K * (k + 1) = K * k + K from by ring, pow_add]
       ring
 
-/-- A fully-decomposed chain (`f numWords = 0`) bounds `f 0` below `2^{K·numWords}`
-(donor `CopyCheck.element_lt`, `K`-generic). The card bound `2^{K·numWords} ≤ |Fp|` reads
-the low part off the field element. -/
+/-- A fully-decomposed chain (`f numWords = 0`) bounds `f 0` below `2^{K·numWords}`. The
+card bound `2^{K·numWords} ≤ |Fp|` reads the low part off the field element. -/
 theorem chain_element_lt (K numWords : ℕ) (hCard : 2 ^ (K * numWords) ≤ PALLAS_BASE_CARD)
     (f : ℕ → Fp)
     (hchain : ∀ i, i < numWords → ∃ w : ℕ, w < 2 ^ K ∧ f i = 2 ^ K * f (i + 1) + (w : Fp))
@@ -930,8 +925,8 @@ theorem chain_element_lt (K numWords : ℕ) (hCard : 2 ^ (K * numWords) ≤ PALL
   exact hlo
 
 /-- The honest running word `z_idx − 2^K·z_{idx+1}` with `z_idx = ↑(b)`,
-`z_{idx+1} = ↑(b / 2^K)` is the low `K`-bit chunk of `b`, hence `< 2^K`.
-Donor `CopyCheck.word_val_lt`, `K`-generic (needs `2^K ≤ |Fp|`). -/
+`z_{idx+1} = ↑(b / 2^K)` is the low `K`-bit chunk of `b`, hence `< 2^K` (this needs
+`2^K ≤ |Fp|`). -/
 theorem honest_word_val_lt (K : ℕ) (hCard : 2 ^ K ≤ PALLAS_BASE_CARD) (b : ℕ) :
     ZMod.val ((b : Fp) - 2 ^ K * ((b / 2 ^ K : ℕ) : Fp)) < 2 ^ K := by
   have hsub : (b : Fp) - 2 ^ K * ((b / 2 ^ K : ℕ) : Fp) = ((b % 2 ^ K : ℕ) : Fp) := by
@@ -942,7 +937,7 @@ theorem honest_word_val_lt (K : ℕ) (hCard : 2 ^ K ≤ PALLAS_BASE_CARD) (b : �
 
 open CompElliptic.Fields.Pasta (PALLAS_BASE_CARD) in
 /-- A fully-decomposed chain pins each running sum to the exact shift of the element:
-`(f k).val = (f 0).val / 2^(K·k)` (donor `CopyCheck.read`, chain-language). -/
+`(f k).val = (f 0).val / 2^(K·k)`. -/
 theorem chain_read (K numWords : ℕ) (hpow : K * numWords ≤ 254) (f : ℕ → Fp)
     (hchain : ∀ i, i < numWords → ∃ w : ℕ, w < 2 ^ K ∧ f i = 2 ^ K * f (i + 1) + (w : Fp))
     (htop : f numWords = 0) (k : ℕ) (hk : k ≤ numWords) :
@@ -997,8 +992,7 @@ recursive `RegionCircuit` def over `numWords` whose `operations` is, by `rfl` (f
 monad's append-bind, `Lemmas.lean`), the concatenation of per-round op lists:
 `(loop (n+1)).operations self = (loop n).operations self ++ (round n).operations self`.
 That append shape is what lets the z-chain invariant be proven by induction over rounds
-(`rangeCheck_loop_word_bounds` below), and the telescoping algebra (lifted `K`-generically
-from the donor `Clean/Orchard/Utilities.lean`, `CopyCheck.chain_telescope`) then reads the
+(`rangeCheck_loop_word_bounds` below), and the telescoping algebra then reads the
 decomposition off the chain. -/
 
 /-- The output of `range_check`: the first (`z_0 = element`) and last (`z_{numWords}`)
@@ -1009,9 +1003,9 @@ structure Output (F : Type) where
   zLast : F
 deriving ProvableStruct
 
-/-- The honest running-sum witness value at word `idx`: `z_idx = element ≫ (K·idx)`
-(donor `CopyCheck.main`). As a witgen program over the `element` cell: cast to ℕ (`.val`),
-shift right by `K·idx` bits (`.div` by `2^(K·idx)`), cast back to the field (`.ofNat`). -/
+/-- The honest running-sum witness value at word `idx`: `z_idx = element ≫ (K·idx)`. As a
+witgen program over the `element` cell: cast to ℕ (`.val`), shift right by `K·idx` bits
+(`.div` by `2^(K·idx)`), cast back to the field (`.ofNat`). -/
 def zWitness (K idx : ℕ) (element : AssignedCell Fp) : WitgenIR Fp 1 :=
   .ofFExpr (.ofNat (.div (.val (.expr element)) (.const (2 ^ (K * idx)))))
 
@@ -1515,7 +1509,7 @@ def rangeCheck (K numWords : ℕ) (strict : Bool) :
 
   -- honest-prover precondition: in `strict` mode the element genuinely fits in `K·numWords`
   -- bits (the assertion precondition — the honest prover can only satisfy `z_last = 0` then).
-  -- Non-strict imposes nothing. Established assertion-gadget pattern (cf. donor `Decomposed`).
+  -- Non-strict imposes nothing. Established assertion-gadget pattern.
   ProverAssumptions input _ _ := strict = true → input.element.val < 2 ^ (K * numWords)
 
   -- honest-prover postcondition (C6): the high-tail cell `zLast` holds the honest NATURAL-NUMBER
@@ -1990,10 +1984,10 @@ theorem rangeCheckAtDecomposedBody_output (numWords : ℕ) (cfg : Config 10)
         z13 := AssignedCell.of self (offset + 13) cfg.runningSum } := rfl
 
 open CompElliptic.Fields.Pasta (PALLAS_BASE_CARD) in
-/-- The positional strict 25-word running-sum check exposing `z_1`/`z_13` (donor
-`CopyCheck.Decomposed`, positional): Rust `witness_check(j, 25, true)` as consumed by
-`y_canonicity` (`note_commit.rs:1997-2010`), which hands out `zs[1]` and `zs[13]`. The
-strict tail derives `elt < 2^250` and pins every running sum to the exact shift. -/
+/-- The positional strict 25-word running-sum check exposing `z_1`/`z_13`: Rust
+`witness_check(j, 25, true)` as consumed by `y_canonicity` (`note_commit.rs:1997-2010`),
+which hands out `zs[1]` and `zs[13]`. The strict tail derives `elt < 2^250` and pins every
+running sum to the exact shift. -/
 def rangeCheckAtDecomposed (numWords : ℕ) (h13 : 13 ≤ numWords)
     (hpow : 10 * numWords ≤ 254) :
     FormalRegionCircuit Fp (Config 10) (Config 10) unit DecomposedOutput where


### PR DESCRIPTION
The circuit layer was copied from the phase-1 Clean-based development, "the donor". Nothing has imported that development for some time, but the layer still carried two kinds of reference to it.

* Four private lemmas in the CommitIvk and NoteCommit main bundles (`pieceChunks_donor_iff`, `zsFacts_donor_iff`, `pieceBounds_donor_iff`, `honestChunks_donor_eq`) had become statements of a proposition's equivalence with itself once the donor's definitions were replaced by the copies here. They and their eight no-op uses are deleted.
* Docstrings and comments across the layer carried provenance notes ("Phase-1 donor: …", "Donor `X`.") and described gate contracts as "the donor …". The notes are deleted; the sentences that also said something about the present code now say only that ("`Spec`, the composite's guarantee, gives …", "the gate `Spec`").
* The `toDonor` row conversions and the private `DRow`/`DSpec`/`DAssumptions` aliases (the "D" stood for the donor) are renamed `toGateRow`, `GateRow`, `GateSpec`, and `GateAssumptions`.

No statement changes: the lemma deletions remove identities, and everything else is documentation or renaming.

🤖 Claude Fable 5.1
